### PR TITLE
Hide chat advisory in Outlook add-in

### DIFF
--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -258,6 +258,12 @@ describe("ChatPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     componentRegistry.ChatWelcomeScreen = null;
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
 
     // Setup useChatContext mock
     (useChatContext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
@@ -547,7 +553,11 @@ describe("ChatPage", () => {
       <TestWrapper>
         <StaticFeatureConfigProvider
           config={{
-            chatInput: { autofocus: true, emptyStateLayout: "centered" },
+            chatInput: {
+              autofocus: true,
+              emptyStateLayout: "centered",
+              showUsageAdvisory: true,
+            },
           }}
         >
           <ChatPageStructure>
@@ -600,7 +610,11 @@ describe("ChatPage", () => {
       <TestWrapper>
         <StaticFeatureConfigProvider
           config={{
-            chatInput: { autofocus: true, emptyStateLayout: "centered" },
+            chatInput: {
+              autofocus: true,
+              emptyStateLayout: "centered",
+              showUsageAdvisory: true,
+            },
           }}
         >
           <ChatPageStructure>

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -110,6 +110,12 @@ describe("ChatInput", () => {
     vi.clearAllMocks();
     componentRegistry.ChatInputAttachmentPreview = null;
     componentRegistry.ChatTopLeftAccessory = null;
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    });
 
     const { i18n } = await import("@lingui/core");
     i18n.load("en", enMessages as unknown as Messages);
@@ -123,7 +129,10 @@ describe("ChatInput", () => {
     });
 
     mockUseUploadFeature.mockReturnValue({ enabled: false });
-    mockUseChatInputFeature.mockReturnValue({ autofocus: false });
+    mockUseChatInputFeature.mockReturnValue({
+      autofocus: false,
+      showUsageAdvisory: true,
+    });
     mockUseOptionalTranslation.mockReturnValue(null);
     mockUseActiveModelSelection.mockReturnValue({
       availableModels: [],
@@ -218,6 +227,60 @@ describe("ChatInput", () => {
 
     expect(textarea).toHaveFocus();
     otherButton.remove();
+  });
+
+  it("renders the AI usage advisory when enabled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const onSendMessage = vi.fn();
+    const advisory =
+      "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use.";
+
+    mockUseOptionalTranslation.mockReturnValue(advisory);
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={onSendMessage} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText(advisory)).toBeInTheDocument();
+  });
+
+  it("hides the AI usage advisory when disabled by feature config", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const onSendMessage = vi.fn();
+    const advisory =
+      "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use.";
+
+    mockUseChatInputFeature.mockReturnValue({
+      autofocus: false,
+      showUsageAdvisory: false,
+    });
+    mockUseOptionalTranslation.mockReturnValue(advisory);
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={onSendMessage} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText(advisory)).not.toBeInTheDocument();
   });
 
   it("uses externally controlled model selection when provided", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -190,10 +190,8 @@ export const ChatInput = ({
 
   // Get feature configurations
   const { enabled: uploadEnabled } = useUploadFeature();
-  const {
-    autofocus: shouldAutofocus,
-    showUsageAdvisory = true,
-  } = useChatInputFeature();
+  const { autofocus: shouldAutofocus, showUsageAdvisory = true } =
+    useChatInputFeature();
   // Dummy for i18n:extract
   const _aiUsageAdvisoryDefault = t({
     id: "chat.ai_usage_advisory",

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -190,7 +190,10 @@ export const ChatInput = ({
 
   // Get feature configurations
   const { enabled: uploadEnabled } = useUploadFeature();
-  const { autofocus: shouldAutofocus } = useChatInputFeature();
+  const {
+    autofocus: shouldAutofocus,
+    showUsageAdvisory = true,
+  } = useChatInputFeature();
   // Dummy for i18n:extract
   const _aiUsageAdvisoryDefault = t({
     id: "chat.ai_usage_advisory",
@@ -995,7 +998,7 @@ export const ChatInput = ({
           )}
         </div>
       </form>
-      {aiUsageAdvisory && (
+      {showUsageAdvisory && aiUsageAdvisory && (
         <div className="relative h-10">
           <p className="absolute inset-0 flex items-center justify-center text-center text-xs text-theme-fg-muted">
             {aiUsageAdvisory}

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -137,6 +137,10 @@ export interface FeatureConfig {
   chatSharing: ChatSharingFeatureConfig;
 }
 
+type FeatureConfigOverrides = {
+  [K in keyof FeatureConfig]?: Partial<FeatureConfig[K]>;
+};
+
 const FeatureConfigContext = createContext<FeatureConfig | null>(null);
 
 export const defaultStaticFeatureConfig: FeatureConfig = {
@@ -256,7 +260,7 @@ function createFeatureConfig(
   };
 }
 
-function mergeFeatureConfig(overrides?: Partial<FeatureConfig>): FeatureConfig {
+function mergeFeatureConfig(overrides?: FeatureConfigOverrides): FeatureConfig {
   if (!overrides) {
     return defaultStaticFeatureConfig;
   }
@@ -321,7 +325,7 @@ export function FeatureConfigProvider({
   config,
 }: {
   children: ReactNode;
-  config?: Partial<FeatureConfig>;
+  config?: FeatureConfigOverrides;
 }) {
   const resolvedConfig = useMemo<FeatureConfig>(
     () => (config ? mergeFeatureConfig(config) : createFeatureConfig(env())),
@@ -340,7 +344,7 @@ export function StaticFeatureConfigProvider({
   config,
 }: {
   children: ReactNode;
-  config?: Partial<FeatureConfig>;
+  config?: FeatureConfigOverrides;
 }) {
   const mergedConfig = useMemo(() => mergeFeatureConfig(config), [config]);
 

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -26,6 +26,8 @@ interface ChatInputFeatureConfig {
   autofocus: boolean;
   /** Layout of the chat input before a conversation has started */
   emptyStateLayout: "bottom" | "centered";
+  /** Whether to show the AI usage advisory below the chat input */
+  showUsageAdvisory: boolean;
 }
 
 /**
@@ -146,6 +148,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   chatInput: {
     autofocus: true,
     emptyStateLayout: "bottom",
+    showUsageAdvisory: true,
   },
   auth: {
     showLogout: false,
@@ -214,6 +217,7 @@ function createFeatureConfig(
     chatInput: {
       autofocus: !environment.disableChatInputAutofocus,
       emptyStateLayout: environment.chatInputEmptyStateLayout,
+      showUsageAdvisory: true,
     },
     auth: {
       showLogout: !environment.disableLogout,

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -26,7 +26,9 @@ import type { ReactNode } from "react";
 const mockEnv = env as ReturnType<typeof vi.fn>;
 
 // Helper to create wrapper with provider
-function createWrapper(config?: Parameters<typeof FeatureConfigProvider>[0]["config"]) {
+function createWrapper(
+  config?: Parameters<typeof FeatureConfigProvider>[0]["config"],
+) {
   // eslint-disable-next-line react/display-name
   return ({ children }: { children: ReactNode }) => (
     <FeatureConfigProvider config={config}>{children}</FeatureConfigProvider>

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -26,10 +26,10 @@ import type { ReactNode } from "react";
 const mockEnv = env as ReturnType<typeof vi.fn>;
 
 // Helper to create wrapper with provider
-function createWrapper() {
+function createWrapper(config?: Parameters<typeof FeatureConfigProvider>[0]["config"]) {
   // eslint-disable-next-line react/display-name
   return ({ children }: { children: ReactNode }) => (
-    <FeatureConfigProvider>{children}</FeatureConfigProvider>
+    <FeatureConfigProvider config={config}>{children}</FeatureConfigProvider>
   );
 }
 
@@ -103,6 +103,7 @@ describe("FeatureConfigProvider", () => {
         chatInput: {
           autofocus: true,
           emptyStateLayout: "bottom",
+          showUsageAdvisory: true,
         },
         chatSharing: {
           enabled: false,
@@ -204,7 +205,22 @@ describe("FeatureConfigProvider", () => {
 
       expect(result.current.upload.enabled).toBe(true);
       expect(result.current.chatInput.autofocus).toBe(false);
+      expect(result.current.chatInput.showUsageAdvisory).toBe(true);
       expect(result.current.auth.showLogout).toBe(true);
+    });
+
+    it("should allow overriding chat input advisory visibility", () => {
+      const { result } = renderHook(() => useFeatureConfig(), {
+        wrapper: createWrapper({
+          chatInput: { showUsageAdvisory: false },
+        }),
+      });
+
+      expect(result.current.chatInput).toEqual({
+        autofocus: true,
+        emptyStateLayout: "bottom",
+        showUsageAdvisory: false,
+      });
     });
 
     it("should return config with logout hidden when disableLogout is true", () => {
@@ -359,6 +375,7 @@ describe("FeatureConfigProvider", () => {
       expect(result.current).toEqual({
         autofocus: true,
         emptyStateLayout: "bottom",
+        showUsageAdvisory: true,
       });
     });
 

--- a/office-addin/src/App.tsx
+++ b/office-addin/src/App.tsx
@@ -54,7 +54,9 @@ export default function App() {
         initialThemeMode="light"
         persistThemeMode={false}
       >
-        <FeatureConfigProvider>
+        <FeatureConfigProvider
+          config={{ chatInput: { showUsageAdvisory: false } }}
+        >
           <ApiProvider enableDevtools={false}>
             <OfficeProvider>
               <MsalNaaProvider>


### PR DESCRIPTION
## Summary
- add a shared `chatInput.showUsageAdvisory` feature flag to the frontend feature config
- gate the shared `ChatInput` advisory footer on that flag
- disable the advisory in the Outlook add-in while keeping the regular web UI default unchanged

## Testing
- `pnpm vitest run src/components/ui/Chat/ChatInput.test.tsx src/providers/__tests__/FeatureConfigProvider.test.tsx`