### PR TITLE
Add non-persistent file upload endpoint

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3245,6 +3245,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -42,7 +42,7 @@ futures = "0.3"
 futures-macro = "0.3"
 tokio-stream = "0.1.17"
 genai = { version = "0.1.24-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "ad7c3a1b70b7629e76719843427652192520a281" }
-reqwest = { version = "0.12.12" }
+reqwest = { version = "0.12.12", features = ["multipart"] }
 
 [dev-dependencies]
 test-log = "0.2.14"

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -91,6 +91,48 @@
         ]
       }
     },
+    "/api/v1beta/me/files": {
+      "post": {
+        "tags": [
+          "files"
+        ],
+        "summary": "Upload files and return UUIDs for each",
+        "description": "This endpoint accepts a multipart form with one or more files and returns UUIDs for each.",
+        "operationId": "upload_file",
+        "requestBody": {
+          "description": "Files to upload",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/MultipartFormFile"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid file upload"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/v1beta/me/messages/regeneratestream": {
       "post": {
         "tags": [],
@@ -429,6 +471,40 @@
           }
         }
       },
+      "FileUploadItem": {
+        "type": "object",
+        "description": "Response for file upload",
+        "required": [
+          "id",
+          "filename"
+        ],
+        "properties": {
+          "filename": {
+            "type": "string",
+            "description": "The original filename of the uploaded file"
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the uploaded file"
+          }
+        }
+      },
+      "FileUploadResponse": {
+        "type": "object",
+        "description": "Response for file upload",
+        "required": [
+          "files"
+        ],
+        "properties": {
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileUploadItem"
+            },
+            "description": "The list of uploaded files with their IDs and filenames"
+          }
+        }
+      },
       "Message": {
         "type": "object",
         "required": [
@@ -614,6 +690,23 @@
           "message_id": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "MultipartFormFile": {
+        "type": "object",
+        "required": [
+          "name",
+          "file"
+        ],
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "contentMediaType": "application/octet-stream"
+          },
+          "name": {
+            "type": "string"
           }
         }
       },

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -213,6 +213,55 @@ export const useChatMessages = <TData = Schemas.ChatMessagesResponse,>(
   });
 };
 
+export type UploadFileError = Fetcher.ErrorWrapper<undefined>;
+
+export type UploadFileRequestBody = Schemas.MultipartFormFile[];
+
+export type UploadFileVariables = {
+  body?: UploadFileRequestBody;
+} & V1betaApiContext["fetcherOptions"];
+
+/**
+ * This endpoint accepts a multipart form with one or more files and returns UUIDs for each.
+ */
+export const fetchUploadFile = (
+  variables: UploadFileVariables,
+  signal?: AbortSignal,
+) =>
+  v1betaApiFetch<
+    Schemas.FileUploadResponse,
+    UploadFileError,
+    UploadFileRequestBody,
+    {},
+    {},
+    {}
+  >({ url: "/api/v1beta/me/files", method: "post", ...variables, signal });
+
+/**
+ * This endpoint accepts a multipart form with one or more files and returns UUIDs for each.
+ */
+export const useUploadFile = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Schemas.FileUploadResponse,
+      UploadFileError,
+      UploadFileVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useV1betaApiContext();
+  return reactQuery.useMutation<
+    Schemas.FileUploadResponse,
+    UploadFileError,
+    UploadFileVariables
+  >({
+    mutationFn: (variables: UploadFileVariables) =>
+      fetchUploadFile(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
 export type RegenerateMessageSseError = Fetcher.ErrorWrapper<undefined>;
 
 export type RegenerateMessageSseVariables = {

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -99,6 +99,30 @@ export type ChatMessagesResponse = {
   stats: ChatMessageStats;
 };
 
+/**
+ * Response for file upload
+ */
+export type FileUploadItem = {
+  /**
+   * The original filename of the uploaded file
+   */
+  filename: string;
+  /**
+   * The unique ID of the uploaded file
+   */
+  id: string;
+};
+
+/**
+ * Response for file upload
+ */
+export type FileUploadResponse = {
+  /**
+   * The list of uploaded files with their IDs and filenames
+   */
+  files: FileUploadItem[];
+};
+
 export type Message = {
   id: string;
 };
@@ -159,6 +183,14 @@ export type MessageSubmitStreamingResponseUserMessageSaved = {
    * @format uuid
    */
   message_id: string;
+};
+
+export type MultipartFormFile = {
+  /**
+   * @format binary
+   */
+  file: Blob;
+  name: string;
 };
 
 export type RecentChat = {


### PR DESCRIPTION
Adds a non-persistent file upload endpoint that allows for uploading one or multiple files, so that we can wire up the frontend implementation of the feature.

Related #13 