### PR TITLE
Use shared login state in tests to speed them up

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/playwright/.auth/
 
 .env
 !.env.example

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -53,14 +53,27 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
+    // Setup project
+    { name: "setup", testMatch: /.*\.setup\.ts/ },
+
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        // Use signed-in state
+        storageState: "playwright/.auth/user.json",
+      },
+      dependencies: ["setup"],
     },
 
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: {
+        ...devices["Desktop Firefox"],
+        // Use signed-in state
+        storageState: "playwright/.auth/user.json",
+      },
+      dependencies: ["setup"],
     },
 
     // TODO: Currently deactivated, because there are issues with using `0.0.0.0` as host during auth flow

--- a/e2e-tests/tests/auth.setup.ts
+++ b/e2e-tests/tests/auth.setup.ts
@@ -1,0 +1,18 @@
+import { test as setup, expect } from "@playwright/test";
+import { login } from "./shared";
+
+const authFile = "playwright/.auth/user.json";
+
+setup("authenticate", async ({ page }) => {
+  // Perform authentication steps
+  await page.goto("/");
+  await login(page, "admin@example.com");
+
+  // Wait until the page receives the cookies
+  await expect(
+    page.getByRole("textbox", { name: "Type a message..." }),
+  ).toBeVisible();
+
+  // End of authentication steps
+  await page.context().storageState({ path: authFile });
+});

--- a/e2e-tests/tests/behaviour.spec.ts
+++ b/e2e-tests/tests/behaviour.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { TAG_CI } from "./tags";
-import { chatIsReadyToChat, login, ensureOpenSidebar } from "./shared";
+import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
 
 test(
   "Can open new chat page and input is focused",
@@ -8,8 +8,6 @@ test(
   async ({ page }) => {
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/");
-
-    await login(page, "admin@example.com");
 
     await expect(
       page.getByRole("textbox", { name: "Type a message..." }),
@@ -25,7 +23,6 @@ test(
   { tag: TAG_CI },
   async ({ page }) => {
     await page.goto("/");
-    await login(page, "admin@example.com");
 
     const textbox = page.getByRole("textbox", { name: "Type a message..." });
     await ensureOpenSidebar(page);

--- a/e2e-tests/tests/chat.spec.ts
+++ b/e2e-tests/tests/chat.spec.ts
@@ -1,14 +1,12 @@
 import { test, expect } from "@playwright/test";
 import { TAG_CI } from "./tags";
-import { chatIsReadyToChat, login } from "./shared";
+import { chatIsReadyToChat } from "./shared";
 
 test(
   "Can upload a file and see it in the UI",
   { tag: TAG_CI },
   async ({ page }) => {
     await page.goto("/");
-
-    await login(page, "admin@example.com");
     await chatIsReadyToChat(page);
 
     // Start waiting for file chooser before clicking the button
@@ -29,8 +27,6 @@ test(
   { tag: TAG_CI },
   async ({ page }) => {
     await page.goto("/");
-
-    await login(page, "admin@example.com");
     await chatIsReadyToChat(page);
 
     const textbox = page.getByRole("textbox", { name: "Type a message..." });
@@ -68,8 +64,6 @@ test(
   { tag: TAG_CI },
   async ({ page }) => {
     await page.goto("/");
-
-    await login(page, "admin@example.com");
     await chatIsReadyToChat(page);
 
     // Start waiting for file chooser before clicking the button

--- a/e2e-tests/tests/login.spec.ts
+++ b/e2e-tests/tests/login.spec.ts
@@ -2,20 +2,26 @@ import { test, expect } from "@playwright/test";
 import { TAG_CI } from "./tags";
 import { login } from "./shared";
 
-test("Can login", { tag: TAG_CI }, async ({ page }) => {
-  await page.goto("/");
+test("Can login", { tag: TAG_CI }, async ({ browser }) => {
+  // Use a fresh context without saved auth state for login testing
+  const context = await browser.newContext({
+    storageState: { cookies: [], origins: [] },
+  });
+  const page = await context.newPage();
 
+  await page.goto("/");
   await login(page, "admin@example.com");
 
   await expect(
     page.getByRole("textbox", { name: "Type a message..." }),
   ).toBeVisible();
+
+  await context.close();
 });
 
 test("Can logout", { tag: TAG_CI }, async ({ page }) => {
+  // This test starts with authenticated state and tests logout
   await page.goto("/");
-
-  await login(page, "admin@example.com");
 
   await expect(
     page.getByRole("textbox", { name: "Type a message..." }),

--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from "@playwright/test";
+import { expect, Page, Browser } from "@playwright/test";
 
 export const login = async (page: Page, email: string, password = "admin") => {
   await page.getByRole("button", { name: "Sign in with" }).click();
@@ -7,6 +7,32 @@ export const login = async (page: Page, email: string, password = "admin") => {
   await page.getByRole("textbox", { name: "Password" }).fill(password);
   await page.getByRole("textbox", { name: "Password" }).press("Enter");
   await page.getByRole("button", { name: "Grant Access" }).click();
+};
+
+/**
+ * Creates a new authenticated context for a different user
+ * Use this when you need to test with a different user than the default admin@example.com
+ */
+export const createAuthenticatedContext = async (
+  browser: Browser,
+  email: string,
+  password = "admin",
+) => {
+  // Create a fresh context without any stored authentication state
+  const context = await browser.newContext({
+    storageState: { cookies: [], origins: [] },
+  });
+  const page = await context.newPage();
+
+  await page.goto("/");
+  await login(page, email, password);
+
+  // Wait for successful login
+  await expect(
+    page.getByRole("textbox", { name: "Type a message..." }),
+  ).toBeVisible();
+
+  return { context, page };
 };
 
 export const chatIsReadyToChat = async (


### PR DESCRIPTION
Previously most of the e2e tests logs in from scratch, which adds some constant overhead for each tests.