### PR TITLE
Fix erato-email renderer font and expose action facet on messages API

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -195,11 +195,11 @@ chat_provider_ids = ["test-token-limit"]
 # display_name = "Outlook Rewrite Selection"
 # platform = "outlook"
 # template = """
-# The user has selected the following text from the email {{source_property}} they are currently composing:
+# FOR THIS MESSAGE ONLY: The user has selected the following text from the email {{source_property}} they are composing:
 #
 # {{selected_text}}
 #
-# When the user asks to rewrite, rephrase, improve, or suggest alternatives for this text, output each suggestion inside a fenced code block with language tag erato-email. The block should contain only the replacement text, no explanations or markdown inside the block. You may provide multiple alternatives as separate erato-email blocks.
+# For this reply only, output each rewrite suggestion inside a fenced code block with language tag erato-email. The block must contain only the replacement text — no explanations, labels, or markdown inside the block. You may offer multiple alternatives as separate erato-email blocks. On follow-up messages without a new selection, respond normally in plain text.
 # """
 # allowed_args = ["selected_text", "source_property"]
 
@@ -208,11 +208,11 @@ chat_provider_ids = ["test-token-limit"]
 # display_name = "Outlook Review Draft"
 # platform = "outlook"
 # template = """
-# The user is composing an email (format: {{body_format}}). The full draft body is:
+# FOR THIS MESSAGE ONLY: The user is composing an email (format: {{body_format}}). The full draft body is:
 #
 # {{full_body}}
 #
-# When suggesting specific rewrites for parts of the email, output each suggestion inside a fenced code block with language tag erato-email. For general feedback (tone, completeness, structure), use plain text.
+# For this reply only, output specific rewrite suggestions inside fenced code blocks with language tag erato-email. For general feedback (tone, completeness, structure), use plain text. On follow-up messages without a new draft, respond normally in plain text.
 # """
 # allowed_args = ["full_body", "body_format"]
 

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -23,7 +23,9 @@ use crate::models::chat::{
 use crate::models::file_capability::{
     FileCapability, FileOperation, find_file_capability_by_filename, get_file_capabilities,
 };
-use crate::models::message::{ContentPart, GenerationErrorType, GenerationMetadata, MessageSchema};
+use crate::models::message::{
+    ContentPart, GenerationErrorType, GenerationMetadata, GenerationParameters, MessageSchema,
+};
 use crate::models::permissions;
 use crate::policy::engine::PolicyEngine;
 use crate::policy::engine::authorize;
@@ -920,6 +922,14 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     feedback: Option<MessageFeedback>,
+    /// The action facet ID used for this generation, if any
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    action_facet_id: Option<String>,
+    /// The action facet arguments used for this generation, if any
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    action_facet_args: Option<HashMap<String, String>>,
 }
 
 /// Statistics for a list of chat messages
@@ -1497,6 +1507,10 @@ impl ChatMessage {
                 serde_json::from_value::<GenerationMetadata>(metadata.clone()).ok()
             })
             .and_then(|metadata| metadata.error);
