### PR TITLE
Make top and bottom padding on Chat history list item symetrical

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -70,7 +70,7 @@ const ChatHistoryListItem = memo<{
       <InteractiveContainer
         useDiv={true}
         className={clsx(
-          "flex flex-col rounded-lg px-3 py-1.5 pr-1.5 text-left",
+          "flex flex-col rounded-lg px-3 py-1.5 pb-3.5 pr-1.5 text-left",
           isActive && "bg-theme-bg-selected",
           "hover:bg-theme-bg-hover",
           layout === "compact" ? "gap-0.5" : "gap-1",


### PR DESCRIPTION
Expands the bottom padding to be symetrical to the top padding

## Before
<img width="320" height="119" alt="image" src="https://github.com/user-attachments/assets/f2cabd6a-9e8e-41cd-9044-4679f7a098b4" />


## After
<img width="319" height="137" alt="image" src="https://github.com/user-attachments/assets/9a666c46-17dc-4098-adab-e810fed0c3c3" />
