### PR TITLE
Make k3d cluster easier to upgrade; Add --build-local;--wait flags

### DIFF
--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: baseUrl,
+    ignoreHTTPSErrors: baseUrl === "https://app.erato.internal",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/infrastructure/k3d/erato-local/config/erato.toml
+++ b/infrastructure/k3d/erato-local/config/erato.toml
@@ -1,0 +1,4 @@
+# NOTE: This currently doesn't point to a deployment inside erato-local
+[file_storage_providers.minio]
+provider_kind = "s3"
+config = { endpoint = "http://localhost:9000", region = "us-east-1", bucket = "erato-storage", access_key_id = "erato-app-user", secret_access_key = "erato-app-password" }

--- a/infrastructure/k3d/erato-local/templates/_helpers.tpl
+++ b/infrastructure/k3d/erato-local/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "erato-local.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "erato-local.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "erato-local.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "erato-local.labels" -}}
+helm.sh/chart: {{ include "erato-local.chart" . }}
+{{ include "erato-local.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "erato-local.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "erato-local.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/infrastructure/k3d/erato-local/templates/erato-toml-secret.yaml
+++ b/infrastructure/k3d/erato-local/templates/erato-toml-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ .Release.Name }}-erato-toml-secret
+data:
+  erato.toml: {{ .Files.Get "config/erato.toml" | b64enc | quote }}

--- a/infrastructure/k3d/erato-local/templates/postgres-cluster.yaml
+++ b/infrastructure/k3d/erato-local/templates/postgres-cluster.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "erato-local.fullname" . }}-postgres
+  labels:
+    {{- include "erato-local.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  instances: {{ .Values.postgresql.instances }}
+  imageName: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+  enableSuperuserAccess: true
+  storage:
+    size: {{ .Values.postgresql.storage.size }}
+{{- end }}

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -17,6 +17,9 @@ erato:
       # NOTE: This currently points nowhere
       - name: CHAT_PROVIDER__BASE_URL
         value: "http://localhost:11434/v1/"
+    configFile:
+      secretName: erato-local-erato-toml-secret
+      secretKey: erato.toml
   
   oauth2Proxy:
     enabled: true
@@ -32,10 +35,10 @@ erato:
       client_id = "erato-app"
       client_secret = "ZXJhdG8tc2VjcmV0"  # Replace in production
       skip_oidc_discovery = true
-      oidc_issuer_url = "http://erato-dex.erato.svc.cluster.local:5556"
+      oidc_issuer_url = "http://erato-local-dex.erato-local-ns.svc.cluster.local:5556"
       login_url = "http://dex.erato.internal/auth"
-      redeem_url = "http://erato-dex.erato.svc.cluster.local:5556/token"
-      oidc_jwks_url = "http://erato-dex.erato.svc.cluster.local:5556/keys"
+      redeem_url = "http://erato-local-dex.erato-local-ns.svc.cluster.local:5556/token"
+      oidc_jwks_url = "http://erato-local-dex.erato-local-ns.svc.cluster.local:5556/keys"
       redirect_url = "http://app.erato.internal/oauth2/callback"
       skip_auth_regex = ["^/health", "^/metrics"]
       pass_authorization_header = true
@@ -45,15 +48,14 @@ erato:
       insecure_oidc_skip_issuer_verification = true
 
   postgresql:
-    # set postgresql.enabled to be false to disable deploy of a PostgreSQL database and use an
-    # existing external PostgreSQL database
     enabled: false
-
-    # If postgresql.enabled is falsse, you can set the following values to connect to an existing
-    # external PostgreSQL database
     external:
       connectionString:
-        value: "postgresql://eratouser:eratopw@host.k3d.internal:5432/erato"
+        valueFrom:
+          secretKeyRef:
+            # This will be created by the postgres-cluster.yaml template
+            name: erato-local-postgres-app
+            key: uri
 
 dex:
   enabled: true
@@ -87,3 +89,13 @@ dex:
       hash: "$2y$10$EI3YbB3STkWvAzAyZ/fU/ehRT6M5ActxvZS9rZ1fXmTV2zxYNgUaK" # password: admin
       username: "admin"
       userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+# Main chart values
+postgresql:
+  enabled: true
+  instances: 1
+  image:
+    repository: ghcr.io/cloudnative-pg/postgresql
+    tag: "17.2"
+  storage:
+    size: 2Gi

--- a/infrastructure/scripts/setup-dev.sh
+++ b/infrastructure/scripts/setup-dev.sh
@@ -1,6 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
+WAIT_FLAG=""
+ERATO_IMAGE_REPOSITORY="harbor.imassage.me/erato/app"
+ERATO_IMAGE_TAG="latest"
+BUILD_LOCAL=false
+HELM_SET_ARGS=""
+
+# Function to display script usage
+usage() {
+    echo "Usage: $0 [--wait] [--build-local] [--erato-image-repository <repo>] [--erato-image-tag <tag>]"
+    exit 1
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --wait) WAIT_FLAG="--wait" ;;
+        --build-local) BUILD_LOCAL=true ;;
+        --erato-image-repository) ERATO_IMAGE_REPOSITORY="$2"; shift ;;
+        --erato-image-tag) ERATO_IMAGE_TAG="$2"; shift ;;
+        -h|--help) usage ;;
+        *) echo "Unknown parameter passed: $1"; usage ;;
+    esac
+    shift
+done
+
+
 CLUSTER_NAME="erato-dev"
 CHART_PATH="./k3d/erato-local"
 
