### PR TITLE
Add support for specifying a system_prompt via Langfuse

### DIFF
--- a/backend/src/server/api/v1beta/message_streaming.rs
+++ b/backend/src/server/api/v1beta/message_streaming.rs
@@ -573,10 +573,13 @@ async fn prepare_chat_request(
     previous_message_id: &Uuid,
     new_input_files: Vec<FileContentsForGeneration>,
 ) -> Result<(ChatRequest, ChatOptions, GenerationInputMessages), Report> {
-    // TODO: Initial system message?
+    // Resolve system prompt dynamically based on chat provider configuration
+    let chat_provider_config = app_state.chat_provider_for_chatcompletion(None)?;
+    let system_prompt = app_state.get_system_prompt(&chat_provider_config).await?;
+
     let generation_input_messages = get_generation_input_messages_by_previous_message_id(
         &app_state.db,
-        app_state.system_prompt.clone(),
+        system_prompt,
         previous_message_id,
         Some(10),
         new_input_files,

--- a/backend/src/server/api/v1beta/token_usage.rs
+++ b/backend/src/server/api/v1beta/token_usage.rs
@@ -220,9 +220,13 @@ async fn prepare_input_messages(
     previous_message_id: &Uuid,
     files_for_generation: Vec<FileContentsForGeneration>,
 ) -> Result<GenerationInputMessages, Report> {
+    // Resolve system prompt dynamically based on chat provider configuration
+    let chat_provider_config = app_state.chat_provider_for_chatcompletion(None)?;
+    let system_prompt = app_state.get_system_prompt(&chat_provider_config).await?;
+
     crate::models::message::get_generation_input_messages_by_previous_message_id(
         &app_state.db,
-        app_state.system_prompt.clone(),
+        system_prompt,
         previous_message_id,
         Some(10),
         files_for_generation,

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -99,7 +99,6 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
         db: db.clone(),
         genai_client: AppState::build_genai_client(app_config.chat_provider.clone()).unwrap(),
         default_file_storage_provider: None,
-        system_prompt: None,
         file_storage_providers,
         mcp_servers: Arc::new(Default::default()),
         config: app_config,

--- a/site/content/docs/_meta.js
+++ b/site/content/docs/_meta.js
@@ -3,4 +3,5 @@ export default {
   deployment: "",
   configuration: "",
   features: "",
+  integrations: "",
 };

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -81,3 +81,141 @@ This will be inejcted into the frontend as:
 ```js
 window.FOO = "bar";
 ```
+
+### `chat_provider`
+
+Configuration for the chat provider (LLM) that Erato will use for generating responses.
+
+#### `chat_provider.provider_kind`
+
+The type of chat provider to use.
+
+**Type:** `string`
+
+**Supported values:** `"openai"`, `"azure_openai"`
+
+**Example:** `"openai"`
+
+#### `chat_provider.model_name`
+
+The name of the model to use with the chat provider.
+
+**Type:** `string`
+
+**Example:** `"gpt-4o"`
+
+#### `chat_provider.base_url`
+
+The base URL for the chat provider API. If not provided, will use the default for the provider.
+
+**Type:** `string | None`
+
+**Example:** `"https://api.openai.com/v1/"`, `"http://localhost:11434/v1/"`
+
+#### `chat_provider.api_key`
+
+The API key for the chat provider.
+
+**Type:** `string | None`
+
+**Example:** `"sk-..."`
+
+#### `chat_provider.system_prompt`
+
+A static system prompt to use with the chat provider. This sets the behavior and personality of the AI assistant.
+
+**Type:** `string | None`
+
+**Note:** This option is mutually exclusive with `system_prompt_langfuse`.
+
+**Example:**
+
+```toml
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4"
+system_prompt = "You are a helpful assistant that provides concise and accurate answers."
+```
+
+#### `chat_provider.system_prompt_langfuse`
+
+Configuration for using a system prompt from [Langfuse](./integrations/langfuse) prompt management instead of a static prompt.
+
+**Type:** `object | None`
+
+**Note:** This option is mutually exclusive with `system_prompt`. Requires the [Langfuse integration](./integrations/langfuse) to be enabled.
+
+**Properties:**
+
+- `prompt_name` (string): The name of the prompt in [Langfuse](./integrations/langfuse) to use
+
+**Example:**
+
+```toml
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4"
+system_prompt_langfuse = { prompt_name = "assistant-prompt-v1" }
+
+[integrations.langfuse]
+enabled = true
+base_url = "https://cloud.langfuse.com"
+public_key = "pk-lf-..."
+secret_key = "sk-lf-..."
+```
+
+### `integrations`
+
+Configuration for external service integrations.
+
+#### `integrations.langfuse`
+
+Configuration for the [Langfuse](./integrations/langfuse) observability and prompt management integration.
+
+##### `integrations.langfuse.enabled`
+
+Whether the [Langfuse](./integrations/langfuse) integration is enabled.
+
+**Default value:** `false`
+
+**Type:** `boolean`
+
+##### `integrations.langfuse.base_url`
+
+The base URL for your [Langfuse](./integrations/langfuse) instance. Use `https://cloud.langfuse.com` for Langfuse Cloud or your self-hosted URL.
+
+**Required when enabled:** Yes
+
+**Type:** `string`
+
+**Example:** `"https://cloud.langfuse.com"` or `"https://langfuse.yourcompany.com"`
+
+##### `integrations.langfuse.public_key`
+
+Your [Langfuse](./integrations/langfuse) project's public key. You can find this in your Langfuse project settings.
+
+**Required when enabled:** Yes
+
+**Type:** `string`
+
+**Example:** `"pk-lf-1234567890abcdef"`
+
+##### `integrations.langfuse.secret_key`
+
+Your [Langfuse](./integrations/langfuse) project's secret key. You can find this in your Langfuse project settings.
+
+**Required when enabled:** Yes
+
+**Type:** `string`
+
+**Example:** `"sk-lf-abcdef1234567890"`
+
+##### `integrations.langfuse.tracing_enabled`
+
+Whether to enable detailed tracing of LLM interactions. When enabled, all chat completions will be logged to [Langfuse](./integrations/langfuse).
+
+**Default value:** `false`
+
+**Type:** `boolean`
+
+See the [Langfuse Integration](./integrations/langfuse) documentation for detailed usage instructions and feature descriptions.

--- a/site/content/docs/integrations/_meta.js
+++ b/site/content/docs/integrations/_meta.js
@@ -1,0 +1,4 @@
+export default {
+  sentry: "",
+  langfuse: "",
+};

--- a/site/content/docs/integrations/langfuse.mdx
+++ b/site/content/docs/integrations/langfuse.mdx
@@ -1,0 +1,134 @@
+# Langfuse
+
+Erato provides support for [Langfuse](https://langfuse.com/) observability and prompt management.
+
+## Features
+
+### Observability and Tracing
+
+Langfuse integration provides comprehensive observability for your LLM interactions:
+
+- **Trace Capture**: Automatically captures all chat completions as traces in Langfuse
+- **Generation Logging**: Records detailed generation information including:
+  - Input messages and context
+  - Model responses and tool usage
+  - Token usage statistics
+  - Generation timing and performance metrics
+- **Error Tracking**: Captures and reports errors during LLM interactions
+- **Session Tracking**: Groups related conversations for better analysis
+
+### Prompt Management
+
+Erato supports Langfuse's prompt management feature, allowing you to:
+
+- **Dynamic System Prompts**: Configure chat providers to use prompts stored in Langfuse instead of static configuration
+- **Version Control**: Leverage Langfuse's prompt versioning for better prompt iteration
+- **Centralized Management**: Manage all your system prompts from the Langfuse dashboard
+- **Multiple Prompt Formats**: Support for both text and chat-format prompts
+
+## Configuration
+
+### Basic Setup
+
+To enable the Langfuse integration, configure the following in your `erato.toml`:
+
+```toml filename="erato.toml"
+[integrations.langfuse]
+enabled = true
+base_url = "https://cloud.langfuse.com"  # or your self-hosted instance
+public_key = "pk-lf-..."
+secret_key = "sk-lf-..."
+tracing_enabled = true  # optional, defaults to false
+```
+
+### Configuration Options
+
+For detailed configuration options and examples, see the [Configuration Reference](../configuration#integrationslangfuse) documentation.
+
+### System Prompt Management
+
+To use Langfuse for system prompt management, configure your chat provider with `system_prompt_langfuse` instead of `system_prompt`:
+
+```toml filename="erato.toml"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4"
+# Use Langfuse prompt management instead of static prompt
+system_prompt_langfuse = { prompt_name = "assistant-prompt-v1" }
+
+[integrations.langfuse]
+enabled = true
+base_url = "https://cloud.langfuse.com"
+public_key = "pk-lf-..."
+secret_key = "sk-lf-..."
+```
+
+For detailed information about the `system_prompt_langfuse` configuration option, see the [Chat Provider Configuration](../configuration#chat_providersystem_prompt_langfuse) documentation.
+
+## Prompt Format Support
+
+Erato supports two types of prompts from Langfuse:
+
+### Text Prompts
+
+Simple text prompts where the entire content is used as the system message:
+
+```json
+{
+  "type": "text",
+  "prompt": "You are a helpful assistant..."
+}
+```
+
+### Chat Prompts
+
+Chat-format prompts with multiple messages. Erato will extract the system message:
+
+```json
+{
+  "type": "chat",
+  "prompt": [
+    {
+      "role": "system",
+      "content": "You are a helpful assistant..."
+    }
+  ]
+}
+```
+
+## Getting Started
+
+1. **Create a Langfuse Account**: Sign up at [langfuse.com](https://langfuse.com/) or set up a self-hosted instance
+2. **Create a Project**: Create a new project in your Langfuse dashboard
+3. **Get API Keys**: Copy your project's public and secret keys from the project settings
+4. **Configure Erato**: Add the Langfuse configuration to your `erato.toml`
+5. **Enable Tracing** (optional): Set `tracing_enabled = true` to start logging LLM interactions
+6. **Set Up Prompt Management** (optional): Create prompts in Langfuse and reference them in your chat provider configuration
+
+## Security Considerations
+
+- Store your Langfuse secret key securely (e.g., in environment variables or a separate `*.auto.erato.toml` file)
+- Use appropriate access controls in your Langfuse project settings
+- Consider network security when connecting to self-hosted Langfuse instances
+
+## Troubleshooting
+
+### Common Issues
+
+**"Langfuse integration is enabled but public_key is not set"**
+
+- Ensure both `public_key` and `secret_key` are configured when `enabled = true`
+
+**"Failed to retrieve prompt from Langfuse"**
+
+- Verify the prompt name exists in your Langfuse project
+- Check that your API keys have the necessary permissions
+- Ensure network connectivity to your Langfuse instance
+
+**"Cannot specify both system_prompt and system_prompt_langfuse"**
+
+- Remove either `system_prompt` or `system_prompt_langfuse` from your chat provider configuration
+
+**"Chat provider uses Langfuse system prompts but Langfuse integration is not enabled"**
+
+- Set `integrations.langfuse.enabled = true` when using `system_prompt_langfuse`


### PR DESCRIPTION
- Added `chat_provider.system_prompt_langfuse` configuration option to configure langfuse as a source for a system prompt
- Extended docs with reference for the `integrations.langfuse` section, and the new `chat_provider.system_prompt_langfuse`
- Extended docs with a page for general information about the Langfuse integration