### PR TITLE
Extend config structure to allow for configuring multiple chat providers

### DIFF
--- a/backend/src/server/api/v1beta/message_streaming.rs
+++ b/backend/src/server/api/v1beta/message_streaming.rs
@@ -810,7 +810,14 @@ async fn stream_generate_chat_completion<
                     turn_start_time,
                 ) {
                     let turn_end_time = SystemTime::now();
-                    let model_name = app_state.config.chat_provider.model_name.clone();
+                    let model_name = match app_state.config.determine_chat_provider(None, None) {
+                        Ok(provider_id) => app_state
+                            .config
+                            .get_chat_provider(provider_id)
+                            .model_name
+                            .clone(),
+                        Err(_) => "unknown".to_string(),
+                    };
 
                     // Generate a unique observation ID for this turn
                     let turn_obs_id = format!("{}_turn_{}", obs_id, current_turn);

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct AppState {
     pub db: DatabaseConnection,
-    pub genai_client: GenaiClient,
     pub default_file_storage_provider: Option<String>,
     pub file_storage_providers: HashMap<String, FileStorage>,
     pub mcp_servers: Arc<McpServers>,
@@ -30,16 +29,12 @@ impl AppState {
     pub async fn new(config: AppConfig) -> Result<Self, Report> {
         let db = Database::connect(&config.database_url).await?;
         let file_storage_providers = Self::build_file_storage_providers(&config)?;
-        let default_chat_provider_id = config.determine_chat_provider(None, None)?;
-        let default_chat_provider = config.get_chat_provider(default_chat_provider_id);
-        let genai_client = Self::build_genai_client(default_chat_provider.clone())?;
         let mcp_servers = Arc::new(McpServers::new(&config).await?);
         let actor_manager = ActorManager::new(db.clone(), config.clone()).await;
         let langfuse_client = LangfuseClient::from_config(&config.integrations.langfuse)?;
 
         Ok(Self {
             db,
-            genai_client,
             default_file_storage_provider: config.default_file_storage_provider.clone(),
             file_storage_providers,
             mcp_servers,

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -30,7 +30,9 @@ impl AppState {
     pub async fn new(config: AppConfig) -> Result<Self, Report> {
         let db = Database::connect(&config.database_url).await?;
         let file_storage_providers = Self::build_file_storage_providers(&config)?;
-        let genai_client = Self::build_genai_client(config.chat_provider.clone())?;
+        let default_chat_provider_id = config.determine_chat_provider(None, None)?;
+        let default_chat_provider = config.get_chat_provider(default_chat_provider_id);
+        let genai_client = Self::build_genai_client(default_chat_provider.clone())?;
         let mcp_servers = Arc::new(McpServers::new(&config).await?);
         let actor_manager = ActorManager::new(db.clone(), config.clone()).await;
         let langfuse_client = LangfuseClient::from_config(&config.integrations.langfuse)?;

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -97,7 +97,11 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
 
     AppState {
         db: db.clone(),
-        genai_client: AppState::build_genai_client(app_config.chat_provider.clone()).unwrap(),
+        genai_client: {
+            let default_provider_id = app_config.determine_chat_provider(None, None).unwrap();
+            let default_provider = app_config.get_chat_provider(default_provider_id);
+            AppState::build_genai_client(default_provider.clone()).unwrap()
+        },
         default_file_storage_provider: None,
         file_storage_providers,
         mcp_servers: Arc::new(Default::default()),

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -97,11 +97,6 @@ pub async fn test_app_state(app_config: AppConfig, pool: Pool<Postgres>) -> AppS
 
     AppState {
         db: db.clone(),
-        genai_client: {
-            let default_provider_id = app_config.determine_chat_provider(None, None).unwrap();
-            let default_provider = app_config.get_chat_provider(default_provider_id);
-            AppState::build_genai_client(default_provider.clone()).unwrap()
-        },
         default_file_storage_provider: None,
         file_storage_providers,
         mcp_servers: Arc::new(Default::default()),

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -82,9 +82,11 @@ This will be inejcted into the frontend as:
 window.FOO = "bar";
 ```
 
-### `chat_provider`
+### `chat_provider` (deprecated)
 
-Configuration for the chat provider (LLM) that Erato will use for generating responses.
+**⚠️ Deprecated:** Please use `chat_providers` instead for multiple provider support and better flexibility.
+
+Configuration for a single chat provider (LLM) that Erato will use for generating responses. This is maintained for backward compatibility but will be automatically migrated to the new `chat_providers` format.
 
 #### `chat_provider.provider_kind`
 
@@ -103,6 +105,14 @@ The name of the model to use with the chat provider.
 **Type:** `string`
 
 **Example:** `"gpt-4o"`
+
+#### `chat_provider.model_display_name`
+
+The display name for the model shown to users. If not provided, falls back to `model_name`.
+
+**Type:** `string | None`
+
+**Example:** `"GPT-4 Omni (Production)"`
 
 #### `chat_provider.base_url`
 
@@ -162,6 +172,91 @@ enabled = true
 base_url = "https://cloud.langfuse.com"
 public_key = "pk-lf-..."
 secret_key = "sk-lf-..."
+```
+
+### `chat_providers`
+
+Configuration for multiple chat providers with priority ordering. This is the recommended way to configure chat providers as it supports multiple providers, fallback mechanisms, and better flexibility.
+
+#### `chat_providers.priority_order`
+
+An ordered list of provider IDs that defines the priority for provider selection. The first provider in the list has the highest priority.
+
+**Type:** `array of strings`
+
+**Required:** Yes
+
+**Example:** `["primary", "backup", "local"]`
+
+#### `chat_providers.providers`
+
+A map of provider configurations, where each key is a unique provider ID and the value is a provider configuration object.
+
+**Type:** `object`
+
+**Required:** Yes
+
+**Example:**
+
+```toml
+[chat_providers]
+priority_order = ["primary", "backup"]
+
+[chat_providers.providers.primary]
+provider_kind = "openai"
+model_name = "gpt-4"
+model_display_name = "GPT-4 (Primary)"
+api_key = "sk-primary-key"
+
+[chat_providers.providers.backup]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+model_display_name = "GPT-3.5 Turbo (Backup)"
+api_key = "sk-backup-key"
+base_url = "https://api.backup-provider.com/v1/"
+```
+
+#### Provider Configuration Fields
+
+Each provider in `chat_providers.providers` supports the following fields:
+
+- **`provider_kind`** - The type of chat provider (`"openai"`, `"azure_openai"`, `"ollama"`)
+- **`model_name`** - The model identifier for the provider
+- **`model_display_name`** - Optional display name for the model (falls back to `model_name`)
+- **`api_key`** - Optional API key for authentication
+- **`base_url`** - Optional custom base URL for the provider API
+- **`system_prompt`** - Optional static system prompt
+- **`system_prompt_langfuse`** - Optional Langfuse prompt configuration (mutually exclusive with `system_prompt`)
+- **`additional_request_parameters`** - Optional array of additional request parameters
+- **`additional_request_headers`** - Optional array of additional request headers
+
+#### Migration from `chat_provider`
+
+If you're using the old `chat_provider` configuration, it will be automatically migrated to the new format:
+
+- The old provider will be given the ID `"default"`
+- The priority order will be set to `["default"]`
+- A deprecation warning will be logged
+
+**Before (deprecated):**
+
+```toml
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4"
+api_key = "sk-key"
+```
+
+**After (recommended):**
+
+```toml
+[chat_providers]
+priority_order = ["main"]
+
+[chat_providers.providers.main]
+provider_kind = "openai"
+model_name = "gpt-4"
+api_key = "sk-key"
 ```
 
 ### `integrations`


### PR DESCRIPTION
Related Linear issue: ERATO-43

- Backend can be configured with multiple chat providers
  - A priority order can be configured
- Multiple providers can be configured via new [chat_providers.providers.<provider_id>] that replaces old single [chat_provider] configuration (same internal structure)
  - Old [chat_provider] key is still supported for now but internally migrated to new structure (with provider_id default), and emits migration warning if still in use
  - The structure of the ChatProvider be extended by the field `model_display_name`. This is different from the `model_name`, but if no `model_display_name` is provided, it may be evaluated to fall back to `model_name`
- Priority order between chat providers is configured via `[chat_providers.priority_order]`
  - Is internally validated, that each key used in the priority order is a configured provider_id
  - Does not error, but warn if a provider_id is not configured (this should support easily commenting out a chat provider config, without immediately breaking the whole config)
  - Warns if a provider is configured, but the provider_id is not used in the priority order
  - If only a single chat provider is configured, the priority order can be trivially inferred
  - Should error if the priority order is explicitly configured as empty list

