### PR TITLE
Bump olllama to 0.9.0; Switch to qwen3:0.6b for ollama-smol

### DIFF
--- a/backend/ollama-smol/Dockerfile
+++ b/backend/ollama-smol/Dockerfile
@@ -1,9 +1,9 @@
-FROM ollama/ollama:0.5.12
+FROM ollama/ollama:0.9.0
 
 # Pull the image
 RUN ollama serve & \
     sleep 5 && \
-    ollama pull smollm2:135m && \
+    ollama pull qwen3:0.6b && \
     ollama pull nomic-embed-text:137m-v1.5-fp16 && \
     pkill ollama
 


### PR DESCRIPTION
Switching to qwen3:0.6n should give us better tool calling capabilities + thinking. Output quality is likely bad, but for some functional test this should be enough.