### PR TITLE
Fix default dark/light mode

### DIFF
--- a/e2e-tests/justfile
+++ b/e2e-tests/justfile
@@ -2,7 +2,21 @@ default:
   just --list
 
 install:
-  pnpm install
+    pnpm install
 
 test:
-  pnpm exec playwright test
+    pnpm exec playwright test
+
+# Opens the Playwright test runner UI
+test_interactive:
+    pnpm exec playwright test --ui
+
+# Opens the Playwright recorder
+record_interactions:
+    pnpm exec playwright codegen
+
+format:
+    pnpm exec prettier . --write
+
+check-format:
+    pnpm exec prettier . --check

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,9 +11,11 @@
   "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92",
   "devDependencies": {
     "@playwright/test": "^1.51.1",
-    "@types/node": "^22.14.1"
+    "@types/node": "^22.14.1",
+    "prettier": "3.5.0"
   },
   "dependencies": {
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "sharp": "^0.34.1"
   }
 }

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -1,19 +1,21 @@
-import { defineConfig, devices } from '@playwright/test';
-import dotenv from 'dotenv';
-import path from 'path';
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-dotenv.config({ path: '.env' });
+dotenv.config({ path: ".env" });
 
 const buildBaseUrl = async () => {
   const url = process.env.BASE_URL;
   if (url) {
     return url;
   } else {
-    console.warn('BASE_URL environment variable is not set. Using http://localhost:4180 as default');
+    console.warn(
+      "BASE_URL environment variable is not set. Using http://localhost:4180 as default",
+    );
     return "http://localhost:4180";
   }
 };
@@ -24,7 +26,7 @@ const baseUrl = await buildBaseUrl();
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -34,30 +36,30 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: baseUrl,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
     contextOptions: {
       // Required for our local auth setup
       // permissions: ['http://0.0.0.0:*/*']
-    }
+    },
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
 
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
 
     // TODO: Currently deactivated, because there are issues with using `0.0.0.0` as host during auth flow

--- a/e2e-tests/pnpm-lock.yaml
+++ b/e2e-tests/pnpm-lock.yaml
@@ -1,70 +1,447 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
+      sharp:
+        specifier: ^0.34.1
+        version: 0.34.1
     devDependencies:
-      '@playwright/test':
+      "@playwright/test":
         specifier: ^1.51.1
         version: 1.51.1
-      '@types/node':
+      "@types/node":
         specifier: ^22.14.1
         version: 22.14.1
+      prettier:
+        specifier: 3.5.0
+        version: 3.5.0
 
 packages:
+  "@emnapi/runtime@1.4.3":
+    resolution:
+      {
+        integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==,
+      }
 
