### PR TITLE
Show error message for too big file upload

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,7 +12,7 @@ path = "./src/gen_openapi.rs"
 axum = { version = "0.7.9", features = ["macros"] }
 axum-extra = { version = "0.9.6", features = ["typed-header"] }
 headers = "0.4.0"
-tower-http = { version = "0.6.2" , features = ["fs", "cors"]}
+tower-http = { version = "0.6.2" , features = ["fs", "cors", "limit"] }
 sea-orm = { version = "1.1.10" , features = ["runtime-tokio", "sqlx-postgres"]}
 sqlx = { version = "0.8.5", features=["postgres", "runtime-tokio"] }
 serde = { version = "1.0.217", features = ["derive"] }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -109,6 +109,15 @@ impl AppConfig {
         // You can deserialize (and thus freeze) the entire configuration as
         schema.try_deserialize()
     }
+
+    /// Returns the maximum configured file upload size in bytes, if any.
+    pub fn max_upload_size_bytes(&self) -> Option<u64> {
+        self.file_storage_providers
+            .values()
+            .filter_map(|p| p.max_upload_size_kb)
+            .max()
+            .map(|kb| kb * 1024)
+    }
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Clone)]
@@ -177,6 +186,9 @@ pub struct FileStorageProviderConfig {
     // - "azblob" - Azure Blob Storage
     pub provider_kind: String,
     pub config: StorageProviderSpecificConfigMerged,
+    // The maximum file size that may be uploaded in kilobytes.
+    #[serde(default)]
+    pub max_upload_size_kb: Option<u64>,
 }
 
 impl FileStorageProviderConfig {

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -20,6 +20,7 @@ pub struct AppState {
     pub default_file_storage_provider: Option<String>,
     pub file_storage_providers: HashMap<String, FileStorage>,
     pub mcp_servers: Arc<McpServers>,
+    pub config: AppConfig,
 }
 
 impl AppState {
@@ -34,9 +35,10 @@ impl AppState {
             db,
             genai_client,
             system_prompt,
-            default_file_storage_provider: config.default_file_storage_provider,
+            default_file_storage_provider: config.default_file_storage_provider.clone(),
             file_storage_providers,
             mcp_servers,
+            config,
         })
     }
 

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -75,17 +75,19 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
             secret_access_key: Some("erato-app-password".to_string()),
             ..StorageProviderSpecificConfigMerged::default()
         },
+        max_upload_size_kb: None,
     })
     .unwrap();
     file_storage_providers.insert("local_minio".to_owned(), provider);
 
     AppState {
         db: db.clone(),
-        genai_client: AppState::build_genai_client(app_config.chat_provider).unwrap(),
+        genai_client: AppState::build_genai_client(app_config.chat_provider.clone()).unwrap(),
         default_file_storage_provider: None,
         system_prompt: None,
         file_storage_providers,
         mcp_servers: Arc::new(Default::default()),
+        config: app_config,
     }
 }
 // This is the main entry point for integration tests

--- a/e2e-tests/tests/chat.spec.ts
+++ b/e2e-tests/tests/chat.spec.ts
@@ -62,3 +62,24 @@ test(
     await newPage.close();
   },
 );
+
+test(
+  "Uploading a file that is too large shows an error",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    await page.goto("/");
+
+    await login(page, "admin@example.com");
+    await chatIsReadyToChat(page);
+
+    // Start waiting for file chooser before clicking the button
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await page.getByLabel("Upload Files").click();
+    const fileChooser = await fileChooserPromise;
+
+    const filePath = "test-files/big-file-100mb.pdf";
+    await fileChooser.setFiles(filePath);
+
+    await expect(page.getByText("File is too large")).toBeVisible();
+  },
+);

