### PR TITLE
Fix token usage not being reported for Azure OpenAI

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "genai"
 version = "0.4.0-alpha.4-WIP"
-source = "git+https://github.com/EratoLab/rust-genai.git?rev=42ef411b480dc4e798c004912c833cbed6bfe3ad#42ef411b480dc4e798c004912c833cbed6bfe3ad"
+source = "git+https://github.com/EratoLab/rust-genai.git?rev=e32b1be1dc135dab61cc4daa7ea2404bc8fe545d#e32b1be1dc135dab61cc4daa7ea2404bc8fe545d"
 dependencies = [
  "bytes",
  "derive_more 2.0.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -38,7 +38,7 @@ lol_html = "2.2.0"
 ordered-multimap = { version = "0.7.3",  features = ["serde"]}
 futures = "0.3"
 tokio-stream = "0.1.17"
-genai = { version = "0.4.0-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "42ef411b480dc4e798c004912c833cbed6bfe3ad" }
+genai = { version = "0.4.0-WIP", git = "https://github.com/EratoLab/rust-genai.git", rev = "e32b1be1dc135dab61cc4daa7ea2404bc8fe545d" }
 reqwest = { version = "0.12.12", features = ["multipart"] }
 opendal = { version = "0.52.0", features = ["services-s3", "services-azblob"] }
 

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -207,7 +207,9 @@ impl AppState {
             header_map.insert(HeaderName::from_str(&key)?, HeaderValue::from_str(&value)?);
         }
 
-        client_builder = client_builder.default_headers(header_map);
+        client_builder = client_builder
+            .default_headers(header_map)
+            .connection_verbose(true);
 
         let custom_client = client_builder.build()?;
 


### PR DESCRIPTION
- Fix token usage not being reported for Azure OpenAI
- Turns on verbose connection logs for reqwest (only visible if trace log level is selected for the reqwest crate) to help debug opaque errors