### PR TITLE
Allow for specifying specific model for chat summaries

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -201,6 +201,7 @@ impl AppConfig {
                 self.chat_providers = Some(ChatProvidersConfig {
                     priority_order: vec!["default".to_string()],
                     providers,
+                    summary: SummaryConfig::default(),
                 });
 
                 // Clear the old chat_provider after migration
@@ -464,6 +465,19 @@ pub struct ChatProvidersConfig {
     pub priority_order: Vec<String>,
     // Map of provider_id to provider configuration.
     pub providers: HashMap<String, ChatProviderConfig>,
+    // Configuration for summary generation.
+    #[serde(default)]
+    pub summary: SummaryConfig,
+}
+
+#[derive(Debug, Default, Deserialize, PartialEq, Eq, Clone)]
+pub struct SummaryConfig {
+    // The chat provider ID to use for summary generation.
+    // If not specified, uses the highest priority chat provider.
+    pub summary_chat_provider_id: Option<String>,
+    // Maximum output tokens for summary generation.
+    // Defaults to 300 if not specified.
+    pub max_tokens: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Clone)]

--- a/backend/src/server/api/v1beta/message_streaming.rs
+++ b/backend/src/server/api/v1beta/message_streaming.rs
@@ -1120,10 +1120,11 @@ pub async fn generate_chat_summary(
 
     let mut chat_request: ChatRequest = Default::default();
     chat_request = chat_request.append_message(GenAiChatMessage::user(prompt));
+    let max_tokens = app_state.max_tokens_for_summary();
     let mut chat_options = ChatOptions::default()
         .with_capture_content(true)
         // NOTE: Desired tokens are more like ~30, but we have some buffer in case a reasoning model is used
-        .with_max_tokens(300);
+        .with_max_tokens(max_tokens);
 
     // HACK: Hacky way to recognize reasoning models right now. Shouldbe replaced with capabilities mechanism in the future.
     let chat_provider = app_state.chat_provider_for_summary()?;

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -230,6 +230,71 @@ Each provider in `chat_providers.providers` supports the following fields:
 - **`additional_request_parameters`** - Optional array of additional request parameters
 - **`additional_request_headers`** - Optional array of additional request headers
 
+#### `chat_providers.summary`
+
+Configuration for chat summary generation. This allows you to specify which provider and settings to use when generating chat summaries.
+
+**Type:** `object | None`
+
+**Example:**
+
+```toml
+[chat_providers.summary]
+summary_chat_provider_id = "summarizer"
+max_tokens = 150
+```
+
+##### `chat_providers.summary.summary_chat_provider_id`
+
+The ID of the chat provider to use specifically for generating chat summaries. This provider must exist in the `chat_providers.providers` map.
+
+If not specified, Erato will use the highest priority provider from `priority_order` for summary generation.
+
+**Type:** `string | None`
+
+**Default value:** `None` (uses highest priority provider)
+
+**Example:** `"summarizer"`
+
+##### `chat_providers.summary.max_tokens`
+
+The maximum number of output tokens to allow when generating chat summaries. This helps control the length and cost of summary generation.
+
+**Type:** `number | None`
+
+**Default value:** `300`
+
+**Example:** `150`
+
+**Complete Example:**
+
+```toml
+[chat_providers]
+priority_order = ["main"]
+
+[chat_providers.summary]
+summary_chat_provider_id = "summarizer"
+max_tokens = 150
+
+[chat_providers.providers.main]
+provider_kind = "openai"
+model_name = "gpt-4"
+api_key = "sk-main-key"
+
+[chat_providers.providers.summarizer]
+provider_kind = "openai"
+model_name = "gpt-4o-mini"
+model_display_name = "GPT-4o Mini (Summarizer)"
+api_key = "sk-summarizer-key"
+```
+
+In this example:
+
+- Regular chat interactions use the "main" provider (GPT-4)
+- Chat summaries are generated using the "summarizer" provider (GPT-4o Mini)
+- Summary generation is limited to 150 output tokens
+- This allows using a faster, cheaper model for summaries while keeping a more powerful model for main interactions
+
 #### Migration from `chat_provider`
 
 If you're using the old `chat_provider` configuration, it will be automatically migrated to the new format:


### PR DESCRIPTION
Related Linear issue: ERATO-54

- Adds new configuration keys:
  - `chat_providers.summary.summary_chat_provider_id`: ChatProvide to use for summary generation
  - `chat_providers.summary.max_tokens`: Token limit for summary generation