### PR TITLE
Make page title suffix translatable / customizable

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LLM Chat</title>
     <style>
       body {
         font-family:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable lingui/no-unlocalized-strings */
 import { Trans } from "@lingui/react/macro";
-import { useEffect } from "react";
 import { Routes, Route, Link, Outlet, Navigate } from "react-router-dom";
 
 import { ClientProviders } from "./components/providers/ClientProviders";
@@ -39,10 +38,6 @@ const NotFoundPage = () => (
 
 // Main App Shell (Global Layout - for things outside ChatLayout or other specific layouts)
 function App() {
-  useEffect(() => {
-    document.title = "LLM Chat";
-  }, []);
-
   return (
     <ClientProviders>
       <Outlet />

--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -10,6 +10,7 @@ import { messages as enMessages } from "@/locales/en/messages";
 import { useChatContext } from "@/providers/ChatProvider";
 
 import ChatPageStructure from "../ChatPageStructure.client";
+
 import "@testing-library/jest-dom";
 
 // Initialize i18n for tests

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Plural } from "@lingui/react/macro";
 import clsx from "clsx";
-import { memo } from "react";
+import { memo, useEffect } from "react";
 
 import { MessageTimestamp } from "@/components/ui";
 
@@ -146,6 +146,17 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
     isLoading = false,
     showTimestamps = true,
   }) => {
+    const currentSession = sessions.find((s) => s.id === currentSessionId);
+    const currentSessionTitle = currentSession?.title;
+
+    useEffect(() => {
+      if (typeof currentSessionTitle === "undefined") {
+        return;
+      }
+      const pageTitle = t({ id: "branding.page_title_suffix" });
+      document.title = `${currentSessionTitle} - ${pageTitle}`;
+    }, [currentSessionTitle]);
+
     if (isLoading) {
       return <ChatHistoryListSkeleton layout={layout} />;
     }

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -300,6 +300,13 @@ msgstr "Heller Modus"
 msgid "Like message"
 msgstr "Nachricht gefällt mir"
 
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+#: src/pages/HomePage.tsx
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "branding.page_title_suffix"
+msgstr ""
+
 #: src/components/ui/Message/LoadMoreButton.tsx
 msgid "Load older messages"
 msgstr "Ältere Nachrichten laden"
@@ -336,6 +343,11 @@ msgstr "Nachricht überschreitet Token-Limit. Bitte kürzen Sie die Nachricht od
 #: src/components/ui/MessageList/MessageListHeader.tsx
 msgid "messages"
 msgstr "Nachrichten"
+
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+msgid "navigation.page.new_chat"
+msgstr ""
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -300,6 +300,13 @@ msgstr "Light mode"
 msgid "Like message"
 msgstr "Like message"
 
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+#: src/pages/HomePage.tsx
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "branding.page_title_suffix"
+msgstr "LLM Chat"
+
 #: src/components/ui/Message/LoadMoreButton.tsx
 msgid "Load older messages"
 msgstr "Load older messages"
@@ -336,6 +343,11 @@ msgstr "Message exceeds token limit. Please reduce length or remove files."
 #: src/components/ui/MessageList/MessageListHeader.tsx
 msgid "messages"
 msgstr "messages"
+
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+msgid "navigation.page.new_chat"
+msgstr "New chat"
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -300,6 +300,13 @@ msgstr "Modo claro"
 msgid "Like message"
 msgstr "Me gusta el mensaje"
 
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+#: src/pages/HomePage.tsx
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "branding.page_title_suffix"
+msgstr ""
+
 #: src/components/ui/Message/LoadMoreButton.tsx
 msgid "Load older messages"
 msgstr "Cargar mensajes más antiguos"
@@ -336,6 +343,11 @@ msgstr "El mensaje excede el límite de tokens. Por favor, reduzca la longitud o
 #: src/components/ui/MessageList/MessageListHeader.tsx
 msgid "messages"
 msgstr "mensajes"
+
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+msgid "navigation.page.new_chat"
+msgstr ""
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -300,6 +300,13 @@ msgstr "Mode clair"
 msgid "Like message"
 msgstr "J'aime ce message"
 
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+#: src/pages/HomePage.tsx
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "branding.page_title_suffix"
+msgstr ""
+
 #: src/components/ui/Message/LoadMoreButton.tsx
 msgid "Load older messages"
 msgstr "Charger les messages plus anciens"
@@ -336,6 +343,11 @@ msgstr "Le message dépasse la limite de tokens. Veuillez réduire la longueur o
 #: src/components/ui/MessageList/MessageListHeader.tsx
 msgid "messages"
 msgstr "messages"
+
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+msgid "navigation.page.new_chat"
+msgstr ""
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -300,6 +300,13 @@ msgstr "Tryb jasny"
 msgid "Like message"
 msgstr "Lubię wiadomość"
 
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+#: src/pages/HomePage.tsx
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "branding.page_title_suffix"
+msgstr ""
+
 #: src/components/ui/Message/LoadMoreButton.tsx
 msgid "Load older messages"
 msgstr "Załaduj starsze wiadomości"
@@ -336,6 +343,11 @@ msgstr "Wiadomość przekracza limit tokenów. Proszę skrócić lub usunąć pl
 #: src/components/ui/MessageList/MessageListHeader.tsx
 msgid "messages"
 msgstr "wiadomości"
+
+#. js-lingui-explicit-id
+#: src/pages/NewChatPage.tsx
+msgid "navigation.page.new_chat"
+msgstr ""
 
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,3 +1,4 @@
+import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -9,12 +10,19 @@ export default function HomePage() {
     // Redirect to the new chat page
     navigate("/chat/new", { replace: true });
   }, [navigate]);
-
+  useEffect(() => {
+    document.title = t({
+      id: "branding.page_title_suffix",
+      message: "LLM Chat",
+    });
+  }, []);
   return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="animate-pulse text-lg">
-        <Trans id="home.redirecting">Redirecting to chat...</Trans>
+    <>
+      <div className="flex h-screen items-center justify-center">
+        <div className="animate-pulse text-lg">
+          <Trans id="home.redirecting">Redirecting to chat...</Trans>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/src/pages/NewChatPage.tsx
+++ b/frontend/src/pages/NewChatPage.tsx
@@ -1,3 +1,4 @@
+import { t } from "@lingui/core/macro";
 import { useEffect } from "react";
 
 import { useChatHistoryStore } from "@/hooks/chat/useChatHistory";
@@ -16,6 +17,14 @@ export default function NewChatPage() {
     );
     setNewChatPending(false);
   }, [setNewChatPending]);
+  useEffect(() => {
+    const pageTitle = t({ id: "branding.page_title_suffix" });
+    const pageTitlePart = t({
+      id: "navigation.page.new_chat",
+      message: "New chat",
+    });
+    document.title = `${pageTitlePart} - ${pageTitle}`;
+  }, []);
 
   // Removed automatic navigation logic - now handled explicitly in message completion
 


### PR DESCRIPTION
- Add page titles and make them translatable; e.g.:
  - New chat: `New chat - LLM Chat`
  - Selected chat: `<chat summary> - LLM Chat`