--- a/frontend/src/components/ui/FileUpload/FileUploadButton.tsx
+++ b/frontend/src/components/ui/FileUpload/FileUploadButton.tsx
@@ -63,6 +63,7 @@ export const FileUploadButtonError = memo<FileUploadButtonErrorProps>(
       title={error.message}
       aria-label={`${t`Error:`} ${error.message}`}
     >
+      {error.message}
       <ErrorIcon className="size-5 text-[var(--theme-error-fg)]" />
     </Button>
   ),

--- a/frontend/src/hooks/files/errors.ts
+++ b/frontend/src/hooks/files/errors.ts
@@ -1,0 +1,79 @@
+import { t } from "@lingui/core/macro";
+
+import type { UploadFileError as ApiUploadFileError } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+
+export class UploadTooLargeError extends Error {
+  constructor() {
+    super(
+      t({
+        id: "upload.error.tooLarge",
+        message:
+          "File is too large. Please reload the page and try a smaller file.",
+      }),
+    );
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    this.name = "UploadTooLargeError";
+  }
+}
+
+export class UploadUnknownError extends Error {
+  constructor(message?: string) {
+    const baseMessage = t({
+      id: "upload.error.unknown",
+      message:
+        "An unknown error occurred during upload. Please reload the page and try again.",
+    });
+    super(message ? `${baseMessage}: ${message}` : baseMessage);
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    this.name = "UploadUnknownError";
+  }
+}
+
+/**
+ * Checks if an error indicates a file upload was too large.
+ *
+ * This function handles two cases:
+ * 1. A standard API error with status 413. This can be from the generated client
+ *    which might have a numeric status, or a custom error with a string status.
+ * 2. A Firefox-specific `TypeError` with the message "NetworkError when attempting
+ *    to fetch resource." This occurs when Firefox's networking stack stops a
+ *    request before it is sent, often due to size limits, resulting in an
+ *    opaque error.
+ *
+ * @param error The error object to inspect.
+ * @returns `true` if the error signifies a "too large" condition, otherwise `false`.
+ */
+export function isUploadTooLarge(error: unknown): error is ApiUploadFileError {
+  // Case 1: Check for a status property (numeric or string) equal to 413
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (error as any).status === "413"
+  ) {
+    return true;
+  }
+
+  // Case 2: Firefox-specific fallback for opaque NetworkError
+  const isFirefox =
+    typeof navigator !== "undefined" &&
+    navigator.userAgent.toLowerCase().includes("firefox");
+  if (
+    isFirefox &&
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any,lingui/no-unlocalized-strings
+    (error.message as any).includes("NetworkError") // More robust check
+  ) {
+    console.warn(
+      "A generic NetworkError was caught in a Firefox environment. This is likely due to the file size exceeding browser or server limits. Treating as UploadTooLargeError.",
+    );
+    return true;
+  }
+
+  return false;
+}
+
+export type UploadError = UploadTooLargeError | UploadUnknownError;

--- a/frontend/src/hooks/files/useFileUploadStore.ts
+++ b/frontend/src/hooks/files/useFileUploadStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 
+import type { UploadError } from "./errors";
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
 /**
@@ -17,7 +18,7 @@ interface FileUploadState {
   /**
    * Error message if upload failed
    */
-  error: Error | null;
+  error: UploadError | null;
   /**
    * Stores the chat ID created silently for file uploads
    */
