### PR TITLE
Support annotations on most resources in Helm chart

### DIFF
--- a/infrastructure/charts/erato/templates/backend-deployment.yaml
+++ b/infrastructure/charts/erato/templates/backend-deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ .Release.Name }}-erato-app
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: erato-app
+  {{- if or .Values.backend.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.backend.deploymentAnnotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.backend.replicaCount }}
   selector:
@@ -14,6 +18,10 @@ spec:
       labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: erato-app
         app.kubernetes.io/app-version: {{ .Chart.AppVersion }}
+      {{- if or .Values.backend.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.backend.podAnnotations .Values.commonAnnotations ) "context" . ) }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" $podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "erato.imagePullSecrets" . | nindent 6 }}
       initContainers:

--- a/infrastructure/charts/erato/templates/oauth2-proxy-deployment.yaml
+++ b/infrastructure/charts/erato/templates/oauth2-proxy-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Release.Name }}-oauth2-proxy
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: oauth2-proxy
+  {{- if or .Values.oauth2Proxy.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.oauth2Proxy.deploymentAnnotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:
@@ -15,6 +19,10 @@ spec:
       labels: {{- include "common.labels.matchLabels" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 8 }}
         app.kubernetes.io/component: oauth2-proxy
         app.kubernetes.io/app-version: {{ .Chart.AppVersion }}
+      {{- if or .Values.oauth2Proxy.podAnnotations .Values.commonAnnotations }}
+      {{- $podAnnotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.oauth2Proxy.podAnnotations .Values.commonAnnotations ) "context" . ) }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" $podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "erato.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/infrastructure/charts/erato/tests/backend-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-deployment_test.yaml
@@ -440,3 +440,170 @@ tests:
             mountPath: /app/additional-config.auto.erato.toml
             subPath: additional-config.auto.erato.toml
             readOnly: true
+
+  # Annotation tests
+  - it: should not include deployment annotations when none are set
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should include deployment annotations when backend.deploymentAnnotations is set
+    set:
+      backend.deploymentAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        custom/annotation: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["custom/annotation"]
+          value: "value"
+
+  - it: should include deployment annotations when commonAnnotations is set
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        environment: "test"
+    asserts:
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "test"
+
+  - it: should merge deployment annotations with commonAnnotations
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        environment: "test"
+      backend.deploymentAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        backend/specific: "backend-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "test"
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["backend/specific"]
+          value: "backend-value"
+
+  - it: should override commonAnnotations with backend.deploymentAnnotations when keys conflict
+    set:
+      commonAnnotations:
+        environment: "common-environment"
+        common/annotation: "common-value"
+      backend.deploymentAnnotations:
+        environment: "backend-environment"
+        backend/specific: "backend-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "backend-environment"
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["backend/specific"]
+          value: "backend-value"
+
+  - it: should not include pod annotations when none are set
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should include pod annotations when backend.podAnnotations is set
+    set:
+      backend.podAnnotations:
+        pod/annotation: "pod-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["pod/annotation"]
+          value: "pod-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should include pod annotations when commonAnnotations is set
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        prometheus.io/port: "8080"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8080"
+
+  - it: should merge pod annotations with commonAnnotations
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        prometheus.io/port: "8080"
+      backend.podAnnotations:
+        pod/annotation: "pod-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "8080"
+      - equal:
+          path: spec.template.metadata.annotations["pod/annotation"]
+          value: "pod-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should override commonAnnotations with backend.podAnnotations when keys conflict
+    set:
+      commonAnnotations:
+        prometheus.io/scrape: "false"
+        common/annotation: "common-value"
+      backend.podAnnotations:
+        prometheus.io/scrape: "true"
+        pod/specific: "pod-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["pod/specific"]
+          value: "pod-value"
+
+  - it: should render annotations with template values
+    set:
+      backend.deploymentAnnotations:
+        app.version: "{{ .Chart.AppVersion }}"
+        release.name: "{{ .Release.Name }}"
+      backend.podAnnotations:
+        chart.version: "{{ .Chart.Version }}"
+        namespace: "{{ .Release.Namespace }}"
+    asserts:
+      - equal:
+          path: metadata.annotations["app.version"]
+          value: "0.1.0"
+      - equal:
+          path: metadata.annotations["release.name"]
+          value: "RELEASE-NAME"
+      - equal:
+          path: spec.template.metadata.annotations["chart.version"]
+          value: "0.1.0"
+      - equal:
+          path: spec.template.metadata.annotations["namespace"]
+          value: "NAMESPACE"

--- a/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
@@ -261,3 +261,181 @@ tests:
           content:
             name: additional-volume
             mountPath: /tmp/additional
+
+  # Annotation tests
+  - it: should not include deployment annotations when none are set
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should include deployment annotations when oauth2Proxy.deploymentAnnotations is set
+    set:
+      oauth2Proxy.deploymentAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        custom/annotation: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["custom/annotation"]
+          value: "value"
+
+  - it: should include deployment annotations when commonAnnotations is set
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        environment: "test"
+    asserts:
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "test"
+
+  - it: should merge deployment annotations with commonAnnotations
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        environment: "test"
+      oauth2Proxy.deploymentAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        oauth2proxy/specific: "oauth2proxy-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "test"
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["oauth2proxy/specific"]
+          value: "oauth2proxy-value"
+
+  - it: should override commonAnnotations with oauth2Proxy.deploymentAnnotations when keys conflict
+    set:
+      commonAnnotations:
+        environment: "common-environment"
+        common/annotation: "common-value"
+      oauth2Proxy.deploymentAnnotations:
+        environment: "oauth2proxy-environment"
+        oauth2proxy/specific: "oauth2proxy-value"
+    asserts:
+      - equal:
+          path: metadata.annotations["environment"]
+          value: "oauth2proxy-environment"
+      - equal:
+          path: metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: metadata.annotations["oauth2proxy/specific"]
+          value: "oauth2proxy-value"
+
+  - it: should not include pod annotations when none are set
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations
+
+  - it: should include pod annotations when oauth2Proxy.podAnnotations is set
+    set:
+      oauth2Proxy.podAnnotations:
+        pod/annotation: "pod-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["pod/annotation"]
+          value: "pod-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should include pod annotations when commonAnnotations is set
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        prometheus.io/port: "4180"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "4180"
+
+  - it: should merge pod annotations with commonAnnotations
+    set:
+      commonAnnotations:
+        common/annotation: "common-value"
+        prometheus.io/port: "4180"
+      oauth2Proxy.podAnnotations:
+        pod/annotation: "pod-value"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "4180"
+      - equal:
+          path: spec.template.metadata.annotations["pod/annotation"]
+          value: "pod-value"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should override commonAnnotations with oauth2Proxy.podAnnotations when keys conflict
+    set:
+      commonAnnotations:
+        prometheus.io/scrape: "false"
+        common/annotation: "common-value"
+      oauth2Proxy.podAnnotations:
+        prometheus.io/scrape: "true"
+        pod/specific: "pod-value"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["common/annotation"]
+          value: "common-value"
+      - equal:
+          path: spec.template.metadata.annotations["pod/specific"]
+          value: "pod-value"
+
+  - it: should render annotations with template values
+    set:
+      oauth2Proxy.deploymentAnnotations:
+        app.version: "{{ .Chart.AppVersion }}"
+        release.name: "{{ .Release.Name }}"
+      oauth2Proxy.podAnnotations:
+        chart.version: "{{ .Chart.Version }}"
+        namespace: "{{ .Release.Namespace }}"
+    asserts:
+      - equal:
+          path: metadata.annotations["app.version"]
+          value: "0.1.0"
+      - equal:
+          path: metadata.annotations["release.name"]
+          value: "RELEASE-NAME"
+      - equal:
+          path: spec.template.metadata.annotations["chart.version"]
+          value: "0.1.0"
+      - equal:
+          path: spec.template.metadata.annotations["namespace"]
+          value: "NAMESPACE"
+
+  - it: should not render when oauth2Proxy is disabled even with annotations set
+    set:
+      oauth2Proxy.enabled: false
+      oauth2Proxy.deploymentAnnotations:
+        test/annotation: "test-value"
+      oauth2Proxy.podAnnotations:
+        pod/annotation: "pod-value"
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/infrastructure/charts/erato/values.yaml
+++ b/infrastructure/charts/erato/values.yaml
@@ -10,6 +10,9 @@ nameOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 ##
 commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
 
 ingress:
   enabled: true
@@ -41,6 +44,12 @@ oauth2Proxy:
     # cookie_secret = ""
     # cookie_secure = true
     # skip_auth_regex = ["^/health", "^/metrics"]
+  ## @param oauth2Proxy.deploymentAnnotations Annotations to add to the oauth2-proxy deployment
+  ##
+  deploymentAnnotations: {}
+  ## @param oauth2Proxy.podAnnotations Annotations to add to the oauth2-proxy pod
+  ##
+  podAnnotations: {}
   resources:
     requests:
       cpu: 100m
@@ -62,6 +71,12 @@ backend:
   extraEnvVarsSecret: ""
   extraVolumes: []
   extraVolumeMounts: []
+  ## @param backend.deploymentAnnotations Annotations to add to the backend deployment
+  ##
+  deploymentAnnotations: {}
+  ## @param backend.podAnnotations Annotations to add to the backend pod
+  ##
+  podAnnotations: {}
   # Optional configuration for mounting erato.toml from a secret, configMap, or inline content
   configFile:
     # Name of the secret containing the erato.toml file

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -1,4 +1,7 @@
 erato:
+  commonAnnotations:
+    reloader.stakater.com/auto: "true"
+  
   ingress:
     enabled: true
     host: app.erato.internal


### PR DESCRIPTION
Related Linear issues:
- ERATO-42

Motivated by supporting workflows around using [Reloader](https://github.com/stakater/Reloader), this adds support for specifying common annotations on all resources and annotations on particular ones.

Extends the `erato` chart with the following config options:
- `commonAnnotations`
- `backend.deploymentAnnotations`
- `backend.podAnnotations`
- `oauth2Proxy.deploymentAnnotations`
- `oauth2Proxy.podAnnotations`