### PR TITLE
Add user_id + session_id metadata to Langfuse traces

### DIFF
--- a/backend/src/server/api/v1beta/message_streaming.rs
+++ b/backend/src/server/api/v1beta/message_streaming.rs
@@ -613,6 +613,8 @@ async fn stream_generate_chat_completion<
     chat_request: ChatRequest,
     chat_options: ChatOptions,
     assistant_message_id: Uuid,
+    user_id: String,
+    chat_id: Uuid,
 ) -> Result<Vec<ContentPart>, ()> {
     // Initialize Langfuse tracing if enabled
     let langfuse_enabled = app_state.config.integrations.langfuse.enabled
@@ -839,8 +841,8 @@ async fn stream_generate_chat_completion<
                                 create_trace_request_from_chat(
                                     langfuse_trace_id.clone().unwrap(),
                                     &current_turn_chat_request,
-                                    None, // user_id - could be extracted from MeProfile if needed
-                                    None, // session_id - could be derived from chat_id if needed
+                                    Some(user_id.clone()),
+                                    Some(chat_id.to_string()),
                                 )
                             } else {
                                 // For subsequent turns, we don't need to create a new trace
@@ -1307,6 +1309,8 @@ pub async fn message_submit_sse(
             chat_request,
             chat_options,
             initial_assistant_message.id, // Pass assistant_message_id
+            me_user.0.id.clone(),         // Pass user_id
+            chat.id,                      // Pass chat_id
         )
         .await?;
 
@@ -1488,6 +1492,8 @@ pub async fn regenerate_message_sse(
             chat_request,
             chat_options,
             initial_assistant_message.id, // Pass assistant_message_id
+            me_user.0.id.clone(),         // Pass user_id
+            chat.id,                      // Pass chat_id
         )
         .await?;
 
@@ -1701,6 +1707,8 @@ pub async fn edit_message_sse(
             chat_request,
             chat_options,
             initial_assistant_message.id, // Pass assistant_message_id
+            me_user.0.id.clone(),         // Pass user_id
+            chat.id,                      // Pass chat_id
         )
         .await?;
 

--- a/site/content/docs/integrations/langfuse.mdx
+++ b/site/content/docs/integrations/langfuse.mdx
@@ -16,6 +16,8 @@ Langfuse integration provides comprehensive observability for your LLM interacti
   - Generation timing and performance metrics
 - **Error Tracking**: Captures and reports errors during LLM interactions
 - **Session Tracking**: Groups related conversations for better analysis
+- **User Context**: Associates traces with user IDs for user-specific analytics
+- **Chat Context**: Links traces to specific chat sessions using chat IDs as session identifiers
 
 ### Prompt Management
 


### PR DESCRIPTION
- Add `user_id` based on user_id as metadata to Langfuse traces
- Add `session_id` based on chat ID as metadata to Langfuse traces