### PR TITLE
Validate helm test suite files JSON schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 frontend/src/lib/generated/**/* linguist-generated
+infrastructure/charts/erato/tests_schema/helm-testsuite.json linguist-generated
+infrastructure/k3d/erato-local/tests_schema/helm-testsuite.json linguist-generated

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -110,7 +110,12 @@ jobs:
 
       - name: "Install helm-unittest plugin"
         if: success() || failure()
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install --version 1.0.1 https://github.com/helm-unittest/helm-unittest
+
+      - name: "Validate Helm test schema for main chart"
+        working-directory: ./infrastructure/charts/erato
+        if: success() || failure()
+        run: pnpx ajv-cli@5.0.0 validate --strict=false -s ./tests_schema/helm-testsuite.json -d "./tests/*.yaml"
 
       - name: "Install dependencies for main chart"
         working-directory: ./infrastructure/charts/erato
@@ -126,6 +131,11 @@ jobs:
         working-directory: ./infrastructure/charts/erato
         if: success() || failure()
         run: helm unittest .
+
+      - name: "Validate Helm test schema for erato-local chart"
+        working-directory: ./infrastructure/k3d/erato-local
+        if: success() || failure()
+        run: pnpx ajv-cli@5.0.0 validate --strict=false -s ./tests_schema/helm-testsuite.json -d "./tests/*.yaml"
 
       - name: "Install dependencies for erato-local chart"
         working-directory: ./infrastructure/k3d/erato-local

--- a/infrastructure/charts/erato/.helmignore
+++ b/infrastructure/charts/erato/.helmignore
@@ -4,6 +4,7 @@
 
 # Test files
 tests/
+tests_schema/
 unittest.yaml
 
 # Common VCS dirs

--- a/infrastructure/charts/erato/justfile
+++ b/infrastructure/charts/erato/justfile
@@ -1,8 +1,12 @@
 default:
     just --list
 
+fetch_json_schema:
+    mkdir -p ./tests_schema
+    curl https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/tags/v1.0.1/schema/helm-testsuite.json --output ./tests_schema/helm-testsuite.json
+
 # Run all tests (unit tests + linting)
-test: unittest lint
+test: validate_schema unittest lint
 
 # Run helm unit tests
 unittest:
@@ -11,6 +15,9 @@ unittest:
 # Run helm lint checks
 lint:
     helm lint .
+
+validate_schema:
+    pnpx ajv-cli@5.0.0 validate --strict=false -s ./tests_schema/helm-testsuite.json -d "./tests/*.yaml"
 
 # Install/update chart dependencies
 deps:

--- a/infrastructure/charts/erato/tests/backend-configmaps_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-configmaps_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test backend configmaps
+minimumVersion: 1.0.1
 templates:
   - backend-configmaps.yaml
 tests:

--- a/infrastructure/charts/erato/tests/backend-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-deployment_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test backend deployment
+minimumVersion: 1.0.1
 templates:
   - backend-deployment.yaml
 tests:
@@ -223,9 +225,9 @@ tests:
       backend.extraVolumes: []
       backend.extraVolumeMounts: []
     asserts:
-      - isNull:
+      - notExists:
           path: spec.template.spec.volumes
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].volumeMounts
 
   - it: should work with both configFile and extraVolumes/extraVolumeMounts

--- a/infrastructure/charts/erato/tests/helpers_test.yaml
+++ b/infrastructure/charts/erato/tests/helpers_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test helper templates
+minimumVersion: 1.0.1
 templates:
   - backend-deployment.yaml  # We use this template to test the helpers
 tests:

--- a/infrastructure/charts/erato/tests/ingress_test.yaml
+++ b/infrastructure/charts/erato/tests/ingress_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test ingress
+minimumVersion: 1.0.1
 templates:
   - ingress.yaml
 tests:

--- a/infrastructure/charts/erato/tests/oauth2-proxy-configmap_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-configmap_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test oauth2-proxy configmap
+minimumVersion: 1.0.1
 templates:
   - oauth2-proxy-configmap.yaml
 tests:

--- a/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test oauth2-proxy deployment
+minimumVersion: 1.0.1
 templates:
   - oauth2-proxy-deployment.yaml
 tests:

--- a/infrastructure/charts/erato/tests/oauth2-proxy-service_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-service_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test oauth2-proxy service
+minimumVersion: 1.0.1
 templates:
   - oauth2-proxy-service.yaml
 tests:

--- a/infrastructure/charts/erato/tests/services_test.yaml
+++ b/infrastructure/charts/erato/tests/services_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test services
+minimumVersion: 1.0.1
 templates:
   - services.yaml
 tests:

