### PR TITLE
Add support for discoverign additional *.auto.erato.toml configs

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Report> {
         }
     }
 
-    let config = AppConfig::new()?;
+    let config = AppConfig::new_for_app(None)?;
 
     let mut _sentry_guard = None;
     setup_sentry(

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -45,7 +45,7 @@ fn set_test_db_url() {
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./sqitch/deploy");
 
 pub fn test_app_config() -> AppConfig {
-    let mut builder = AppConfig::config_schema_builder().unwrap();
+    let mut builder = AppConfig::config_schema_builder(None, true).unwrap();
     builder = builder
         .set_override("chat_provider.provider_kind", "ollama")
         .unwrap();


### PR DESCRIPTION
Implements the auto-discovery part and general support for multiple config files of #199