### PR TITLE
Rename backend crate to erato

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -12,4 +12,4 @@ FROM ${REGISTRY}/${BACKEND_IMAGE}
 COPY --from=frontend /public /app/public/
 
 # The backend will serve these files directly
-CMD ["./backend"]
+CMD ["./erato"]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -348,45 +348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backend"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "axum 0.7.9",
- "axum-extra",
- "color-eyre",
- "config",
- "ctor",
- "dotenv-flow",
- "env_logger",
- "eyre",
- "futures",
- "futures-macro",
- "headers",
- "http-body",
- "http-body-util",
- "jsonwebtoken",
- "lol_html",
- "ordered-multimap",
- "pretty_assertions",
- "regorus",
- "sea-orm",
- "serde",
- "serde_json",
- "sqlx",
- "synonym",
- "test-log",
- "tokio",
- "tokio-stream",
- "tower-http",
- "tracing-subscriber",
- "utoipa",
- "utoipa-axum",
- "utoipa-scalar",
- "utoipa-swagger-ui",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1018,45 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erato"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "axum-extra",
+ "color-eyre",
+ "config",
+ "ctor",
+ "dotenv-flow",
+ "env_logger",
+ "eyre",
+ "futures",
+ "futures-macro",
+ "headers",
+ "http-body",
+ "http-body-util",
+ "jsonwebtoken",
+ "lol_html",
+ "ordered-multimap",
+ "pretty_assertions",
+ "regorus",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "synonym",
+ "test-log",
+ "tokio",
+ "tokio-stream",
+ "tower-http",
+ "tracing-subscriber",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-scalar",
+ "utoipa-swagger-ui",
+]
 
 [[package]]
 name = "errno"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "backend"
+name = "erato"
 version = "0.1.0"
 edition = "2021"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,10 +26,10 @@ WORKDIR /app
 #     && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary from builder
-COPY --from=builder /app/target/release/backend /app/backend
+COPY --from=builder /app/target/release/erato /app/erato
 
 EXPOSE 3130
 
 ENV HTTP_HOST="0.0.0.0"
 
-CMD ["./backend"] 
+CMD ["./erato"]

--- a/backend/src/gen_openapi.rs
+++ b/backend/src/gen_openapi.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use backend::ApiDoc;
+use erato::ApiDoc;
 
 fn main() {
     let doc = ApiDoc::build_openapi_full().to_pretty_json().unwrap();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,11 +4,11 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use utoipa_scalar::{Scalar, Servable as ScalarServable};
 
-use backend::config::AppConfig;
-use backend::frontend_environment::{
+use erato::config::AppConfig;
+use erato::frontend_environment::{
     serve_files_with_script, FrontedEnvironment, FrontendBundlePath,
 };
-use backend::{server, ApiDoc};
+use erato::{server, ApiDoc};
 use tower_http::cors::CorsLayer;
 
 #[tokio::main]


### PR DESCRIPTION
The name `backend` was too generic, and as in distribution we don't have a split between frontend and backend, the "backend" binary will just be named `erato`.