@@ -37,25 +63,146 @@ kubectl wait --for=condition=Ready nodes --all --timeout=60s
 echo "Waiting for CoreDNS to be ready..."
 kubectl -n kube-system wait --for=condition=Available deployment/coredns --timeout=60s
 
+# Add bitnami helm repo
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+# helm repo update
+
+if [[ -n "$ERATO_IMAGE_REPOSITORY" ]]; then
+    HELM_SET_ARGS="$HELM_SET_ARGS --set erato.backend.image.repository=$ERATO_IMAGE_REPOSITORY"
+fi
+
+if [[ -n "$ERATO_IMAGE_TAG" ]]; then
+    HELM_SET_ARGS="$HELM_SET_ARGS --set erato.backend.image.tag=$ERATO_IMAGE_TAG"
+fi
+
+if [ "$BUILD_LOCAL" = true ]; then
+    PROJECT_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+    echo "Performing local build..."
+    
+    # Generate a unique tag for the build
+    BUILD_TAG=$(date +%s)
+    
+    # Define image names for local registry
+    LOCAL_REGISTRY="harbor.imassage.me"
+    FRONTEND_IMAGE_NAME="erato/frontend"
+
+    # Use provided values for base image or fall back to defaults
+    REPO_BASE=${ERATO_IMAGE_REPOSITORY:-harbor.imassage.me/erato/app}
+    TAG_BASE=${ERATO_IMAGE_TAG:-latest}
+
+    # Determine backend image to use as base for combined image
+    BACKEND_IMAGE_REPO=$(echo "${REPO_BASE}" | sed 's|/app$|/backend|')
+    BASE_BACKEND_IMAGE="${BACKEND_IMAGE_REPO}:${TAG_BASE}"
+    echo "Using base backend image: ${BASE_BACKEND_IMAGE}"
+
+    # Determine path for the combined image in the registry
+    COMBINED_IMAGE_PATH=$(echo "${REPO_BASE}" | sed 's|^[^/]*/||')
+    
+    LOCAL_FRONTEND_IMAGE="${LOCAL_REGISTRY}/${FRONTEND_IMAGE_NAME}:${BUILD_TAG}"
+    LOCAL_COMBINED_IMAGE="k3d-registry.localhost:5000/${COMBINED_IMAGE_PATH}:${BUILD_TAG}"
+    
+    # Build and push the frontend image
+    echo "Building frontend image: ${LOCAL_FRONTEND_IMAGE}"
+    docker build -t "${LOCAL_FRONTEND_IMAGE}" -f "${PROJECT_ROOT}/frontend/Dockerfile" "${PROJECT_ROOT}/frontend" --platform=linux/amd64
+    docker push "${LOCAL_FRONTEND_IMAGE}"
+    
+    # Strip the registry from the backend image path for the build-arg, as the Dockerfile will prepend it.
+    BACKEND_IMAGE_FOR_BUILD_ARG=$(echo "${BASE_BACKEND_IMAGE}" | sed 's|^[^/]*/||')
+
+    # Build and push the combined image
+    echo "Building combined image: ${LOCAL_COMBINED_IMAGE}"
+    docker build \
+        --build-arg REGISTRY=${LOCAL_REGISTRY} \
+        --build-arg FRONTEND_IMAGE="${FRONTEND_IMAGE_NAME}:${BUILD_TAG}" \
+        --build-arg BACKEND_IMAGE="${BACKEND_IMAGE_FOR_BUILD_ARG}" \
+        -t "${LOCAL_COMBINED_IMAGE}" -f "${PROJECT_ROOT}/Dockerfile.combined" "${PROJECT_ROOT}" --platform=linux/amd64
+    # Not pushing the image to the registry, as we're using the local registry.
+    docker push $LOCAL_COMBINED_IMAGE
+    
+    # Override helm arguments to use the locally built image
+    HELM_SET_ARGS="--set erato.backend.image.repository=k3d-registry.localhost:5000/${COMBINED_IMAGE_PATH} --set erato.backend.image.tag=${BUILD_TAG}"
+fi
+
 # Install nginx ingress controller
 echo "Installing nginx ingress controller..."
