### PR TITLE
Allow chart to provide erato.toml via plaintext + .auto.erato.toml

### DIFF
--- a/infrastructure/charts/erato/templates/backend-configmaps.yaml
+++ b/infrastructure/charts/erato/templates/backend-configmaps.yaml
@@ -1,0 +1,30 @@
+{{/*
+ConfigMaps for inline config content
+*/}}
+{{- if .Values.backend.configFile.inlineContent }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-erato-inline-config
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: erato-app
+data:
+  erato.toml: |
+    {{- .Values.backend.configFile.inlineContent | nindent 4 }}
+---
+{{- end }}
+
+{{- range $index, $configFile := .Values.backend.extraConfigFiles }}
+{{- if $configFile.inlineContent }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-extra-config-{{ $configFile.name }}-inline
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: erato-app
+data:
+  {{ $configFile.name | default (printf "config-%d" $index) }}.toml: |
+    {{- $configFile.inlineContent | nindent 4 }}
+---
+{{- end }}
+{{- end }}

--- a/infrastructure/charts/erato/templates/backend-deployment.yaml
+++ b/infrastructure/charts/erato/templates/backend-deployment.yaml
@@ -80,27 +80,31 @@ spec:
                 name: {{ .Values.backend.extraEnvVarsSecret }}
             {{- end }}
           {{- end }}
-          {{- if or (and .Values.backend.configFile.secretName .Values.backend.configFile.secretKey) .Values.backend.extraVolumeMounts }}
+          {{- if or (include "erato.hasMainConfigFile" .) (include "erato.hasExtraConfigFiles" .) .Values.backend.extraVolumeMounts }}
           volumeMounts:
-            {{- if and .Values.backend.configFile.secretName .Values.backend.configFile.secretKey }}
+            {{- if include "erato.hasMainConfigFile" . }}
             - name: erato-config
               mountPath: /app/erato.toml
               subPath: erato.toml
+              readOnly: true
+            {{- end }}
+            {{- range $index, $configFile := .Values.backend.extraConfigFiles }}
+            - name: extra-config-{{ $configFile.name }}
+              mountPath: /app/{{ $configFile.name }}.auto.erato.toml
+              subPath: {{ $configFile.name }}.auto.erato.toml
               readOnly: true
             {{- end }}
             {{- if .Values.backend.extraVolumeMounts }}
             {{- toYaml .Values.backend.extraVolumeMounts | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or (and .Values.backend.configFile.secretName .Values.backend.configFile.secretKey) .Values.backend.extraVolumes }}
+      {{- if or (include "erato.hasMainConfigFile" .) (include "erato.hasExtraConfigFiles" .) .Values.backend.extraVolumes }}
       volumes:
-        {{- if and .Values.backend.configFile.secretName .Values.backend.configFile.secretKey }}
-        - name: erato-config
-          secret:
-            secretName: {{ .Values.backend.configFile.secretName }}
-            items:
-              - key: {{ .Values.backend.configFile.secretKey }}
-                path: erato.toml
+        {{- if include "erato.hasMainConfigFile" . }}
+        {{- include "erato.renderMainConfigVolume" . | nindent 8 }}
+        {{- end }}
+        {{- range $index, $configFile := .Values.backend.extraConfigFiles }}
+        {{- include "erato.renderExtraConfigVolume" (dict "configFile" $configFile "index" $index "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.backend.extraVolumes }}
         {{- toYaml .Values.backend.extraVolumes | nindent 8 }}

--- a/infrastructure/charts/erato/tests/backend-configmaps_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-configmaps_test.yaml
@@ -1,0 +1,100 @@
+suite: test backend configmaps
+templates:
+  - backend-configmaps.yaml
+tests:
+  - it: should not render configmaps by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render configmap for inline main config
+    set:
+      backend.configFile.inlineContent: "main"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-erato-inline-config
+
+  - it: should render configmaps for inline extra configs
+    set:
+      backend.extraConfigFiles:
+        - name: extra0
+          inlineContent: "extra0"
+        - name: extra1
+          inlineContent: "extra1"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extra-config-extra0-inline
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extra-config-extra1-inline
+        documentIndex: 1
+
+  - it: should render both main and extra configmaps
+    set:
+      backend.configFile.inlineContent: "main"
+      backend.extraConfigFiles:
+        - name: extra0
+          inlineContent: "extra0"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-erato-inline-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extra-config-extra0-inline
+        documentIndex: 1
+
+  - it: should not render configmaps for secret-based configs
+    set:
+      backend.configFile.secretName: "s"
+      backend.configFile.secretKey: "k"
+      backend.extraConfigFiles:
+        - name: extra0
+          secretName: "s"
+          secretKey: "k"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render configmaps for configmap-based configs
+    set:
+      backend.configFile.configMapName: "cm"
+      backend.configFile.configMapKey: "k"
+      backend.extraConfigFiles:
+        - name: extra0
+          configMapName: "cm"
+          configMapKey: "k"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render only inline configmaps when mixed
+    set:
+      backend.configFile.inlineContent: "main"
+      backend.extraConfigFiles:
+        - name: extra0
+          secretName: "s"
+          secretKey: "k"
+        - name: extra1
+          inlineContent: "extra1"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-erato-inline-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extra-config-extra1-inline
+        documentIndex: 1

--- a/infrastructure/charts/erato/tests/backend-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-deployment_test.yaml
@@ -265,3 +265,176 @@ tests:
           content:
             name: additional-volume
             mountPath: /tmp/additional
+
+  - it: should mount config file from configMap
+    set:
+      backend.configFile.configMapName: erato-config-cm
+      backend.configFile.configMapKey: erato.toml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: erato-config
+            mountPath: /app/erato.toml
+            subPath: erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: erato-config
+            configMap:
+              name: erato-config-cm
+              items:
+                - key: erato.toml
+                  path: erato.toml
+
+  - it: should mount config file from inline content
+    set:
+      backend.configFile.inlineContent: |
+        [database]
+        host = "localhost"
+        port = 5432
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: erato-config
+            mountPath: /app/erato.toml
+            subPath: erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: erato-config
+            configMap:
+              name: RELEASE-NAME-erato-inline-config
+              items:
+                - key: erato.toml
+                  path: erato.toml
+
+  - it: should mount extra config files from secrets
+    set:
+      backend.extraConfigFiles:
+        - name: mcp-config
+          secretName: mcp-secret
+          secretKey: mcp.toml
+        - name: additional-config
+          secretName: additional-secret
+          secretKey: additional.toml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-mcp-config
+            mountPath: /app/mcp-config.auto.erato.toml
+            subPath: mcp-config.auto.erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-additional-config
+            mountPath: /app/additional-config.auto.erato.toml
+            subPath: additional-config.auto.erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config-mcp-config
+            secret:
+              secretName: mcp-secret
+              items:
+                - key: mcp.toml
+                  path: mcp-config.auto.erato.toml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config-additional-config
+            secret:
+              secretName: additional-secret
+              items:
+                - key: additional.toml
+                  path: additional-config.auto.erato.toml
+
+  - it: should mount extra config files from configMaps
+    set:
+      backend.extraConfigFiles:
+        - name: mcp-config
+          configMapName: mcp-config-cm
+          configMapKey: mcp.toml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-mcp-config
+            mountPath: /app/mcp-config.auto.erato.toml
+            subPath: mcp-config.auto.erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config-mcp-config
+            configMap:
+              name: mcp-config-cm
+              items:
+                - key: mcp.toml
+                  path: mcp-config.auto.erato.toml
+
+  - it: should mount extra config files from inline content
+    set:
+      backend.extraConfigFiles:
+        - name: mcp-config
+          inlineContent: |
+            [mcp_servers.example]
+            command = "example-server"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-mcp-config
+            mountPath: /app/mcp-config.auto.erato.toml
+            subPath: mcp-config.auto.erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config-mcp-config
+            configMap:
+              name: RELEASE-NAME-extra-config-mcp-config-inline
+              items:
+                - key: mcp-config.toml
+                  path: mcp-config.auto.erato.toml
+
+  - it: should handle mixed config file sources
+    set:
+      backend.configFile.inlineContent: |
+        [database]
+        host = "localhost"
+      backend.extraConfigFiles:
+        - name: mcp-config
+          secretName: mcp-secret
+          secretKey: mcp.toml
+        - name: additional-config
+          configMapName: additional-cm
+          configMapKey: additional.toml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: erato-config
+            mountPath: /app/erato.toml
+            subPath: erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-mcp-config
+            mountPath: /app/mcp-config.auto.erato.toml
+            subPath: mcp-config.auto.erato.toml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config-additional-config
+            mountPath: /app/additional-config.auto.erato.toml
+            subPath: additional-config.auto.erato.toml
+            readOnly: true

--- a/infrastructure/charts/erato/values.yaml
+++ b/infrastructure/charts/erato/values.yaml
@@ -62,12 +62,33 @@ backend:
   extraEnvVarsSecret: ""
   extraVolumes: []
   extraVolumeMounts: []
-  # Optional configuration for mounting erato.toml from a secret
+  # Optional configuration for mounting erato.toml from a secret, configMap, or inline content
   configFile:
     # Name of the secret containing the erato.toml file
     secretName: ""
     # Key in the secret that contains the erato.toml content
     secretKey: ""
+    # Name of the configMap containing the erato.toml file (alternative to secretName/secretKey)
+    configMapName: ""
+    # Key in the configMap that contains the erato.toml content
+    configMapKey: ""
+    # Inline content for erato.toml (alternative to secret/configMap)
+    inlineContent: ""
+  # Optional list of additional config files to mount (e.g., *.auto.erato.toml files)
+  # Each item can use secret, configMap, or inline content just like configFile above
+  extraConfigFiles: []
+  # Example:
+  # extraConfigFiles:
+  #   - name: mcp-servers
+  #     secretName: mcp-config-secret
+  #     secretKey: mcp-servers.toml
+  #   - name: additional-config
+  #     configMapName: additional-config-cm
+  #     configMapKey: additional.toml
+  #   - name: inline-config
+  #     inlineContent: |
+  #       [mcp_servers.example]
+  #       ...
   resources:
     requests:
       cpu: 100m

--- a/infrastructure/k3d/erato-local/.helmignore
+++ b/infrastructure/k3d/erato-local/.helmignore
@@ -6,8 +6,8 @@
 tests/
 unittest.yaml
 
-# Configuration files that shouldn't be in the package
-config/
+# Configuration files shouldn't be in the .helmignore, otherwise `.Files.Get` can't access them!
+# config/
 
 # Common VCS dirs
 .git/

--- a/infrastructure/k3d/erato-local/templates/erato-toml-secret.yaml
+++ b/infrastructure/k3d/erato-local/templates/erato-toml-secret.yaml
@@ -4,7 +4,8 @@ type: Opaque
 metadata:
   name: {{ .Release.Name }}-erato-toml-secret
 data:
-  erato.toml: {{ .Files.Get "config/erato.toml" | b64enc | quote }}
 {{- if .Values.erato.backend.configFile.useAlt }}
-  erato.alt.toml: {{ .Files.Get "config/erato.alt.toml" | b64enc | quote }}
+  erato.toml: {{ .Files.Get "config/erato.alt.toml" | b64enc | quote }}
+{{ else}}
+  erato.toml: {{ .Files.Get "config/erato.toml" | b64enc | quote }}
 {{- end }}

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -16,7 +16,14 @@ erato:
     configFile:
       secretName: erato-local-erato-toml-secret
       secretKey: erato.toml
+      # `useAlt` is not part of the `erato` chart
+      # If it is provided, `config/erato.alt.toml` will be used instead of `config/erato.toml`
       useAlt: false
+    extraConfigFiles:
+      - name: frontend-env
+        inlineContent: |
+          [frontend.additional_environment]
+          FOO_BAR = "true"
   
   oauth2Proxy:
     enabled: true

--- a/infrastructure/scripts/setup-dev.sh
+++ b/infrastructure/scripts/setup-dev.sh
@@ -158,7 +158,6 @@ if [ "$USE_ALT_ERATO_TOML" = true ]; then
     fi
 
     HELM_SET_ARGS="$HELM_SET_ARGS --set erato.backend.configFile.useAlt=true"
-    HELM_SET_ARGS="$HELM_SET_ARGS --set erato.backend.configFile.secretKey=erato.alt.toml"
 fi
 
 # Install nginx ingress controller


### PR DESCRIPTION
Related Linear issues:
- ERATO-40
- ERATO-41

Extends the Helm chart with more ways to provide `erato.toml` config + builtin way to provide `*.auto.erato.toml` config files.

# New features

- Adds ability to provide the `erato.toml` file via config instead of just via secret:
  - Via configMap: `backend.configFile.configMapName` + `backend.configFile.configMapKey`
  - Via inline string: `backend.configFile.inlineContent`
- Adds ability to provide additional config files, that will be mounted as `.auto.erato.toml` files
  - Via `backend.extraConfigFiles` array, with each item having the same structure as `backend.configFile`
  
# Other fixes / adjustments

- Simplified the `useAlt` flag for the `erato-local` chart
- Fixed the config files in `erato-local` not being loadable anymore after being put in the `.helmignore` (broken in https://github.com/EratoLab/erato/pull/245)