### PR TITLE
Fix reasoning models not working due to max_completion_tokens

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1823,9 +1823,8 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.4.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31f664bff41c387ba4636e281d07b22ebc847046e79f6eda3ec0cecc1eec17"
+version = "0.4.0-alpha.4-WIP"
+source = "git+https://github.com/EratoLab/rust-genai.git?rev=42ef411b480dc4e798c004912c833cbed6bfe3ad#42ef411b480dc4e798c004912c833cbed6bfe3ad"
 dependencies = [
  "bytes",
  "derive_more 2.0.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,7 +38,7 @@ lol_html = "2.2.0"
 ordered-multimap = { version = "0.7.3" , features = ["serde"]}
 futures = "0.3"
 tokio-stream = "0.1.17"
-genai = "0.4.0-alpha.3"
+genai = { version = "0.4.0-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "42ef411b480dc4e798c004912c833cbed6bfe3ad" }
 reqwest = { version = "0.12.12", features = ["multipart"] }
 opendal = { version = "0.52.0", features = ["services-s3", "services-azblob"] }
 


### PR DESCRIPTION
Update to our fork with a quickfix for usage with reasoning models, based on a basic prefix-based matching of o-series OpenAI models.

This only adds very rudimentary support regarding reasoning models (summary generation stays intact). We are not yet capturing reasoning tokens to display them as intermediary content in the chat. That will follow in a later PR.

See https://github.com/jeremychone/rust-genai/issues/73 for more long-term solution to this issue