### PR TITLE
Move sentry config key to integrations

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -6,3 +6,7 @@ config = { endpoint = "http://localhost:9000", bucket = "erato-storage", region 
 # [mcp_servers.file_provider]
 # transport_type = "sse"
 # url = "http://127.0.0.1:63490/sse"
+
+# Example Sentry integration configuration
+# [integrations.sentry]
+# sentry_dsn = "https://your-sentry-dsn@sentry.io/project-id"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Report> {
 
     let mut _sentry_guard = None;
     setup_sentry(
-        config.sentry_dsn.as_ref(),
+        config.get_sentry_dsn(),
         config.environment.clone(),
         &mut _sentry_guard,
     );

--- a/backend/tests/integration_tests/config.rs
+++ b/backend/tests/integration_tests/config.rs
@@ -186,3 +186,326 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
         "postgres://user:pass@localhost:5432/test"
     );
 }
+
+#[test]
+#[allow(deprecated)]
+fn test_config_with_new_sentry_integration() {
+    // Test the new nested sentry configuration under integrations
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[integrations.sentry]
+sentry_dsn = "https://test-key@sentry.io/12345"
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+
+    // Flush the file to ensure content is written
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    // Get the path of the temporary file
+    let temp_path = temp_file.path().to_str().unwrap();
+
+    // Load configuration from the temporary file
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+
+    // Add required fields that don't have defaults
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    // Verify the new sentry configuration is parsed correctly
+    assert_eq!(
+        config.integrations.sentry.sentry_dsn,
+        Some("https://test-key@sentry.io/12345".to_string())
+    );
+    // The get_sentry_dsn() method should return the new config value
+    assert_eq!(
+        config.get_sentry_dsn(),
+        Some(&"https://test-key@sentry.io/12345".to_string())
+    );
+    // The old deprecated field should be None
+    assert_eq!(config.sentry_dsn, None);
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_config_with_old_deprecated_sentry_dsn() {
+    // Test backward compatibility with the old sentry_dsn field
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+sentry_dsn = "https://old-key@sentry.io/67890"
+
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+
+    // Flush the file to ensure content is written
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    // Get the path of the temporary file
+    let temp_path = temp_file.path().to_str().unwrap();
+
+    // Load configuration from the temporary file
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+
+    // Add required fields that don't have defaults
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    // Before migration - verify the old field is loaded from TOML
+    assert_eq!(
+        config.sentry_dsn,
+        Some("https://old-key@sentry.io/67890".to_string())
+    );
+
+    // After migration - the value should be moved to the new location and old cleared
+    let migrated_config = config.migrate();
+    assert_eq!(migrated_config.sentry_dsn, None);
+    assert_eq!(
+        migrated_config.integrations.sentry.sentry_dsn,
+        Some("https://old-key@sentry.io/67890".to_string())
+    );
+    // The get_sentry_dsn() method should return the migrated value
+    assert_eq!(
+        migrated_config.get_sentry_dsn(),
+        Some(&"https://old-key@sentry.io/67890".to_string())
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_config_with_both_old_and_new_sentry_dsn() {
+    // Test that the new config takes precedence over the old deprecated one
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+sentry_dsn = "https://old-key@sentry.io/67890"
+
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[integrations.sentry]
+sentry_dsn = "https://new-key@sentry.io/12345"
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+
+    // Flush the file to ensure content is written
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    // Get the path of the temporary file
+    let temp_path = temp_file.path().to_str().unwrap();
+
+    // Load configuration from the temporary file
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+
+    // Add required fields that don't have defaults
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    // Before migration - verify both values are loaded from TOML
+    assert_eq!(
+        config.sentry_dsn,
+        Some("https://old-key@sentry.io/67890".to_string())
+    );
+    assert_eq!(
+        config.integrations.sentry.sentry_dsn,
+        Some("https://new-key@sentry.io/12345".to_string())
+    );
+
+    // After migration - the new config should be preserved, old should be cleared
+    let migrated_config = config.migrate();
+    assert_eq!(migrated_config.sentry_dsn, None);
+    assert_eq!(
+        migrated_config.integrations.sentry.sentry_dsn,
+        Some("https://new-key@sentry.io/12345".to_string())
+    );
+
+    // The get_sentry_dsn() method should return the new value (taking precedence)
+    assert_eq!(
+        migrated_config.get_sentry_dsn(),
+        Some(&"https://new-key@sentry.io/12345".to_string())
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_config_migration_sentry_dsn() {
+    // Test that the migrate method moves sentry_dsn to integrations.sentry.sentry_dsn
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+sentry_dsn = "https://old-key@sentry.io/67890"
+
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+
+    // Flush the file to ensure content is written
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    // Get the path of the temporary file
+    let temp_path = temp_file.path().to_str().unwrap();
+
+    // Load configuration from the temporary file
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+
+    // Add required fields that don't have defaults
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    // Before migration - the old field should have the value, the new should be None
+    assert_eq!(
+        config.sentry_dsn,
+        Some("https://old-key@sentry.io/67890".to_string())
+    );
+    assert_eq!(config.integrations.sentry.sentry_dsn, None);
+
+    // After migration - the value should be moved to the new location
+    let migrated_config = config.migrate();
+    assert_eq!(migrated_config.sentry_dsn, None);
+    assert_eq!(
+        migrated_config.integrations.sentry.sentry_dsn,
+        Some("https://old-key@sentry.io/67890".to_string())
+    );
+
+    // The get_sentry_dsn() method should return the migrated value
+    assert_eq!(
+        migrated_config.get_sentry_dsn(),
+        Some(&"https://old-key@sentry.io/67890".to_string())
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn test_config_migration_preserves_new_sentry_dsn() {
+    // Test that migration doesn't overwrite an existing new config value
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+sentry_dsn = "https://old-key@sentry.io/67890"
+
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[integrations.sentry]
+sentry_dsn = "https://new-key@sentry.io/12345"
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+
+    // Flush the file to ensure content is written
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    // Get the path of the temporary file
+    let temp_path = temp_file.path().to_str().unwrap();
+
+    // Load configuration from the temporary file
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+
+    // Add required fields that don't have defaults
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    // After migration - the new config should be preserved, old should be cleared
+    let migrated_config = config.migrate();
+    assert_eq!(migrated_config.sentry_dsn, None);
+    assert_eq!(
+        migrated_config.integrations.sentry.sentry_dsn,
+        Some("https://new-key@sentry.io/12345".to_string())
+    );
+
+    // The get_sentry_dsn() method should return the new value (not the old one)
+    assert_eq!(
+        migrated_config.get_sentry_dsn(),
+        Some(&"https://new-key@sentry.io/12345".to_string())
+    );
+}

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -219,3 +219,24 @@ Whether to enable detailed tracing of LLM interactions. When enabled, all chat c
 **Type:** `boolean`
 
 See the [Langfuse Integration](./integrations/langfuse) documentation for detailed usage instructions and feature descriptions.
+
+#### `integrations.sentry`
+
+Configuration for the [Sentry](./integrations/sentry) error reporting and performance monitoring integration.
+
+##### `integrations.sentry.sentry_dsn`
+
+The Sentry DSN (Data Source Name) for your Sentry project. This enables error reporting and performance monitoring.
+
+**Default value:** `None`
+
+**Type:** `string | None`
+
+**Example:**
+
+```toml
+[integrations.sentry]
+sentry_dsn = "https://public@sentry.example.com/1"
+```
+
+See the [Sentry Integration](./integrations/sentry) documentation for detailed setup instructions.

--- a/site/content/docs/integrations/sentry.mdx
+++ b/site/content/docs/integrations/sentry.mdx
@@ -4,9 +4,10 @@ Erato provides support for [Sentry](https://sentry.io/) tracing and error report
 
 ## Configuration
 
-To enable the Sentry integration, the Sentry DSN of the project must be configured:
+To enable the Sentry integration, the Sentry DSN of the project must be configured in the integrations section:
 
 ```toml filename="erato.toml"
+[integrations.sentry]
 sentry_dsn = "https://public@sentry.example.com/1"
 ```
 


### PR DESCRIPTION
Similar to other recent config refactor, where we try to clear up top-level keys, the `sentry_dsn` key is move to `integrations.sentry.sentry_dsn`

- Moves the config key from `sentry_dsn` -> `integrations.sentry.sentry_dsn`
- Adds the corresponding migration warning logs
- Documents the config key in the Configuration reference