-helm upgrade --install ingress-nginx ingress-nginx \
-    --repo https://kubernetes.github.io/ingress-nginx \
-    --namespace ingress-nginx --create-namespace
+if ! helm list -n ingress-nginx | grep -q "^ingress-nginx"; then
+    echo "Installing nginx ingress controller..."
+    helm upgrade --install ingress-nginx ingress-nginx \
+        --repo https://kubernetes.github.io/ingress-nginx \
+        --namespace ingress-nginx --create-namespace
+else
+    echo "nginx ingress controller already installed, skipping..."
+fi
+# Install CNPG operator
+if ! helm list -n cnpg-system | grep -q "^cnpg"; then
+    echo "Installing CNPG operator..."
+    helm upgrade --install cnpg \
+      --namespace cnpg-system \
+      --create-namespace \
+      cnpg/cloudnative-pg
+else
+    echo "CNPG operator already installed, skipping..."
+fi
 
 # Install Reloader
 echo "Installing Reloader for ConfigMap auto-reloading..."
 kubectl apply -f https://raw.githubusercontent.com/stakater/Reloader/master/deployments/kubernetes/reloader.yaml
 
 
-# Add bitnami helm repo
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm repo update
+wait_for_nginx_webhook() {
+    local max_attempts=60
+    local attempt=1
+
+    echo "Waiting for NGINX admission webhook to be ready..."
+
+    while [ $attempt -le $max_attempts ]; do
+        # Check if service has endpoints
+        if kubectl get endpoints -n ingress-nginx ingress-nginx-controller-admission -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; then
+            echo "Webhook is ready!"
+            return 0
+        fi
+
+        echo "Attempt $attempt/$max_attempts: Webhook not ready, waiting 5 seconds..."
+        sleep 5
+        ((attempt++))
+    done
+
+    echo "Timeout: Webhook did not become ready"
+    return 1
+}
+
+wait_for_cnpg_webhook() {
+    local max_attempts=60
+    local attempt=1
+
+    echo "Waiting for CNPG webhook to be ready..."
+
+    while [ $attempt -le $max_attempts ]; do
+        # Check if service has endpoints
+        if kubectl get endpoints -n cnpg-system cnpg-webhook-service -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q .; then
+            echo "Webhook is ready!"
+            return 0
+        fi
+
+        echo "Attempt $attempt/$max_attempts: Webhook not ready, waiting 5 seconds..."
+        sleep 5
+        ((attempt++))
+    done
+
+    echo "Timeout: Webhook did not become ready"
+    return 1
+}
+
+wait_for_nginx_webhook
+wait_for_cnpg_webhook
 
 # Install/upgrade local development chart
 echo "Installing/upgrading Erato local development chart..."
+set -x
 helm upgrade --install erato-local "${CHART_PATH}" \
-    --namespace erato-local-ns --create-namespace
+    --namespace erato-local-ns --create-namespace ${WAIT_FLAG} ${HELM_SET_ARGS}
+set +x
 
 # Ensure local DNS entries exist
 for host in "${APP_HOST}" "${DEX_HOST}" "k3d-registry.localhost"; do
@@ -67,8 +214,8 @@ done
 
 echo
 echo "Setup complete! Your development environment is ready."
-echo "Access the application at: http://${APP_HOST}"
-echo "Access Dex at: http://${DEX_HOST}"
+echo "Access the application at: https://${APP_HOST}"
+echo "Access Dex at: https://${DEX_HOST}"
 echo
 echo "Default login credentials:"
 echo "  Username: admin@example.com"


### PR DESCRIPTION
- Adjusts `e2e-tetst` config to allow ignoring HTTPS for the k3d setup
- Updated k3d to a more current setup
  - Added a dummy erato.toml config to fix missing required keys
  - Added CloudnativePG for easy Postgres setup
- Make local k3d setup/run script easier to use
  - All steps are properly made optional if they aren't run for the first time (e.g. to update the cluster with a second execution)
  - Fixed missing wait for the nginx-ingress controller which always forced a second execution to actually bring the cluster online
  - Added a `--wait` flag to the script, which waits for the erato-local deployment to complete
  - Added a `--build-local` flag, which causes a erato combined image to be build based on the current frontend code + an existing backend container (should allow quicker verification of how frontend changes actually end up looking)