### PR TITLE
Fix missing dev env config loading

### DIFF
--- a/office-addin/src/providers/MsalNaaProvider.tsx
+++ b/office-addin/src/providers/MsalNaaProvider.tsx
@@ -44,7 +44,7 @@ export function MsalNaaProvider({ children }: { children: React.ReactNode }) {
   const [loginHint, setLoginHint] = useState<string | undefined>();
 
   useEffect(() => {
-    const clientId = env().msalClientId;
+    const clientId = import.meta.env.VITE_MSAL_CLIENT_ID ?? env().msalClientId;
     if (!clientId) {
       setError("MSAL client ID is not configured");
       setIsInitialized(true);
@@ -72,7 +72,9 @@ export function MsalNaaProvider({ children }: { children: React.ReactNode }) {
     }
 
     const authority =
-      env().msalAuthority ?? "https://login.microsoftonline.com/common";
+      import.meta.env.VITE_MSAL_AUTHORITY ??
+      env().msalAuthority ??
+      "https://login.microsoftonline.com/common";
 
     const msalConfig = {
       auth: {

--- a/office-addin/src/vite-env.d.ts
+++ b/office-addin/src/vite-env.d.ts
@@ -1,2 +1,7 @@
 /// <reference types="vite/client" />
 /// <reference types="office-js" />
+
+interface ImportMetaEnv {
+  readonly VITE_MSAL_CLIENT_ID?: string;
+  readonly VITE_MSAL_AUTHORITY?: string;
+}


### PR DESCRIPTION
This pull request updates the way MSAL configuration values are loaded in the `MsalNaaProvider` component to allow overriding environment variables at build time. Now, the provider will first check for Vite-specific environment variables before falling back to the existing configuration, making it easier to configure the app in different environments.

Configuration loading improvements:

* The `clientId` is now loaded from `import.meta.env.VITE_MSAL_CLIENT_ID` if available, before falling back to `env().msalClientId`.
* The `authority` is now loaded from `import.meta.env.VITE_MSAL_AUTHORITY` if available, before falling back to `env().msalAuthority` and then the default value.