### PR TITLE
Allow to configure model capabilities

### DIFF
--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -1764,6 +1764,14 @@
           "user_message"
         ],
         "properties": {
+          "chat_provider_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional chat provider ID to use for token estimation. If not provided, uses the default provider.",
+            "example": "gpt-4o"
+          },
           "existing_chat_id": {
             "type": [
               "string",
@@ -1852,9 +1860,14 @@
           "history_tokens",
           "file_tokens",
           "max_tokens",
-          "remaining_tokens"
+          "remaining_tokens",
+          "chat_provider_id"
         ],
         "properties": {
+          "chat_provider_id": {
+            "type": "string",
+            "description": "The chat provider ID that was used for this estimation"
+          },
           "file_tokens": {
             "type": "integer",
             "description": "Number of tokens in file contents",

--- a/backend/tests/integration_tests/main.rs
+++ b/backend/tests/integration_tests/main.rs
@@ -1983,7 +1983,7 @@ async fn test_token_usage_estimate_with_file(pool: Pool<Postgres>) {
 
     // Max tokens should be a reasonable value (the test expects 10000 from the implementation)
     let max_tokens = token_usage["stats"]["max_tokens"].as_u64().unwrap();
-    assert_eq!(max_tokens, 10000, "Max tokens should be 10000");
+    assert_eq!(max_tokens, 1_000_000, "Max tokens should be 10000");
 
     // Remaining tokens should be max_tokens - total_tokens
     let remaining_tokens = token_usage["stats"]["remaining_tokens"].as_u64().unwrap();

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -208,12 +208,24 @@ model_name = "gpt-4"
 model_display_name = "GPT-4 (Primary)"
 api_key = "sk-primary-key"
 
+[chat_providers.providers.primary.model_capabilities]
+context_size_tokens = 8192
+supports_image_understanding = false
+cost_input_tokens_per_1m = 30.0
+cost_output_tokens_per_1m = 60.0
+
 [chat_providers.providers.backup]
 provider_kind = "openai"
 model_name = "gpt-3.5-turbo"
 model_display_name = "GPT-3.5 Turbo (Backup)"
 api_key = "sk-backup-key"
 base_url = "https://api.backup-provider.com/v1/"
+
+[chat_providers.providers.backup.model_capabilities]
+context_size_tokens = 16385
+supports_image_understanding = false
+cost_input_tokens_per_1m = 1.0
+cost_output_tokens_per_1m = 2.0
 ```
 
 #### Provider Configuration Fields
@@ -229,6 +241,36 @@ Each provider in `chat_providers.providers` supports the following fields:
 - **`system_prompt_langfuse`** - Optional Langfuse prompt configuration (mutually exclusive with `system_prompt`)
 - **`additional_request_parameters`** - Optional array of additional request parameters
 - **`additional_request_headers`** - Optional array of additional request headers
+- **`model_capabilities`** - Optional configuration for model capabilities and limitations
+
+##### `model_capabilities`
+
+The `model_capabilities` field allows you to configure the capabilities and limitations of each chat provider's model. This information is used for token usage estimation, cost calculation, and determining which features are available.
+
+**Type:** `object | None`
+
+**Example:**
+
+```toml
+[chat_providers.providers.main.model_capabilities]
+context_size_tokens = 128000
+supports_image_understanding = true
+supports_reasoning = false
+supports_verbosity = false
+cost_input_tokens_per_1m = 5.0
+cost_output_tokens_per_1m = 15.0
+```
+
+**Fields:**
+
+- **`context_size_tokens`** _(default: 1000000)_ - Maximum number of tokens that may be provided to the model including input messages, system prompt, and files
+- **`supports_image_understanding`** _(default: false)_ - Whether the model supports being provided with images for understanding
+- **`supports_reasoning`** _(default: false)_ - Whether the model supports reasoning mode (e.g., OpenAI o1 family)
+- **`supports_verbosity`** _(default: false)_ - Whether the model supports providing a verbosity parameter (for future support of advanced models)
+- **`cost_input_tokens_per_1m`** _(default: 0.0)_ - Price per 1 million input tokens (unit-less, for cost estimation)
+- **`cost_output_tokens_per_1m`** _(default: 0.0)_ - Price per 1 million output tokens (unit-less, for cost estimation)
+
+If not explicitly configured, all capabilities default to conservative values (large context window, no special features, no cost tracking).
 
 #### `chat_providers.summary`
 


### PR DESCRIPTION
Related Linear issue: ERATO-51

- Adds model capability config under `chat_providers.providers.<provider_id>.model_capabilities`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-provider `model_capabilities` config and uses it to compute token limits in token usage API with optional provider selection; updates OpenAPI, tests, and docs.
> 
> - **Backend Config**:
>   - Add `ModelCapabilities` with defaults and integrate into `ChatProviderConfig` via `model_capabilities` (incl. `context_size_tokens`, feature flags, and cost fields).
>   - Migration applies Azure OpenAI -> OpenAI conversion and preserves `model_capabilities`.
> - **API (Token Usage)**:
>   - Extend `TokenUsageRequest` with optional `chat_provider_id`.
>   - Compute `max_tokens`/`remaining_tokens` from selected provider's `model_capabilities.context_size_tokens` and return resolved `chat_provider_id` in `TokenUsageStats`.
>   - Update OpenAPI schemas to reflect new fields and requirements.
> - **Tests**:
>   - Add integration tests for `model_capabilities` parsing and defaults.
>   - Adjust token usage test to expect large default `max_tokens` (1_000_000) and provider resolution.
> - **Docs**:
>   - Document `chat_providers.providers.*.model_capabilities` with examples and field descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1790670e3f3bf7e495af0e0f2fedd3a3e0362e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->