--- a/infrastructure/charts/erato/tests_schema/helm-testsuite.json
+++ b/infrastructure/charts/erato/tests_schema/helm-testsuite.json
@@ -1,0 +1,1316 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "A helm test suite is a collection of tests with the same purpose and scope defined in one single file.",
+  "required": [
+    "tests"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "suite": {
+      "type": "string",
+      "description": "The suite name to show on test result output.",
+      "markdownDescription": "**suite** (string) _optional_\n\nThe suite name to show on test result output."
+    },
+    "snapshotId": {
+      "type": "string",
+      "description": "A suffix to your snapshot file for the tests.  Ideal for helm tests.",
+      "markdownDescription": "**snapshotId** (string) _optional_\n\nA suffix to your snapshot file for the tests.  Ideal for helm tests."
+    },
+    "values": {
+      "$ref": "#/definitions/values"
+    },
+    "set": {
+      "$ref": "#/definitions/set"
+    },
+    "templates": {
+      "$ref": "#/definitions/templates"
+    },
+    "excludeTemplates": {
+      "$ref": "#/definitions/excludeTemplates"
+    },
+    "release": {
+      "$ref": "#/definitions/release"
+    },
+    "capabilities": {
+      "$ref": "#/definitions/capabilities"
+    },
+    "skip": {
+      "$ref": "#/definitions/skip"
+    },
+    "postRenderer": {
+      "$ref": "#/definitions/postRenderer"
+    },
+    "chart": {
+      "$ref": "#/definitions/chart"
+    },
+    "kubernetesProvider": {
+      "$ref": "#/definitions/kubernetesProvider"
+    },
+    "minimumVersion": {
+      "type": "string",
+      "description": "The minimum version of helm-unittest plugin required to run this test suite.",
+      "markdownDescription": "**minimumVersion** (string) _optional_\n\nThe minimum version of helm-unittest plugin required to run this test suite."
+    },
+    "tests": {
+      "type": "array",
+      "description": "Where you define your test jobs to run",
+      "markdownDescription": "**tests** (array<object>) _required_\n\nWhere you define your test jobs to run",
+      "required": [
+        "asserts"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "it": {
+            "type": "string",
+            "description": "Define the name of the test with TDD style or any message you like.",
+            "markdownDescription": "**it** (string) _recommended_\n\nDefine the name of the test with TDD style or any message you like."
+          },
+          "values": {
+            "$ref": "#/definitions/values"
+          },
+          "set": {
+            "$ref": "#/definitions/set"
+          },
+          "skip": {
+            "$ref": "#/definitions/skip"
+          },
+          "postRenderer": {
+            "$ref": "#/definitions/postRenderer"
+          },
+          "template": {
+            "type": "string",
+            "description": "The template file(s) which render the manifest to be tested, default to the list of template file defined in templates of suite file, unless template is defined in the assertion(s).",
+            "markdownDescription": "**template** (string) _optional_\n\nThe template file(s) which render the manifest to be tested, default to the list of template file defined in templates of suite file, unless template is defined in the assertion(s)."
+          },
+          "templates": {
+            "$ref": "#/definitions/templates"
+          },
+          "documentIndex": {
+            "$ref": "#/definitions/documentIndex"
+          },
+          "documentSelector": {
+            "$ref": "#/definitions/documentSelector"
+          },
+          "release": {
+            "$ref": "#/definitions/release"
+          },
+          "capabilities": {
+            "$ref": "#/definitions/capabilities"
+          },
+          "chart": {
+            "$ref": "#/definitions/chart"
+          },
+          "kubernetesProvider": {
+            "$ref": "#/definitions/kubernetesProvider"
+          },
+          "asserts": {
+            "type": "array",
+            "description": "The assertions to validate the rendered chart.",
+            "markdownDescription": "**asserts** (array<object>) _required_\n\nThe assertions to validate the rendered chart.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "containsDocument": true,
+                "contains": true,
+                "notContains": true,
+                "equal": true,
+                "notEqual": true,
+                "equalRaw": true,
+                "notEqualRaw": true,
+                "exists": true,
+                "notExists": true,
+                "failedTemplate": true,
+                "notFailedTemplate": true,
+                "greaterOrEqual": true,
+                "notGreaterOrEqual": true,
+                "hasDocuments": true,
+                "lessOrEqual": true,
+                "notLessOrEqual": true,
+                "isAPIVersion": true,
+                "isKind": true,
+                "isNullOrEmpty": true,
+                "isNotNullOrEmpty": true,
+                "isEmpty": true,
+                "isNotEmpty": true,
+                "isSubset": true,
+                "isNotSubset": true,
+                "isType": true,
+                "isNotType": true,
+                "lengthEqual": true,
+                "notLengthEqual": true,
+                "matchRegex": true,
+                "notMatchRegex": true,
+                "matchRegexRaw": true,
+                "notMatchRegexRaw": true,
+                "matchSnapshot": true,
+                "matchSnapshotRaw": true,
+                "not": {
+                  "type": "boolean",
+                  "description": "Set to true to assert contrarily, default to false.",
+                  "markdownDescription": "**not** (boolean) _optional_\n\nSet to `true` to assert contrarily, default to `false`."
+                },
+                "template": {
+                  "type": "string",
+                  "description": "The template file which render the manifest to be asserted, default to the list of template files defined in templates of the suite file, unless the template is in the testjob.",
+                  "markdownDescription": "**template** (string) _optional_\n\nThe template file which render the manifest to be asserted, default to the list of template files defined in `templates` of the suite file, unless the template is in the testjob."
+                },
+                "documentIndex": {
+                  "$ref": "#/definitions/documentIndex"
+                },
+                "documentSelector": {
+                  "$ref": "#/definitions/documentSelector"
+                }
+              },
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "properties": {
+                    "containsDocument": {
+                      "type": "object",
+                      "description": "Asserts the documents rendered by the kind and apiVersion specified.",
+                      "markdownDescription": "**containsDocument** (object)\n\nAsserts the documents rendered by the `kind` and `apiVersion` specified.",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "description": "Expected kind of manifest.",
+                          "markdownDescription": "**kind** (string) _required_\n\nExpected `kind` of manifest.",
+                          "examples": [
+                            "Deployment"
+                          ]
+                        },
+                        "apiVersion": {
+                          "type": "string",
+                          "description": "Expected apiVersion of manifest.",
+                          "markdownDescription": "**apiVersion** (string) _required_\n\nExpected `apiVersion` of manifest.",
+                          "examples": [
+                            "apps/v1"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The value of the metadata.name.",
+                          "markdownDescription": "**name** (string) _optional_\n\nThe value of the `metadata.name`.",
+                          "examples": [
+                            "foo"
+                          ]
+                        },
+                        "namespace": {
+                          "type": "string",
+                          "description": "The value of the metadata.namespace.",
+                          "markdownDescription": "**namespace** (string) _optional_\n\nThe value of the `metadata.namespace`.",
+                          "examples": [
+                            "bar"
+                          ]
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other documents.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other documents."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "containsDocument"
+                  ]
+                },
+                {
+                  "properties": {
+                    "contains": {
+                      "type": "object",
+                      "description": "Assert the array as the value of specified path contains the content.",
+                      "markdownDescription": "**contains** (object)\n\nAssert the array as the value of specified path contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content to be contained."
+                        },
+                        "count": {
+                          "type": "integer",
+                          "description": "The count of content to be contained.",
+                          "markdownDescription": "**count** (integer) _optional_\n\nThe count of content to be contained."
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other values within the found content.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other values within the found content."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "contains"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notContains": {
+                      "type": "object",
+                      "description": "Assert the array as the value of specified path NOT contains the content.",
+                      "markdownDescription": "**notContains** (object)\n\nAssert the array as the value of specified path NOT contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content NOT to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content NOT to be contained."
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other values within the found content.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other values within the found content."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notContains"
+                  ]
+                },
+                {
+                  "properties": {
+                    "equal": {
+                      "type": "object",
+                      "description": "Assert the value of the specified path is equal to the value.",
+                      "markdownDescription": "**equal** (object)\n\nAssert the value of the specified path is equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (object) _requried_\n\nThe expected value."
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "equal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path NOT equal to the value.",
+                      "markdownDescription": "**notEqual** (object)\n\nAssert the value of specified path NOT equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The value expected not to be.",
+                          "markdownDescription": "**value** (object) _required_\n\nThe value expected not to be."
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "equalRaw": {
+                      "type": "object",
+                      "description": "Assert equal to the raw value.",
+                      "markdownDescription": "**equal** (object)\n\nAssert equal to the raw value.",
+                      "required": [
+                        "value"
+                      ],
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Assert the expected value in a NOTES.txt file.",
+                          "markdownDescription": "**value** (string) _required_\n\nAssert the expected value in a `NOTES.txt` file."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "equalRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notEqualRaw": {
+                      "type": "object",
+                      "description": "Assert equal NOT to the value.",
+                      "markdownDescription": "**notEqualRaw** (object)\n\nAssert equal NOT to the value.",
+                      "required": [
+                        "value"
+                      ],
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Assert the expected value in a NOTES.txt file not to be.",
+                          "markdownDescription": "**value** (string) _required_\n\nAssert the expected value in a `NOTES.txt` file not to be."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notEqualRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "exists": {
+                      "type": "object",
+                      "description": "Assert if the specified path exists.",
+                      "markdownDescription": "**exists** (object)\n\nAssert if the specified path `exists`.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "exists"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notExists": {
+                      "type": "object",
+                      "description": "Assert if the specified path NOT exists.",
+                      "markdownDescription": "**notExists** (object)\n\nAssert if the specified path NOT `exists`.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notExists"
+                  ]
+                },
+                {
+                  "properties": {
+                    "failedTemplate": {
+                      "type": "object",
+                      "description": "Assert the value of errorMessage is the same as the human readable template error, or assert that a template failure occurs.",
+                      "markdownDescription": "**failedTemplate** (object)\n\nAssert the value of `errorMessage` is the same as the human readable template error.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errorMessage": {
+                              "type": "string",
+                              "description": "The (human readable) errorMessage that should occur.",
+                              "markdownDescription": "**errorMessage** (string) _required_\n\nThe (human readable) `errorMessage` that should occur.",
+                              "examples": [
+                                "Required value"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "errorMessage"
+                          ]
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errorPattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the error (without quoting /).",
+                              "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match the error (without quoting `/`).",
+                              "examples": [
+                                "Required Pattern"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "errorPattern"
+                          ]
+                        },
+                        {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "description": "Assert that a failure occurs while templating",
+                          "markdownDescription": "**failedTemplate** (object)\n\nAssert that a failure occurs while templating."
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "failedTemplate"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notFailedTemplate": {
+                      "type": "object",
+                      "description": "Assert that no failure occurs while templating.",
+                      "markdownDescription": "**notFailedTemplate** (object)\n\nAssert that no failure occurs while templating.",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notFailedTemplate"
+                  ]
+                },
+                {
+                  "properties": {
+                    "greaterOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is greater or equal to the value.",
+                      "markdownDescription": "**greaterOrEqual** (object)\n\nAssert the value of specified path is greater or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "greaterOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notGreaterOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT greater or equal to the value.",
+                      "markdownDescription": "**notGreaterOrEqual** (object)\n\nAssert the value of specified path is NOT greater or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notGreaterOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "hasDocuments": {
+                      "type": "object",
+                      "description": "Assert the documents count rendered by the template specified. The documentIndex or documentSelector option is by default ignored here.",
+                      "markdownDescription": "**hasDocuments** (object)\n\nAssert the documents count rendered by the `template` specified. The `documentIndex` or `documentSelector` option is by default ignored here.",
+                      "required": [
+                        "count"
+                      ],
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of documents rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of documents rendered."
+                        },
+                        "filterAware": {
+                          "type": "boolean",
+                          "description": "When true documentIndex or documentSelector is taken into account.",
+                          "markdownDescription": "**filterAware** (boolean) _optional_\n\nWhen true `documentIndex` or `documentSelector` is taken into account."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "hasDocuments"
+                  ]
+                },
+                {
+                  "properties": {
+                    "lessOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is less or equal to the value.",
+                      "markdownDescription": "**lessOrEqual** (object)\n\nAssert the value of specified path is less or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "lessOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notLessOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT less or equal to the value.",
+                      "markdownDescription": "**notLessOrEqual** (object)\n\nAssert the value of specified path is NOT less or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notLessOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isAPIVersion": {
+                      "type": "object",
+                      "description": "Assert the apiVersion value of manifest.",
+                      "markdownDescription": "**isAPIVersion** (object)\n\nAssert the `apiVersion` value of manifest.",
+                      "properties": {
+                        "of": {
+                          "type": "string",
+                          "description": "Expected apiVersion of manifest.",
+                          "markdownDescription": "**of** (string) _required_\n\nExpected `apiVersion` of manifest."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isAPIVersion"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isKind": {
+                      "type": "object",
+                      "description": "Assert the kind value of manifest.",
+                      "markdownDescription": "**isKind** (object)\n\nAssert the `kind` value of manifest.",
+                      "properties": {
+                        "of": {
+                          "type": "string",
+                          "description": "Expected kind of manifest.",
+                          "markdownDescription": "**of** (string) _required_\n\nExpected `kind` of manifest."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isKind"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNullOrEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is null or empty (null, \"\", 0, [], {}).",
+                      "markdownDescription": "**isNullOrEmpty** (object)\n\nAssert the value of specified path is null or empty (`null`, `\"\"`, `0`, `[]`, `{}`).",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNullOrEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotNullOrEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT null or empty (null, \"\", 0, [], {}).",
+                      "markdownDescription": "**isNotNullOrEmpty** (object)\n\nAssert the value of specified path is NOT null or empty (`null`, `\"\"`, `0`, `[]`, `{}`).",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotNullOrEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isSubset": {
+                      "type": "object",
+                      "description": "Assert the object as the value of specified path that contains the content.",
+                      "markdownDescription": "**isSubset** (object)\n\nAssert the object as the value of specified path that contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content to be contained."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isSubset"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotSubset": {
+                      "type": "object",
+                      "description": "Assert the object as the value of specified path that NOT contains the content.",
+                      "markdownDescription": "**isNotSubset** (object)\n\nAssert the object as the value of specified path that NOT contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content NOT to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content NOT to be contained."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotSubset"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isType": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is the type.",
+                      "markdownDescription": "**isType** (object)\n\nAssert the value of specified path is the type.",
+                      "required": [
+                        "path",
+                        "type"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The expected type.",
+                          "markdownDescription": "**type** (string) _required_\n\nThe expected type."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isType"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotType": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT the type.",
+                      "markdownDescription": "**isNotType** (object)\n\nAssert the value of specified path is NOT the type.",
+                      "required": [
+                        "path",
+                        "type"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The expected type.",
+                          "markdownDescription": "**type** (string) _required_\n\nThe expected type."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotType"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT empty.",
+                      "markdownDescription": "**isNotEmpty** (object)\n\nAssert the value of specified path is NOT empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is empty.",
+                      "markdownDescription": "**isEmpty** (object)\n\nAssert the value of specified path is empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "lengthEqual": {
+                      "type": "object",
+                      "description": "Assert the documents count rendered by the template specified. The documentIndex option is ignored here.",
+                      "markdownDescription": "**lengthEqual** (object)\n\nAssert the spec count rendered by the `path|paths` specified.",
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of spec rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of spec rendered."
+                        },
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "paths": {
+                          "$ref": "#/definitions/assertion/paths"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "lengthEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notLengthEqual": {
+                      "type": "object",
+                      "description": "Assert the count rendered by the template specified to be equal. The documentIndex option is ignored here.",
+                      "markdownDescription": "**notLengthEqual** (object)\n\nAssert the spec count rendered by the `path|paths` specified NOT to be equal.",
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of spec rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of spec rendered."
+                        },
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "paths": {
+                          "$ref": "#/definitions/assertion/paths"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notLengthEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchRegex": {
+                      "type": "object",
+                      "description": "Assert the value of specified path match pattern.",
+                      "markdownDescription": "**matchRegex** (object)\n\nAssert the value of specified path match pattern.",
+                      "required": [
+                        "path",
+                        "pattern"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern to match (without quoting /).",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match (without quoting `/`).",
+                          "examples": [
+                            "-my-chart$"
+                          ]
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchRegex"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notMatchRegex": {
+                      "type": "object",
+                      "description": "Assert the value of specified path NOT match pattern.",
+                      "markdownDescription": "**notMatchRegex** (object)\n\nAssert the value of specified path NOT match pattern.",
+                      "required": [
+                        "path",
+                        "pattern"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern NOT to match (without quoting /).",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern NOT to match (without quoting `/`).",
+                          "examples": [
+                            "-my-chart$"
+                          ]
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notMatchRegex"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchRegexRaw": {
+                      "type": "object",
+                      "description": "Assert the value match pattern.",
+                      "markdownDescription": "**matchRegexRaw** (object)\n\nAssert the value match pattern.",
+                      "required": [
+                        "pattern"
+                      ],
+                      "properties": {
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern to match (without quoting /) in a NOTES.txt file.",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match (without quoting `/`) in a `NOTES.txt` file.",
+                          "examples": [
+                            "-my-notes$"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchRegexRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notMatchRegexRaw": {
+                      "type": "object",
+                      "description": "Assert the value NOT match pattern.",
+                      "markdownDescription": "**notMatchRegexRaw** (object)\n\nAssert the value NOT match pattern.",
+                      "required": [
+                        "pattern"
+                      ],
+                      "properties": {
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern NOT to match (without quoting /) in a NOTES.txt file.",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern NOT to match (without quoting `/`) in a `NOTES.txt` file.",
+                          "examples": [
+                            "-my-notes$"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notMatchRegexRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchSnapshot": {
+                      "type": "object",
+                      "description": "Assert the value of path is the same as snapshotted last time. ",
+                      "markdownDescription": "**matchSnapshot** (object)\n\nAssert the value of `path` is the same as snapshotted last time.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "matchRegex": {
+                          "type": "object",
+                          "description": "Assert the value of regex is the same as snapshotted last time. ",
+                          "markdownDescription": "**matchRegex** (object)\n\nAssert the value of `regex` is the same as snapshotted last time.",
+                          "properties": {
+                            "pattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the snapshot.",
+                              "markdownDescription": "**pattern** (string) _required_ The regex pattern to match the snapshot."
+                            }
+                          }
+                        },
+                        "notMatchRegex": {
+                          "type": "object",
+                          "description": "Assert the value of regex is not as snapshotted last time. ",
+                          "markdownDescription": "**matchRegex** (object)\n\nAssert the value of `regex` is no assnapshotted last time.",
+                          "properties": {
+                            "pattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the snapshot.",
+                              "markdownDescription": "**pattern** (string) _required_ The regex pattern to match the snapshot."
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchSnapshot"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchSnapshotRaw": {
+                      "type": "object",
+                      "description": "Assert the value in the NOTES.txt is the same as snapshotted last time. ",
+                      "markdownDescription": "**matchSnapshotRaw**\n\nAssert the value in the NOTES.txt is the same as snapshotted last time.",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchSnapshotRaw"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "definitions": {
+    "assertion": {
+      "paths": {
+        "type": "array",
+        "description": "The set of paths to assert.Map keys in path containing periods (.) are supported with the use of a jq-like syntax.",
+        "markdownDescription": "**templates** (array<string>) _optional_\n. List of specs for length comparison. ",
+        "items": {
+          "type": "string"
+        }
+      },
+      "path": {
+        "type": "string",
+        "description": "The set path to assert. Map keys in path containing periods (.) are supported with the use of a jq-like syntax.",
+        "markdownDescription": "**path** (string) _required_\n\nThe `set` path to assert.\n\nMap keys in path containing periods (.) are supported with the use of a jq-like syntax."
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "description": "Define the {{ .Capabilities }} object.",
+      "markdownDescription": "**capabilities** (object) _optional_\n\nDefine the `{{ .Capabilities }}` object.",
+      "properties": {
+        "majorVersion": {
+          "type": "integer",
+          "description": "The kubernetes major version, default to the major version which is set by helm.",
+          "markdownDescription": "**majorVersion** (integer) _optional_\n\nThe kubernetes major version, default to the major version which is set by helm."
+        },
+        "minorVersion": {
+          "type": "integer",
+          "description": "The kubernetes minor version, default to the minor version which is set by helm.",
+          "markdownDescription": "**minorVersion** (integer) _optional_\n\nThe kubernetes minor version, default to the minor version which is set by helm."
+        },
+        "apiVersions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "A set of versions, default to the versionset used by the defined kubernetes version.",
+          "markdownDescription": "**apiVersions** (array<string>) _optional_\n\nA set of versions, default to the versionset used by the defined kubernetes version.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "chart": {
+      "type": "object",
+      "description": "Define the {{ .Chart }} object.",
+      "markdownDescription": "**chart** (object) _optional_\n\nDefine the `{{ .Chart }}` object.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The semantic version of the chart, default to the version set in the Chart.",
+          "markdownDescription": "**version** (string) _optional_\n\nThe semantic version of the chart, default to the version set in the Chart."
+        },
+        "appVersion": {
+          "type": "string",
+          "description": "The app-version of the chart, default to the app-version set in the Chart.",
+          "markdownDescription": "**appVersion** (string) _optional_\n\nThe app-version of the chart, default to the app-version set in the Chart."
+        }
+      },
+      "additionalProperties": false
+    },
+    "documentIndex": {
+      "type": "integer",
+      "description": "The index of rendered documents (divided by ---) to be tested, default to -1, which results in asserting all documents (see Assertion). Generally you can ignored this field if the template file render only one document.",
+      "markdownDescription": "**documentIndex** (integer) _optional_\n\nThe index of rendered documents (divided by ---) to be tested, default to -1, which results in asserting all documents (see Assertion).\n\nGenerally you can ignored this field if the template file render only one document."
+    },
+    "documentSelector": {
+      "type": "object",
+      "description": "The path of the key to find and the value to match. Using this information, helm-unittest will automatically discover the documentIndex. Generally you can ignored this field if the template file render only one document.",
+      "markdownDescription": "**documentSelector** (object) _optional_\n\nThe path of the key to be match and the match value to assert.\n\nUsing this information, helm-unittest will automatically discover the documentIndex.\n\nGenerally you can ignored this field if the template file render only one document.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The `documentSelector` path to find.",
+          "markdownDescription": "**path** (string)\n\nThe `documentSelector` path to find."
+        },
+        "value": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "description": "When set, filter on value to match. When not set, filters on all documents where the path is found.",
+          "markdownDescription": "**value** (string|object) _optional_\n\nWhen set, filter on value to match. When not set, filters on all documents where the path is found.",
+          "additionalProperties": true
+        },
+        "matchMany": {
+          "type": "boolean",
+          "description": "Set to true to allow matching multiple documents.",
+          "markdownDescription": "**matchMany** (boolean) _optional_\n\nSet to **true* to allow matching multiple documents. Defaults to **false** which means selector has to match single document across all templates."
+        },
+        "skipEmptyTemplates": {
+          "type": "boolean",
+          "description": "Set to true to skip asserting templates which didn't render any matching documents.",
+          "markdownDescription": "**skipEmptyTemplates** (boolean) _optional_\n\nSet to **true** to skip asserting templates which didn't render any matching documents. Defaults to **false* which means selector have to find at least one document in every template."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "skip": {
+      "type": "object",
+      "description": "Using this flag, helm-unittest will automatically skip the 'suite' or 'test'.",
+      "markdownDescription": "**skip** (object) _optional_\n\nUsing this flag, helm-unittest will automatically skip the 'suite' or 'test'.",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "The reason to skip the `suite` or 'test'.",
+          "markdownDescription": "**reason** (string)\n\nThe reason to skip the `suite` or 'test'."
+        },
+        "minimumVersion": {
+          "type": "string",
+          "description": "The minimum version of helm-unittest plugin required to run this test suite. Do not set **minimumVersion** if you set this.",
+          "markdownDescription": "**minimumVersion** (string) _optional_\n\nThe minimum version of helm-unittest plugin required to run this test suite. If set, do not set reason, otherwise the test suite will be skipped regardless of the version."
+        }
+      },
+      "additionalProperties": false
+    },
+    "postRenderer": {
+      "type": "object",
+      "description": "A helm 'post-renderer' to apply after chart rendering but before validation.",
+      "markdownDescription": "**postRenderer** (object) _optional_\n\nA helm [post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering) to apply after chart rendering but before validation.",
+      "properties": {
+        "cmd": {
+          "type": "string",
+          "description": "The full path to the command to invoke, or just its name if it's on `$PATH`.",
+          "markdownDescription": "**cmd** (string)\n\nThe full path to the command to invoke, or just its name if it's on '$PATH'."
+        },
+        "args": {
+          "type": "array",
+          "description": "A list of command-line arguments to pass to the 'cmd'.",
+          "markdownDescription": "**args** (array<string>)\n\nA list of command-line arguments to pass to the `cmd`.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "kubernetesProvider": {
+      "type": "object",
+      "description": "Define Kubernetes resources to fake.",
+      "markdownDescription": "**kubernetesProvider**: (object) _optional_\n\nDefine Kubernetes resources to fake.",
+      "properties": {
+        "scheme": {
+          "type": "object",
+          "description": "Define the Kubernetes schema to fake",
+          "markdownDescription": "**scheme**: (object)\n\nDefine the Kubernetes schema to fake",
+          "additionalProperties": true
+        },
+        "objects": {
+          "type": "array",
+          "description": "Define the Kubernetes objects to fake",
+          "markdownDescription": "**objects**: (array of objects)\n\nDefine the Kubernetes objects to fake",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "required": [
+        "objects"
+      ],
+      "additionalProperties": false
+    },
+    "release": {
+      "type": "object",
+      "description": "Define the {{ .Release }} object.",
+      "markdownDescription": "**release** (object) _optional_\n\nDefine the `{{ .Release }}` object.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The release name, default to \"RELEASE-NAME\".",
+          "markdownDescription": "**name** (string) _optional_\n\nThe release name, default to `\"RELEASE-NAME\"`."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace which release be installed to, default to \"NAMESPACE\".",
+          "markdownDescription": "**namespace** (string) _optional_\n\nThe namespace which release be installed to, default to `\"NAMESPACE\"`."
+        },
+        "revision": {
+          "type": "integer",
+          "description": "The revision of current build, default to 0.",
+          "markdownDescription": "**revision** (integer) _optional_\n\nThe revision of current build, default to `0`."
+        },
+        "upgrade": {
+          "type": "boolean",
+          "description": "Whether the build is an upgrade, default to false.",
+          "markdownDescription": "**upgrade** (boolean) _optional_\n\nWhether the build is an upgrade, default to `false`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "templates": {
+      "type": "array",
+      "description": "The template files scope to test in this suite. The full chart will be rendered, however only the listed templates are filtered for validation. Template files that are put in a templates sub-folder can be addressed with a linux path separator. Also the templates/ can be omitted. Partial templates (which are prefixed with and _) are added automatically even if it is in a templates sub-folder, you don't need to add them again.",
+      "markdownDescription": "**templates** (array<string>) _recommended_\n\nThe template files scope to test in this suite. The full chart will be rendered, however only the listed templates are filtered for validation.\n\n Template files that are put in a templates sub-folder can be addressed with a linux path separator. Also the `templates/` can be omitted.\n\nPartial templates (which are prefixed with and _) are added automatically even if it is in a templates sub-folder, you don't need to add them again.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "excludeTemplates": {
+      "type": "array",
+      "description": "The template files which should be excluded from the scope of this test suite. Using wildcards it is possible to exclude multiple templates without listing them one-by-one.",
+      "markdownDescription": "**excludeTemplates** (array<string>) _optional_\n\nThe template files which should be excluded from the scope of this test suite. Using wildcards it is possible to exclude multiple templates without listing them one-by-one.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "set": {
+      "type": "object",
+      "description": "Set the values directly in the suite file. The key is the value path with the format just like --set option of helm install, for example image.pullPolicy. The value is anything you want to set to the path specified by the key, which can be even an array or an object.",
+      "markdownDescription": "**set** (object) _optional_\n\nSet the values directly in the suite file. The key is the value path with the format just like `--set` option of `helm install`, for example `image.pullPolicy`.\n\nThe value is anything you want to set to the path specified by the key, which can be even an array or an object.",
+      "additionalProperties": true
+    },
+    "values": {
+      "type": "array",
+      "description": "The test values to apply for rendering of this chart.",
+      "markdownDescription": "**values** (array<string>) _recommended_\n\n.The test values to apply for rendering of this chart.",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/infrastructure/k3d/erato-local/justfile
+++ b/infrastructure/k3d/erato-local/justfile
@@ -2,7 +2,7 @@ default:
     just --list
 
 # Run all tests (unit tests + linting)
-test: unittest lint
+test: validate_schema unittest lint
 
 # Run helm unit tests (erato-local templates only)
 unittest:
@@ -11,6 +11,9 @@ unittest:
 # Run helm lint checks (note: dependency errors expected without Chart.yaml dependencies)
 lint:
     helm lint . || echo "⚠️  Lint may fail due to missing Chart.yaml dependencies - this is expected for erato-local"
+
+validate_schema:
+    pnpx ajv-cli@5.0.0 validate --strict=false -s ./tests_schema/helm-testsuite.json -d "./tests/*.yaml"
 
 # Install/update chart dependencies
 deps:

--- a/infrastructure/k3d/erato-local/tests/azurite-init-job_test.yaml
+++ b/infrastructure/k3d/erato-local/tests/azurite-init-job_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test azurite init job
+minimumVersion: 1.0.1
 templates:
   - azurite-init-job.yaml
 tests:

--- a/infrastructure/k3d/erato-local/tests/azurite_test.yaml
+++ b/infrastructure/k3d/erato-local/tests/azurite_test.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=../tests_schema/helm-testsuite.json
 suite: test azurite components
+minimumVersion: 1.0.1
 templates:
   - azurite.yaml
 tests:

--- a/infrastructure/k3d/erato-local/tests_schema/helm-testsuite.json
+++ b/infrastructure/k3d/erato-local/tests_schema/helm-testsuite.json
@@ -1,0 +1,1316 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "A helm test suite is a collection of tests with the same purpose and scope defined in one single file.",
+  "required": [
+    "tests"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "suite": {
+      "type": "string",
+      "description": "The suite name to show on test result output.",
+      "markdownDescription": "**suite** (string) _optional_\n\nThe suite name to show on test result output."
+    },
+    "snapshotId": {
+      "type": "string",
+      "description": "A suffix to your snapshot file for the tests.  Ideal for helm tests.",
+      "markdownDescription": "**snapshotId** (string) _optional_\n\nA suffix to your snapshot file for the tests.  Ideal for helm tests."
+    },
+    "values": {
+      "$ref": "#/definitions/values"
+    },
+    "set": {
+      "$ref": "#/definitions/set"
+    },
+    "templates": {
+      "$ref": "#/definitions/templates"
+    },
+    "excludeTemplates": {
+      "$ref": "#/definitions/excludeTemplates"
+    },
+    "release": {
+      "$ref": "#/definitions/release"
+    },
+    "capabilities": {
+      "$ref": "#/definitions/capabilities"
+    },
+    "skip": {
+      "$ref": "#/definitions/skip"
+    },
+    "postRenderer": {
+      "$ref": "#/definitions/postRenderer"
+    },
+    "chart": {
+      "$ref": "#/definitions/chart"
+    },
+    "kubernetesProvider": {
+      "$ref": "#/definitions/kubernetesProvider"
+    },
+    "minimumVersion": {
+      "type": "string",
+      "description": "The minimum version of helm-unittest plugin required to run this test suite.",
+      "markdownDescription": "**minimumVersion** (string) _optional_\n\nThe minimum version of helm-unittest plugin required to run this test suite."
+    },
+    "tests": {
+      "type": "array",
+      "description": "Where you define your test jobs to run",
+      "markdownDescription": "**tests** (array<object>) _required_\n\nWhere you define your test jobs to run",
+      "required": [
+        "asserts"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "it": {
+            "type": "string",
+            "description": "Define the name of the test with TDD style or any message you like.",
+            "markdownDescription": "**it** (string) _recommended_\n\nDefine the name of the test with TDD style or any message you like."
+          },
+          "values": {
+            "$ref": "#/definitions/values"
+          },
+          "set": {
+            "$ref": "#/definitions/set"
+          },
+          "skip": {
+            "$ref": "#/definitions/skip"
+          },
+          "postRenderer": {
+            "$ref": "#/definitions/postRenderer"
+          },
+          "template": {
+            "type": "string",
+            "description": "The template file(s) which render the manifest to be tested, default to the list of template file defined in templates of suite file, unless template is defined in the assertion(s).",
+            "markdownDescription": "**template** (string) _optional_\n\nThe template file(s) which render the manifest to be tested, default to the list of template file defined in templates of suite file, unless template is defined in the assertion(s)."
+          },
+          "templates": {
+            "$ref": "#/definitions/templates"
+          },
+          "documentIndex": {
+            "$ref": "#/definitions/documentIndex"
+          },
+          "documentSelector": {
+            "$ref": "#/definitions/documentSelector"
+          },
+          "release": {
+            "$ref": "#/definitions/release"
+          },
+          "capabilities": {
+            "$ref": "#/definitions/capabilities"
+          },
+          "chart": {
+            "$ref": "#/definitions/chart"
+          },
+          "kubernetesProvider": {
+            "$ref": "#/definitions/kubernetesProvider"
+          },
+          "asserts": {
+            "type": "array",
+            "description": "The assertions to validate the rendered chart.",
+            "markdownDescription": "**asserts** (array<object>) _required_\n\nThe assertions to validate the rendered chart.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "containsDocument": true,
+                "contains": true,
+                "notContains": true,
+                "equal": true,
+                "notEqual": true,
+                "equalRaw": true,
+                "notEqualRaw": true,
+                "exists": true,
+                "notExists": true,
+                "failedTemplate": true,
+                "notFailedTemplate": true,
+                "greaterOrEqual": true,
+                "notGreaterOrEqual": true,
+                "hasDocuments": true,
+                "lessOrEqual": true,
+                "notLessOrEqual": true,
+                "isAPIVersion": true,
+                "isKind": true,
+                "isNullOrEmpty": true,
+                "isNotNullOrEmpty": true,
+                "isEmpty": true,
+                "isNotEmpty": true,
+                "isSubset": true,
+                "isNotSubset": true,
+                "isType": true,
+                "isNotType": true,
+                "lengthEqual": true,
+                "notLengthEqual": true,
+                "matchRegex": true,
+                "notMatchRegex": true,
+                "matchRegexRaw": true,
+                "notMatchRegexRaw": true,
+                "matchSnapshot": true,
+                "matchSnapshotRaw": true,
+                "not": {
+                  "type": "boolean",
+                  "description": "Set to true to assert contrarily, default to false.",
+                  "markdownDescription": "**not** (boolean) _optional_\n\nSet to `true` to assert contrarily, default to `false`."
+                },
+                "template": {
+                  "type": "string",
+                  "description": "The template file which render the manifest to be asserted, default to the list of template files defined in templates of the suite file, unless the template is in the testjob.",
+                  "markdownDescription": "**template** (string) _optional_\n\nThe template file which render the manifest to be asserted, default to the list of template files defined in `templates` of the suite file, unless the template is in the testjob."
+                },
+                "documentIndex": {
+                  "$ref": "#/definitions/documentIndex"
+                },
+                "documentSelector": {
+                  "$ref": "#/definitions/documentSelector"
+                }
+              },
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "properties": {
+                    "containsDocument": {
+                      "type": "object",
+                      "description": "Asserts the documents rendered by the kind and apiVersion specified.",
+                      "markdownDescription": "**containsDocument** (object)\n\nAsserts the documents rendered by the `kind` and `apiVersion` specified.",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "description": "Expected kind of manifest.",
+                          "markdownDescription": "**kind** (string) _required_\n\nExpected `kind` of manifest.",
+                          "examples": [
+                            "Deployment"
+                          ]
+                        },
+                        "apiVersion": {
+                          "type": "string",
+                          "description": "Expected apiVersion of manifest.",
+                          "markdownDescription": "**apiVersion** (string) _required_\n\nExpected `apiVersion` of manifest.",
+                          "examples": [
+                            "apps/v1"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The value of the metadata.name.",
+                          "markdownDescription": "**name** (string) _optional_\n\nThe value of the `metadata.name`.",
+                          "examples": [
+                            "foo"
+                          ]
+                        },
+                        "namespace": {
+                          "type": "string",
+                          "description": "The value of the metadata.namespace.",
+                          "markdownDescription": "**namespace** (string) _optional_\n\nThe value of the `metadata.namespace`.",
+                          "examples": [
+                            "bar"
+                          ]
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other documents.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other documents."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "containsDocument"
+                  ]
+                },
+                {
+                  "properties": {
+                    "contains": {
+                      "type": "object",
+                      "description": "Assert the array as the value of specified path contains the content.",
+                      "markdownDescription": "**contains** (object)\n\nAssert the array as the value of specified path contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content to be contained."
+                        },
+                        "count": {
+                          "type": "integer",
+                          "description": "The count of content to be contained.",
+                          "markdownDescription": "**count** (integer) _optional_\n\nThe count of content to be contained."
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other values within the found content.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other values within the found content."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "contains"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notContains": {
+                      "type": "object",
+                      "description": "Assert the array as the value of specified path NOT contains the content.",
+                      "markdownDescription": "**notContains** (object)\n\nAssert the array as the value of specified path NOT contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content NOT to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content NOT to be contained."
+                        },
+                        "any": {
+                          "type": "boolean",
+                          "description": "Ignores any other values within the found content.",
+                          "markdownDescription": "**any** (boolean) _optional_\n\nIgnores any other values within the found content."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notContains"
+                  ]
+                },
+                {
+                  "properties": {
+                    "equal": {
+                      "type": "object",
+                      "description": "Assert the value of the specified path is equal to the value.",
+                      "markdownDescription": "**equal** (object)\n\nAssert the value of the specified path is equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (object) _requried_\n\nThe expected value."
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "equal"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path NOT equal to the value.",
+                      "markdownDescription": "**notEqual** (object)\n\nAssert the value of specified path NOT equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The value expected not to be.",
+                          "markdownDescription": "**value** (object) _required_\n\nThe value expected not to be."
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "equalRaw": {
+                      "type": "object",
+                      "description": "Assert equal to the raw value.",
+                      "markdownDescription": "**equal** (object)\n\nAssert equal to the raw value.",
+                      "required": [
+                        "value"
+                      ],
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Assert the expected value in a NOTES.txt file.",
+                          "markdownDescription": "**value** (string) _required_\n\nAssert the expected value in a `NOTES.txt` file."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "equalRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notEqualRaw": {
+                      "type": "object",
+                      "description": "Assert equal NOT to the value.",
+                      "markdownDescription": "**notEqualRaw** (object)\n\nAssert equal NOT to the value.",
+                      "required": [
+                        "value"
+                      ],
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "description": "Assert the expected value in a NOTES.txt file not to be.",
+                          "markdownDescription": "**value** (string) _required_\n\nAssert the expected value in a `NOTES.txt` file not to be."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notEqualRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "exists": {
+                      "type": "object",
+                      "description": "Assert if the specified path exists.",
+                      "markdownDescription": "**exists** (object)\n\nAssert if the specified path `exists`.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "exists"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notExists": {
+                      "type": "object",
+                      "description": "Assert if the specified path NOT exists.",
+                      "markdownDescription": "**notExists** (object)\n\nAssert if the specified path NOT `exists`.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notExists"
+                  ]
+                },
+                {
+                  "properties": {
+                    "failedTemplate": {
+                      "type": "object",
+                      "description": "Assert the value of errorMessage is the same as the human readable template error, or assert that a template failure occurs.",
+                      "markdownDescription": "**failedTemplate** (object)\n\nAssert the value of `errorMessage` is the same as the human readable template error.",
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errorMessage": {
+                              "type": "string",
+                              "description": "The (human readable) errorMessage that should occur.",
+                              "markdownDescription": "**errorMessage** (string) _required_\n\nThe (human readable) `errorMessage` that should occur.",
+                              "examples": [
+                                "Required value"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "errorMessage"
+                          ]
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errorPattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the error (without quoting /).",
+                              "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match the error (without quoting `/`).",
+                              "examples": [
+                                "Required Pattern"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "errorPattern"
+                          ]
+                        },
+                        {
+                          "additionalProperties": false,
+                          "type": "object",
+                          "description": "Assert that a failure occurs while templating",
+                          "markdownDescription": "**failedTemplate** (object)\n\nAssert that a failure occurs while templating."
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "failedTemplate"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notFailedTemplate": {
+                      "type": "object",
+                      "description": "Assert that no failure occurs while templating.",
+                      "markdownDescription": "**notFailedTemplate** (object)\n\nAssert that no failure occurs while templating.",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notFailedTemplate"
+                  ]
+                },
+                {
+                  "properties": {
+                    "greaterOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is greater or equal to the value.",
+                      "markdownDescription": "**greaterOrEqual** (object)\n\nAssert the value of specified path is greater or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "greaterOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notGreaterOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT greater or equal to the value.",
+                      "markdownDescription": "**notGreaterOrEqual** (object)\n\nAssert the value of specified path is NOT greater or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notGreaterOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "hasDocuments": {
+                      "type": "object",
+                      "description": "Assert the documents count rendered by the template specified. The documentIndex or documentSelector option is by default ignored here.",
+                      "markdownDescription": "**hasDocuments** (object)\n\nAssert the documents count rendered by the `template` specified. The `documentIndex` or `documentSelector` option is by default ignored here.",
+                      "required": [
+                        "count"
+                      ],
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of documents rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of documents rendered."
+                        },
+                        "filterAware": {
+                          "type": "boolean",
+                          "description": "When true documentIndex or documentSelector is taken into account.",
+                          "markdownDescription": "**filterAware** (boolean) _optional_\n\nWhen true `documentIndex` or `documentSelector` is taken into account."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "hasDocuments"
+                  ]
+                },
+                {
+                  "properties": {
+                    "lessOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is less or equal to the value.",
+                      "markdownDescription": "**lessOrEqual** (object)\n\nAssert the value of specified path is less or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "lessOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notLessOrEqual": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT less or equal to the value.",
+                      "markdownDescription": "**notLessOrEqual** (object)\n\nAssert the value of specified path is NOT less or equal to the value.",
+                      "required": [
+                        "path",
+                        "value"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "value": {
+                          "description": "The expected value.",
+                          "markdownDescription": "**value** (number|string) _required_\n\nThe expected value."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notLessOrEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isAPIVersion": {
+                      "type": "object",
+                      "description": "Assert the apiVersion value of manifest.",
+                      "markdownDescription": "**isAPIVersion** (object)\n\nAssert the `apiVersion` value of manifest.",
+                      "properties": {
+                        "of": {
+                          "type": "string",
+                          "description": "Expected apiVersion of manifest.",
+                          "markdownDescription": "**of** (string) _required_\n\nExpected `apiVersion` of manifest."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isAPIVersion"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isKind": {
+                      "type": "object",
+                      "description": "Assert the kind value of manifest.",
+                      "markdownDescription": "**isKind** (object)\n\nAssert the `kind` value of manifest.",
+                      "properties": {
+                        "of": {
+                          "type": "string",
+                          "description": "Expected kind of manifest.",
+                          "markdownDescription": "**of** (string) _required_\n\nExpected `kind` of manifest."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isKind"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNullOrEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is null or empty (null, \"\", 0, [], {}).",
+                      "markdownDescription": "**isNullOrEmpty** (object)\n\nAssert the value of specified path is null or empty (`null`, `\"\"`, `0`, `[]`, `{}`).",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNullOrEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotNullOrEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT null or empty (null, \"\", 0, [], {}).",
+                      "markdownDescription": "**isNotNullOrEmpty** (object)\n\nAssert the value of specified path is NOT null or empty (`null`, `\"\"`, `0`, `[]`, `{}`).",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotNullOrEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isSubset": {
+                      "type": "object",
+                      "description": "Assert the object as the value of specified path that contains the content.",
+                      "markdownDescription": "**isSubset** (object)\n\nAssert the object as the value of specified path that contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content to be contained."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isSubset"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotSubset": {
+                      "type": "object",
+                      "description": "Assert the object as the value of specified path that NOT contains the content.",
+                      "markdownDescription": "**isNotSubset** (object)\n\nAssert the object as the value of specified path that NOT contains the content.",
+                      "required": [
+                        "path",
+                        "content"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "content": {
+                          "description": "The content NOT to be contained.",
+                          "markdownDescription": "**content** (object) _required_\n\nThe content NOT to be contained."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotSubset"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isType": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is the type.",
+                      "markdownDescription": "**isType** (object)\n\nAssert the value of specified path is the type.",
+                      "required": [
+                        "path",
+                        "type"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The expected type.",
+                          "markdownDescription": "**type** (string) _required_\n\nThe expected type."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isType"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotType": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT the type.",
+                      "markdownDescription": "**isNotType** (object)\n\nAssert the value of specified path is NOT the type.",
+                      "required": [
+                        "path",
+                        "type"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "The expected type.",
+                          "markdownDescription": "**type** (string) _required_\n\nThe expected type."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotType"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isNotEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is NOT empty.",
+                      "markdownDescription": "**isNotEmpty** (object)\n\nAssert the value of specified path is NOT empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isNotEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "isEmpty": {
+                      "type": "object",
+                      "description": "Assert the value of specified path is empty.",
+                      "markdownDescription": "**isEmpty** (object)\n\nAssert the value of specified path is empty.",
+                      "required": [
+                        "path"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "isEmpty"
+                  ]
+                },
+                {
+                  "properties": {
+                    "lengthEqual": {
+                      "type": "object",
+                      "description": "Assert the documents count rendered by the template specified. The documentIndex option is ignored here.",
+                      "markdownDescription": "**lengthEqual** (object)\n\nAssert the spec count rendered by the `path|paths` specified.",
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of spec rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of spec rendered."
+                        },
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "paths": {
+                          "$ref": "#/definitions/assertion/paths"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "lengthEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notLengthEqual": {
+                      "type": "object",
+                      "description": "Assert the count rendered by the template specified to be equal. The documentIndex option is ignored here.",
+                      "markdownDescription": "**notLengthEqual** (object)\n\nAssert the spec count rendered by the `path|paths` specified NOT to be equal.",
+                      "properties": {
+                        "count": {
+                          "type": "integer",
+                          "description": "Expected count of spec rendered.",
+                          "markdownDescription": "**count** (integer) _required_\n\nExpected count of spec rendered."
+                        },
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "paths": {
+                          "$ref": "#/definitions/assertion/paths"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notLengthEqual"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchRegex": {
+                      "type": "object",
+                      "description": "Assert the value of specified path match pattern.",
+                      "markdownDescription": "**matchRegex** (object)\n\nAssert the value of specified path match pattern.",
+                      "required": [
+                        "path",
+                        "pattern"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern to match (without quoting /).",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match (without quoting `/`).",
+                          "examples": [
+                            "-my-chart$"
+                          ]
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchRegex"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notMatchRegex": {
+                      "type": "object",
+                      "description": "Assert the value of specified path NOT match pattern.",
+                      "markdownDescription": "**notMatchRegex** (object)\n\nAssert the value of specified path NOT match pattern.",
+                      "required": [
+                        "path",
+                        "pattern"
+                      ],
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern NOT to match (without quoting /).",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern NOT to match (without quoting `/`).",
+                          "examples": [
+                            "-my-chart$"
+                          ]
+                        },
+                        "decodeBase64": {
+                          "type": "boolean",
+                          "description": "Decode the base64 before checking.",
+                          "markdownDescription": "**decodeBase64** (boolean) _optional_\n\nDecode the base64 before checking."
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notMatchRegex"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchRegexRaw": {
+                      "type": "object",
+                      "description": "Assert the value match pattern.",
+                      "markdownDescription": "**matchRegexRaw** (object)\n\nAssert the value match pattern.",
+                      "required": [
+                        "pattern"
+                      ],
+                      "properties": {
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern to match (without quoting /) in a NOTES.txt file.",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern to match (without quoting `/`) in a `NOTES.txt` file.",
+                          "examples": [
+                            "-my-notes$"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchRegexRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "notMatchRegexRaw": {
+                      "type": "object",
+                      "description": "Assert the value NOT match pattern.",
+                      "markdownDescription": "**notMatchRegexRaw** (object)\n\nAssert the value NOT match pattern.",
+                      "required": [
+                        "pattern"
+                      ],
+                      "properties": {
+                        "pattern": {
+                          "type": "string",
+                          "description": "The regex pattern NOT to match (without quoting /) in a NOTES.txt file.",
+                          "markdownDescription": "**pattern** (string) _required_\n\nThe regex pattern NOT to match (without quoting `/`) in a `NOTES.txt` file.",
+                          "examples": [
+                            "-my-notes$"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "notMatchRegexRaw"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchSnapshot": {
+                      "type": "object",
+                      "description": "Assert the value of path is the same as snapshotted last time. ",
+                      "markdownDescription": "**matchSnapshot** (object)\n\nAssert the value of `path` is the same as snapshotted last time.",
+                      "properties": {
+                        "path": {
+                          "$ref": "#/definitions/assertion/path"
+                        },
+                        "matchRegex": {
+                          "type": "object",
+                          "description": "Assert the value of regex is the same as snapshotted last time. ",
+                          "markdownDescription": "**matchRegex** (object)\n\nAssert the value of `regex` is the same as snapshotted last time.",
+                          "properties": {
+                            "pattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the snapshot.",
+                              "markdownDescription": "**pattern** (string) _required_ The regex pattern to match the snapshot."
+                            }
+                          }
+                        },
+                        "notMatchRegex": {
+                          "type": "object",
+                          "description": "Assert the value of regex is not as snapshotted last time. ",
+                          "markdownDescription": "**matchRegex** (object)\n\nAssert the value of `regex` is no assnapshotted last time.",
+                          "properties": {
+                            "pattern": {
+                              "type": "string",
+                              "description": "The regex pattern to match the snapshot.",
+                              "markdownDescription": "**pattern** (string) _required_ The regex pattern to match the snapshot."
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchSnapshot"
+                  ]
+                },
+                {
+                  "properties": {
+                    "matchSnapshotRaw": {
+                      "type": "object",
+                      "description": "Assert the value in the NOTES.txt is the same as snapshotted last time. ",
+                      "markdownDescription": "**matchSnapshotRaw**\n\nAssert the value in the NOTES.txt is the same as snapshotted last time.",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "matchSnapshotRaw"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "definitions": {
+    "assertion": {
+      "paths": {
+        "type": "array",
+        "description": "The set of paths to assert.Map keys in path containing periods (.) are supported with the use of a jq-like syntax.",
+        "markdownDescription": "**templates** (array<string>) _optional_\n. List of specs for length comparison. ",
+        "items": {
+          "type": "string"
+        }
+      },
+      "path": {
+        "type": "string",
+        "description": "The set path to assert. Map keys in path containing periods (.) are supported with the use of a jq-like syntax.",
+        "markdownDescription": "**path** (string) _required_\n\nThe `set` path to assert.\n\nMap keys in path containing periods (.) are supported with the use of a jq-like syntax."
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "description": "Define the {{ .Capabilities }} object.",
+      "markdownDescription": "**capabilities** (object) _optional_\n\nDefine the `{{ .Capabilities }}` object.",
+      "properties": {
+        "majorVersion": {
+          "type": "integer",
+          "description": "The kubernetes major version, default to the major version which is set by helm.",
+          "markdownDescription": "**majorVersion** (integer) _optional_\n\nThe kubernetes major version, default to the major version which is set by helm."
+        },
+        "minorVersion": {
+          "type": "integer",
+          "description": "The kubernetes minor version, default to the minor version which is set by helm.",
+          "markdownDescription": "**minorVersion** (integer) _optional_\n\nThe kubernetes minor version, default to the minor version which is set by helm."
+        },
+        "apiVersions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "A set of versions, default to the versionset used by the defined kubernetes version.",
+          "markdownDescription": "**apiVersions** (array<string>) _optional_\n\nA set of versions, default to the versionset used by the defined kubernetes version.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "chart": {
+      "type": "object",
+      "description": "Define the {{ .Chart }} object.",
+      "markdownDescription": "**chart** (object) _optional_\n\nDefine the `{{ .Chart }}` object.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The semantic version of the chart, default to the version set in the Chart.",
+          "markdownDescription": "**version** (string) _optional_\n\nThe semantic version of the chart, default to the version set in the Chart."
+        },
+        "appVersion": {
+          "type": "string",
+          "description": "The app-version of the chart, default to the app-version set in the Chart.",
+          "markdownDescription": "**appVersion** (string) _optional_\n\nThe app-version of the chart, default to the app-version set in the Chart."
+        }
+      },
+      "additionalProperties": false
+    },
+    "documentIndex": {
+      "type": "integer",
+      "description": "The index of rendered documents (divided by ---) to be tested, default to -1, which results in asserting all documents (see Assertion). Generally you can ignored this field if the template file render only one document.",
+      "markdownDescription": "**documentIndex** (integer) _optional_\n\nThe index of rendered documents (divided by ---) to be tested, default to -1, which results in asserting all documents (see Assertion).\n\nGenerally you can ignored this field if the template file render only one document."
+    },
+    "documentSelector": {
+      "type": "object",
+      "description": "The path of the key to find and the value to match. Using this information, helm-unittest will automatically discover the documentIndex. Generally you can ignored this field if the template file render only one document.",
+      "markdownDescription": "**documentSelector** (object) _optional_\n\nThe path of the key to be match and the match value to assert.\n\nUsing this information, helm-unittest will automatically discover the documentIndex.\n\nGenerally you can ignored this field if the template file render only one document.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The `documentSelector` path to find.",
+          "markdownDescription": "**path** (string)\n\nThe `documentSelector` path to find."
+        },
+        "value": {
+          "type": [
+            "string",
+            "object"
+          ],
+          "description": "When set, filter on value to match. When not set, filters on all documents where the path is found.",
+          "markdownDescription": "**value** (string|object) _optional_\n\nWhen set, filter on value to match. When not set, filters on all documents where the path is found.",
+          "additionalProperties": true
+        },
+        "matchMany": {
+          "type": "boolean",
+          "description": "Set to true to allow matching multiple documents.",
+          "markdownDescription": "**matchMany** (boolean) _optional_\n\nSet to **true* to allow matching multiple documents. Defaults to **false** which means selector has to match single document across all templates."
+        },
+        "skipEmptyTemplates": {
+          "type": "boolean",
+          "description": "Set to true to skip asserting templates which didn't render any matching documents.",
+          "markdownDescription": "**skipEmptyTemplates** (boolean) _optional_\n\nSet to **true** to skip asserting templates which didn't render any matching documents. Defaults to **false* which means selector have to find at least one document in every template."
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false
+    },
+    "skip": {
+      "type": "object",
+      "description": "Using this flag, helm-unittest will automatically skip the 'suite' or 'test'.",
+      "markdownDescription": "**skip** (object) _optional_\n\nUsing this flag, helm-unittest will automatically skip the 'suite' or 'test'.",
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "The reason to skip the `suite` or 'test'.",
+          "markdownDescription": "**reason** (string)\n\nThe reason to skip the `suite` or 'test'."
+        },
+        "minimumVersion": {
+          "type": "string",
+          "description": "The minimum version of helm-unittest plugin required to run this test suite. Do not set **minimumVersion** if you set this.",
+          "markdownDescription": "**minimumVersion** (string) _optional_\n\nThe minimum version of helm-unittest plugin required to run this test suite. If set, do not set reason, otherwise the test suite will be skipped regardless of the version."
+        }
+      },
+      "additionalProperties": false
+    },
+    "postRenderer": {
+      "type": "object",
+      "description": "A helm 'post-renderer' to apply after chart rendering but before validation.",
+      "markdownDescription": "**postRenderer** (object) _optional_\n\nA helm [post-renderer](https://helm.sh/docs/topics/advanced/#post-rendering) to apply after chart rendering but before validation.",
+      "properties": {
+        "cmd": {
+          "type": "string",
+          "description": "The full path to the command to invoke, or just its name if it's on `$PATH`.",
+          "markdownDescription": "**cmd** (string)\n\nThe full path to the command to invoke, or just its name if it's on '$PATH'."
+        },
+        "args": {
+          "type": "array",
+          "description": "A list of command-line arguments to pass to the 'cmd'.",
+          "markdownDescription": "**args** (array<string>)\n\nA list of command-line arguments to pass to the `cmd`.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "kubernetesProvider": {
+      "type": "object",
+      "description": "Define Kubernetes resources to fake.",
+      "markdownDescription": "**kubernetesProvider**: (object) _optional_\n\nDefine Kubernetes resources to fake.",
+      "properties": {
+        "scheme": {
+          "type": "object",
+          "description": "Define the Kubernetes schema to fake",
+          "markdownDescription": "**scheme**: (object)\n\nDefine the Kubernetes schema to fake",
+          "additionalProperties": true
+        },
+        "objects": {
+          "type": "array",
+          "description": "Define the Kubernetes objects to fake",
+          "markdownDescription": "**objects**: (array of objects)\n\nDefine the Kubernetes objects to fake",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "required": [
+        "objects"
+      ],
+      "additionalProperties": false
+    },
+    "release": {
+      "type": "object",
+      "description": "Define the {{ .Release }} object.",
+      "markdownDescription": "**release** (object) _optional_\n\nDefine the `{{ .Release }}` object.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The release name, default to \"RELEASE-NAME\".",
+          "markdownDescription": "**name** (string) _optional_\n\nThe release name, default to `\"RELEASE-NAME\"`."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace which release be installed to, default to \"NAMESPACE\".",
+          "markdownDescription": "**namespace** (string) _optional_\n\nThe namespace which release be installed to, default to `\"NAMESPACE\"`."
+        },
+        "revision": {
+          "type": "integer",
+          "description": "The revision of current build, default to 0.",
+          "markdownDescription": "**revision** (integer) _optional_\n\nThe revision of current build, default to `0`."
+        },
+        "upgrade": {
+          "type": "boolean",
+          "description": "Whether the build is an upgrade, default to false.",
+          "markdownDescription": "**upgrade** (boolean) _optional_\n\nWhether the build is an upgrade, default to `false`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "templates": {
+      "type": "array",
+      "description": "The template files scope to test in this suite. The full chart will be rendered, however only the listed templates are filtered for validation. Template files that are put in a templates sub-folder can be addressed with a linux path separator. Also the templates/ can be omitted. Partial templates (which are prefixed with and _) are added automatically even if it is in a templates sub-folder, you don't need to add them again.",
+      "markdownDescription": "**templates** (array<string>) _recommended_\n\nThe template files scope to test in this suite. The full chart will be rendered, however only the listed templates are filtered for validation.\n\n Template files that are put in a templates sub-folder can be addressed with a linux path separator. Also the `templates/` can be omitted.\n\nPartial templates (which are prefixed with and _) are added automatically even if it is in a templates sub-folder, you don't need to add them again.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "excludeTemplates": {
+      "type": "array",
+      "description": "The template files which should be excluded from the scope of this test suite. Using wildcards it is possible to exclude multiple templates without listing them one-by-one.",
+      "markdownDescription": "**excludeTemplates** (array<string>) _optional_\n\nThe template files which should be excluded from the scope of this test suite. Using wildcards it is possible to exclude multiple templates without listing them one-by-one.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "set": {
+      "type": "object",
+      "description": "Set the values directly in the suite file. The key is the value path with the format just like --set option of helm install, for example image.pullPolicy. The value is anything you want to set to the path specified by the key, which can be even an array or an object.",
+      "markdownDescription": "**set** (object) _optional_\n\nSet the values directly in the suite file. The key is the value path with the format just like `--set` option of `helm install`, for example `image.pullPolicy`.\n\nThe value is anything you want to set to the path specified by the key, which can be even an array or an object.",
+      "additionalProperties": true
+    },
+    "values": {
+      "type": "array",
+      "description": "The test values to apply for rendering of this chart.",
+      "markdownDescription": "**values** (array<string>) _recommended_\n\n.The test values to apply for rendering of this chart.",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
I was stuck quite some time in the implementation of #246 due to a schema-mismatch issue, so this adds a way to validate that the Helm testsuites have the correct schema.