@@ -33,7 +34,7 @@ interface FileUploadState {
   /**
    * Set error state
    */
-  setError: (error: Error | null) => void;
+  setError: (error: UploadError | null) => void;
   /**
    * Clear all uploaded files
    */
@@ -71,7 +72,7 @@ export const useFileUploadStore = create<FileUploadState>((set) => ({
       uploadedFiles: [...state.uploadedFiles, ...files],
     })),
 
-  setError: (error: Error | null) => set({ error }),
+  setError: (error: UploadError | null) => set({ error }),
 
   clearFiles: () => set({ uploadedFiles: [] }),
 

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiFetcher.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiFetcher.ts
@@ -4,7 +4,8 @@ const baseUrl = ""; // TODO add your baseUrl
 
 export type ErrorWrapper<TError> =
   | TError
-  | { status: "unknown"; payload: string };
+  | { status: "unknown"; payload: string }
+  | { status: "413"; payload: string };
 
 export type V1betaApiFetcherOptions<
   TBody,
@@ -80,13 +81,20 @@ export async function v1betaApiFetch<
       try {
         error = await response.json();
       } catch (e) {
-        error = {
-          status: "unknown" as const,
-          payload:
-            e instanceof Error
-              ? `Unexpected error (${e.message})`
-              : "Unexpected error",
-        };
+        if (response.status === 413) {
+          error = {
+            status: "413",
+            payload: "Request entity too large",
+          };
+        } else {
+          error = {
+            status: "unknown" as const,
+            payload:
+                e instanceof Error
+                    ? `Unexpected error (${e.message})`
+                    : "Unexpected error",
+          };
+        }
       }
     } else if (response.headers.get("content-type")?.includes("json")) {
       return await response.json();

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -64,6 +64,11 @@ msgstr "Akzeptierte Dateitypen:"
 msgid "All file types accepted"
 msgstr "Alle Dateitypen akzeptiert"
 
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.unknown"
+msgstr ""
+
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 msgid "Approaching Token Limit"
@@ -250,6 +255,11 @@ msgstr "fehlgeschlagen"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 msgid "File"
 msgstr "Datei"
+
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.tooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -64,6 +64,11 @@ msgstr "Accepted types:"
 msgid "All file types accepted"
 msgstr "All file types accepted"
 
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.unknown"
+msgstr "An unknown error occurred during upload. Please reload the page and try again."
+
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 msgid "Approaching Token Limit"
@@ -250,6 +255,11 @@ msgstr "failed"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 msgid "File"
 msgstr "File"
+
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.tooLarge"
+msgstr "File is too large. Please reload the page and try a smaller file."
 
 #. js-lingui-explicit-id
 #: src/App.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -64,6 +64,11 @@ msgstr "Tipos aceptados:"
 msgid "All file types accepted"
 msgstr "Todos los tipos de archivo aceptados"
 
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.unknown"
+msgstr ""
+
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 msgid "Approaching Token Limit"
@@ -250,6 +255,11 @@ msgstr "falló"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 msgid "File"
 msgstr "Archivo"
+
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.tooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -64,6 +64,11 @@ msgstr "Types acceptés :"
 msgid "All file types accepted"
 msgstr "Tous les types de fichiers acceptés"
 
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.unknown"
+msgstr ""
+
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 msgid "Approaching Token Limit"
@@ -250,6 +255,11 @@ msgstr "échoué"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 msgid "File"
 msgstr "Fichier"
+
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.tooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -64,6 +64,11 @@ msgstr "Akceptowane typy plików:"
 msgid "All file types accepted"
 msgstr "Wszystkie typy plików akceptowane"
 
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.unknown"
+msgstr ""
+
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 #: src/components/ui/Chat/TokenUsageWarning.tsx
 msgid "Approaching Token Limit"
@@ -250,6 +255,11 @@ msgstr "nie udało się"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 msgid "File"
 msgstr "Plik"
+
+#. js-lingui-explicit-id
+#: src/hooks/files/errors.ts
+msgid "upload.error.tooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -6,7 +6,7 @@ erato:
     annotations:
       nginx.ingress.kubernetes.io/proxy-buffer-size: 8k
       nginx.ingress.kubernetes.io/proxy-buffers-number: '4'
-      nginx.ingress.kubernetes.io/proxy-body-size: 50m
+      nginx.ingress.kubernetes.io/proxy-body-size: 0
 
   backend:
     image:


### PR DESCRIPTION
Related #207

- Add test to check that error is displayed when trying to upload a file that's too big
- Add explicit backend config field to configure maximum file size
- Additionally enforce file upload limit via Content-Length
- Adjust File upload error button to display error
- Adjust frontend file upload error handling to handle Firefox
- Make error messages for file upload translatable