### PR TITLE
Add `just run_local_services` command

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -34,5 +34,10 @@ lint:
 run $FRONTEND_BUNDLE_PATH="../frontend/out":
     cargo run --bin erato
 
+# Run the local services required for running app (Postgres and Ollama-smol)
+run_local_services:
+    ./run_postgres.sh
+    ./run_ollama_smol.sh
+
 format:
     cargo fmt --all

--- a/backend/run_ollama_smol.sh
+++ b/backend/run_ollama_smol.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Check if container is already running
+if docker ps --format '{{.Names}}' | grep -q "^erato-ollama-smol$"; then
+    echo "Ollama container 'erato-ollama-smol' is already running."
+    echo "API endpoint: http://localhost:12434"
+    echo
+    echo "Example chat completion request:"
+    echo "curl http://localhost:12434/v1/chat/completions \\"
+    echo "    -H \"Content-Type: application/json\" \\"
+    echo "    -d '{"
+    echo "        \"model\": \"smollm2:135m\","
+    echo "        \"messages\": ["
+    echo "            {"
+    echo "                \"role\": \"user\","
+    echo "                \"content\": \"Hello!\""
+    echo "            }"
+    echo "        ]"
+    echo "    }'"
+    exit 0
+fi
+
+# Stop and remove existing container if it exists
+docker stop erato-ollama-smol 2>/dev/null || true
+docker rm erato-ollama-smol 2>/dev/null || true
+
+# Check if port 12434 is already in use
+if lsof -i :12434 >/dev/null 2>&1; then
+    echo "Error: Port 12434 is already in use. Please stop any other Ollama instances first."
+    exit 1
+fi
+
+# Run Ollama container
+docker run -d \
+  --name erato-ollama-smol \
+  --rm \
+  -p 12434:11434 \
+  harbor.imassage.me/erato/ollama-smol:47bfa34ad02fd643fc00a794c5fabf74ce94402a
+
+echo "Ollama container is running!"
+echo "API endpoint: http://localhost:12434"
+echo
+echo "Example chat completion request:"
+echo "curl http://localhost:12434/v1/chat/completions \\"
+echo "    -H \"Content-Type: application/json\" \\"
+echo "    -d '{"
+echo "        \"model\": \"smollm2:135m\","
+echo "        \"messages\": ["
+echo "            {"
+echo "                \"role\": \"user\","
+echo "                \"content\": \"Hello!\""
+echo "            }"
+echo "        ]"
+echo "    }'" 

--- a/backend/run_postgres.sh
+++ b/backend/run_postgres.sh
@@ -3,9 +3,24 @@
 # Create postgres data directory if it doesn't exist
 mkdir -p postgres_data
 
+# Check if container is already running
+if docker ps --format '{{.Names}}' | grep -q "^erato-postgres$"; then
+    echo "PostgreSQL container 'erato-postgres' is already running."
+    echo "Connection details:"
+    echo "  Host: localhost"
+    echo "  Port: 5432"
+    echo "  User: eratouser"
+    echo "  Password: eratopw"
+    echo "  Database: erato"
+    echo
+    echo "Connection string:"
+    echo "  postgresql://eratouser:eratopw@localhost:5432/erato"
+    exit 0
+fi
+
 # Stop and remove existing container if it exists
-docker stop dagster-postgres 2>/dev/null || true
-docker rm dagster-postgres 2>/dev/null || true
+docker stop erato-postgres 2>/dev/null || true
+docker rm erato-postgres 2>/dev/null || true
 
 # Check if port 5432 is already in use
 if lsof -i :5432 >/dev/null 2>&1; then
@@ -16,6 +31,7 @@ fi
 # Run PostgreSQL container
 docker run -d \
   --name erato-postgres \
+  --rm \
   -e POSTGRES_USER=eratouser \
   -e POSTGRES_PASSWORD=eratopw \
   -e POSTGRES_DB=erato \


### PR DESCRIPTION
Adds a `just run_local_services` command that starts up Postgres and ollama-smol, so that everything that needs to be running for the backend is running.

Can be run naively, as it also handles the case where the containers are already running.