### PR TITLE
Set up Rust integration tests with per-test DB setup

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -85,6 +85,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,11 +351,14 @@ dependencies = [
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum 0.7.9",
  "axum-extra",
  "color-eyre",
  "config",
+ "ctor",
  "dotenv-flow",
+ "env_logger",
  "eyre",
  "futures",
  "futures-macro",
@@ -314,11 +367,14 @@ dependencies = [
  "http-body-util",
  "lol_html",
  "ordered-multimap",
+ "pretty_assertions",
  "regorus",
  "sea-orm",
  "serde",
  "serde_json",
+ "sqlx",
  "synonym",
+ "test-log",
  "tokio",
  "tokio-stream",
  "tower-http",
@@ -587,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +935,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.96",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -951,6 +1029,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,8 +1106,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1402,6 +1503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,7 +1808,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "referencing",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "serde",
  "serde_json",
  "uuid-simd",
@@ -1796,6 +1909,15 @@ dependencies = [
  "mime",
  "selectors",
  "thiserror 2.0.11",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2415,6 +2537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,8 +2771,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2651,8 +2792,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3290,6 +3437,8 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.11",
  "time",
+ "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",
@@ -3330,6 +3479,7 @@ dependencies = [
  "sqlx-sqlite",
  "syn 2.0.96",
  "tempfile",
+ "tokio",
  "url",
 ]
 
@@ -3559,6 +3709,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3874,10 +4046,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3979,6 +4155,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,6 +14,7 @@ axum-extra = { version = "0.9.6", features = ["typed-header"] }
 headers = "0.4.0"
 tower-http = { version = "0.6.2" , features = ["fs", "cors"]}
 sea-orm = "1.1.4"
+sqlx = { version = "0.8.3", features=["postgres", "runtime-tokio"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 tokio = { version = "1.43.0", features = ["rt-multi-thread"] }
@@ -22,6 +23,7 @@ synonym = "0.1.5"
 regorus = "0.2.8"
 eyre = "0.6.12"
 color-eyre = "0.6.3"
+async-trait = "0.1.77"
 # OpenAPI handling
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.1.3"
@@ -37,3 +39,9 @@ ordered-multimap = "0.7.3"
 futures = "0.3"
 futures-macro = "0.3"
 tokio-stream = "0.1.17"
+
+[dev-dependencies]
+test-log = "0.2.14"
+env_logger = "0.11.2"
+pretty_assertions = "1.4.0"
+ctor = "0.2.9"

--- a/backend/sqitch/deploy_distributed.sh
+++ b/backend/sqitch/deploy_distributed.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Function to print usage
+usage() {
+    echo "Usage: $0 --db-uri <database_uri>"
+    echo "Example: $0 --db-uri 'db:pg://user:pass@host:5432/dbname'"
+    exit 1
+}
+
+# Function to test database name extraction
+test_db_extraction() {
+    local uri="$1"
+    local expected="$2"
+    local result=$(echo "$uri" | sed -E 's/.*\/([^?]+).*/\1/')
+    if [ "$result" = "$expected" ]; then
+        echo "✓ Correctly extracted '$expected' from '$uri'"
+    else
+        echo "✗ Failed to extract from '$uri'. Expected '$expected' but got '$result'"
+        exit 1
+    fi
+}
+
+# Run tests if --test flag is provided
+if [ "$1" = "--test" ]; then
+    echo "Running database name extraction tests..."
+    test_db_extraction "db:pg://user:pass@host:5432/mydb" "mydb"
+    test_db_extraction "postgresql://user:pass@host:5432/mydb" "mydb"
+    test_db_extraction "db:pg://user:pass@host:5432/mydb?sslmode=disable" "mydb"
+    echo "All tests passed!"
+    exit 0
+fi
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --db-uri) DB_URI="$2"; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+# Check if DB_URI is provided
+if [ -z "$DB_URI" ]; then
+    usage
+fi
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change to the script directory to ensure sqitch commands work correctly
+cd "$SCRIPT_DIR"
+
+# Extract database name from URI
+# This handles both formats:
+# - db:pg://user:pass@host:5432/dbname
+# - postgresql://user:pass@host:5432/dbname
+# - db:pg://user:pass@host:5432/dbname?sslmode=disable
+DB_NAME=$(echo "$DB_URI" | sed -E 's/.*\/([^?]+).*/\1/')
+
+echo "Extracted database name (will be used as registry): $DB_NAME"
+
+# Deploy using the distributed target, overriding URI and registry
+sqitch deploy "distributed" \
+    --registry "$DB_NAME" \
+    --uri "$DB_URI"
+
+echo "Deployment completed successfully" 

--- a/backend/sqitch/generate_summary.sh
+++ b/backend/sqitch/generate_summary.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change to the script directory to ensure sqitch commands work correctly
+cd "$SCRIPT_DIR"
+
+# Get the list of migrations from sqitch plan
+MIGRATIONS=$(sqitch plan --no-headers --format 'format:%F' | jq -R -s 'split("\n")[:-1]')
+
+# Create the JSON output and format it with jq
+cat << EOF | jq '.' > sqitch_summary.json
+{
+  "migrations": ${MIGRATIONS}
+}
+EOF
+
+echo "Generated sqitch_summary.json successfully" 

--- a/backend/sqitch/justfile
+++ b/backend/sqitch/justfile
@@ -1,0 +1,6 @@
+default:
+    just --list
+
+deploy_local:
+    sqitch deploy local_dev
+    ./generate_summary.sh

--- a/backend/sqitch/sqitch.conf
+++ b/backend/sqitch/sqitch.conf
@@ -1,4 +1,12 @@
 [core]
 	engine = pg
+
 [target "local_dev"]
 	uri = db:pg://eratouser:eratopw@127.0.0.1:5432/erato
+	registry = erato
+
+# Mostly a placholder for the target we use for distributing.
+# This will be used with CLI provided flags in a script.
+[target "distributed"]
+	uri = db:pg://eratouser:eratopw@127.0.0.1:5432/placeholder
+	registry = placeholder

--- a/backend/sqitch/sqitch_summary.json
+++ b/backend/sqitch/sqitch_summary.json
@@ -1,0 +1,6 @@
+{
+  "migrations": [
+    "deploy/0001_init_database.sql",
+    "deploy/0002_add_chat_and_messages_tables.sql"
+  ]
+}

--- a/backend/tests/integration_tests/db.rs
+++ b/backend/tests/integration_tests/db.rs
@@ -1,0 +1,21 @@
+// use sqlx::{PgPool, Postgres};
+// use test_log::test;
+//
+// pub async fn setup_test_db() -> PgPool {
+//     let database_url = std::env::var("DATABASE_URL")
+//         .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/erato_test".to_string());
+//
+//     PgPool::connect(&database_url)
+//         .await
+//         .expect("Failed to create database connection pool")
+// }
+//
+//
+// #[test]
+// fn test_setup_db() {
+//     let rt = tokio::runtime::Runtime::new().unwrap();
+//     rt.block_on(async {
+//         let pool = setup_test_db().await;
+//         assert!(pool.acquire().await.is_ok());
+//     });
+// }

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+use sqlx::Pool;
+use test_log::test;
+use sqlx::pool::PoolConnection;
+use sqlx::postgres::Postgres;
+use ctor::ctor;
+use sqlx::migrate::Migrator;
+use crate::migrations::SqitchMigrationSource;
+
+mod db;
+mod migrations;
+
+// Using a (possibly brittle?) life-before-main method to set the DATABASE_URL before any tests run.
+#[ctor]
+fn set_test_db_url() {
+    std::env::set_var("DATABASE_URL", "postgres://eratouser:eratopw@127.0.0.1:5432/erato")
+}
+
+// TODO: More proper way would be via SqitchMigration but we can't build them in a static way yet.
+// pub static MIGRATOR: sqlx::migrate::Migrator = Migrator::new(SqitchMigrationSource::new(PathBuf::from("./sqitch/sqitch_summary.json")));
+pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./sqitch/deploy");
+
+// This is the main entry point for integration tests
+// Add more test modules here as needed
+#[test]
+fn dummy() {
+    // This test exists to make sure the test binary is built
+    // Individual tests should go in their respective modules
+    assert!(true);
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn test_db_connection(pool: Pool<Postgres>) {
+    dbg!(&pool.connect_options());
+    // Basic test to ensure we can execute a query
+    let result = sqlx::query_scalar::<_, i32>("SELECT 1 FROM messages;")
+        .fetch_all(&pool)
+        .await
+        .expect("Failed to execute test query");
+
+    assert_eq!(result, Vec::<i32>::new());
+}

--- a/backend/tests/integration_tests/migrations.rs
+++ b/backend/tests/integration_tests/migrations.rs
@@ -1,0 +1,74 @@
+use std::path::{Path, PathBuf};
+use sqlx::migrate::{MigrationSource, Migration, MigrationType};
+use serde::Deserialize;
+use std::fs;
+use std::borrow::Cow;
+use std::pin::{Pin, pin};
+use futures::future::BoxFuture;
+use serde::de::StdError;
+
+#[derive(Debug, Deserialize)]
+struct SqitchSummary {
+    migrations: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct SqitchMigrationSource {
+    summary_path: PathBuf,
+}
+
+impl SqitchMigrationSource {
+    pub fn new<P: AsRef<Path>>(summary_path: P) -> Self {
+        Self {
+            summary_path: summary_path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl<'a> MigrationSource<'a> for SqitchMigrationSource {
+
+    fn resolve(self) -> BoxFuture<'a, Result<Vec<Migration>, Box<(dyn StdError + std::marker::Send + Sync + 'static)>>> {
+        // Read and parse the summary file
+        let summary_content = fs::read_to_string(&self.summary_path)
+            .map_err(|e| sqlx::Error::Configuration(format!("Failed to read summary file: {}", e).into())).unwrap();
+        
+        let summary: SqitchSummary = serde_json::from_str(&summary_content)
+            .map_err(|e| sqlx::Error::Configuration(format!("Failed to parse summary file: {}", e).into())).unwrap();
+        
+        // Get the directory containing the summary file
+        let base_dir = self.summary_path.parent()
+            .ok_or_else(|| sqlx::Error::Configuration("Summary file has no parent directory".into())).unwrap();
+        
+        // Process each migration
+        let mut migrations = Vec::new();
+        for (idx, migration_path) in summary.migrations.iter().enumerate() {
+            let full_path = base_dir.join(migration_path);
+            
+            // Extract description from the filename
+            let file_name = full_path.file_name()
+                .and_then(|f| f.to_str())
+                .ok_or_else(|| sqlx::Error::Configuration(format!("Invalid migration filename: {}", migration_path).into())).unwrap();
+            
+            let description = file_name
+                .trim_end_matches(".sql")
+                .replace('_', " ");
+            
+            // Read the migration content
+            let sql = fs::read_to_string(&full_path)
+                .map_err(|e| sqlx::Error::Configuration(format!("Failed to read migration file {}: {}", migration_path, e).into())).unwrap();
+
+            // Create a checksum of the SQL content
+            // let checksum = blake3::hash(sql.as_bytes()).as_bytes().to_vec();
+            
+            migrations.push(Migration::new(
+                idx as i64,
+                Cow::Owned(description),
+                MigrationType::Simple,
+                Cow::Owned(sql),
+                false, // no_tx
+            ));
+        }
+        
+        Box::pin(futures::future::ok(migrations))
+    }
+}


### PR DESCRIPTION
- Sets up integration test structure as single test binary as per recommendation: https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html
- Sets up a basic migration setup in the tests, where per test, a DB is created and migrated to the correct state
- Prepares migration for the distribution setup (`./deploy_distributed.sh`); See #31 