### PR TITLE
Standardize frontend config

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3141,6 +3141,7 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -35,7 +35,7 @@ dotenv-flow = "0.16.2"
 config = "0.15.6"
 http-body-util = "0.1.2"
 lol_html = "2.2.0"
-ordered-multimap = "0.7.3"
+ordered-multimap = { version = "0.7.3" , features = ["serde"]}
 futures = "0.3"
 tokio-stream = "0.1.17"
 genai = { version = "0.1.24-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "e92ed0b5053bdb8411ac83fd8d9ca499832d6a24" }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -136,7 +136,7 @@ impl AppConfig {
             config
                 .frontend
                 .additional_environment
-                .extend(additional_frontend_env.into_iter());
+                .extend(additional_frontend_env);
         }
         config.additional_frontend_environment = None;
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -36,11 +36,16 @@ pub struct AppConfig {
     // If present, will enable Sentry for error reporting.
     pub sentry_dsn: Option<String>,
 
-    // Additional values to inject into the frontend environment as global variables.
+    // **Deprecated**: Please use `frontend.additional_environment` instead.
+    //
     // This is a dictionary where each value can be a string or a map (string key, string value).
     // These will be available on the frontend via the frontend_environment mechanism, and added to the `windows` object.
     #[serde(default)]
-    pub additional_frontend_environment: HashMap<String, serde_json::Value>,
+    #[deprecated(note = "Please use `frontend.additional_environment` instead.")]
+    pub additional_frontend_environment: Option<HashMap<String, serde_json::Value>>,
+
+    #[serde(default)]
+    pub frontend: FrontendConfig,
 
     // If true, enables the cleanup worker that periodically deletes old data.
     // Defaults to `false`.
@@ -117,7 +122,25 @@ impl AppConfig {
     pub fn new_for_app(config_file_paths: Option<Vec<String>>) -> Result<Self, ConfigError> {
         let schema = Self::config_schema(config_file_paths, true)?;
         // You can deserialize (and thus freeze) the entire configuration as
-        schema.try_deserialize()
+        let mut config: Self = schema.try_deserialize()?;
+        config = config.migrate();
+        Ok(config)
+    }
+
+    #[allow(deprecated)]
+    pub fn migrate(self) -> Self {
+        let mut config = self;
+
+        if let Some(additional_frontend_env) = config.additional_frontend_environment.clone() {
+            tracing::warn!("Config key `additional_frontend_environment` is deprecated. Please use `frontend.additional_environment` instead.");
+            config
+                .frontend
+                .additional_environment
+                .extend(additional_frontend_env.into_iter());
+        }
+        config.additional_frontend_environment = None;
+
+        config
     }
 
     /// Returns the maximum configured file upload size in bytes, if any.
@@ -127,6 +150,10 @@ impl AppConfig {
             .filter_map(|p| p.max_upload_size_kb)
             .max()
             .map(|kb| kb * 1024)
+    }
+
+    pub fn additional_frontend_environment(&self) -> HashMap<String, serde_json::Value> {
+        self.frontend.additional_environment.clone()
     }
 }
 
@@ -292,4 +319,13 @@ pub struct McpServerConfig {
     pub url: String,
     // For `transport_type = "sse"`, these static headers will be sent with every request.
     pub http_headers: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Default)]
+pub struct FrontendConfig {
+    // Additional values to inject into the frontend environment as global variables.
+    // This is a dictionary where each value can be a string or a map (string key, string value).
+    // These will be available on the frontend via the frontend_environment mechanism, and added to the `windows` object.
+    #[serde(default)]
+    pub additional_environment: HashMap<String, serde_json::Value>,
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -140,6 +140,15 @@ impl AppConfig {
         }
         config.additional_frontend_environment = None;
 
+        if let Some(serde_json::Value::String(theme_name)) = config
+            .frontend
+            .additional_environment
+            .get("THEME_CUSTOMER_NAME")
+        {
+            tracing::warn!("The `additional_environment` key `THEME_CUSTOMER_NAME` is deprecated for setting the theme. Please use `frontend.theme` instead.");
+            config.frontend.theme = Some(theme_name.to_string());
+        }
+
         config
     }
 