+        let gen_params = msg
+            .generation_parameters
+            .as_ref()
+            .and_then(|p| serde_json::from_value::<GenerationParameters>(p.clone()).ok());
         Ok(ChatMessage {
             id: msg.id.to_string(),
             chat_id: msg.chat_id.to_string(),
@@ -1522,6 +1536,8 @@ impl ChatMessage {
                 created_at: f.created_at,
                 updated_at: f.updated_at,
             }),
+            action_facet_id: gen_params.as_ref().and_then(|p| p.action_facet_id.clone()),
+            action_facet_args: gen_params.and_then(|p| p.action_facet_args),
         })
     }
 }

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2407,6 +2407,20 @@
           "files"
         ],
         "properties": {
+          "action_facet_args": {
+            "type": "object",
+            "description": "The action facet arguments used for this generation, if any",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "action_facet_id": {
+            "type": "string",
+            "description": "The action facet ID used for this generation, if any"
+          },
           "chat_id": {
             "type": "string",
             "description": "The ID of the chat this message belongs to"

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -15,6 +15,7 @@ import { isImageFile } from "@/utils/file/fileTypeUtils";
 import { Alert } from "../Feedback/Alert";
 import { Avatar } from "../Feedback/Avatar";
 import { LoadingIndicator } from "../Feedback/LoadingIndicator";
+import { ActionFacetContext } from "../Message/ActionFacetContext";
 import { DefaultMessageControls } from "../Message/DefaultMessageControls";
 import { ImageLightbox } from "../Message/ImageLightbox";
 import { MessageContent } from "../Message/MessageContent";
@@ -189,6 +190,10 @@ export const ChatMessage = memo(function ChatMessage({
                 message.error.filter_details,
               )}
             </Alert>
+          )}
+
+          {!isUser && message.action_facet_args && (
+            <ActionFacetContext actionFacetArgs={message.action_facet_args} />
           )}
 
           <MessageContent

--- a/frontend/src/components/ui/Message/ActionFacetContext.tsx
+++ b/frontend/src/components/ui/Message/ActionFacetContext.tsx
@@ -1,0 +1,33 @@
+import { t } from "@lingui/core/macro";
+
+interface ActionFacetContextProps {
+  actionFacetArgs?: Record<string, string>;
+}
+
+/**
+ * Renders a quote block showing the contextual text that was sent alongside
+ * an action facet request (e.g., selected text from Outlook compose, cell
+ * content from Excel). Displays any arg named `selected_text` as a blockquote.
+ *
+ * Returns null when no displayable context is present.
+ */
+export function ActionFacetContext({
+  actionFacetArgs,
+}: ActionFacetContextProps) {
+  const selectedText = actionFacetArgs?.selected_text;
+
+  if (!selectedText) {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 rounded-md border-l-2 border-theme-border bg-theme-bg-secondary px-3 py-2">
+      <div className="mb-0.5 text-xs font-medium text-theme-fg-muted">
+        {t`Selection`}
+      </div>
+      <div className="line-clamp-3 text-sm text-theme-fg-secondary">
+        {selectedText}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -50,12 +50,36 @@ type MarkdownPreProps = React.ComponentPropsWithoutRef<"pre"> & {
   node?: unknown;
 };
 
+function isEratoEmailCodeChild(children: React.ReactNode): boolean {
+  const child = React.Children.only(children) as React.ReactElement<{
+    className?: string;
+  }>;
+  const cls = child.props.className ?? "";
+  return cls.includes("language-erato-email");
+}
+
 function MarkdownPre({
   node: _node,
   className,
   children,
   ...props
 }: MarkdownPreProps) {
+  // erato-email blocks render a custom component, not a code block —
+  // use a plain <div> to avoid inheriting <pre> monospace font.
+  try {
+    if (isEratoEmailCodeChild(children)) {
+      return (
+        <div>
+          <BlockCodeContext.Provider value={true}>
+            {children}
+          </BlockCodeContext.Provider>
+        </div>
+      );
+    }
+  } catch {
+    // Children structure didn't match — fall through to default <pre>.
+  }
+
   return (
     <pre
       className={["message-content-code-block", className]

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -259,6 +259,16 @@ export type Chat = {
  */
 export type ChatMessage = {
   /**
+   * The action facet arguments used for this generation, if any
+   */
+  action_facet_args?: {
+    [key: string]: string;
+  };
+  /**
+   * The action facet ID used for this generation, if any
+   */
+  action_facet_id?: string;
+  /**
    * The ID of the chat this message belongs to
    */
   chat_id: string;

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1810,6 +1810,10 @@ msgstr "Durchsuchen Sie Ihre Chats"
 msgid "Searching..."
 msgstr "Suchen..."
 
+#: src/components/ui/Message/ActionFacetContext.tsx
+msgid "Selection"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Send message"
 msgstr "Nachricht senden"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1810,6 +1810,10 @@ msgstr "Search Your Chats"
 msgid "Searching..."
 msgstr "Searching..."
 
+#: src/components/ui/Message/ActionFacetContext.tsx
+msgid "Selection"
+msgstr "Selection"
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Send message"
 msgstr "Send message"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1810,6 +1810,10 @@ msgstr "Buscar en sus chats"
 msgid "Searching..."
 msgstr "Buscando..."
 
+#: src/components/ui/Message/ActionFacetContext.tsx
+msgid "Selection"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Send message"
 msgstr "Enviar mensaje"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1810,6 +1810,10 @@ msgstr "Rechercher dans vos chats"
 msgid "Searching..."
 msgstr "Recherche en cours..."
 
+#: src/components/ui/Message/ActionFacetContext.tsx
+msgid "Selection"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Send message"
 msgstr "Envoyer le message"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1810,6 +1810,10 @@ msgstr "Przeszukaj swoje czaty"
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
+#: src/components/ui/Message/ActionFacetContext.tsx
+msgid "Selection"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Send message"
 msgstr "Wyślij wiadomość"

--- a/frontend/src/utils/adapters/messageAdapter.ts
+++ b/frontend/src/utils/adapters/messageAdapter.ts
@@ -28,6 +28,10 @@ export interface UiChatMessage extends Message {
   toolCalls?: UiToolCall[];
   /** Existing feedback for this message, if any */
   feedback?: MessageFeedback;
+  /** The action facet ID used for this generation, if any */
+  action_facet_id?: string;
+  /** The action facet arguments used for this generation, if any */
+  action_facet_args?: Record<string, string>;
 }
 
 /**
@@ -65,6 +69,8 @@ export function mapApiMessageToUiMessage(
     toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     feedback: apiMessage.feedback ?? undefined,
     error: isMessageError(error) ? error : undefined,
+    action_facet_id: apiMessage.action_facet_id ?? undefined,
+    action_facet_args: apiMessage.action_facet_args ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

### Fix erato-email renderer inheriting monospace font
- `MarkdownPre` now detects `erato-email` / `erato-email-html` code blocks and renders a `<div>` instead of `<pre>`, so the suggestion component uses the regular body font
- Line breaks are preserved via `whitespace-pre-wrap` on the inner component
- Other code blocks continue using `<pre>` as before

### Expose action facet metadata on chat messages API
- Add `action_facet_id` and `action_facet_args` fields to `ChatMessage` response struct (both optional, omitted when null)
- Extracted from `generation_parameters` JSONB during `from_model`
- Enables the frontend to show what selection/context was used for a given assistant response
- Frontend codegen updated with new schema types