### PR TITLE
chore: Update genai to 0.4.0-alpha.3

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1823,8 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.4.0-WIP"
-source = "git+https://github.com/EratoLab/rust-genai.git?rev=38dd115943a9184ee16fad40fe9c96bedea04d37#38dd115943a9184ee16fad40fe9c96bedea04d37"
+version = "0.4.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e31f664bff41c387ba4636e281d07b22ebc847046e79f6eda3ec0cecc1eec17"
 dependencies = [
  "bytes",
  "derive_more 2.0.1",
@@ -2637,7 +2638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6360,7 +6361,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,7 +38,7 @@ lol_html = "2.2.0"
 ordered-multimap = { version = "0.7.3" , features = ["serde"]}
 futures = "0.3"
 tokio-stream = "0.1.17"
-genai = { version = "0.4.0-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "38dd115943a9184ee16fad40fe9c96bedea04d37" }
+genai = "0.4.0-alpha.3"
 reqwest = { version = "0.12.12", features = ["multipart"] }
 opendal = { version = "0.52.0", features = ["services-s3", "services-azblob"] }
 

--- a/backend/src/services/mcp_manager.rs
+++ b/backend/src/services/mcp_manager.rs
@@ -418,6 +418,7 @@ pub fn convert_mcp_tools_to_genai_tools(managed_mcp_tools: Vec<ManagedTool>) -> 
                 name: tool.name,
                 description: tool.description.clone(),
                 schema: Some(schema),
+                config: None,
             }
         })
         .collect()


### PR DESCRIPTION
Update genai dependency from forked version to official 0.4.0-alpha.3 release