-  '@playwright/test@1.51.1':
-    resolution: {integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
-
-  dotenv@16.5.0:
-    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
-    engines: {node: '>=12'}
-
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+  "@img/sharp-darwin-arm64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
     os: [darwin]
 
+  "@img/sharp-darwin-x64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@img/sharp-libvips-darwin-arm64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@img/sharp-libvips-darwin-x64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@img/sharp-libvips-linux-arm64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-arm@1.1.0":
+    resolution:
+      {
+        integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==,
+      }
+    cpu: [arm]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-ppc64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-s390x@1.1.0":
+    resolution:
+      {
+        integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==,
+      }
+    cpu: [s390x]
+    os: [linux]
+
+  "@img/sharp-libvips-linux-x64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-libvips-linuxmusl-arm64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==,
+      }
+    cpu: [arm64]
+    os: [linux]
+
+  "@img/sharp-libvips-linuxmusl-x64@1.1.0":
+    resolution:
+      {
+        integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==,
+      }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-linux-arm64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@img/sharp-linux-arm@0.34.1":
+    resolution:
+      {
+        integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@img/sharp-linux-s390x@0.34.1":
+    resolution:
+      {
+        integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  "@img/sharp-linux-x64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-linuxmusl-arm64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@img/sharp-linuxmusl-x64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@img/sharp-wasm32@0.34.1":
+    resolution:
+      {
+        integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [wasm32]
+
+  "@img/sharp-win32-ia32@0.34.1":
+    resolution:
+      {
+        integrity: sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@img/sharp-win32-x64@0.34.1":
+    resolution:
+      {
+        integrity: sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@playwright/test@1.51.1":
+    resolution:
+      {
+        integrity: sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  "@types/node@22.14.1":
+    resolution:
+      {
+        integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==,
+      }
+
+  color-convert@2.0.1:
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
+
+  color-name@1.1.4:
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
+
+  color-string@1.9.1:
+    resolution:
+      {
+        integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==,
+      }
+
+  color@4.2.3:
+    resolution:
+      {
+        integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==,
+      }
+    engines: { node: ">=12.5.0" }
+
+  detect-libc@2.0.3:
+    resolution:
+      {
+        integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==,
+      }
+    engines: { node: ">=8" }
+
+  dotenv@16.5.0:
+    resolution:
+      {
+        integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==,
+      }
+    engines: { node: ">=12" }
+
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
+  is-arrayish@0.3.2:
+    resolution:
+      {
+        integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==,
+      }
+
   playwright-core@1.51.1:
-    resolution: {integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   playwright@1.51.1:
-    resolution: {integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
+  prettier@3.5.0:
+    resolution:
+      {
+        integrity: sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
+
+  semver@7.7.1:
+    resolution:
+      {
+        integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  sharp@0.34.1:
+    resolution:
+      {
+        integrity: sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+
+  simple-swizzle@0.2.2:
+    resolution:
+      {
+        integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==,
+      }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
   undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
 
 snapshots:
+  "@emnapi/runtime@1.4.3":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
-  '@playwright/test@1.51.1':
+  "@img/sharp-darwin-arm64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-arm64": 1.1.0
+    optional: true
+
+  "@img/sharp-darwin-x64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-x64": 1.1.0
+    optional: true
+
+  "@img/sharp-libvips-darwin-arm64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-darwin-x64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linux-ppc64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linux-s390x@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linux-x64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-arm64@1.1.0":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-x64@1.1.0":
+    optional: true
+
+  "@img/sharp-linux-arm64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm64": 1.1.0
+    optional: true
+
+  "@img/sharp-linux-arm@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm": 1.1.0
+    optional: true
+
+  "@img/sharp-linux-s390x@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-s390x": 1.1.0
+    optional: true
+
+  "@img/sharp-linux-x64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-x64": 1.1.0
+    optional: true
+
+  "@img/sharp-linuxmusl-arm64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-arm64": 1.1.0
+    optional: true
+
+  "@img/sharp-linuxmusl-x64@0.34.1":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-x64": 1.1.0
+    optional: true
+
+  "@img/sharp-wasm32@0.34.1":
+    dependencies:
+      "@emnapi/runtime": 1.4.3
+    optional: true
+
+  "@img/sharp-win32-ia32@0.34.1":
+    optional: true
+
+  "@img/sharp-win32-x64@0.34.1":
+    optional: true
+
+  "@playwright/test@1.51.1":
     dependencies:
       playwright: 1.51.1
 
-  '@types/node@22.14.1':
+  "@types/node@22.14.1":
     dependencies:
       undici-types: 6.21.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
+  detect-libc@2.0.3: {}
 
   dotenv@16.5.0: {}
 
   fsevents@2.3.2:
     optional: true
+
+  is-arrayish@0.3.2: {}
 
   playwright-core@1.51.1: {}
 
@@ -73,5 +450,43 @@ snapshots:
       playwright-core: 1.51.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  prettier@3.5.0: {}
+
+  semver@7.7.1: {}
+
+  sharp@0.34.1:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.3
+      semver: 7.7.1
+    optionalDependencies:
+      "@img/sharp-darwin-arm64": 0.34.1
+      "@img/sharp-darwin-x64": 0.34.1
+      "@img/sharp-libvips-darwin-arm64": 1.1.0
+      "@img/sharp-libvips-darwin-x64": 1.1.0
+      "@img/sharp-libvips-linux-arm": 1.1.0
+      "@img/sharp-libvips-linux-arm64": 1.1.0
+      "@img/sharp-libvips-linux-ppc64": 1.1.0
+      "@img/sharp-libvips-linux-s390x": 1.1.0
+      "@img/sharp-libvips-linux-x64": 1.1.0
+      "@img/sharp-libvips-linuxmusl-arm64": 1.1.0
+      "@img/sharp-libvips-linuxmusl-x64": 1.1.0
+      "@img/sharp-linux-arm": 0.34.1
+      "@img/sharp-linux-arm64": 0.34.1
+      "@img/sharp-linux-s390x": 0.34.1
+      "@img/sharp-linux-x64": 0.34.1
+      "@img/sharp-linuxmusl-arm64": 0.34.1
+      "@img/sharp-linuxmusl-x64": 0.34.1
+      "@img/sharp-wasm32": 0.34.1
+      "@img/sharp-win32-ia32": 0.34.1
+      "@img/sharp-win32-x64": 0.34.1
+
+  simple-swizzle@0.2.2:
+    dependencies:
+      is-arrayish: 0.3.2
+
+  tslib@2.8.1:
+    optional: true
 
   undici-types@6.21.0: {}

--- a/e2e-tests/tests-examples/demo-todo-app.spec.ts
+++ b/e2e-tests/tests-examples/demo-todo-app.spec.ts
@@ -1,75 +1,77 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('https://demo.playwright.dev/todomvc');
+  await page.goto("https://demo.playwright.dev/todomvc");
 });
 
 const TODO_ITEMS = [
-  'buy some cheese',
-  'feed the cat',
-  'book a doctors appointment'
+  "buy some cheese",
+  "feed the cat",
+  "book a doctors appointment",
 ] as const;
 
-test.describe('New Todo', () => {
-  test('should allow me to add todo items', async ({ page }) => {
+test.describe("New Todo", () => {
+  test("should allow me to add todo items", async ({ page }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
+    const newTodo = page.getByPlaceholder("What needs to be done?");
 
     // Create 1st todo.
     await newTodo.fill(TODO_ITEMS[0]);
-    await newTodo.press('Enter');
+    await newTodo.press("Enter");
 
     // Make sure the list only has one todo item.
-    await expect(page.getByTestId('todo-title')).toHaveText([
-      TODO_ITEMS[0]
-    ]);
+    await expect(page.getByTestId("todo-title")).toHaveText([TODO_ITEMS[0]]);
 
     // Create 2nd todo.
     await newTodo.fill(TODO_ITEMS[1]);
-    await newTodo.press('Enter');
+    await newTodo.press("Enter");
 
     // Make sure the list now has two todo items.
-    await expect(page.getByTestId('todo-title')).toHaveText([
+    await expect(page.getByTestId("todo-title")).toHaveText([
       TODO_ITEMS[0],
-      TODO_ITEMS[1]
+      TODO_ITEMS[1],
     ]);
 
     await checkNumberOfTodosInLocalStorage(page, 2);
   });
 
-  test('should clear text input field when an item is added', async ({ page }) => {
+  test("should clear text input field when an item is added", async ({
+    page,
+  }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
+    const newTodo = page.getByPlaceholder("What needs to be done?");
 
     // Create one todo item.
     await newTodo.fill(TODO_ITEMS[0]);
-    await newTodo.press('Enter');
+    await newTodo.press("Enter");
 
     // Check that input is empty.
     await expect(newTodo).toBeEmpty();
     await checkNumberOfTodosInLocalStorage(page, 1);
   });
 
-  test('should append new items to the bottom of the list', async ({ page }) => {
+  test("should append new items to the bottom of the list", async ({
+    page,
+  }) => {
     // Create 3 items.
     await createDefaultTodos(page);
 
     // create a todo count locator
-    const todoCount = page.getByTestId('todo-count')
-  
+    const todoCount = page.getByTestId("todo-count");
+
     // Check test using different methods.
-    await expect(page.getByText('3 items left')).toBeVisible();
-    await expect(todoCount).toHaveText('3 items left');
-    await expect(todoCount).toContainText('3');
+    await expect(page.getByText("3 items left")).toBeVisible();
+    await expect(todoCount).toHaveText("3 items left");
+    await expect(todoCount).toContainText("3");
     await expect(todoCount).toHaveText(/3/);
 
     // Check all items in one call.
-    await expect(page.getByTestId('todo-title')).toHaveText(TODO_ITEMS);
+    await expect(page.getByTestId("todo-title")).toHaveText(TODO_ITEMS);
     await checkNumberOfTodosInLocalStorage(page, 3);
   });
 });
 
-test.describe('Mark all as completed', () => {
+test.describe("Mark all as completed", () => {
   test.beforeEach(async ({ page }) => {
     await createDefaultTodos(page);
     await checkNumberOfTodosInLocalStorage(page, 3);
@@ -79,39 +81,47 @@ test.describe('Mark all as completed', () => {
     await checkNumberOfTodosInLocalStorage(page, 3);
   });
 
-  test('should allow me to mark all items as completed', async ({ page }) => {
+  test("should allow me to mark all items as completed", async ({ page }) => {
     // Complete all todos.
-    await page.getByLabel('Mark all as complete').check();
+    await page.getByLabel("Mark all as complete").check();
 
     // Ensure all todos have 'completed' class.
-    await expect(page.getByTestId('todo-item')).toHaveClass(['completed', 'completed', 'completed']);
+    await expect(page.getByTestId("todo-item")).toHaveClass([
+      "completed",
+      "completed",
+      "completed",
+    ]);
     await checkNumberOfCompletedTodosInLocalStorage(page, 3);
   });
 
-  test('should allow me to clear the complete state of all items', async ({ page }) => {
-    const toggleAll = page.getByLabel('Mark all as complete');
+  test("should allow me to clear the complete state of all items", async ({
+    page,
+  }) => {
+    const toggleAll = page.getByLabel("Mark all as complete");
     // Check and then immediately uncheck.
     await toggleAll.check();
     await toggleAll.uncheck();
 
     // Should be no completed classes.
-    await expect(page.getByTestId('todo-item')).toHaveClass(['', '', '']);
+    await expect(page.getByTestId("todo-item")).toHaveClass(["", "", ""]);
   });
 
-  test('complete all checkbox should update state when items are completed / cleared', async ({ page }) => {
-    const toggleAll = page.getByLabel('Mark all as complete');
+  test("complete all checkbox should update state when items are completed / cleared", async ({
+    page,
+  }) => {
+    const toggleAll = page.getByLabel("Mark all as complete");
     await toggleAll.check();
     await expect(toggleAll).toBeChecked();
     await checkNumberOfCompletedTodosInLocalStorage(page, 3);
 
     // Uncheck first todo.
-    const firstTodo = page.getByTestId('todo-item').nth(0);
-    await firstTodo.getByRole('checkbox').uncheck();
+    const firstTodo = page.getByTestId("todo-item").nth(0);
+    await firstTodo.getByRole("checkbox").uncheck();
 
     // Reuse toggleAll locator and make sure its not checked.
     await expect(toggleAll).not.toBeChecked();
 
-    await firstTodo.getByRole('checkbox').check();
+    await firstTodo.getByRole("checkbox").check();
     await checkNumberOfCompletedTodosInLocalStorage(page, 3);
 
     // Assert the toggle all is checked again.
@@ -119,205 +129,236 @@ test.describe('Mark all as completed', () => {
   });
 });
 
-test.describe('Item', () => {
-
-  test('should allow me to mark items as complete', async ({ page }) => {
+test.describe("Item", () => {
+  test("should allow me to mark items as complete", async ({ page }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
+    const newTodo = page.getByPlaceholder("What needs to be done?");
 
     // Create two items.
     for (const item of TODO_ITEMS.slice(0, 2)) {
       await newTodo.fill(item);
-      await newTodo.press('Enter');
+      await newTodo.press("Enter");
     }
 
     // Check first item.
-    const firstTodo = page.getByTestId('todo-item').nth(0);
-    await firstTodo.getByRole('checkbox').check();
-    await expect(firstTodo).toHaveClass('completed');
+    const firstTodo = page.getByTestId("todo-item").nth(0);
+    await firstTodo.getByRole("checkbox").check();
+    await expect(firstTodo).toHaveClass("completed");
 
     // Check second item.
-    const secondTodo = page.getByTestId('todo-item').nth(1);
-    await expect(secondTodo).not.toHaveClass('completed');
-    await secondTodo.getByRole('checkbox').check();
+    const secondTodo = page.getByTestId("todo-item").nth(1);
+    await expect(secondTodo).not.toHaveClass("completed");
+    await secondTodo.getByRole("checkbox").check();
 
     // Assert completed class.
-    await expect(firstTodo).toHaveClass('completed');
-    await expect(secondTodo).toHaveClass('completed');
+    await expect(firstTodo).toHaveClass("completed");
+    await expect(secondTodo).toHaveClass("completed");
   });
 
-  test('should allow me to un-mark items as complete', async ({ page }) => {
+  test("should allow me to un-mark items as complete", async ({ page }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
+    const newTodo = page.getByPlaceholder("What needs to be done?");
 
     // Create two items.
     for (const item of TODO_ITEMS.slice(0, 2)) {
       await newTodo.fill(item);
-      await newTodo.press('Enter');
+      await newTodo.press("Enter");
     }
 
-    const firstTodo = page.getByTestId('todo-item').nth(0);
-    const secondTodo = page.getByTestId('todo-item').nth(1);
-    const firstTodoCheckbox = firstTodo.getByRole('checkbox');
+    const firstTodo = page.getByTestId("todo-item").nth(0);
+    const secondTodo = page.getByTestId("todo-item").nth(1);
+    const firstTodoCheckbox = firstTodo.getByRole("checkbox");
 
     await firstTodoCheckbox.check();
-    await expect(firstTodo).toHaveClass('completed');
-    await expect(secondTodo).not.toHaveClass('completed');
+    await expect(firstTodo).toHaveClass("completed");
+    await expect(secondTodo).not.toHaveClass("completed");
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
 
     await firstTodoCheckbox.uncheck();
-    await expect(firstTodo).not.toHaveClass('completed');
-    await expect(secondTodo).not.toHaveClass('completed');
+    await expect(firstTodo).not.toHaveClass("completed");
+    await expect(secondTodo).not.toHaveClass("completed");
     await checkNumberOfCompletedTodosInLocalStorage(page, 0);
   });
 
-  test('should allow me to edit an item', async ({ page }) => {
+  test("should allow me to edit an item", async ({ page }) => {
     await createDefaultTodos(page);
 
-    const todoItems = page.getByTestId('todo-item');
+    const todoItems = page.getByTestId("todo-item");
     const secondTodo = todoItems.nth(1);
     await secondTodo.dblclick();
-    await expect(secondTodo.getByRole('textbox', { name: 'Edit' })).toHaveValue(TODO_ITEMS[1]);
-    await secondTodo.getByRole('textbox', { name: 'Edit' }).fill('buy some sausages');
-    await secondTodo.getByRole('textbox', { name: 'Edit' }).press('Enter');
+    await expect(secondTodo.getByRole("textbox", { name: "Edit" })).toHaveValue(
+      TODO_ITEMS[1],
+    );
+    await secondTodo
+      .getByRole("textbox", { name: "Edit" })
+      .fill("buy some sausages");
+    await secondTodo.getByRole("textbox", { name: "Edit" }).press("Enter");
 
     // Explicitly assert the new text value.
     await expect(todoItems).toHaveText([
       TODO_ITEMS[0],
-      'buy some sausages',
-      TODO_ITEMS[2]
+      "buy some sausages",
+      TODO_ITEMS[2],
     ]);
-    await checkTodosInLocalStorage(page, 'buy some sausages');
+    await checkTodosInLocalStorage(page, "buy some sausages");
   });
 });
 
-test.describe('Editing', () => {
+test.describe("Editing", () => {
   test.beforeEach(async ({ page }) => {
     await createDefaultTodos(page);
     await checkNumberOfTodosInLocalStorage(page, 3);
   });
 
-  test('should hide other controls when editing', async ({ page }) => {
-    const todoItem = page.getByTestId('todo-item').nth(1);
+  test("should hide other controls when editing", async ({ page }) => {
+    const todoItem = page.getByTestId("todo-item").nth(1);
     await todoItem.dblclick();
-    await expect(todoItem.getByRole('checkbox')).not.toBeVisible();
-    await expect(todoItem.locator('label', {
-      hasText: TODO_ITEMS[1],
-    })).not.toBeVisible();
+    await expect(todoItem.getByRole("checkbox")).not.toBeVisible();
+    await expect(
+      todoItem.locator("label", {
+        hasText: TODO_ITEMS[1],
+      }),
+    ).not.toBeVisible();
     await checkNumberOfTodosInLocalStorage(page, 3);
   });
 
-  test('should save edits on blur', async ({ page }) => {
-    const todoItems = page.getByTestId('todo-item');
+  test("should save edits on blur", async ({ page }) => {
+    const todoItems = page.getByTestId("todo-item");
     await todoItems.nth(1).dblclick();
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).fill('buy some sausages');
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).dispatchEvent('blur');
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .fill("buy some sausages");
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .dispatchEvent("blur");
 
     await expect(todoItems).toHaveText([
       TODO_ITEMS[0],
-      'buy some sausages',
+      "buy some sausages",
       TODO_ITEMS[2],
     ]);
-    await checkTodosInLocalStorage(page, 'buy some sausages');
+    await checkTodosInLocalStorage(page, "buy some sausages");
   });
 
-  test('should trim entered text', async ({ page }) => {
-    const todoItems = page.getByTestId('todo-item');
+  test("should trim entered text", async ({ page }) => {
+    const todoItems = page.getByTestId("todo-item");
     await todoItems.nth(1).dblclick();
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).fill('    buy some sausages    ');
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).press('Enter');
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .fill("    buy some sausages    ");
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .press("Enter");
 
     await expect(todoItems).toHaveText([
       TODO_ITEMS[0],
-      'buy some sausages',
+      "buy some sausages",
       TODO_ITEMS[2],
     ]);
-    await checkTodosInLocalStorage(page, 'buy some sausages');
+    await checkTodosInLocalStorage(page, "buy some sausages");
   });
 
-  test('should remove the item if an empty text string was entered', async ({ page }) => {
-    const todoItems = page.getByTestId('todo-item');
+  test("should remove the item if an empty text string was entered", async ({
+    page,
+  }) => {
+    const todoItems = page.getByTestId("todo-item");
     await todoItems.nth(1).dblclick();
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).fill('');
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).press('Enter');
+    await todoItems.nth(1).getByRole("textbox", { name: "Edit" }).fill("");
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .press("Enter");
 
-    await expect(todoItems).toHaveText([
-      TODO_ITEMS[0],
-      TODO_ITEMS[2],
-    ]);
+    await expect(todoItems).toHaveText([TODO_ITEMS[0], TODO_ITEMS[2]]);
   });
 
-  test('should cancel edits on escape', async ({ page }) => {
-    const todoItems = page.getByTestId('todo-item');
+  test("should cancel edits on escape", async ({ page }) => {
+    const todoItems = page.getByTestId("todo-item");
     await todoItems.nth(1).dblclick();
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).fill('buy some sausages');
-    await todoItems.nth(1).getByRole('textbox', { name: 'Edit' }).press('Escape');
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .fill("buy some sausages");
+    await todoItems
+      .nth(1)
+      .getByRole("textbox", { name: "Edit" })
+      .press("Escape");
     await expect(todoItems).toHaveText(TODO_ITEMS);
   });
 });
 
-test.describe('Counter', () => {
-  test('should display the current number of todo items', async ({ page }) => {
+test.describe("Counter", () => {
+  test("should display the current number of todo items", async ({ page }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
-    
+    const newTodo = page.getByPlaceholder("What needs to be done?");
+
     // create a todo count locator
-    const todoCount = page.getByTestId('todo-count')
+    const todoCount = page.getByTestId("todo-count");
 
     await newTodo.fill(TODO_ITEMS[0]);
-    await newTodo.press('Enter');
+    await newTodo.press("Enter");
 
-    await expect(todoCount).toContainText('1');
+    await expect(todoCount).toContainText("1");
 
     await newTodo.fill(TODO_ITEMS[1]);
-    await newTodo.press('Enter');
-    await expect(todoCount).toContainText('2');
+    await newTodo.press("Enter");
+    await expect(todoCount).toContainText("2");
 
     await checkNumberOfTodosInLocalStorage(page, 2);
   });
 });
 
-test.describe('Clear completed button', () => {
+test.describe("Clear completed button", () => {
   test.beforeEach(async ({ page }) => {
     await createDefaultTodos(page);
   });
 
-  test('should display the correct text', async ({ page }) => {
-    await page.locator('.todo-list li .toggle').first().check();
-    await expect(page.getByRole('button', { name: 'Clear completed' })).toBeVisible();
+  test("should display the correct text", async ({ page }) => {
+    await page.locator(".todo-list li .toggle").first().check();
+    await expect(
+      page.getByRole("button", { name: "Clear completed" }),
+    ).toBeVisible();
   });
 
-  test('should remove completed items when clicked', async ({ page }) => {
-    const todoItems = page.getByTestId('todo-item');
-    await todoItems.nth(1).getByRole('checkbox').check();
-    await page.getByRole('button', { name: 'Clear completed' }).click();
+  test("should remove completed items when clicked", async ({ page }) => {
+    const todoItems = page.getByTestId("todo-item");
+    await todoItems.nth(1).getByRole("checkbox").check();
+    await page.getByRole("button", { name: "Clear completed" }).click();
     await expect(todoItems).toHaveCount(2);
     await expect(todoItems).toHaveText([TODO_ITEMS[0], TODO_ITEMS[2]]);
   });
 
-  test('should be hidden when there are no items that are completed', async ({ page }) => {
-    await page.locator('.todo-list li .toggle').first().check();
-    await page.getByRole('button', { name: 'Clear completed' }).click();
-    await expect(page.getByRole('button', { name: 'Clear completed' })).toBeHidden();
+  test("should be hidden when there are no items that are completed", async ({
+    page,
+  }) => {
+    await page.locator(".todo-list li .toggle").first().check();
+    await page.getByRole("button", { name: "Clear completed" }).click();
+    await expect(
+      page.getByRole("button", { name: "Clear completed" }),
+    ).toBeHidden();
   });
 });
 
-test.describe('Persistence', () => {
-  test('should persist its data', async ({ page }) => {
+test.describe("Persistence", () => {
+  test("should persist its data", async ({ page }) => {
     // create a new todo locator
-    const newTodo = page.getByPlaceholder('What needs to be done?');
+    const newTodo = page.getByPlaceholder("What needs to be done?");
 
     for (const item of TODO_ITEMS.slice(0, 2)) {
       await newTodo.fill(item);
-      await newTodo.press('Enter');
+      await newTodo.press("Enter");
     }
 
-    const todoItems = page.getByTestId('todo-item');
-    const firstTodoCheck = todoItems.nth(0).getByRole('checkbox');
+    const todoItems = page.getByTestId("todo-item");
+    const firstTodoCheck = todoItems.nth(0).getByRole("checkbox");
     await firstTodoCheck.check();
     await expect(todoItems).toHaveText([TODO_ITEMS[0], TODO_ITEMS[1]]);
     await expect(firstTodoCheck).toBeChecked();
-    await expect(todoItems).toHaveClass(['completed', '']);
+    await expect(todoItems).toHaveClass(["completed", ""]);
 
     // Ensure there is 1 completed item.
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
@@ -326,11 +367,11 @@ test.describe('Persistence', () => {
     await page.reload();
     await expect(todoItems).toHaveText([TODO_ITEMS[0], TODO_ITEMS[1]]);
     await expect(firstTodoCheck).toBeChecked();
-    await expect(todoItems).toHaveClass(['completed', '']);
+    await expect(todoItems).toHaveClass(["completed", ""]);
   });
 });
 
-test.describe('Routing', () => {
+test.describe("Routing", () => {
   test.beforeEach(async ({ page }) => {
     await createDefaultTodos(page);
     // make sure the app had a chance to save updated todos in storage
@@ -339,33 +380,33 @@ test.describe('Routing', () => {
     await checkTodosInLocalStorage(page, TODO_ITEMS[0]);
   });
 
-  test('should allow me to display active items', async ({ page }) => {
-    const todoItem = page.getByTestId('todo-item');
-    await page.getByTestId('todo-item').nth(1).getByRole('checkbox').check();
+  test("should allow me to display active items", async ({ page }) => {
+    const todoItem = page.getByTestId("todo-item");
+    await page.getByTestId("todo-item").nth(1).getByRole("checkbox").check();
 
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
-    await page.getByRole('link', { name: 'Active' }).click();
+    await page.getByRole("link", { name: "Active" }).click();
     await expect(todoItem).toHaveCount(2);
     await expect(todoItem).toHaveText([TODO_ITEMS[0], TODO_ITEMS[2]]);
   });
 
-  test('should respect the back button', async ({ page }) => {
-    const todoItem = page.getByTestId('todo-item'); 
-    await page.getByTestId('todo-item').nth(1).getByRole('checkbox').check();
+  test("should respect the back button", async ({ page }) => {
+    const todoItem = page.getByTestId("todo-item");
+    await page.getByTestId("todo-item").nth(1).getByRole("checkbox").check();
 
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
 
-    await test.step('Showing all items', async () => {
-      await page.getByRole('link', { name: 'All' }).click();
+    await test.step("Showing all items", async () => {
+      await page.getByRole("link", { name: "All" }).click();
       await expect(todoItem).toHaveCount(3);
     });
 
-    await test.step('Showing active items', async () => {
-      await page.getByRole('link', { name: 'Active' }).click();
+    await test.step("Showing active items", async () => {
+      await page.getByRole("link", { name: "Active" }).click();
     });
 
-    await test.step('Showing completed items', async () => {
-      await page.getByRole('link', { name: 'Completed' }).click();
+    await test.step("Showing completed items", async () => {
+      await page.getByRole("link", { name: "Completed" }).click();
     });
 
     await expect(todoItem).toHaveCount(1);
@@ -375,63 +416,74 @@ test.describe('Routing', () => {
     await expect(todoItem).toHaveCount(3);
   });
 
-  test('should allow me to display completed items', async ({ page }) => {
-    await page.getByTestId('todo-item').nth(1).getByRole('checkbox').check();
+  test("should allow me to display completed items", async ({ page }) => {
+    await page.getByTestId("todo-item").nth(1).getByRole("checkbox").check();
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
-    await page.getByRole('link', { name: 'Completed' }).click();
-    await expect(page.getByTestId('todo-item')).toHaveCount(1);
+    await page.getByRole("link", { name: "Completed" }).click();
+    await expect(page.getByTestId("todo-item")).toHaveCount(1);
   });
 
-  test('should allow me to display all items', async ({ page }) => {
-    await page.getByTestId('todo-item').nth(1).getByRole('checkbox').check();
+  test("should allow me to display all items", async ({ page }) => {
+    await page.getByTestId("todo-item").nth(1).getByRole("checkbox").check();
     await checkNumberOfCompletedTodosInLocalStorage(page, 1);
-    await page.getByRole('link', { name: 'Active' }).click();
-    await page.getByRole('link', { name: 'Completed' }).click();
-    await page.getByRole('link', { name: 'All' }).click();
-    await expect(page.getByTestId('todo-item')).toHaveCount(3);
+    await page.getByRole("link", { name: "Active" }).click();
+    await page.getByRole("link", { name: "Completed" }).click();
+    await page.getByRole("link", { name: "All" }).click();
+    await expect(page.getByTestId("todo-item")).toHaveCount(3);
   });
 
-  test('should highlight the currently applied filter', async ({ page }) => {
-    await expect(page.getByRole('link', { name: 'All' })).toHaveClass('selected');
-    
+  test("should highlight the currently applied filter", async ({ page }) => {
+    await expect(page.getByRole("link", { name: "All" })).toHaveClass(
+      "selected",
+    );
+
     //create locators for active and completed links
-    const activeLink = page.getByRole('link', { name: 'Active' });
-    const completedLink = page.getByRole('link', { name: 'Completed' });
+    const activeLink = page.getByRole("link", { name: "Active" });
+    const completedLink = page.getByRole("link", { name: "Completed" });
     await activeLink.click();
 
     // Page change - active items.
-    await expect(activeLink).toHaveClass('selected');
+    await expect(activeLink).toHaveClass("selected");
     await completedLink.click();
 
     // Page change - completed items.
-    await expect(completedLink).toHaveClass('selected');
+    await expect(completedLink).toHaveClass("selected");
   });
 });
 
 async function createDefaultTodos(page: Page) {
   // create a new todo locator
-  const newTodo = page.getByPlaceholder('What needs to be done?');
+  const newTodo = page.getByPlaceholder("What needs to be done?");
 
   for (const item of TODO_ITEMS) {
     await newTodo.fill(item);
-    await newTodo.press('Enter');
+    await newTodo.press("Enter");
   }
 }
 
 async function checkNumberOfTodosInLocalStorage(page: Page, expected: number) {
-  return await page.waitForFunction(e => {
-    return JSON.parse(localStorage['react-todos']).length === e;
+  return await page.waitForFunction((e) => {
+    return JSON.parse(localStorage["react-todos"]).length === e;
   }, expected);
 }
 
-async function checkNumberOfCompletedTodosInLocalStorage(page: Page, expected: number) {
-  return await page.waitForFunction(e => {
-    return JSON.parse(localStorage['react-todos']).filter((todo: any) => todo.completed).length === e;
+async function checkNumberOfCompletedTodosInLocalStorage(
+  page: Page,
+  expected: number,
+) {
+  return await page.waitForFunction((e) => {
+    return (
+      JSON.parse(localStorage["react-todos"]).filter(
+        (todo: any) => todo.completed,
+      ).length === e
+    );
   }, expected);
 }
 
 async function checkTodosInLocalStorage(page: Page, title: string) {
-  return await page.waitForFunction(t => {
-    return JSON.parse(localStorage['react-todos']).map((todo: any) => todo.title).includes(t);
+  return await page.waitForFunction((t) => {
+    return JSON.parse(localStorage["react-todos"])
+      .map((todo: any) => todo.title)
+      .includes(t);
   }, title);
 }

--- a/e2e-tests/tests/login.spec.ts
+++ b/e2e-tests/tests/login.spec.ts
@@ -1,15 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('Can login', async ({ page }) => {
+test("Can login", async ({ page }) => {
   await page.goto("/");
 
-  await page.getByRole('button', { name: 'Sign in with Dex' }).click();
+  await page.getByRole("button", { name: "Sign in with Dex" }).click();
   await page.waitForURL((url) => url.pathname.includes("auth"));
   // await page.getByRole('textbox', { name: 'email address' }).click();
-  await page.getByRole('textbox', { name: 'email address' }).fill('admin@example.com');
-  await page.getByRole('textbox', { name: 'Password' }).fill('admin');
-  await page.getByRole('textbox', { name: 'Password' }).press('Enter');
-  await page.getByRole('button', { name: 'Grant Access' }).click();
+  await page
+    .getByRole("textbox", { name: "email address" })
+    .fill("admin@example.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("admin");
+  await page.getByRole("textbox", { name: "Password" }).press("Enter");
+  await page.getByRole("button", { name: "Grant Access" }).click();
 
-  await expect(page.getByRole('textbox', { name: 'Type a message...' })).toBeVisible();
+  await expect(
+    page.getByRole("textbox", { name: "Type a message..." }),
+  ).toBeVisible();
 });

--- a/e2e-tests/tests/presentation.spec.ts
+++ b/e2e-tests/tests/presentation.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+import Sharp from "sharp";
+
+/**
+ * Analyzes a screenshot buffer to determine if it shows a light or dark theme
+ * @param {Buffer} screenshotBuffer - The buffer containing the screenshot
+ * @returns {Promise<{theme: string, brightness: number, confidence: number}>}
+ */
+async function analyzeThemeFromScreenshot(screenshotBuffer) {
+  // Use sharp to get pixel data
+  const { data, info } = await Sharp(screenshotBuffer)
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  const { width, height, channels } = info;
+
+  // Sample pixels from the image (avoiding edges)
+  const sampleSize = 100; // Number of sample points
+  const borderMargin = 0.1; // Avoid sampling 10% from each edge
+
+  let totalBrightness = 0;
+  let sampleCount = 0;
+
+  for (let i = 0; i < sampleSize; i++) {
+    // Generate random coordinates within the central area of the image
+    const x = Math.floor(
+      width * (borderMargin + Math.random() * (1 - 2 * borderMargin)),
+    );
+    const y = Math.floor(
+      height * (borderMargin + Math.random() * (1 - 2 * borderMargin)),
+    );
+
+    // Calculate pixel position in the buffer
+    const pixelPos = (y * width + x) * channels;
+
+    // Get RGB values (assuming RGB or RGBA format)
+    const r = data[pixelPos];
+    const g = data[pixelPos + 1];
+    const b = data[pixelPos + 2];
+
+    // Calculate perceived brightness using the weighted formula
+    const brightness = 0.299 * r + 0.587 * g + 0.114 * b;
+
+    totalBrightness += brightness;
+    sampleCount++;
+  }
+
+  // Calculate average brightness (0-255)
+  const averageBrightness = totalBrightness / sampleCount;
+
+  // Threshold for dark/light determination (0-255)
+  const threshold = 128;
+
+  return {
+    theme: averageBrightness < threshold ? "dark" : "light",
+    brightness: averageBrightness,
+    confidence: Math.abs((averageBrightness - threshold) / threshold),
+  };
+}
+
+const expectIsLightPage = async (page, expectMessage = "Page should be light") => {
+  // HACK: Replace with better way to check if rendering is setteled
+  await page.waitForTimeout(500);
+  const buffer = await page.screenshot();
+  const analysisResult = await analyzeThemeFromScreenshot(buffer);
+  expect(analysisResult.theme, expectMessage).toBe("light");
+};
+
+const expectIsDarkPage = async (page, expectMessage = "Page should be light") => {
+  // HACK: Replace with better way to check if rendering is setteled
+  await page.waitForTimeout(500);
+  const buffer = await page.screenshot();
+  const analysisResult = await analyzeThemeFromScreenshot(buffer);
+  expect(analysisResult.theme, expectMessage).toBe("dark");
+};
+
+test("Can login and see dark mode by default", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Sign in with Dex" }).click();
+  await page.waitForURL((url) => url.pathname.includes("auth"));
+  // await page.getByRole('textbox', { name: 'email address' }).click();
+  await page
+    .getByRole("textbox", { name: "email address" })
+    .fill("admin@example.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("admin");
+  await page.getByRole("textbox", { name: "Password" }).press("Enter");
+  await page.getByRole("button", { name: "Grant Access" }).click();
+
+  await expect(
+    page.getByRole("textbox", { name: "Type a message..." }),
+  ).toBeVisible();
+  await expectIsDarkPage(page, "Page should be dark by default");
+  // Toggle to light and check if it persists after reload
+  await page.getByRole("button", { name: "expand sidebar" }).click();
+  await page.getByRole("button", { name: "Open menu" }).click();
+  await page.getByRole("menuitem", { name: "Light mode" }).click();
+  await expectIsLightPage(page, "Page should switch to light after selecting light mode");
+  await page.reload();
+  await expectIsLightPage(page, "Page should stay light after reload");
+});
+
+test("Can login and see light mode by default", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Sign in with Dex" }).click();
+  await page.waitForURL((url) => url.pathname.includes("auth"));
+  // await page.getByRole('textbox', { name: 'email address' }).click();
+  await page
+    .getByRole("textbox", { name: "email address" })
+    .fill("admin@example.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("admin");
+  await page.getByRole("textbox", { name: "Password" }).press("Enter");
+  await page.getByRole("button", { name: "Grant Access" }).click();
+
+  await expect(
+    page.getByRole("textbox", { name: "Type a message..." }),
+  ).toBeVisible();
+  await expectIsLightPage(page, "Page should be light by default");
+  // Toggle to light and check if it persists after reload
+  await page.getByRole("button", { name: "expand sidebar" }).click();
+  await page.getByRole("button", { name: "Open menu" }).click();
+  await page.getByRole("menuitem", { name: "Dark mode" }).click();
+  await expectIsDarkPage(page, "Page should switch to dark after selecting dark mode");
+  await page.reload();
+  await expectIsDarkPage(page, "Page should stay dark after reload");
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig = (phase: any) => {
   const nextConfig: NextConfig = {
     output: phase === "phase-production-build" ? "export" : "standalone",
+    devIndicators: {
+      appIsrStatus: false,
+    },
   };
   return nextConfig;
 };

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -12,6 +12,8 @@ import type { PropsWithChildren } from "react";
 
 export type ThemeMode = "light" | "dark";
 
+export const THEME_MODE_LOCAL_STORAGE_KEY = "theme-mode";
+
 type ThemeContextType = {
   theme: Theme;
   themeMode: ThemeMode;
@@ -26,7 +28,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 const getSavedTheme = (): ThemeMode => {
   if (typeof window === "undefined") return "light";
 
-  const savedTheme = localStorage.getItem("theme-mode");
+  const savedTheme = localStorage.getItem(THEME_MODE_LOCAL_STORAGE_KEY);
   if (savedTheme === "dark" || savedTheme === "light") {
     return savedTheme;
   }
@@ -40,7 +42,10 @@ const getSavedTheme = (): ThemeMode => {
 };
 
 export function ThemeProvider({ children }: PropsWithChildren) {
-  const [themeMode, setThemeMode] = useState<ThemeMode>("light");
+  const savedOrDefaultThemeMode = getSavedTheme();
+  const [themeMode, setThemeMode] = useState<ThemeMode>(
+    savedOrDefaultThemeMode,
+  );
   const [theme, setTheme] = useState<Theme>(defaultTheme);
   const [customThemeConfig, setCustomThemeConfig] =
     useState<CustomThemeConfig | null>(null);
@@ -48,9 +53,6 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
   // Initialize theme from saved settings and try to load custom theme
   useEffect(() => {
-    const savedMode = getSavedTheme();
-    setThemeMode(savedMode);
-
     // Load theme using the configuration module
     const loadTheme = async () => {
       const themeConfig = await loadThemeConfig(defaultThemeConfig);
@@ -86,8 +88,6 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
     // Save to localStorage
     if (typeof window !== "undefined") {
-      localStorage.setItem("theme-mode", themeMode);
-
       // Update data-theme attributes on document for potential CSS selectors
       document.documentElement.setAttribute("data-theme", themeMode);
 
@@ -227,6 +227,7 @@ export function ThemeProvider({ children }: PropsWithChildren) {
   }, [theme]);
 
   const toggleTheme = (mode: ThemeMode) => {
+    localStorage.setItem(THEME_MODE_LOCAL_STORAGE_KEY, mode);
     setThemeMode(mode);
   };
 

--- a/frontend/src/components/ui/ThemeApplier.tsx
+++ b/frontend/src/components/ui/ThemeApplier.tsx
@@ -31,8 +31,7 @@ export function ThemeApplier() {
         if (!themeData) return;
 
         const root = document.documentElement;
-        const mode = themeMode === "dark" ? "dark" : "light";
-        const colors = themeData.theme[mode]?.colors;
+        const colors = themeData.theme[themeMode]?.colors;
 
         if (!colors) return;
 


### PR DESCRIPTION
- Adds tests that check the light/dark theme behaviour
- Fixes the dark/light mode to be correctly picked up by default
  - The old mechanism had some useState cascades that could cause the value to be set wrong and the persisted in a wrong way to the localStorage
  - Now initial state value is seeded with the detected default value (instead of always defaulting to "light" and relying on initial useState execution to fill in the detected value), and we only persist to localStorage if the user explicitly selected a preference
- Also removes Next.js static rendering indicator icon, as it got in the way of the e2e tests


Long term it would be better to have a 3-way selection mechanism for the theme of Light/Dark/System, where system removes the preference and allows the browser to do its thing. It may also be more robust in the future to do as much picking up values based on the "light"/"dark" state value, and instead only set the CSS media preference and let CSS do more of the lifting.