### PR TITLE
Simplify sidebar history items

### DIFF
--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -128,6 +128,7 @@ export const Chat = ({
             content: chat.title_by_summary || "", // Reuse title as a preview if no actual message available
             timestamp: chat.last_message_at || new Date().toISOString(),
           },
+          fileCount: chat.file_uploads.length,
         },
       }))
     : [];

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -1,10 +1,13 @@
 import { t } from "@lingui/core/macro";
+import { Plural } from "@lingui/react/macro";
 import clsx from "clsx";
 import { memo } from "react";
 
+import { MessageTimestamp } from "@/components/ui";
+
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { DropdownMenu } from "../Controls/DropdownMenu";
-import { Info, LogOutIcon } from "../icons";
+import { LogOutIcon } from "../icons";
 
 import type { ChatSession } from "@/types/chat";
 
@@ -67,10 +70,10 @@ const ChatHistoryListItem = memo<{
       <InteractiveContainer
         useDiv={true}
         className={clsx(
-          "flex flex-col rounded-lg px-4 py-3 text-left",
+          "flex flex-col rounded-lg px-3 py-1.5 pr-1.5 text-left",
           isActive && "bg-theme-bg-selected",
           "hover:bg-theme-bg-hover",
-          layout === "compact" ? "gap-0.5" : "gap-2",
+          layout === "compact" ? "gap-0.5" : "gap-1",
         )}
         data-chat-id={session.id}
       >
@@ -88,11 +91,6 @@ const ChatHistoryListItem = memo<{
             <DropdownMenu
               items={[
                 {
-                  label: t`Show Details`,
-                  icon: <Info className="size-4" />,
-                  onClick: onShowDetails ?? (() => {}),
-                },
-                {
                   label: t`Remove`,
                   icon: <LogOutIcon className="size-4" />,
                   onClick: onArchive ?? (() => {}),
@@ -106,14 +104,24 @@ const ChatHistoryListItem = memo<{
         </div>
         {layout !== "compact" && (
           <>
-            {session.metadata?.lastMessage && (
-              <p className="truncate text-sm text-theme-fg-secondary">
-                {session.metadata.lastMessage.content}
-              </p>
-            )}
+            <p
+              className={clsx(
+                "truncate text-xs",
+                session.metadata?.fileCount == 0
+                  ? "text-theme-fg-muted"
+                  : "text-theme-fg-secondary",
+              )}
+            >
+              <Plural
+                value={session.metadata?.fileCount ?? 0}
+                _0="No files"
+                one="# file"
+                other="# files"
+              />
+            </p>
             {showTimestamps && session.updatedAt && (
               <p className="text-xs text-theme-fg-secondary">
-                {new Date(session.updatedAt).toLocaleString()}
+                <MessageTimestamp createdAt={new Date(session.updatedAt)} />
               </p>
             )}
           </>

--- a/frontend/src/components/ui/Controls/DropdownMenu.tsx
+++ b/frontend/src/components/ui/Controls/DropdownMenu.tsx
@@ -344,6 +344,7 @@ export const DropdownMenu = memo(
             e.stopPropagation();
             setIsOpen(!isOpen);
           }}
+          className={"flex items-center justify-center"}
           icon={triggerIcon}
           aria-label={t`Open menu`}
           aria-expanded={isOpen}

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -13,13 +13,18 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:53
+#: src/components/ui/MessageList/MessageListHeader.tsx:52
 msgid " (more available)"
 msgstr " (weitere verfügbar)"
 
 #: src/components/ui/Chat/TokenUsageWarning.tsx:74
 msgid " File attachments account for {fileTokensFormatted} tokens."
 msgstr " Dateianhänge beanspruchen {fileTokensFormatted} Token."
+
+#. placeholder {0}: session.metadata?.fileCount ?? 0
+#: src/components/ui/Chat/ChatHistoryList.tsx:114
+msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+msgstr "{0, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx:119
 msgid "• Change browser language in settings and refresh"
@@ -64,12 +69,12 @@ msgstr "Alle Dateitypen akzeptiert"
 msgid "Approaching Token Limit"
 msgstr "Token-Limit wird erreicht"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:368
+#: src/components/ui/Controls/DropdownMenu.tsx:365
 #: src/components/ui/Controls/Button.tsx:93
 msgid "Are you sure you want to proceed?"
 msgstr "Möchten Sie wirklich fortfahren?"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:80
+#: src/components/ui/Chat/ChatHistoryList.tsx:98
 msgid "Are you sure you want to remove this chat?"
 msgstr "Möchten Sie diesen Chat wirklich entfernen?"
 
@@ -110,11 +115,11 @@ msgstr "Aktion abbrechen"
 msgid "Cannot send: Token limit exceeded"
 msgstr "Senden nicht möglich: Token-Limit überschritten"
 
-#: src/components/ui/Chat/Chat.tsx:273
+#: src/components/ui/Chat/Chat.tsx:275
 msgid "Chat conversation"
 msgstr "Chat-Unterhaltung"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:41
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:42
 msgid "Chat Error"
 msgstr "Chat-Fehler"
 
@@ -122,7 +127,7 @@ msgstr "Chat-Fehler"
 msgid "Chat History"
 msgstr "Chat-Verlauf"
 
-#: src/components/ui/Chat/ChatWidget.tsx:53
+#: src/components/ui/Chat/ChatWidget.tsx:54
 msgid "Chat messages"
 msgstr "Chat-Nachrichten"
 
@@ -130,11 +135,11 @@ msgstr "Chat-Nachrichten"
 msgid "Clear All"
 msgstr "Alle löschen"
 
-#: src/components/ui/Modal/ModalBase.tsx:101
+#: src/components/ui/Modal/ModalBase.tsx:103
 msgid "Close modal"
 msgstr "Dialog schließen"
 
-#: src/components/ui/Modal/ModalBase.tsx:73
+#: src/components/ui/Modal/ModalBase.tsx:75
 msgid "Close modal overlay"
 msgstr "Dialog-Overlay schließen"
 
@@ -150,12 +155,12 @@ msgstr "Bestätigen"
 msgid "Confirm action"
 msgstr "Aktion bestätigen"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:365
+#: src/components/ui/Controls/DropdownMenu.tsx:362
 #: src/components/ui/Controls/Button.tsx:92
 msgid "Confirm Action"
 msgstr "Aktion bestätigen"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:79
+#: src/components/ui/Chat/ChatHistoryList.tsx:97
 msgid "Confirm Removal"
 msgstr "Entfernung bestätigen"
 
@@ -172,7 +177,7 @@ msgstr "Dunkler Modus"
 msgid "Default Locale:"
 msgstr ""
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "details for"
 msgstr "Details für"
 
@@ -189,7 +194,7 @@ msgstr "Nachricht ablehnen"
 msgid "Dismiss"
 msgstr "Schließen"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:74
+#: src/components/ui/Modal/FilePreviewModal.tsx:73
 msgid "Download File"
 msgstr "Datei herunterladen"
 
@@ -210,7 +215,7 @@ msgstr "Nachricht bearbeiten"
 msgid "End of conversation"
 msgstr "Gesprächsende"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:35
+#: src/components/ui/ToolCall/ToolCallItem.tsx:36
 msgid "Error"
 msgstr "Fehler"
 
@@ -222,7 +227,7 @@ msgstr "Fehler beim Laden der Datei"
 msgid "Error loading theme:"
 msgstr "Fehler beim Laden des Themes:"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Error Output"
 msgstr "Fehlerausgabe"
 
@@ -230,7 +235,7 @@ msgstr "Fehlerausgabe"
 msgid "Error:"
 msgstr "Fehler:"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:87
+#: src/components/ui/Settings/ToolCallSettings.tsx:88
 msgid "Expand by default"
 msgstr "Standardmäßig erweitern"
 
@@ -238,11 +243,11 @@ msgstr "Standardmäßig erweitern"
 msgid "expand sidebar"
 msgstr "Seitenleiste erweitern"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "failed"
 msgstr "fehlgeschlagen"
 
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:168
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:169
 msgid "File"
 msgstr "Datei"
 
@@ -252,11 +257,11 @@ msgstr "Datei"
 msgid "navigation.goHome"
 msgstr "Zur Startseite"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Hide details"
 msgstr "Details ausblenden"
 
@@ -264,11 +269,11 @@ msgstr "Details ausblenden"
 msgid "How to Test:"
 msgstr ""
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:41
+#: src/components/ui/ToolCall/ToolCallItem.tsx:42
 msgid "In Progress"
 msgstr "In Bearbeitung"
 
-#: src/components/ui/ToolCall/ToolCallInput.tsx:21
+#: src/components/ui/ToolCall/ToolCallInput.tsx:22
 msgid "Input Parameters"
 msgstr "Eingabeparameter"
 
@@ -289,7 +294,7 @@ msgstr "Nachricht gefällt mir"
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:93
+#: src/components/ui/Feedback/LoadingIndicator.tsx:92
 msgid "Loading"
 msgstr "Laden"
 
@@ -314,17 +319,18 @@ msgstr "Logo"
 msgid "message"
 msgstr "Nachricht"
 
-#: src/components/ui/Chat/ChatInput.tsx:274
+#: src/components/ui/Chat/ChatInput.tsx:272
 msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Nachricht überschreitet Token-Limit. Bitte kürzen Sie die Nachricht oder entfernen Sie Dateien."
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:52
+#: src/components/ui/MessageList/MessageListHeader.tsx:51
 msgid "messages"
 msgstr "Nachrichten"
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx:88
-#: src/components/ui/Chat/ChatHistoryList.tsx:65
-#: src/components/ui/Chat/Chat.tsx:122
+#: src/components/ui/Chat/ChatHistoryList.tsx:67
+#: src/components/ui/Chat/ChatHistoryList.tsx:81
+#: src/components/ui/Chat/Chat.tsx:123
 msgid "New Chat"
 msgstr "Neuer Chat"
 
@@ -332,15 +338,15 @@ msgstr "Neuer Chat"
 msgid "No messages yet"
 msgstr "Noch keine Nachrichten"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:50
+#: src/components/ui/MessageList/MessageListHeader.tsx:49
 msgid "of"
 msgstr "von"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:352
+#: src/components/ui/Controls/DropdownMenu.tsx:349
 msgid "Open menu"
 msgstr "Menü öffnen"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Output"
 msgstr "Ausgabe"
 
@@ -352,16 +358,16 @@ msgstr "Angehängte Datei anzeigen:"
 msgid "Preview attachment"
 msgstr "Anhang anzeigen"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:66
+#: src/components/ui/Modal/FilePreviewModal.tsx:65
 msgid "Preview is not available for this file type."
 msgstr "Vorschau ist für diesen Dateityp nicht verfügbar."
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:47
-#: src/components/ui/Modal/FilePreviewModal.tsx:57
+#: src/components/ui/Modal/FilePreviewModal.tsx:46
+#: src/components/ui/Modal/FilePreviewModal.tsx:56
 msgid "Preview of"
 msgstr "Vorschau von"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:85
+#: src/components/ui/Modal/FilePreviewModal.tsx:84
 msgid "Preview:"
 msgstr "Vorschau:"
 
@@ -371,8 +377,8 @@ msgid "home.redirecting"
 msgstr "Weiterleitung zum Chat..."
 
 #: src/components/ui/FileUpload/FilePreviewButton.tsx:62
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:218
-#: src/components/ui/Chat/ChatHistoryList.tsx:75
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:219
+#: src/components/ui/Chat/ChatHistoryList.tsx:93
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -396,16 +402,12 @@ msgstr ""
 msgid "Send message"
 msgstr "Nachricht senden"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Show"
 msgstr "Anzeigen"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Show details"
-msgstr "Details anzeigen"
-
-#: src/components/ui/Chat/ChatHistoryList.tsx:70
-msgid "Show Details"
 msgstr "Details anzeigen"
 
 #: src/components/ui/Message/DefaultMessageControls.tsx:115
@@ -418,11 +420,11 @@ msgstr "Formatiert anzeigen"
 msgid "Show raw markdown"
 msgstr "Rohes Markdown anzeigen"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:61
+#: src/components/ui/Settings/ToolCallSettings.tsx:62
 msgid "Show tool calls"
 msgstr "Tool-Aufrufe anzeigen"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:42
+#: src/components/ui/MessageList/MessageListHeader.tsx:41
 msgid "Showing"
 msgstr "Anzeige"
 
@@ -438,15 +440,15 @@ msgstr "Einige Dateien werden nicht akzeptiert..."
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:45
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:46
 msgid "Something went wrong while loading the chat interface."
 msgstr "Beim Laden der Chat-Oberfläche ist ein Fehler aufgetreten."
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:29
+#: src/components/ui/ToolCall/ToolCallItem.tsx:30
 msgid "Success"
 msgstr "Erfolgreich"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "successful"
 msgstr "erfolgreich"
 
@@ -462,7 +464,7 @@ msgstr "System-Theme"
 msgid "Test Locale Changes:"
 msgstr ""
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:91
+#: src/components/ui/Feedback/LoadingIndicator.tsx:90
 msgid "Thinking"
 msgstr "Denkt nach"
 
@@ -482,31 +484,31 @@ msgstr "Token-Limit überschritten"
 msgid "Token Usage"
 msgstr "Token-Verbrauch"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:36
+#: src/components/ui/Settings/ToolCallSettings.tsx:37
 msgid "Tool Call Display"
 msgstr "Tool-Aufruf-Anzeige"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "Tool calls"
 msgstr "Tool-Aufrufe"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:82
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:83
 msgid "Tool Calls"
 msgstr "Tool-Aufrufe"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:95
+#: src/components/ui/Settings/ToolCallSettings.tsx:96
 msgid "Tool calls show how the assistant used external tools to generate responses."
 msgstr "Tool-Aufrufe zeigen, wie der Assistent externe Tools zur Antwortgenerierung verwendet hat."
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:102
+#: src/components/ui/Feedback/LoadingIndicator.tsx:101
 msgid "Tool usage:"
 msgstr "Tool-Verwendung:"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "total"
 msgstr "gesamt"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:48
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:49
 msgid "Try Again"
 msgstr "Erneut versuchen"
 
@@ -514,7 +516,7 @@ msgstr "Erneut versuchen"
 msgid "Type a message..."
 msgstr "Nachricht eingeben..."
 
-#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:59
+#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:60
 #: src/components/ui/FileUpload/FileUpload.tsx:69
 msgid "Upload Files"
 msgstr "Dateien hochladen"
@@ -528,11 +530,11 @@ msgid "Uploading file"
 msgstr "Datei wird hochgeladen"
 
 #: src/components/ui/Feedback/Avatar.tsx:59
-#: src/components/ui/Feedback/Avatar.tsx:65
+#: src/components/ui/Feedback/Avatar.tsx:64
 msgid "User avatar"
 msgstr "Benutzer-Avatar"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:89
+#: src/components/ui/Feedback/LoadingIndicator.tsx:88
 msgid "Using tools"
 msgstr "Tools werden verwendet"
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,13 +13,18 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:53
+#: src/components/ui/MessageList/MessageListHeader.tsx:52
 msgid " (more available)"
 msgstr " (more available)"
 
 #: src/components/ui/Chat/TokenUsageWarning.tsx:74
 msgid " File attachments account for {fileTokensFormatted} tokens."
 msgstr " File attachments account for {fileTokensFormatted} tokens."
+
+#. placeholder {0}: session.metadata?.fileCount ?? 0
+#: src/components/ui/Chat/ChatHistoryList.tsx:114
+msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+msgstr "{0, plural, =0 {No files} one {# file} other {# files}}"
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx:119
 msgid "• Change browser language in settings and refresh"
@@ -64,12 +69,12 @@ msgstr "All file types accepted"
 msgid "Approaching Token Limit"
 msgstr "Approaching Token Limit"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:368
+#: src/components/ui/Controls/DropdownMenu.tsx:365
 #: src/components/ui/Controls/Button.tsx:93
 msgid "Are you sure you want to proceed?"
 msgstr "Are you sure you want to proceed?"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:80
+#: src/components/ui/Chat/ChatHistoryList.tsx:98
 msgid "Are you sure you want to remove this chat?"
 msgstr "Are you sure you want to remove this chat?"
 
@@ -110,11 +115,11 @@ msgstr "Cancel action"
 msgid "Cannot send: Token limit exceeded"
 msgstr "Cannot send: Token limit exceeded"
 
-#: src/components/ui/Chat/Chat.tsx:273
+#: src/components/ui/Chat/Chat.tsx:275
 msgid "Chat conversation"
 msgstr "Chat conversation"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:41
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:42
 msgid "Chat Error"
 msgstr "Chat Error"
 
@@ -122,7 +127,7 @@ msgstr "Chat Error"
 msgid "Chat History"
 msgstr "Chat History"
 
-#: src/components/ui/Chat/ChatWidget.tsx:53
+#: src/components/ui/Chat/ChatWidget.tsx:54
 msgid "Chat messages"
 msgstr "Chat messages"
 
@@ -130,11 +135,11 @@ msgstr "Chat messages"
 msgid "Clear All"
 msgstr "Clear All"
 
-#: src/components/ui/Modal/ModalBase.tsx:101
+#: src/components/ui/Modal/ModalBase.tsx:103
 msgid "Close modal"
 msgstr "Close modal"
 
-#: src/components/ui/Modal/ModalBase.tsx:73
+#: src/components/ui/Modal/ModalBase.tsx:75
 msgid "Close modal overlay"
 msgstr "Close modal overlay"
 
@@ -150,12 +155,12 @@ msgstr "Confirm"
 msgid "Confirm action"
 msgstr "Confirm action"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:365
+#: src/components/ui/Controls/DropdownMenu.tsx:362
 #: src/components/ui/Controls/Button.tsx:92
 msgid "Confirm Action"
 msgstr "Confirm Action"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:79
+#: src/components/ui/Chat/ChatHistoryList.tsx:97
 msgid "Confirm Removal"
 msgstr "Confirm Removal"
 
@@ -172,7 +177,7 @@ msgstr "Dark mode"
 msgid "Default Locale:"
 msgstr "Default Locale:"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "details for"
 msgstr "details for"
 
@@ -189,7 +194,7 @@ msgstr "Dislike message"
 msgid "Dismiss"
 msgstr "Dismiss"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:74
+#: src/components/ui/Modal/FilePreviewModal.tsx:73
 msgid "Download File"
 msgstr "Download File"
 
@@ -210,7 +215,7 @@ msgstr "Edit message"
 msgid "End of conversation"
 msgstr "End of conversation"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:35
+#: src/components/ui/ToolCall/ToolCallItem.tsx:36
 msgid "Error"
 msgstr "Error"
 
@@ -222,7 +227,7 @@ msgstr "Error loading file"
 msgid "Error loading theme:"
 msgstr "Error loading theme:"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Error Output"
 msgstr "Error Output"
 
@@ -230,7 +235,7 @@ msgstr "Error Output"
 msgid "Error:"
 msgstr "Error:"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:87
+#: src/components/ui/Settings/ToolCallSettings.tsx:88
 msgid "Expand by default"
 msgstr "Expand by default"
 
@@ -238,11 +243,11 @@ msgstr "Expand by default"
 msgid "expand sidebar"
 msgstr "expand sidebar"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "failed"
 msgstr "failed"
 
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:168
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:169
 msgid "File"
 msgstr "File"
 
@@ -252,11 +257,11 @@ msgstr "File"
 msgid "navigation.goHome"
 msgstr "Go Home"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Hide"
 msgstr "Hide"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Hide details"
 msgstr "Hide details"
 
@@ -264,11 +269,11 @@ msgstr "Hide details"
 msgid "How to Test:"
 msgstr "How to Test:"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:41
+#: src/components/ui/ToolCall/ToolCallItem.tsx:42
 msgid "In Progress"
 msgstr "In Progress"
 
-#: src/components/ui/ToolCall/ToolCallInput.tsx:21
+#: src/components/ui/ToolCall/ToolCallInput.tsx:22
 msgid "Input Parameters"
 msgstr "Input Parameters"
 
@@ -289,7 +294,7 @@ msgstr "Like message"
 msgid "Load older messages"
 msgstr "Load older messages"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:93
+#: src/components/ui/Feedback/LoadingIndicator.tsx:92
 msgid "Loading"
 msgstr "Loading"
 
@@ -314,17 +319,18 @@ msgstr "Logo"
 msgid "message"
 msgstr "message"
 
-#: src/components/ui/Chat/ChatInput.tsx:274
+#: src/components/ui/Chat/ChatInput.tsx:272
 msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Message exceeds token limit. Please reduce length or remove files."
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:52
+#: src/components/ui/MessageList/MessageListHeader.tsx:51
 msgid "messages"
 msgstr "messages"
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx:88
-#: src/components/ui/Chat/ChatHistoryList.tsx:65
-#: src/components/ui/Chat/Chat.tsx:122
+#: src/components/ui/Chat/ChatHistoryList.tsx:67
+#: src/components/ui/Chat/ChatHistoryList.tsx:81
+#: src/components/ui/Chat/Chat.tsx:123
 msgid "New Chat"
 msgstr "New Chat"
 
@@ -332,15 +338,15 @@ msgstr "New Chat"
 msgid "No messages yet"
 msgstr "No messages yet"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:50
+#: src/components/ui/MessageList/MessageListHeader.tsx:49
 msgid "of"
 msgstr "of"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:352
+#: src/components/ui/Controls/DropdownMenu.tsx:349
 msgid "Open menu"
 msgstr "Open menu"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Output"
 msgstr "Output"
 
@@ -352,16 +358,16 @@ msgstr "Preview attached file:"
 msgid "Preview attachment"
 msgstr "Preview attachment"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:66
+#: src/components/ui/Modal/FilePreviewModal.tsx:65
 msgid "Preview is not available for this file type."
 msgstr "Preview is not available for this file type."
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:47
-#: src/components/ui/Modal/FilePreviewModal.tsx:57
+#: src/components/ui/Modal/FilePreviewModal.tsx:46
+#: src/components/ui/Modal/FilePreviewModal.tsx:56
 msgid "Preview of"
 msgstr "Preview of"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:85
+#: src/components/ui/Modal/FilePreviewModal.tsx:84
 msgid "Preview:"
 msgstr "Preview:"
 
@@ -371,8 +377,8 @@ msgid "home.redirecting"
 msgstr "Redirecting to chat..."
 
 #: src/components/ui/FileUpload/FilePreviewButton.tsx:62
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:218
-#: src/components/ui/Chat/ChatHistoryList.tsx:75
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:219
+#: src/components/ui/Chat/ChatHistoryList.tsx:93
 msgid "Remove"
 msgstr "Remove"
 
@@ -396,17 +402,13 @@ msgstr "Reset to Browser Detection"
 msgid "Send message"
 msgstr "Send message"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Show"
 msgstr "Show"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Show details"
 msgstr "Show details"
-
-#: src/components/ui/Chat/ChatHistoryList.tsx:70
-msgid "Show Details"
-msgstr "Show Details"
 
 #: src/components/ui/Message/DefaultMessageControls.tsx:115
 #: src/components/ui/Message/DefaultMessageControls.tsx:117
@@ -418,11 +420,11 @@ msgstr "Show formatted"
 msgid "Show raw markdown"
 msgstr "Show raw markdown"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:61
+#: src/components/ui/Settings/ToolCallSettings.tsx:62
 msgid "Show tool calls"
 msgstr "Show tool calls"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:42
+#: src/components/ui/MessageList/MessageListHeader.tsx:41
 msgid "Showing"
 msgstr "Showing"
 
@@ -438,15 +440,15 @@ msgstr "Some files won't be accepted..."
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:45
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:46
 msgid "Something went wrong while loading the chat interface."
 msgstr "Something went wrong while loading the chat interface."
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:29
+#: src/components/ui/ToolCall/ToolCallItem.tsx:30
 msgid "Success"
 msgstr "Success"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "successful"
 msgstr "successful"
 
@@ -462,7 +464,7 @@ msgstr "System theme"
 msgid "Test Locale Changes:"
 msgstr "Test Locale Changes:"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:91
+#: src/components/ui/Feedback/LoadingIndicator.tsx:90
 msgid "Thinking"
 msgstr "Thinking"
 
@@ -482,31 +484,31 @@ msgstr "Token Limit Exceeded"
 msgid "Token Usage"
 msgstr "Token Usage"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:36
+#: src/components/ui/Settings/ToolCallSettings.tsx:37
 msgid "Tool Call Display"
 msgstr "Tool Call Display"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "Tool calls"
 msgstr "Tool calls"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:82
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:83
 msgid "Tool Calls"
 msgstr "Tool Calls"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:95
+#: src/components/ui/Settings/ToolCallSettings.tsx:96
 msgid "Tool calls show how the assistant used external tools to generate responses."
 msgstr "Tool calls show how the assistant used external tools to generate responses."
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:102
+#: src/components/ui/Feedback/LoadingIndicator.tsx:101
 msgid "Tool usage:"
 msgstr "Tool usage:"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "total"
 msgstr "total"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:48
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:49
 msgid "Try Again"
 msgstr "Try Again"
 
@@ -514,7 +516,7 @@ msgstr "Try Again"
 msgid "Type a message..."
 msgstr "Type a message..."
 
-#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:59
+#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:60
 #: src/components/ui/FileUpload/FileUpload.tsx:69
 msgid "Upload Files"
 msgstr "Upload Files"
@@ -528,11 +530,11 @@ msgid "Uploading file"
 msgstr "Uploading file"
 
 #: src/components/ui/Feedback/Avatar.tsx:59
-#: src/components/ui/Feedback/Avatar.tsx:65
+#: src/components/ui/Feedback/Avatar.tsx:64
 msgid "User avatar"
 msgstr "User avatar"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:89
+#: src/components/ui/Feedback/LoadingIndicator.tsx:88
 msgid "Using tools"
 msgstr "Using tools"
 

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -13,13 +13,18 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:53
+#: src/components/ui/MessageList/MessageListHeader.tsx:52
 msgid " (more available)"
 msgstr " (plus disponibles)"
 
 #: src/components/ui/Chat/TokenUsageWarning.tsx:74
 msgid " File attachments account for {fileTokensFormatted} tokens."
 msgstr " Les pièces jointes représentent {fileTokensFormatted} tokens."
+
+#. placeholder {0}: session.metadata?.fileCount ?? 0
+#: src/components/ui/Chat/ChatHistoryList.tsx:114
+msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+msgstr "{0, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx:119
 msgid "• Change browser language in settings and refresh"
@@ -64,12 +69,12 @@ msgstr "Tous les types de fichiers acceptés"
 msgid "Approaching Token Limit"
 msgstr "Limite de tokens bientôt atteinte"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:368
+#: src/components/ui/Controls/DropdownMenu.tsx:365
 #: src/components/ui/Controls/Button.tsx:93
 msgid "Are you sure you want to proceed?"
 msgstr "Êtes-vous sûr de vouloir continuer ?"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:80
+#: src/components/ui/Chat/ChatHistoryList.tsx:98
 msgid "Are you sure you want to remove this chat?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce chat ?"
 
@@ -110,11 +115,11 @@ msgstr "Annuler l'action"
 msgid "Cannot send: Token limit exceeded"
 msgstr "Impossible d'envoyer : limite de tokens dépassée"
 
-#: src/components/ui/Chat/Chat.tsx:273
+#: src/components/ui/Chat/Chat.tsx:275
 msgid "Chat conversation"
 msgstr "Conversation de chat"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:41
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:42
 msgid "Chat Error"
 msgstr "Erreur de chat"
 
@@ -122,7 +127,7 @@ msgstr "Erreur de chat"
 msgid "Chat History"
 msgstr "Historique des chats"
 
-#: src/components/ui/Chat/ChatWidget.tsx:53
+#: src/components/ui/Chat/ChatWidget.tsx:54
 msgid "Chat messages"
 msgstr "Messages du chat"
 
@@ -130,11 +135,11 @@ msgstr "Messages du chat"
 msgid "Clear All"
 msgstr "Tout effacer"
 
-#: src/components/ui/Modal/ModalBase.tsx:101
+#: src/components/ui/Modal/ModalBase.tsx:103
 msgid "Close modal"
 msgstr "Fermer la modal"
 
-#: src/components/ui/Modal/ModalBase.tsx:73
+#: src/components/ui/Modal/ModalBase.tsx:75
 msgid "Close modal overlay"
 msgstr "Fermer le fond de modal"
 
@@ -150,12 +155,12 @@ msgstr "Confirmer"
 msgid "Confirm action"
 msgstr "Confirmer l'action"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:365
+#: src/components/ui/Controls/DropdownMenu.tsx:362
 #: src/components/ui/Controls/Button.tsx:92
 msgid "Confirm Action"
 msgstr "Confirmer l'action"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx:79
+#: src/components/ui/Chat/ChatHistoryList.tsx:97
 msgid "Confirm Removal"
 msgstr "Confirmer la suppression"
 
@@ -172,7 +177,7 @@ msgstr "Mode sombre"
 msgid "Default Locale:"
 msgstr ""
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "details for"
 msgstr "détails pour"
 
@@ -189,7 +194,7 @@ msgstr "Je n'aime pas ce message"
 msgid "Dismiss"
 msgstr "Fermer"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:74
+#: src/components/ui/Modal/FilePreviewModal.tsx:73
 msgid "Download File"
 msgstr "Télécharger le fichier"
 
@@ -210,7 +215,7 @@ msgstr "Modifier le message"
 msgid "End of conversation"
 msgstr "Fin de la conversation"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:35
+#: src/components/ui/ToolCall/ToolCallItem.tsx:36
 msgid "Error"
 msgstr "Erreur"
 
@@ -222,7 +227,7 @@ msgstr "Erreur lors du chargement du fichier"
 msgid "Error loading theme:"
 msgstr "Erreur lors du chargement du thème :"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Error Output"
 msgstr "Sortie d'erreur"
 
@@ -230,7 +235,7 @@ msgstr "Sortie d'erreur"
 msgid "Error:"
 msgstr "Erreur :"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:87
+#: src/components/ui/Settings/ToolCallSettings.tsx:88
 msgid "Expand by default"
 msgstr "Développer par défaut"
 
@@ -238,11 +243,11 @@ msgstr "Développer par défaut"
 msgid "expand sidebar"
 msgstr "développer la barre latérale"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "failed"
 msgstr "échoué"
 
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:168
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:169
 msgid "File"
 msgstr "Fichier"
 
@@ -252,11 +257,11 @@ msgstr "Fichier"
 msgid "navigation.goHome"
 msgstr "Retour à l'accueil"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Hide"
 msgstr "Masquer"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Hide details"
 msgstr "Masquer les détails"
 
@@ -264,11 +269,11 @@ msgstr "Masquer les détails"
 msgid "How to Test:"
 msgstr ""
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:41
+#: src/components/ui/ToolCall/ToolCallItem.tsx:42
 msgid "In Progress"
 msgstr "En cours"
 
-#: src/components/ui/ToolCall/ToolCallInput.tsx:21
+#: src/components/ui/ToolCall/ToolCallInput.tsx:22
 msgid "Input Parameters"
 msgstr "Paramètres d'entrée"
 
@@ -289,7 +294,7 @@ msgstr "J'aime ce message"
 msgid "Load older messages"
 msgstr "Charger les messages plus anciens"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:93
+#: src/components/ui/Feedback/LoadingIndicator.tsx:92
 msgid "Loading"
 msgstr "Chargement"
 
@@ -314,17 +319,18 @@ msgstr "Logo"
 msgid "message"
 msgstr "message"
 
-#: src/components/ui/Chat/ChatInput.tsx:274
+#: src/components/ui/Chat/ChatInput.tsx:272
 msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Le message dépasse la limite de tokens. Veuillez réduire la longueur ou supprimer des fichiers."
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:52
+#: src/components/ui/MessageList/MessageListHeader.tsx:51
 msgid "messages"
 msgstr "messages"
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx:88
-#: src/components/ui/Chat/ChatHistoryList.tsx:65
-#: src/components/ui/Chat/Chat.tsx:122
+#: src/components/ui/Chat/ChatHistoryList.tsx:67
+#: src/components/ui/Chat/ChatHistoryList.tsx:81
+#: src/components/ui/Chat/Chat.tsx:123
 msgid "New Chat"
 msgstr "Nouveau chat"
 
@@ -332,15 +338,15 @@ msgstr "Nouveau chat"
 msgid "No messages yet"
 msgstr "Aucun message pour l'instant"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:50
+#: src/components/ui/MessageList/MessageListHeader.tsx:49
 msgid "of"
 msgstr "sur"
 
-#: src/components/ui/Controls/DropdownMenu.tsx:352
+#: src/components/ui/Controls/DropdownMenu.tsx:349
 msgid "Open menu"
 msgstr "Ouvrir le menu"
 
-#: src/components/ui/ToolCall/ToolCallOutput.tsx:29
+#: src/components/ui/ToolCall/ToolCallOutput.tsx:30
 msgid "Output"
 msgstr "Sortie"
 
@@ -352,16 +358,16 @@ msgstr "Aperçu du fichier joint :"
 msgid "Preview attachment"
 msgstr "Aperçu de la pièce jointe"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:66
+#: src/components/ui/Modal/FilePreviewModal.tsx:65
 msgid "Preview is not available for this file type."
 msgstr "L'aperçu n'est pas disponible pour ce type de fichier."
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:47
-#: src/components/ui/Modal/FilePreviewModal.tsx:57
+#: src/components/ui/Modal/FilePreviewModal.tsx:46
+#: src/components/ui/Modal/FilePreviewModal.tsx:56
 msgid "Preview of"
 msgstr "Aperçu de"
 
-#: src/components/ui/Modal/FilePreviewModal.tsx:85
+#: src/components/ui/Modal/FilePreviewModal.tsx:84
 msgid "Preview:"
 msgstr "Aperçu :"
 
@@ -371,8 +377,8 @@ msgid "home.redirecting"
 msgstr "Redirection vers le chat..."
 
 #: src/components/ui/FileUpload/FilePreviewButton.tsx:62
-#: src/components/ui/FileUpload/FilePreviewBase.tsx:218
-#: src/components/ui/Chat/ChatHistoryList.tsx:75
+#: src/components/ui/FileUpload/FilePreviewBase.tsx:219
+#: src/components/ui/Chat/ChatHistoryList.tsx:93
 msgid "Remove"
 msgstr "Supprimer"
 
@@ -396,16 +402,12 @@ msgstr ""
 msgid "Send message"
 msgstr "Envoyer le message"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:70
+#: src/components/ui/ToolCall/ToolCallItem.tsx:71
 msgid "Show"
 msgstr "Afficher"
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:72
+#: src/components/ui/ToolCall/ToolCallItem.tsx:73
 msgid "Show details"
-msgstr "Afficher les détails"
-
-#: src/components/ui/Chat/ChatHistoryList.tsx:70
-msgid "Show Details"
 msgstr "Afficher les détails"
 
 #: src/components/ui/Message/DefaultMessageControls.tsx:115
@@ -418,11 +420,11 @@ msgstr "Afficher formaté"
 msgid "Show raw markdown"
 msgstr "Afficher le markdown brut"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:61
+#: src/components/ui/Settings/ToolCallSettings.tsx:62
 msgid "Show tool calls"
 msgstr "Afficher les appels d'outils"
 
-#: src/components/ui/MessageList/MessageListHeader.tsx:42
+#: src/components/ui/MessageList/MessageListHeader.tsx:41
 msgid "Showing"
 msgstr "Affichage de"
 
@@ -438,15 +440,15 @@ msgstr "Certains fichiers ne seront pas acceptés..."
 msgid "Something went wrong"
 msgstr "Une erreur s'est produite"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:45
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:46
 msgid "Something went wrong while loading the chat interface."
 msgstr "Une erreur s'est produite lors du chargement de l'interface de chat."
 
-#: src/components/ui/ToolCall/ToolCallItem.tsx:29
+#: src/components/ui/ToolCall/ToolCallItem.tsx:30
 msgid "Success"
 msgstr "Succès"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "successful"
 msgstr "réussi"
 
@@ -462,7 +464,7 @@ msgstr "Thème système"
 msgid "Test Locale Changes:"
 msgstr ""
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:91
+#: src/components/ui/Feedback/LoadingIndicator.tsx:90
 msgid "Thinking"
 msgstr "Réflexion"
 
@@ -482,31 +484,31 @@ msgstr "Limite de tokens dépassée"
 msgid "Token Usage"
 msgstr "Utilisation des tokens"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:36
+#: src/components/ui/Settings/ToolCallSettings.tsx:37
 msgid "Tool Call Display"
 msgstr "Affichage des appels d'outils"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "Tool calls"
 msgstr "Appels d'outils"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:82
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:83
 msgid "Tool Calls"
 msgstr "Appels d'outils"
 
-#: src/components/ui/Settings/ToolCallSettings.tsx:95
+#: src/components/ui/Settings/ToolCallSettings.tsx:96
 msgid "Tool calls show how the assistant used external tools to generate responses."
 msgstr "Les appels d'outils montrent comment l'assistant a utilisé des outils externes pour générer des réponses."
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:102
+#: src/components/ui/Feedback/LoadingIndicator.tsx:101
 msgid "Tool usage:"
 msgstr "Utilisation d'outils :"
 
-#: src/components/ui/ToolCall/ToolCallDisplay.tsx:77
+#: src/components/ui/ToolCall/ToolCallDisplay.tsx:78
 msgid "total"
 msgstr "total"
 
-#: src/components/ui/Feedback/ChatErrorBoundary.tsx:48
+#: src/components/ui/Feedback/ChatErrorBoundary.tsx:49
 msgid "Try Again"
 msgstr "Réessayer"
 
@@ -514,7 +516,7 @@ msgstr "Réessayer"
 msgid "Type a message..."
 msgstr "Tapez un message..."
 
-#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:59
+#: src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx:60
 #: src/components/ui/FileUpload/FileUpload.tsx:69
 msgid "Upload Files"
 msgstr "Télécharger des fichiers"
@@ -528,11 +530,11 @@ msgid "Uploading file"
 msgstr "Téléchargement du fichier"
 
 #: src/components/ui/Feedback/Avatar.tsx:59
-#: src/components/ui/Feedback/Avatar.tsx:65
+#: src/components/ui/Feedback/Avatar.tsx:64
 msgid "User avatar"
 msgstr "Avatar de l'utilisateur"
 
-#: src/components/ui/Feedback/LoadingIndicator.tsx:89
+#: src/components/ui/Feedback/LoadingIndicator.tsx:88
 msgid "Using tools"
 msgstr "Utilisation d'outils"
 

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -21,6 +21,7 @@ export interface ChatSessionMetadata {
     timestamp: string;
     sender?: "user" | "assistant" | "system";
   };
+  fileCount?: number;
 }
 
 export interface ChatSession {


### PR DESCRIPTION
- In sidebar item dropdown removed non-functional "Show Details" option
- Reduced excessive padding in sidebar items
- Timestamp in sidebar item is now rendered as human-readable relative date (e.g. "4 hours ago")
- The middle item which duplicated the chat title is now replaced with an indicator for amount of files used in the chat
  - Long term this should evolve to other chat summaries