### PR TITLE
Add basic local development OIDC setup

### DIFF
--- a/backend/src/server/api/v1beta/mod.rs
+++ b/backend/src/server/api/v1beta/mod.rs
@@ -91,7 +91,16 @@ struct MessageSubmitStreamingResponseMessageOther {
 #[utoipa::path(post, path = "/messages/submitstream", responses((status = OK, content_type="text/event-stream", body = MessageSubmitStreamingResponseMessage)))]
 pub async fn message_submit_sse(
     TypedHeader(user_agent): TypedHeader<headers::UserAgent>,
+    headers: axum::http::HeaderMap,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    // Log all headers for debugging
+    dbg!("Received headers:");
+    for (name, value) in headers.iter() {
+        if let Ok(value_str) = value.to_str() {
+            dbg!("  {}: {}", name, value_str);
+        }
+    }
+
     let message = "Hey there this is the full message";
     let words: Vec<&str> = message.split_whitespace().collect();
 

--- a/frontend/local-auth/dex-config.yml
+++ b/frontend/local-auth/dex-config.yml
@@ -1,0 +1,26 @@
+issuer: http://0.0.0.0:5556
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+staticClients:
+  - id: example-app
+    redirectURIs:
+      - "http://localhost:4180/oauth2/callback"
+    name: "Example App"
+    secret: example-app-secret
+
+enablePasswordDB: true
+staticPasswords:
+  - email: "admin@example.com"
+    hash: "$2y$10$EI3YbB3STkWvAzAyZ/fU/ehRT6M5ActxvZS9rZ1fXmTV2zxYNgUaK" # password: admin
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+  - email: "user@example.com"
+    hash: "$2y$10$EI3YbB3STkWvAzAyZ/fU/ehRT6M5ActxvZS9rZ1fXmTV2zxYNgUaK" # password: admin
+    username: "user"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5467"

--- a/frontend/local-auth/docker-compose.yml
+++ b/frontend/local-auth/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.7"
+
+services:
+  dex:
+    # https://github.com/dexidp/dex/releases
+    image: dexidp/dex:v2.41.1
+    network_mode: host
+    volumes:
+      - ./dex-config.yml:/etc/dex/config.yml
+    command: ["dex", "serve", "/etc/dex/config.yml"]
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:5556/healthz"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+      start_period: 2s
+
+  oauth2-proxy:
+    # https://github.com/oauth2-proxy/oauth2-proxy/releases
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.8.1
+    network_mode: host
+    environment:
+      - OAUTH2_PROXY_PROVIDER=oidc
+      - OAUTH2_PROXY_CLIENT_ID=example-app
+      - OAUTH2_PROXY_CLIENT_SECRET=example-app-secret
+      - OAUTH2_PROXY_COOKIE_SECRET=cookie-secret-replace-me
+      - OAUTH2_PROXY_OIDC_ISSUER_URL=http://localhost:5556
+      - OAUTH2_PROXY_INSECURE_OIDC_SKIP_ISSUER_VERIFICATION=true
+      - OAUTH2_PROXY_PROVIDER_DISPLAY_NAME=Dex
+      - OAUTH2_PROXY_REDIRECT_URL=http://localhost:4180/oauth2/callback
+      - OAUTH2_PROXY_UPSTREAMS=http://localhost:3000/#/,http://localhost:3130/api/#/api/
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_COOKIE_SECURE=false
+      - OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:4180
+      - OAUTH2_PROXY_COOKIE_DOMAINS=.localhost
+      - OAUTH2_PROXY_WHITELIST_DOMAINS=.localhost:4180,.localhost:3000,.localhost:3130
+      - OAUTH2_PROXY_COOKIE_NAME=_oauth2_proxy
+      - OAUTH2_PROXY_SET_XAUTHREQUEST=true
+      - OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER=true
+    depends_on:
+      dex:
+        condition: service_healthy


### PR DESCRIPTION
Related #9 

- Adds a local setup with oauth2-proxy and Dex
- oauth2-proxy is responsible for securing the upstream endpoint(s) and doing the OIDC flow with the OIDC endpoint (here Dex)
- Dex is configured with 2 fixed users
- Once the OIDC login flow is completed, all subsequent requests have auth requests headers attached to them
  - I think the best way here would be to inspect the forwarded ID token OIDC provider. There doesn't seem to be another way to get the used issuer from oauth2-proxy. This way, we can create a user-id on the backend that is connected to the tuple of `issuer` and `sub`