### PR TITLE
Enable loading of custom-theme locales

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -49,3 +49,4 @@ next-env.d.ts
 
 # Compiled translation files
 src/locales/**/*.ts
+src/locales/**/*.json

--- a/frontend/lingui.config.ts
+++ b/frontend/lingui.config.ts
@@ -10,8 +10,13 @@ export default defineConfig({
       include: ["src"],
       exclude: ["**/node_modules/**", "**/out/**", "**/.next/**", "**/test/**"],
     },
+    {
+      path: "<rootDir>/public/custom-theme/{name}/locales/{locale}/messages",
+      include: ["<rootDir>/public/custom-theme/{name}/"],
+      exclude: ["**/node_modules/**", "**/out/**", "**/.next/**", "**/test/**"],
+    },
   ],
-  compileNamespace: "ts", // Generate TypeScript files
+  compileNamespace: "json", // Generate JSON files, as those can be more easily loaded dynamically for the custom-theme
   // Use industry-standard PO format
   format: poFormatter({ lineNumbers: false }),
 });

--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -1,4 +1,4 @@
-import { i18n } from "@lingui/core";
+import { i18n, Messages } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, fireEvent } from "@testing-library/react";
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
 import { useChatMessaging } from "@/hooks/chat/useChatMessaging";
-import { messages as enMessages } from "@/locales/en/messages";
+import { messages as enMessages } from "@/locales/en/messages.json";
 import { useChatContext } from "@/providers/ChatProvider";
 
 import ChatPageStructure from "../ChatPageStructure.client";
@@ -14,7 +14,7 @@ import ChatPageStructure from "../ChatPageStructure.client";
 import "@testing-library/jest-dom";
 
 // Initialize i18n for tests
-i18n.load("en", enMessages);
+i18n.load("en", enMessages as unknown as Messages);
 i18n.activate("en");
 
 // Mock necessary hooks and components

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,6 +1,8 @@
 import { i18n } from "@lingui/core";
 import { detect, fromNavigator } from "@lingui/detect-locale";
 
+import { env } from "@/app/env";
+
 export const defaultLocale = "en";
 export const supportedLocales = ["en", "de", "fr", "pl", "es"];
 
@@ -59,6 +61,26 @@ export async function dynamicActivate(locale: string) {
         locale: defaultLocale,
         messages,
       });
+    }
+  }
+  // Additionally try to load custom-theme translations
+  const customThemePath = env().themeCustomerName;
+  if (customThemePath) {
+    try {
+      const { messages } = await (
+        await fetch(
+          `/custom-theme/${customThemePath}/locales/${validLocale}/messages.json`,
+        )
+      ).json();
+      i18n.loadAndActivate({
+        locale: validLocale,
+        messages,
+      });
+    } catch (error) {
+      console.warn(
+        `Failed to load locale ${validLocale} for custom theme.`,
+        error,
+      );
     }
   }
 }

--- a/frontend/src/lib/setupTests.ts
+++ b/frontend/src/lib/setupTests.ts
@@ -2,12 +2,14 @@ import "@testing-library/jest-dom";
 import { i18n } from "@lingui/core";
 import { beforeAll, afterEach, afterAll } from "vitest";
 
-import { messages as enMessages } from "@/locales/en/messages";
+import { messages as enMessages } from "@/locales/en/messages.json";
 
 import { server } from "./mocks/server";
 
+import type { Messages } from "@lingui/core";
+
 // Initialize i18n for all tests
-i18n.load("en", enMessages);
+i18n.load("en", enMessages as unknown as Messages);
 i18n.activate("en");
 
 // Polyfill ResizeObserver for tests


### PR DESCRIPTION
Related #205 

If a custom theme is specified via the env config, locales for that theme are also being loaded at runtime.
The output files are built via the same `pnpm i18n:compile` step, which now also takes the `public/custom-theme` directory into account.
To make runtime loading possible, the format of the compiled catalogues has been switched to JSON.

# Usage

To add locales for a custom theme, they can be placed in e.g. (for example theme name XYZ):
- `/frontend/public/custom-theme/XZY/locales/en/messages.po`
  - the `/locales/{locale}/messages.po` structure follows the one in the `/frontend/src/` directory

Only messages that have an explicit `msgid` can be reliably overwritten (as the auto-generated IDs between the two catalogues diverge), and the `#. js-lingui-explicit-id` comment needs to be present.

E.g. to override the page title suffix, this would be in the `messages.po` file:
```po
#. js-lingui-explicit-id
msgid "branding.page_title_suffix"
msgstr "XYZ AI Chat"
```