### PR TITLE
Use non-namespace service name in erato-local chart

### DIFF
--- a/infrastructure/charts/erato/values.yaml
+++ b/infrastructure/charts/erato/values.yaml
@@ -7,7 +7,7 @@ ingress:
   className: nginx
 
 oauth2Proxy:
-  enabled: false
+  enabled: true
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
     tag: v7.8.1

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -9,7 +9,7 @@ erato:
     config: |
       http_address = "0.0.0.0:4180"
 
-      upstreams = ["http://erato-backend.erato.svc.cluster.local:3130"]
+      upstreams = ["http://erato-backend:3130"]
       email_domains = ["*"]
       cookie_secret = "0123456789abcdef0123456789abcdef"  # Replace in production
       cookie_secure = false
@@ -56,6 +56,8 @@ dex:
     issuer: http://dex.erato.internal
     storage:
       type: memory
+    oauth2:
+      skipApprovalScreen: true
     web:
       http: 0.0.0.0:5556
     staticClients:


### PR DESCRIPTION
Two small tweaks when deploying the latest demo setup:
- oauth2Proxy is enabled by default (may even remove in the future, as for the forseesable future a deployment without it doesn't make sense)
- In the erato-local deployment uses a non-namespace service name which serves as a better example, as it doesn't need to be adjusted based on the namespace name