@@ -323,6 +332,10 @@ pub struct McpServerConfig {
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Default)]
 pub struct FrontendConfig {
+    // The name of a theme to use for the frontend.
+    // Themes can be placed in `frontend/public/custom-theme/<THEME_NAME>` directories.
+    pub theme: Option<String>,
+
     // Additional values to inject into the frontend environment as global variables.
     // This is a dictionary where each value can be a string or a map (string key, string value).
     // These will be available on the frontend via the frontend_environment mechanism, and added to the `windows` object.

--- a/backend/src/frontend_environment.rs
+++ b/backend/src/frontend_environment.rs
@@ -11,7 +11,10 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+// The following keys are aligned with the `env.ts` of the frontend.
+// If you change the keys, you must also update them in the frontend.
 const FRONTEND_ENV_KEY_API_ROOT_URL: &str = "API_ROOT_URL";
+const FRONTEND_ENV_KEY_THEME_CUSTOMER_NAME: &str = "THEME_CUSTOMER_NAME";
 
 #[derive(Debug, Clone, Default)]
 /// Map of values that will be provided as environment-variable-like global variables to the frontend.
@@ -32,6 +35,12 @@ pub fn build_frontend_environment(config: &AppConfig) -> FrontedEnvironment {
         FRONTEND_ENV_KEY_API_ROOT_URL.to_string(),
         Value::String(api_root_url.clone()),
     );
+    if let Some(theme) = &config.frontend.theme {
+        env.additional_environment.insert(
+            FRONTEND_ENV_KEY_THEME_CUSTOMER_NAME.to_string(),
+            Value::String(theme.clone()),
+        );
+    }
 
     // Inject pairs from frontend.additional_environment
     for (key, value) in &config.additional_frontend_environment() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,12 +3,11 @@ use axum::handler::HandlerWithoutStateExt;
 use axum::http::Request;
 use axum::{Extension, Router};
 use eyre::Report;
-use serde_json::{json, Value};
 use utoipa_scalar::{Scalar, Servable as ScalarServable};
 
 use erato::config::AppConfig;
 use erato::frontend_environment::{
-    serve_files_with_script, FrontedEnvironment, FrontendBundlePath,
+    build_frontend_environment, serve_files_with_script, FrontendBundlePath,
 };
 use erato::models;
 use erato::state::AppState;
@@ -75,26 +74,6 @@ async fn main() -> Result<(), Report> {
     axum::serve(listener, app.into_make_service()).await?;
 
     Ok(())
-}
-
-pub fn build_frontend_environment(config: &AppConfig) -> FrontedEnvironment {
-    let mut env = FrontedEnvironment::default();
-
-    let api_root_url = "/api/".to_string();
-
-    env.0.insert(
-        "API_ROOT_URL".to_owned(),
-        Value::String(api_root_url.clone()),
-    );
-    env.0
-        .insert("SOME_OBJECT".to_owned(), json!({ "foo": "bar" }));
-
-    // Inject additional_frontend_environment
-    for (key, value) in &config.additional_frontend_environment {
-        env.0.insert(key.clone(), value.clone());
-    }
-
-    env
 }
 
 #[allow(unused_mut)]

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -4,3 +4,10 @@ pub mod genai;
 // pub mod mcp_servers;
 pub mod mcp_manager;
 pub mod mcp_servers_sse;
+
+#[cfg(feature = "sentry")]
+pub mod sentry;
+#[cfg(not(feature = "sentry"))]
+pub mod sentry_stub;
+#[cfg(not(feature = "sentry"))]
+pub use sentry_stub as sentry;

--- a/backend/src/services/sentry.rs
+++ b/backend/src/services/sentry.rs
@@ -1,0 +1,61 @@
+use crate::state::AppState;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::Router;
+use eyre::Report;
+use sentry::{event_from_error, Hub};
+use std::error::Error;
+
+pub fn setup_sentry(
+    sentry_dsn: Option<&String>,
+    environment: String,
+    _sentry_guard: &mut Option<sentry::ClientInitGuard>,
+) {
+    if let Some(sentry_dsn) = sentry_dsn {
+        *_sentry_guard = Some(sentry::init((
+            sentry_dsn.as_str(),
+            sentry::ClientOptions {
+                release: sentry::release_name!(),
+                debug: std::env::var("SENTRY_DEBUG").is_ok(),
+                environment: Some(environment.into()),
+                ..Default::default()
+            },
+        )));
+    } else {
+        println!("No SENTRY_DSN specified. Observability via Sentry is disabled");
+    }
+}
+
+pub fn extend_with_sentry_layers(mut router: Router<AppState>) -> Router<AppState> {
+    router = router.layer(sentry_tower::NewSentryLayer::<Request<Body>>::new_from_top());
+    router = router.layer(sentry_tower::SentryHttpLayer::new().enable_transaction());
+    router
+}
+
+pub fn capture_report(report: &Report) {
+    Hub::with_active(|hub| {
+        let err: &dyn Error = report.as_ref();
+        let event = event_from_error(err);
+        // if let Some(exc) = event.exception.iter_mut().last() {
+        //     let backtrace = err.backtrace();
+        //     exc.stacktrace = sentry_backtrace::parse_stacktrace(&format!("{backtrace:#}"));
+        // }
+
+        hub.capture_event(event);
+    });
+}
+
+pub fn log_internal_server_error(report: Report) -> StatusCode {
+    tracing::error!("{}", report.to_string());
+    Hub::with_active(|hub| {
+        let err: &dyn Error = report.as_ref();
+        let event = event_from_error(err);
+        // if let Some(exc) = event.exception.iter_mut().last() {
+        //     let backtrace = err.backtrace();
+        //     exc.stacktrace = sentry_backtrace::parse_stacktrace(&format!("{backtrace:#}"));
+        // }
+
+        hub.capture_event(event);
+    });
+    StatusCode::INTERNAL_SERVER_ERROR
+}

--- a/backend/src/services/sentry_stub.rs
+++ b/backend/src/services/sentry_stub.rs
@@ -1,0 +1,25 @@
+use crate::state::AppState;
+use axum::http::StatusCode;
+use axum::Router;
+use eyre::Report;
+
+pub fn setup_sentry(
+    _sentry_dsn: Option<&String>,
+    _environment: String,
+    _sentry_guard: &mut Option<()>,
+) {
+}
+
+#[allow(unused_mut)]
+pub fn extend_with_sentry_layers(mut router: Router<AppState>) -> Router<AppState> {
+    router
+}
+
+pub fn log_internal_server_error(err: Report) -> StatusCode {
+    tracing::error!("{}", err.to_string());
+    StatusCode::INTERNAL_SERVER_ERROR
+}
+
+pub fn capture_report(err: &Report) {
+    tracing::error!("{}", err.to_string());
+}


### PR DESCRIPTION
Previously, the config key `additional_frontend_environment` and the key for that `THEME_CUSTOMER_NAME` were used to control the usage of themes.

To give frontend config in general more room to grow, and also to support theming better as first class feature, I moved them into seperate config keys.

- `additional_frontend_environment` -> `frontend.additional_environment` (still allows for injecting frontend envvars for easy forked frontend usage)
- `frontend.theme` now sets the theme usage, which was previously achieved by providing the `THEME_CUSTOMER_NAME` frontend environment variable
- Both old usages are still supported, and automatically converted internally to the new way together with a deprecation warning

## Example old `erato.toml`
```toml
[additional_frontend_environment]
THEME_CUSTOMER_NAME = "foobar"
MY_OBJECT = { foo = "bar", baz = "qux" }
```

## Example new `erato.toml`
```toml
[frontend]
theme = "foobar"

[frontend.additional_environment]
MY_OBJECT = { foo = "bar", baz = "qux" }
```

----

Seperately to the frontend config changes, I also refactored the way the `sentry` usage is done, so that there is only a central `cfg` feature toggle that switches between actual a module that provides actual sentry functionality and a stub sentry module that provides the same interface.