### PR TITLE
Fix locale detection if browser provides long language tag

### DIFF
--- a/e2e-tests/tests/presentation.spec.ts
+++ b/e2e-tests/tests/presentation.spec.ts
@@ -148,3 +148,29 @@ test(
     await expectIsDarkPage(page, "Page should stay dark after reload");
   },
 );
+
+test(
+  "Can login and see german language by default",
+  { tag: TAG_CI },
+  async ({ browser }) => {
+    const context = await browser.newContext({
+      locale: "de-DE",
+    });
+    const page = await context.newPage();
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Sign in with" }).click();
+    await page.waitForURL((url) => url.pathname.includes("auth"));
+    // await page.getByRole('textbox', { name: 'email address' }).click();
+    await page
+      .getByRole("textbox", { name: "email address" })
+      .fill("admin@example.com");
+    await page.getByRole("textbox", { name: "Password" }).fill("admin");
+    await page.getByRole("textbox", { name: "Password" }).press("Enter");
+    await page.getByRole("button", { name: "Grant Access" }).click();
+
+    await expect(
+      page.getByRole("textbox", { name: "Nachricht eingeben..." }),
+    ).toBeVisible();
+  },
+);

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -6,7 +6,18 @@ export const supportedLocales = ["en", "de", "fr"];
 
 // Validate detected locale
 export function getValidLocale(locale: string): string {
-  return supportedLocales.includes(locale) ? locale : defaultLocale;
+  // Exact match
+  if (supportedLocales.includes(locale)) {
+    return locale;
+  }
+  // Partial match on BCP-47 language tag. For example, "en-US" will match "en".
+  else if (locale.length > 2 && supportedLocales.includes(locale.slice(0, 2))) {
+    return locale.slice(0, 2);
+  }
+  // Fallback
+  else {
+    return defaultLocale;
+  }
 }
 
 // Browser locale detection without persistence


### PR DESCRIPTION
- Fixes regression from change in browser/navigator language detection introduced in https://github.com/EratoLab/erato/pull/183; Browsers generally report language tags as `de-DE` and not `de`, so partial matches need to be taken into consideration
- Added test to check that German is correctly auto-detected