### PR TITLE
Add cleanup background worker

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -252,6 +252,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +482,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.8.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.11.0",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.96",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +568,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+dependencies = [
+ "darling",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -763,6 +832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1052,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1182,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1284,6 +1387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,8 +1454,10 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-test",
+ "chrono",
  "color-eyre",
  "config",
+ "cron",
  "ctor",
  "dotenv-flow",
  "eyre",
@@ -1359,6 +1470,8 @@ dependencies = [
  "opendal",
  "ordered-multimap",
  "parser-core",
+ "ractor",
+ "ractor_actors",
  "regorus",
  "reqwest",
  "rust-mcp-schema",
@@ -1483,6 +1596,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1683,21 @@ checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2288,6 +2428,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.8.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,6 +2568,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2619,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da627c72b2499a8106f4dd33143843015e4a631f445d561f3481f7fba35b6151"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "pkg-config",
  "vcpkg",
 ]
@@ -2465,6 +2645,17 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2651,6 +2842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -2704,6 +2896,31 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.8.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3405,6 +3622,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3806,40 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "ractor"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164cbdac94cb8f5c3bbb031f959643619e7e74f13d94381d69ba6161640f063e"
+dependencies = [
+ "bon",
+ "dashmap",
+ "futures",
+ "once_cell",
+ "strum",
+ "tokio",
+ "tokio_with_wasm",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "ractor_actors"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5142ea740eeb967f05caa66e911f58d2863d33a405c0810bfc9fd9b17a9d5b15"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "cron",
+ "notify",
+ "ractor",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tracing",
+]
 
 [[package]]
 name = "radium"
@@ -4168,6 +4429,8 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4200,6 +4463,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4216,6 +4480,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -5000,6 +5273,22 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "subtle"
@@ -5130,7 +5419,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd33f6f216124cfaf0fa86c2c0cdf04da39b6257bd78c5e44fa4fa98c3a5857b"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "leptonica-sys",
  "pkg-config",
  "vcpkg",
@@ -5315,6 +5604,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -5371,6 +5661,30 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded28f47ec75b323c57d6752b0c4aa03cbb3cafc18a4f64eefc221b47facb6fa"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ab10ef5cedbe0955cc210ffa852567f9c4bcfd16fd8fb7b7870eef9b7dcec"
+dependencies = [
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5805,6 +6119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6028,6 +6352,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -48,6 +48,10 @@ tiktoken-rs = "0.6.0"
 rust-mcp-sdk = { version = "0.4.2", default-features = false, features = ["client"] }
 rust-mcp-schema = { version = "0.5.2", features = ["schema_utils"] }
 rust-mcp-transport = "0.3.4"
+ractor = "0.15.6"
+ractor_actors = { version = "0.4.9", features = ["time"] }
+chrono = "0.4"
+cron = "0.12.1"
 
 [dependencies.sentry]
 version = "0.41.0"

--- a/backend/src/actors/cleanup_worker.rs
+++ b/backend/src/actors/cleanup_worker.rs
@@ -1,0 +1,107 @@
+use crate::db::entity::{chats, messages};
+use chrono::{Duration, Utc};
+use ractor::{Actor, ActorProcessingErr, ActorRef};
+use sea_orm::{
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter, TransactionTrait,
+};
+
+#[derive(Debug, Clone)]
+pub enum CleanupWorkerMessage {
+    Tick,
+}
+
+#[derive(Clone)]
+pub struct CleanupWorkerArgs {
+    pub db: DatabaseConnection,
+    pub cleanup_archived_max_age_days: u32,
+}
+
+pub struct CleanupWorker;
+
+pub async fn cleanup_archived_chats(
+    db: &DatabaseConnection,
+    max_age_days: u32,
+) -> Result<(), ActorProcessingErr> {
+    let cutoff_date = Utc::now() - Duration::days(max_age_days as i64);
+    tracing::info!("Cleaning up archived chats older than {}", cutoff_date);
+
+    let chats_to_delete = chats::Entity::find()
+        .filter(
+            Condition::all()
+                .add(chats::Column::ArchivedAt.is_not_null())
+                .add(chats::Column::ArchivedAt.lt(cutoff_date)),
+        )
+        .all(db)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to query chats for cleanup: {}", e);
+            ActorProcessingErr::from(e)
+        })?;
+
+    if chats_to_delete.is_empty() {
+        tracing::info!("No old archived chats to delete.");
+        return Ok(());
+    }
+
+    let chat_ids: Vec<sea_orm::prelude::Uuid> = chats_to_delete.iter().map(|c| c.id).collect();
+    tracing::info!("Found {} chats to delete.", chat_ids.len());
+
+    let txn = db.begin().await.map_err(|e| {
+        tracing::error!("Failed to begin transaction for cleanup: {}", e);
+        ActorProcessingErr::from(e)
+    })?;
+
+    messages::Entity::delete_many()
+        .filter(messages::Column::ChatId.is_in(chat_ids.clone()))
+        .exec(&txn)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete messages for cleanup: {}", e);
+            ActorProcessingErr::from(e)
+        })?;
+
+    chats::Entity::delete_many()
+        .filter(chats::Column::Id.is_in(chat_ids))
+        .exec(&txn)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete chats for cleanup: {}", e);
+            ActorProcessingErr::from(e)
+        })?;
+
+    txn.commit().await.map_err(|e| {
+        tracing::error!("Failed to commit transaction for cleanup: {}", e);
+        ActorProcessingErr::from(e)
+    })?;
+
+    tracing::info!("Cleanup complete.");
+    Ok(())
+}
+
+impl Actor for CleanupWorker {
+    type Msg = CleanupWorkerMessage;
+    type State = CleanupWorkerArgs;
+    type Arguments = CleanupWorkerArgs;
+
+    async fn pre_start(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        args: Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        Ok(args)
+    }
+
+    async fn handle(
+        &self,
+        _myself: ActorRef<Self::Msg>,
+        message: Self::Msg,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            CleanupWorkerMessage::Tick => {
+                cleanup_archived_chats(&state.db, state.cleanup_archived_max_age_days).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/backend/src/actors/cron_jobs.rs
+++ b/backend/src/actors/cron_jobs.rs
@@ -1,0 +1,27 @@
+use ractor::registry;
+use ractor::ActorRef;
+use ractor_actors::time::cron::Job;
+
+use crate::actors::cleanup_worker::CleanupWorkerMessage;
+
+pub struct CleanupTickJob;
+
+#[async_trait::async_trait]
+impl Job for CleanupTickJob {
+    fn id<'a>(&self) -> &'a str {
+        "cleanup_tick_job"
+    }
+
+    async fn work(&mut self) -> Result<(), ractor::ActorProcessingErr> {
+        tracing::info!("Running cleanup_worker_cron");
+        if let Some(actor_cell) = registry::where_is("cleanup_worker".to_string()) {
+            let worker: ActorRef<CleanupWorkerMessage> = actor_cell.into();
+            if let Err(e) = worker.cast(CleanupWorkerMessage::Tick) {
+                tracing::error!("Failed to send Tick to cleanup_worker_cron: {e}");
+            }
+        } else {
+            tracing::warn!("cleanup_worker_cron not found in registry. Tick skipped.");
+        }
+        Ok(())
+    }
+}

--- a/backend/src/actors/manager.rs
+++ b/backend/src/actors/manager.rs
@@ -1,0 +1,29 @@
+use crate::actors::supervisor::WorkerSupervisor;
+use crate::config::AppConfig;
+use ractor::Actor;
+use sea_orm::DatabaseConnection;
+
+#[derive(Clone, Debug)]
+pub struct ActorManager;
+
+impl ActorManager {
+    pub async fn new(db: DatabaseConnection, config: AppConfig) -> Self {
+        let args = (db, config);
+        // Spawn the top-level supervisor
+        let (_supervisor, supervisor_handle) = Actor::spawn(
+            Some("worker_supervisor".to_string()),
+            WorkerSupervisor,
+            args,
+        )
+        .await
+        .expect("Failed to spawn WorkerSupervisor");
+
+        // We'll spawn the supervisor handle in a background task to ensure it's not dropped
+        // and the actor system keeps running.
+        tokio::spawn(async move {
+            supervisor_handle.await.unwrap();
+        });
+
+        Self
+    }
+}

--- a/backend/src/actors/mod.rs
+++ b/backend/src/actors/mod.rs
@@ -1,0 +1,4 @@
+pub mod cleanup_worker;
+pub mod cron_jobs;
+pub mod manager;
+pub mod supervisor;

--- a/backend/src/actors/supervisor.rs
+++ b/backend/src/actors/supervisor.rs
@@ -1,0 +1,118 @@
+use std::str::FromStr;
+
+use cron::Schedule;
+use ractor::{Actor, ActorProcessingErr, ActorRef, SupervisionEvent};
+use ractor_actors::time::cron::{CronManager, CronManagerMessage, CronSettings};
+use sea_orm::DatabaseConnection;
+
+use crate::actors::cleanup_worker::{CleanupWorker, CleanupWorkerArgs};
+use crate::actors::cron_jobs::CleanupTickJob;
+use crate::config::AppConfig;
+
+pub struct WorkerSupervisor;
+
+impl Actor for WorkerSupervisor {
+    type Msg = (); // No messages for supervisor itself for now
+    type State = Option<CleanupWorkerArgs>;
+    type Arguments = (DatabaseConnection, AppConfig);
+
+    async fn pre_start(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        (db, config): Self::Arguments,
+    ) -> Result<Self::State, ActorProcessingErr> {
+        if !config.cleanup_enabled {
+            tracing::info!("Cleanup worker is disabled via config. Supervisor will be idle.");
+            return Ok(None);
+        }
+
+        let args = CleanupWorkerArgs {
+            db: db.clone(),
+            cleanup_archived_max_age_days: config.cleanup_archived_max_age_days,
+        };
+
+        // Start the cron manager
+        let (cron_manager, cron_manager_handle) = Actor::spawn_linked(
+            Some("cleanup_worker_cron".to_string()),
+            CronManager,
+            (),
+            myself.get_cell(),
+        )
+        .await
+        .expect("Failed to spawn CronManager");
+        tokio::spawn(async move {
+            cron_manager_handle.await.unwrap();
+        });
+
+        // Schedule the cleanup tick job
+        let schedule = Schedule::from_str("0 */5 * * * *").expect("Failed to parse cron schedule");
+        let settings = CronSettings {
+            schedule,
+            job: Box::new(CleanupTickJob),
+        };
+        cron_manager
+            .call(|prt| CronManagerMessage::Start(settings, prt), None)
+            .await
+            .expect("Failed to send Start to CronManager")
+            .expect("CronManager timed out starting job")
+            .expect("Failed to start CleanupTickJob");
+
+        // Start and supervise the cleanup worker
+        let (_cleanup_actor, _cleanup_handle) = Actor::spawn_linked(
+            Some("cleanup_worker".to_string()),
+            CleanupWorker,
+            args.clone(),
+            myself.get_cell(),
+        )
+        .await
+        .expect("Failed to spawn CleanupWorker");
+
+        Ok(Some(args))
+    }
+
+    async fn handle_supervisor_evt(
+        &self,
+        myself: ActorRef<Self::Msg>,
+        message: SupervisionEvent,
+        state: &mut Self::State,
+    ) -> Result<(), ActorProcessingErr> {
+        match message {
+            SupervisionEvent::ActorStarted(who) => {
+                let name = who.get_name().unwrap_or_else(|| "un-named".to_string());
+                tracing::info!("Actor '{name}' started and supervised.");
+            }
+            SupervisionEvent::ActorFailed(who, reason) => {
+                let name = who.get_name().unwrap_or_else(|| "un-named".to_string());
+                tracing::error!("Actor '{name}' panicked with reason: {reason}. Restarting...",);
+
+                if name == "cleanup_worker" {
+                    if let Some(worker_args) = state {
+                        // Restart the panicked actor
+                        let (_restarted_actor, _handle) = Actor::spawn_linked(
+                            who.get_name(),
+                            CleanupWorker,
+                            worker_args.clone(),
+                            myself.get_cell(),
+                        )
+                        .await
+                        .expect("Failed to restart actor");
+
+                        tracing::info!("Restarted '{name}'.");
+                    } else {
+                        tracing::error!(
+                            "cleanup_worker failed, but supervisor has no state to restart it."
+                        );
+                    }
+                }
+            }
+            SupervisionEvent::ActorTerminated(who, _, reason) => {
+                let name = who.get_name().unwrap_or_else(|| "un-named".to_string());
+                tracing::error!(
+                    "Actor '{name}' terminated with reason: {reason:?}. Not restarting.",
+                );
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -41,6 +41,14 @@ pub struct AppConfig {
     // These will be available on the frontend via the frontend_environment mechanism, and added to the `windows` object.
     #[serde(default)]
     pub additional_frontend_environment: HashMap<String, serde_json::Value>,
+
+    // If true, enables the cleanup worker that periodically deletes old data.
+    // Defaults to `false`.
+    pub cleanup_enabled: bool,
+    // Number of days after which archived chats should be deleted by the cleanup worker.
+    // Only has an effect if `cleanup_enabled` is `true`.
+    // Defaults to 30.
+    pub cleanup_archived_max_age_days: u32,
 }
 
 impl AppConfig {
@@ -58,7 +66,9 @@ impl AppConfig {
             .set_default("environment", "development")?
             .set_default("http_host", "127.0.0.1")?
             .set_default("http_port", "3130")?
-            .set_default("frontend_bundle_path", "./public")?;
+            .set_default("frontend_bundle_path", "./public")?
+            .set_default("cleanup_enabled", false)?
+            .set_default("cleanup_archived_max_age_days", 30)?;
 
         let config_files_to_load: Vec<String> = if let Some(paths) = config_file_paths {
             paths

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,7 @@ use server::router::MainRouterApiDoc;
 
 use crate::server::router::MAIN_ROUTER_DOC;
 
+pub mod actors;
 pub mod config;
 pub mod db;
 pub mod frontend_environment;

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,3 +1,4 @@
+use crate::actors::manager::ActorManager;
 use crate::config::{AppConfig, ChatProviderConfig};
 use crate::services::file_storage::FileStorage;
 use crate::services::mcp_manager::McpServers;
@@ -21,6 +22,7 @@ pub struct AppState {
     pub file_storage_providers: HashMap<String, FileStorage>,
     pub mcp_servers: Arc<McpServers>,
     pub config: AppConfig,
+    pub actor_manager: ActorManager,
 }
 
 impl AppState {
@@ -30,6 +32,7 @@ impl AppState {
         let file_storage_providers = Self::build_file_storage_providers(&config)?;
         let genai_client = Self::build_genai_client(config.chat_provider.clone())?;
         let mcp_servers = Arc::new(McpServers::new(&config).await?);
+        let actor_manager = ActorManager::new(db.clone(), config.clone()).await;
 
         Ok(Self {
             db,
@@ -39,6 +42,7 @@ impl AppState {
             file_storage_providers,
             mcp_servers,
             config,
+            actor_manager,
         })
     }
 

--- a/backend/tests/integration_tests/actors.rs
+++ b/backend/tests/integration_tests/actors.rs
@@ -1,0 +1,87 @@
+use crate::{test_app_config, test_app_state, MIGRATOR};
+use axum_test::TestServer;
+use chrono::{Duration, Utc};
+use erato::actors::cleanup_worker::cleanup_archived_chats;
+use erato::db::entity::chats;
+use sea_orm::{ActiveModelTrait, ActiveValue, EntityTrait};
+use serde_json::{json, Value};
+use sqlx::{Pool, Postgres};
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn test_cleanup_logic(pool: Pool<Postgres>) {
+    let app_config = test_app_config();
+    let app_state = test_app_state(app_config, pool).await;
+
+    let server = TestServer::new(
+        erato::server::router::router(app_state.clone())
+            .split_for_parts()
+            .0
+            .with_state(app_state.clone()),
+    )
+    .expect("Failed to create test server");
+
+    let mock_jwt = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjMzNTUwZjNkZWE2MDFhNjlmODM1MmVkNDA3OTRhYTlmYWMzNDhhODAifQ.eyJpc3MiOiJodHRwOi8vMC4wLjAuMDo1NTU2Iiwic3ViIjoiQ2lRd09HRTROamcwWWkxa1lqZzRMVFJpTnpNdE9UQmhPUzB6WTJReE5qWXhaalUwTmpZU0JXeHZZMkZzIiwiYXVkIjoiZXhhbXBsZS1hcHAiLCJleHAiOjE3NDA2MDkzNTAsImlhdCI6MTc0MDUyMjk1MCwiYXRfaGFzaCI6IldVVjNiUWNEbFN4M2Vod3o2QTZkYnciLCJjX2hhc2giOiJHcHVSdW52Y25rTjR3bGY4Q1RYamh3IiwiZW1haWwiOiJhZG1pbkBleGFtcGxlLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoiYWRtaW4ifQ.h8Fo6PAl2dG3xosBd6a6U6QAWalJvpX62-F3rJaS4hft7qnh9Sv_xDB2Cp1cjj-vS0e4xveDNuMGGnGKeUAk496q4xtuhwU9oUMoAsRQwnCXdp--_ngIG7QZK80h4jhvfutOc6Gltn0TTr-N5i8Yb9tW-ubVE68_-uX3lkx771MyJxgg9sL1YY7eKKEWx7UlRZEHmY6F134fY-ZFegrEnkESxi2qLTRo5hWSSIYmNlCSwStmNBBSPIOLl_Gu4wvqfPER5qXWgYn5dkISPZmcGVqyQuOBQkGOrAKMefvWP_Y97KHOwE9Od4au-Pgg7kuTA7Ywateg1VCdxLM3FMK-Sw";
+
+    let mut chat_ids = Vec::new();
+
+    for i in 0..2 {
+        let response = server
+            .post("/api/v1beta/me/messages/submitstream")
+            .add_header(
+                axum::http::header::AUTHORIZATION,
+                format!("Bearer {}", mock_jwt),
+            )
+            .json(&json!({ "user_message": format!("Chat {}", i) }))
+            .await;
+        response.assert_status_ok();
+
+        let body = response.as_bytes();
+        let body_str = String::from_utf8_lossy(body);
+        let events: Vec<String> = body_str
+            .split("\n\n")
+            .filter(|chunk| chunk.contains("data:"))
+            .map(|chunk| chunk.to_string())
+            .collect();
+
+        let chat_id = events
+            .iter()
+            .find_map(|event| {
+                let data = event.split("data:").nth(1).unwrap_or("").trim();
+                if let Ok(json) = serde_json::from_str::<Value>(data) {
+                    if json["message_type"] == "chat_created" {
+                        return json["chat_id"].as_str().map(|s| s.to_string());
+                    }
+                }
+                None
+            })
+            .unwrap_or_else(|| panic!("Did not find chat_created event for chat {}", i));
+        chat_ids.push(sea_orm::prelude::Uuid::parse_str(&chat_id).unwrap());
+    }
+    // Verify
+    let remaining_chats = chats::Entity::find().all(&app_state.db).await.unwrap();
+    assert_eq!(remaining_chats.len(), 2);
+
+    // Archive chat 0 (to be deleted)
+    let chat1_model = chats::ActiveModel {
+        id: ActiveValue::Unchanged(chat_ids[0]),
+        archived_at: ActiveValue::Set(Some((Utc::now() - Duration::days(10)).into())),
+        ..Default::default()
+    };
+    chat1_model.update(&app_state.db).await.unwrap();
+
+    // Archive chat 1 (to be kept)
+    let chat2_model = chats::ActiveModel {
+        id: ActiveValue::Unchanged(chat_ids[1]),
+        archived_at: ActiveValue::Set(Some(Utc::now().into())),
+        ..Default::default()
+    };
+    chat2_model.update(&app_state.db).await.unwrap();
+
+    // Run cleanup
+    cleanup_archived_chats(&app_state.db, 7).await.unwrap();
+
+    // Verify
+    let remaining_chats = chats::Entity::find().all(&app_state.db).await.unwrap();
+    assert_eq!(remaining_chats.len(), 1);
+    assert_eq!(remaining_chats[0].id, chat_ids[1]);
+}

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -28,6 +28,7 @@ struct Event {
     retry: Option<u32>,
 }
 
+mod actors;
 mod db;
 mod migrations;
 
@@ -80,6 +81,9 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
     .unwrap();
     file_storage_providers.insert("local_minio".to_owned(), provider);
 
+    let actor_manager =
+        erato::actors::manager::ActorManager::new(db.clone(), app_config.clone()).await;
+
     AppState {
         db: db.clone(),
         genai_client: AppState::build_genai_client(app_config.chat_provider.clone()).unwrap(),
@@ -88,6 +92,7 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
         file_storage_providers,
         mcp_servers: Arc::new(Default::default()),
         config: app_config,
+        actor_manager,
     }
 }
 // This is the main entry point for integration tests


### PR DESCRIPTION
In order to help with GDPR (and general) compliance.

Adds a general background worker system based on the `ractor` crate, and a specific background worker job that deletes old archived chats.

The cleanup worker needs to be enabled manually, and can be configured the following way in the `erato.toml`:
```toml
cleanup_enabled = true
# Optionally adjust max age in days. Defaults to 30
# cleanup_archived_max_age_days = 30
```