### PR TITLE
Update API endpoints from v1 to v1beta

### DIFF
--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2,11 +2,11 @@
   "openapi": "3.1.0",
   "info": {
     "title": "",
-    "description": "The main API structure\n\n- `/api/v1/` <- Most of the API is nested under here. All of the resources there are scoped to what is accessible by the authenticated identity.\n- `/api/v1/me` <- Everything under this path is scoped to the subject of the authenticated identity.\nThis means that the identity may be authorized to view more resources, but this is the default view for them.\nE.g. the chats route scoped under there will only list the chats created by the user, but the user may be authorized to also view chats shared by other users.\n",
+    "description": "The main API structure\n\n- `/api/v1beta/` <- Most of the API is nested under here. All of the resources there are scoped to what is accessible by the authenticated identity.\n- `/api/v1beta/me` <- Everything under this path is scoped to the subject of the authenticated identity.\nThis means that the identity may be authorized to view more resources, but this is the default view for them.\nE.g. the chats route scoped under there will only list the chats created by the user, but the user may be authorized to also view chats shared by other users.\n",
     "version": ""
   },
   "paths": {
-    "/api/v1/chats": {
+    "/api/v1beta/chats": {
       "get": {
         "tags": [],
         "operationId": "chats",
@@ -27,7 +27,7 @@
         }
       }
     },
-    "/api/v1/me/profile": {
+    "/api/v1beta/me/profile": {
       "get": {
         "tags": [],
         "operationId": "profile",
@@ -53,7 +53,7 @@
         ]
       }
     },
-    "/api/v1/messages": {
+    "/api/v1beta/messages": {
       "get": {
         "tags": [],
         "operationId": "messages",
@@ -74,7 +74,7 @@
         }
       }
     },
-    "/api/v1/messages/submitstream": {
+    "/api/v1beta/messages/submitstream": {
       "post": {
         "tags": [],
         "operationId": "message_submit_sse",

--- a/backend/src/server/router.rs
+++ b/backend/src/server/router.rs
@@ -1,10 +1,10 @@
 use super::api::v1beta::ApiV1ApiDoc;
 use crate::state::AppState;
 use axum::routing::{get, head};
-use utoipa::openapi::OpenApiBuilder;
+// use utoipa::openapi::OpenApiBuilder;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
-use utoipa_axum::routes;
+// use utoipa_axum::routes;
 
 /// Get health of the API.
 #[utoipa::path(
@@ -30,15 +30,15 @@ pub fn router() -> OpenApiRouter<AppState> {
 #[openapi(
     paths(health),
     nest(
-        (path = "api/v1", api = ApiV1ApiDoc)
+        (path = "api/v1beta", api = ApiV1ApiDoc)
     )
 )]
 pub struct MainRouterApiDoc;
 
 pub const MAIN_ROUTER_DOC: &'static str = r#"The main API structure
 
-- `/api/v1/` <- Most of the API is nested under here. All of the resources there are scoped to what is accessible by the authenticated identity.
-- `/api/v1/me` <- Everything under this path is scoped to the subject of the authenticated identity.
+- `/api/v1beta/` <- Most of the API is nested under here. All of the resources there are scoped to what is accessible by the authenticated identity.
+- `/api/v1beta/me` <- Everything under this path is scoped to the subject of the authenticated identity.
 This means that the identity may be authorized to view more resources, but this is the default view for them.
 E.g. the chats route scoped under there will only list the chats created by the user, but the user may be authorized to also view chats shared by other users.
 "#;

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -26,7 +26,7 @@ export type ChatsVariables = V1betaApiContext["fetcherOptions"];
 
 export const fetchChats = (variables: ChatsVariables, signal?: AbortSignal) =>
   v1betaApiFetch<ChatsResponse, ChatsError, undefined, {}, {}, {}>({
-    url: "/api/v1/chats",
+    url: "/api/v1beta/chats",
     method: "get",
     ...variables,
     signal,
@@ -47,7 +47,7 @@ export function chatsQuery(variables: ChatsVariables | reactQuery.SkipToken): {
 export function chatsQuery(variables: ChatsVariables | reactQuery.SkipToken) {
   return {
     queryKey: queryKeyFn({
-      path: "/api/v1/chats",
+      path: "/api/v1beta/chats",
       operationId: "chats",
       variables,
     }),
@@ -97,7 +97,7 @@ export const fetchProfile = (
   signal?: AbortSignal,
 ) =>
   v1betaApiFetch<Schemas.UserProfile, ProfileError, undefined, {}, {}, {}>({
-    url: "/api/v1/me/profile",
+    url: "/api/v1beta/me/profile",
     method: "get",
     ...variables,
     signal,
@@ -122,7 +122,7 @@ export function profileQuery(
 ) {
   return {
     queryKey: queryKeyFn({
-      path: "/api/v1/me/profile",
+      path: "/api/v1beta/me/profile",
       operationId: "profile",
       variables,
     }),
@@ -174,7 +174,7 @@ export const fetchMessages = (
   signal?: AbortSignal,
 ) =>
   v1betaApiFetch<MessagesResponse, MessagesError, undefined, {}, {}, {}>({
-    url: "/api/v1/messages",
+    url: "/api/v1beta/messages",
     method: "get",
     ...variables,
     signal,
@@ -199,7 +199,7 @@ export function messagesQuery(
 ) {
   return {
     queryKey: queryKeyFn({
-      path: "/api/v1/messages",
+      path: "/api/v1beta/messages",
       operationId: "messages",
       variables,
     }),
@@ -249,7 +249,7 @@ export const fetchMessageSubmitSse = (
   signal?: AbortSignal,
 ) =>
   v1betaApiFetch<undefined, MessageSubmitSseError, undefined, {}, {}, {}>({
-    url: "/api/v1/messages/submitstream",
+    url: "/api/v1beta/messages/submitstream",
     method: "post",
     ...variables,
     signal,
@@ -349,17 +349,17 @@ export const useHealth = <TData = undefined,>(
 
 export type QueryOperation =
   | {
-      path: "/api/v1/chats";
+      path: "/api/v1beta/chats";
       operationId: "chats";
       variables: ChatsVariables | reactQuery.SkipToken;
     }
   | {
-      path: "/api/v1/me/profile";
+      path: "/api/v1beta/me/profile";
       operationId: "profile";
       variables: ProfileVariables | reactQuery.SkipToken;
     }
   | {
-      path: "/api/v1/messages";
+      path: "/api/v1beta/messages";
       operationId: "messages";
       variables: MessagesVariables | reactQuery.SkipToken;
     }


### PR DESCRIPTION
- Changed API version from v1 to v1beta in OpenAPI specification
- Updated router paths in backend code
- Modified frontend API calls to use v1beta endpoints
- Adjusted query paths in frontend components