### PR TITLE
Keep chat component mounted across page reloads

### DIFF
--- a/frontend/src/app/chat/ChatPageStructure.client.tsx
+++ b/frontend/src/app/chat/ChatPageStructure.client.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import { Chat } from "@/components/ui/Chat/Chat";
+import { WelcomeScreen } from "@/components/ui/WelcomeScreen";
+import { useChatContext } from "@/providers/ChatProvider";
+import { createLogger } from "@/utils/debugLogger";
+
+import type { MessageAction } from "@/types/message-controls";
+
+const logger = createLogger("UI", "ChatPageStructure");
+
+// This component contains the actual UI and logic that uses chat context
+export default function ChatPageStructure({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const {
+    messages: contextMessages,
+    messageOrder: contextMessageOrder,
+    currentChatId,
+    mountKey,
+  } = useChatContext();
+  const pathname = usePathname();
+  const prevChatIdRef = useRef<string | null | undefined>(currentChatId);
+
+  useEffect(() => {
+    if (prevChatIdRef.current !== currentChatId) {
+      logger.log(
+        `ChatPageStructure: currentChatId changed from ${prevChatIdRef.current ?? "null"} to ${currentChatId ?? "null"}.`,
+      );
+      prevChatIdRef.current = currentChatId;
+    }
+  }, [currentChatId]);
+
+  const displayMessages = contextMessages;
+  const displayMessageOrder = contextMessageOrder;
+
+  logger.log(
+    `ChatPageStructure render. Path: ${pathname}, currentChatId: ${currentChatId ?? "null"}`,
+  );
+
+  return (
+    <div className="flex size-full flex-col">
+      <Chat
+        key={mountKey}
+        messages={displayMessages}
+        messageOrder={displayMessageOrder}
+        controlsContext={{
+          currentUserId: "user1",
+          dialogOwnerId: "user1",
+          isSharedDialog: false,
+        }}
+        className="h-full"
+        showAvatars={true}
+        showTimestamps={true}
+        layout="default"
+        maxWidth={768}
+        emptyStateComponent={<WelcomeScreen />}
+        onMessageAction={async (action: MessageAction) => {
+          logger.log("Handling message action in ChatPageStructure:", action);
+          if (action.type === "copy") {
+            const messageToCopy = displayMessages[action.messageId];
+            if (messageToCopy.content) {
+              try {
+                await navigator.clipboard.writeText(messageToCopy.content);
+                if (typeof navigator.vibrate === "function") {
+                  navigator.vibrate(50);
+                }
+                return true;
+              } catch (err) {
+                console.error("Failed to copy message content:", err);
+                return false;
+              }
+            } else {
+              console.warn(
+                "Could not find message content to copy for id:",
+                action.messageId,
+              );
+              return false;
+            }
+          }
+          logger.log(`Unhandled message action type: ${action.type}`);
+          return false;
+        }}
+      />
+      {/* Page specific content (new/page.tsx or [id]/page.tsx) will be minimal and rendered invisibly if not needed */}
+      <div style={{ display: "none" }}>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/app/chat/[id]/ChatPage.tsx
+++ b/frontend/src/app/chat/[id]/ChatPage.tsx
@@ -1,116 +1,31 @@
 "use client";
 
 import { useDynamicParams } from "next-static-utils";
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 
-import { Chat } from "@/components/ui/Chat/Chat";
-import { useChatTransition } from "@/hooks/chat";
 import { useChatContext } from "@/providers/ChatProvider";
 import { createLogger } from "@/utils/debugLogger";
 
-// Create logger for this component
-const logger = createLogger("UI", "ChatPage");
+const logger = createLogger("UI", "ChatPage(ID)");
 
 export default function ChatPage() {
   const params = useDynamicParams();
-  const chatId = params.id;
-  const isFirstRender = useRef(true);
-  const [isTransitioning, setIsTransitioning] = useState(true);
+  const chatIdFromUrl = params.id;
 
-  const { messages, messageOrder, currentChatId, navigateToChat } =
-    useChatContext();
-  // Use our chat context
+  const { currentChatId, navigateToChat } = useChatContext();
 
-  // Handle only the initial setting of chat ID and page refreshes
-  // ? TODO: wtf?
+  // When navigation was changed via the URL (e.g. router push) navigate to the chat.
   useEffect(() => {
-    // Only on initial render or page refresh, sync with URL
-    if (isFirstRender.current && chatId && chatId !== currentChatId) {
+    if (chatIdFromUrl && chatIdFromUrl !== currentChatId) {
       logger.log(
-        `Initial load: setting currentChatId to URL param (${chatId})`,
+        `ChatPage [id]: URL chatId (${chatIdFromUrl}) differs from context (${currentChatId ?? "null"}). Syncing context.`,
       );
-
-      // Set transitioning state to true during navigation
-      setIsTransitioning(true);
-
-      // Start navigation
-      navigateToChat(chatId);
-
-      // After a brief delay to allow navigation to complete, set as not transitioning
-      const timer = setTimeout(() => {
-        setIsTransitioning(false);
-        isFirstRender.current = false;
-      }, 350);
-
-      return () => clearTimeout(timer);
-    } else if (isFirstRender.current) {
-      // If we don't need to navigate but it's still first render,
-      // just mark as not transitioning after a brief delay
-      const timer = setTimeout(() => {
-        setIsTransitioning(false);
-        isFirstRender.current = false;
-      }, 200);
-
-      return () => clearTimeout(timer);
+      // Navigate to the chatId that was newly set in state
+      navigateToChat(chatIdFromUrl);
     }
-  }, [chatId, currentChatId, navigateToChat]);
+    // currentChatId excluded on purpose, as we don't want to use it as trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatIdFromUrl, navigateToChat]);
 
-  // Use the chat transition hook here
-  const { displayMessages, displayMessageOrder } = useChatTransition({
-    messages,
-    messageOrder,
-    isTransitioning,
-  });
-
-  return (
-    <div className="flex size-full flex-col">
-      <Chat
-        messages={displayMessages}
-        messageOrder={displayMessageOrder}
-        controlsContext={{
-          currentUserId: "user1",
-          dialogOwnerId: "user1",
-          isSharedDialog: false,
-        }}
-        className="h-full"
-        showAvatars={true}
-        showTimestamps={true}
-        layout="default"
-        maxWidth={768}
-        onMessageAction={async (action) => {
-          logger.log("Handling message action:", action);
-          if (action.type === "copy") {
-            const messageToCopy = displayMessages[action.messageId];
-            if (messageToCopy.content) {
-              try {
-                await navigator.clipboard.writeText(messageToCopy.content);
-
-                // Add haptic feedback if supported
-                if (typeof navigator.vibrate === "function") {
-                  navigator.vibrate(50); // Vibrate for 50ms
-                }
-
-                // TODO: Add a user-facing notification (e.g., toast)
-                return true; // Indicate success
-              } catch (err) {
-                console.error("Failed to copy message content:", err);
-                // TODO: Add user-facing error feedback
-                return false; // Indicate failure
-              }
-            } else {
-              console.warn(
-                "Could not find message content to copy for id:",
-                action.messageId,
-              );
-              return false; // Indicate failure
-            }
-          } else {
-            // Handle other actions (like, dislike, edit, etc.) if needed
-            logger.log(`Unhandled message action type: ${action.type}`);
-            return false; // Indicate failure for unhandled actions
-          }
-        }}
-      />
-    </div>
-  );
+  return null; // The ChatLayout handles UI
 }

--- a/frontend/src/app/chat/layout.tsx
+++ b/frontend/src/app/chat/layout.tsx
@@ -1,8 +1,13 @@
+// No "use client" directive here, making this a Server Component by default
+
+import { ChatProvider } from "@/providers/ChatProvider";
 import { RootProvider } from "@/providers/RootProvider";
+
+import ChatPageStructure from "./ChatPageStructure.client"; // Import the client component
 
 import type { FileType } from "@/utils/fileTypes";
 
-// Set the accepted file types for the chat
+// ACCEPTED_FILE_TYPES remains here as it's static configuration for RootProvider
 const ACCEPTED_FILE_TYPES: FileType[] = [
   "pdf",
   "document",
@@ -11,15 +16,18 @@ const ACCEPTED_FILE_TYPES: FileType[] = [
   "image",
 ];
 
-// This is a server component
+// This is the new default export for the layout (Server Component)
 export default function ChatLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // The logger related to ChatPageStructure has moved to that file
   return (
     <RootProvider acceptedFileTypes={ACCEPTED_FILE_TYPES}>
-      {children}
+      <ChatProvider>
+        <ChatPageStructure>{children}</ChatPageStructure>
+      </ChatProvider>
     </RootProvider>
   );
 }

--- a/frontend/src/app/chat/new/page.tsx
+++ b/frontend/src/app/chat/new/page.tsx
@@ -1,90 +1,46 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 
-import { Chat } from "@/components/ui/Chat/Chat";
-import { WelcomeScreen } from "@/components/ui/WelcomeScreen";
 import { useChatHistoryStore } from "@/hooks/chat/useChatHistory";
 import { useChatContext } from "@/providers/ChatProvider";
+import { createLogger } from "@/utils/debugLogger";
 
-import type { MessageAction } from "@/types/message-controls";
+const logger = createLogger("UI", "NewChatPage");
 
 export default function NewChatPage() {
   const router = useRouter();
-  // Get messages and order from context (will be empty for new chat)
-  const { isStreaming, currentChatId, messages, messageOrder } =
-    useChatContext();
+  const pathname = usePathname();
+  const { isStreaming, currentChatId } = useChatContext();
   const setNewChatPending = useChatHistoryStore(
     (state) => state.setNewChatPending,
   );
   const redirectedRef = useRef(false);
 
-  // Reset the new chat pending flag when this page loads
   useEffect(() => {
-    console.log(
-      "[CHAT_FLOW] NewChatPage mounted - resetting new chat pending flag",
-    );
+    logger.log("NewChatPage mounted - resetting new chat pending flag");
     setNewChatPending(false);
   }, [setNewChatPending]);
 
-  // Navigate to the chat page when a chat ID is available AND streaming has stopped
   useEffect(() => {
-    console.log(
-      `[CHAT_FLOW_REDIRECT_CHECK] Effect triggered. chatId: ${currentChatId ?? "null"}, isStreaming: ${isStreaming}, redirected: ${redirectedRef.current}`,
-    );
-
-    // Check if this is explicitly a new chat (null ID)
-    const isNewChat = currentChatId === null;
-
-    if (isNewChat) {
-      console.log(
-        "[CHAT_FLOW] NewChatPage - This is a new chat. Not redirecting until messages are sent.",
+    if (
+      currentChatId &&
+      !isStreaming &&
+      !redirectedRef.current &&
+      pathname === "/chat/new"
+    ) {
+      logger.log(
+        `NewChatPage - currentChatId is now ${currentChatId}. Updating URL from /chat/new.`,
       );
-      return; // Don't redirect for new chats
-    }
-
-    // Only redirect if:
-    // 1. We have a currentChatId that is not null
-    // 2. We're not currently streaming (meaning the response completed)
-    // 3. We haven't already redirected (prevents double redirects)
-    if (currentChatId && !isStreaming && !redirectedRef.current) {
-      console.log(
-        `[CHAT_FLOW] NewChatPage - Ready to redirect to: /chat/${currentChatId}`,
-      );
-      // Set the flag to prevent multiple redirects
       redirectedRef.current = true;
-
-      // Directly navigate using Next.js router - no need for a timeout
-      console.log(
-        `[CHAT_FLOW] NewChatPage - Executing redirect to: /chat/${currentChatId}`,
-      );
-      router.push(`/chat/${currentChatId}`);
+      router.replace(`/chat/${currentChatId}`);
     }
-  }, [currentChatId, router, isStreaming]);
 
-  return (
-    <div className="flex size-full flex-col">
-      <Chat
-        messages={messages}
-        messageOrder={messageOrder}
-        controlsContext={{
-          currentUserId: "user1",
-          dialogOwnerId: "user1",
-          isSharedDialog: false,
-        }}
-        className="h-full"
-        showAvatars={true}
-        showTimestamps={true}
-        layout="default"
-        maxWidth={768}
-        onMessageAction={async (action: MessageAction) => {
-          // Handle message actions here
-          console.log("Message action:", action);
-          return true; // Return true to satisfy Promise<boolean>
-        }}
-        emptyStateComponent={<WelcomeScreen />}
-      />
-    </div>
-  );
+    if (!currentChatId && pathname === "/chat/new") {
+      redirectedRef.current = false; // Reset if we are back on new chat page and ID is null
+    }
+  }, [currentChatId, router, isStreaming, pathname]);
+
+  return null; // The ChatLayout handles UI
 }

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -88,7 +88,7 @@ export function useChatHistory() {
 
       // Make sure we actually navigate to the chat URL using the router
       // Use replace to ensure a clean navigation
-      router.replace(`/chat/${chatId}`);
+      router.push(`/chat/${chatId}`);
     },
     [router, setCurrentChatId, isNewChatPending],
   );


### PR DESCRIPTION
Addresses #143 . There is still a rerender happening of the chat message once that has finished streaming, as the `key` for that changes, but the page as a whole doesn't do a reload.

The main structural change is that the `<Chat>` component is now mounted in `chat/layout.tsx`, which stays mounted across navigating between the `chat/new` and `chat/[id]` pages, instead of having it mounted in both pages seperately.
In addition, the logic that dictates the `key` for the `<Chat>` element has been changed to be based on a counter, that increments when new chats are created. Previously, by switching between the "new chat marker value" and the chat ID once it had materialized, that would still remount the Chat, causing a big render flicker.

Some things I tested manually:
- Start from `new` page and start new chat
- Start from existing chat and start new chat from there
- Navigate between historic chats by clicking. Checked whether navigating via back/forward browser history works