### PR TITLE
Fix Outlook action-facet HTML preview and insertion

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -200,6 +200,45 @@ chat_provider_ids = ["test-token-limit"]
 # platform = "slack"
 # template = "Summarize the following content for posting to {{channel}}: {{content}}"
 # allowed_args = ["channel", "content"]
+#
+# Outlook override example: redefine the builtin Outlook facets only if you
+# need to customize them. If you do, keep the text-vs-HTML contract aligned
+# with the frontend renderer and Outlook insertion behavior.
+#
+# [action_facets.facets.outlook_rewrite_selection]
+# display_name = "Outlook Rewrite Selection"
+# platform = "outlook"
+# template = """
+# FOR THIS MESSAGE ONLY: The user is composing an email in {{body_format}} format and has selected the following text from the email {{source_property}}:
+#
+# {{selected_text}}
+#
+# Rewrite ONLY the selected text above - do not include surrounding email content such as greetings, sign-offs, or other paragraphs.
+#
+# If {{body_format}} is "text", output the rewrite inside exactly one fenced code block with language tag erato-email. The block must contain only plain text replacement content - no HTML tags, no explanations, no labels, and no markdown inside the block.
+#
+# If {{body_format}} is "html", output the rewrite inside exactly one fenced code block with language tag erato-email-html. The block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no markdown, no explanations, no labels, and no full document wrappers such as <html> or <body>.
+#
+# Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new selection, respond normally in plain text.
+# """
+# allowed_args = ["selected_text", "source_property", "body_format"]
+#
+# [action_facets.facets.outlook_review_draft]
+# display_name = "Outlook Review Draft"
+# platform = "outlook"
+# template = """
+# FOR THIS MESSAGE ONLY: The user is composing an email (format: {{body_format}}). The full draft body is:
+#
+# {{full_body}}
+#
+# For this reply only:
+#
+# - If {{body_format}} is "text", output specific rewrite suggestions inside fenced code blocks with language tag erato-email. Each such block must contain only plain text suggestion content - no HTML tags, no labels, and no markdown inside the block.
+# - If {{body_format}} is "html", output specific rewrite suggestions inside fenced code blocks with language tag erato-email-html. Each such block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no labels, no markdown inside the block, and no full document wrappers such as <html> or <body>.
+#
+# For general feedback (tone, completeness, structure), use plain text. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new draft, respond normally in plain text.
+# """
+# allowed_args = ["full_body", "body_format"]
 
 # Experimental facets feature configuration
 # [experimental_facets]

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -40,11 +40,17 @@ Output format:
 - No headings, no bullet points, no quotes, no explanations."#;
 
 const BUILTIN_OUTLOOK_REWRITE_SELECTION_TEMPLATE: &str = r#"
-FOR THIS MESSAGE ONLY: The user has selected the following text from the email {{source_property}} they are composing:
+FOR THIS MESSAGE ONLY: The user is composing an email in {{body_format}} format and has selected the following text from the email {{source_property}}:
 
 {{selected_text}}
 
-Rewrite ONLY the selected text above - do not include surrounding email content such as greetings, sign-offs, or other paragraphs. For this reply only, output the rewrite inside a fenced code block with language tag erato-email. The block must contain only the replacement text - no explanations, labels, or markdown inside the block. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new selection, respond normally in plain text.
+Rewrite ONLY the selected text above - do not include surrounding email content such as greetings, sign-offs, or other paragraphs.
+
+If {{body_format}} is "text", output the rewrite inside exactly one fenced code block with language tag erato-email. The block must contain only plain text replacement content - no HTML tags, no explanations, no labels, and no markdown inside the block.
+
+If {{body_format}} is "html", output the rewrite inside exactly one fenced code block with language tag erato-email-html. The block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no markdown, no explanations, no labels, and no full document wrappers such as <html> or <body>.
+
+Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new selection, respond normally in plain text.
 "#;
 
 const BUILTIN_OUTLOOK_REVIEW_DRAFT_TEMPLATE: &str = r#"
@@ -52,7 +58,12 @@ FOR THIS MESSAGE ONLY: The user is composing an email (format: {{body_format}}).
 
 {{full_body}}
 
-For this reply only, output specific rewrite suggestions inside fenced code blocks with language tag erato-email. For general feedback (tone, completeness, structure), use plain text. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new draft, respond normally in plain text.
+For this reply only:
+
+- If {{body_format}} is "text", output specific rewrite suggestions inside fenced code blocks with language tag erato-email. Each such block must contain only plain text suggestion content - no HTML tags, no labels, and no markdown inside the block.
+- If {{body_format}} is "html", output specific rewrite suggestions inside fenced code blocks with language tag erato-email-html. Each such block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no labels, no markdown inside the block, and no full document wrappers such as <html> or <body>.
+
+For general feedback (tone, completeness, structure), use plain text. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new draft, respond normally in plain text.
 "#;
 
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
@@ -1716,7 +1727,11 @@ impl ActionFacetsConfig {
                 template: BUILTIN_OUTLOOK_REWRITE_SELECTION_TEMPLATE
                     .trim()
                     .to_string(),
-                allowed_args: vec!["selected_text".to_string(), "source_property".to_string()],
+                allowed_args: vec![
+                    "selected_text".to_string(),
+                    "source_property".to_string(),
+                    "body_format".to_string(),
+                ],
             });
 
         self.facets

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -2237,14 +2237,16 @@ enable_builtin_ms_office_addin = true
     assert_eq!(rewrite.platform.as_deref(), Some("outlook"));
     assert_eq!(
         rewrite.allowed_args,
-        vec!["selected_text", "source_property"]
+        vec!["selected_text", "source_property", "body_format"]
     );
     assert!(rewrite.template.contains("{{selected_text}}"));
+    assert!(rewrite.template.contains("erato-email-html"));
 
     let review = &config.action_facets.facets["outlook_review_draft"];
     assert_eq!(review.platform.as_deref(), Some("outlook"));
     assert_eq!(review.allowed_args, vec!["full_body", "body_format"]);
     assert!(review.template.contains("{{full_body}}"));
+    assert!(review.template.contains("erato-email-html"));
 }
 
 #[test]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.3.3",
     "eslint-plugin-tailwindcss": "^3.18.0",
     "fuse.js": "^7.1.0",
     "iconoir-react": "^7.11.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       eslint-plugin-tailwindcss:
         specifier: ^3.18.0
         version: 3.18.0(tailwindcss@3.4.17)
@@ -1517,6 +1520,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2299,6 +2305,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6115,6 +6124,9 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -6933,6 +6945,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
+++ b/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
@@ -1,7 +1,8 @@
 import { t } from "@lingui/core/macro";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { componentRegistry } from "@/config/componentRegistry";
+import { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 
 import type { EratoEmailCodeBlockProps } from "@/config/componentRegistry";
 
@@ -12,8 +13,15 @@ import type { EratoEmailCodeBlockProps } from "@/config/componentRegistry";
  * The Office addin registers a richer version via componentRegistry that
  * adds "Replace Selection" and "Insert at Cursor" buttons.
  */
-function DefaultEratoEmailCodeBlock({ content }: EratoEmailCodeBlockProps) {
+function DefaultEratoEmailCodeBlock({
+  content,
+  isHtml,
+}: EratoEmailCodeBlockProps) {
   const [copied, setCopied] = useState(false);
+  const previewHtml = useMemo(
+    () => sanitizeHtmlPreview(content),
+    [content],
+  );
 
   const handleCopy = useCallback(() => {
     void navigator.clipboard
@@ -29,7 +37,14 @@ function DefaultEratoEmailCodeBlock({ content }: EratoEmailCodeBlockProps) {
 
   return (
     <div className="my-2 rounded-lg border border-theme-border bg-theme-bg-secondary p-3">
-      <div className="mb-2 whitespace-pre-wrap text-sm">{content}</div>
+      {isHtml ? (
+        <div
+          className="mb-2 text-sm [&_blockquote]:border-l-2 [&_blockquote]:border-theme-border [&_blockquote]:pl-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+          dangerouslySetInnerHTML={{ __html: previewHtml }}
+        />
+      ) : (
+        <div className="mb-2 whitespace-pre-wrap text-sm">{content}</div>
+      )}
       <div className="flex gap-2">
         <button
           type="button"
@@ -53,5 +68,5 @@ export function EratoEmailSuggestion({
     return <CustomRenderer content={content} isHtml={isHtml} />;
   }
 
-  return <DefaultEratoEmailCodeBlock content={content} />;
+  return <DefaultEratoEmailCodeBlock content={content} isHtml={isHtml} />;
 }

--- a/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
+++ b/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
@@ -18,10 +18,7 @@ function DefaultEratoEmailCodeBlock({
   isHtml,
 }: EratoEmailCodeBlockProps) {
   const [copied, setCopied] = useState(false);
-  const previewHtml = useMemo(
-    () => sanitizeHtmlPreview(content),
-    [content],
-  );
+  const previewHtml = useMemo(() => sanitizeHtmlPreview(content), [content]);
 
   const handleCopy = useCallback(() => {
     void navigator.clipboard
@@ -40,6 +37,8 @@ function DefaultEratoEmailCodeBlock({
       {isHtml ? (
         <div
           className="mb-2 text-sm [&_blockquote]:border-l-2 [&_blockquote]:border-theme-border [&_blockquote]:pl-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+          // Sanitized with DOMPurify before rendering.
+          // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: previewHtml }}
         />
       ) : (

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -98,6 +98,7 @@ export {
   type EratoEmailCodeBlockProps,
 } from "@/config/componentRegistry";
 export { createLogger } from "@/utils/debugLogger";
+export { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 export {
   extractTextFromContent,
   parseContent,

--- a/frontend/src/utils/__tests__/sanitizeHtmlPreview.test.ts
+++ b/frontend/src/utils/__tests__/sanitizeHtmlPreview.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeHtmlPreview } from "../sanitizeHtmlPreview";
+
+describe("sanitizeHtmlPreview", () => {
+  it("preserves simple email formatting", () => {
+    expect(
+      sanitizeHtmlPreview("<p>Hello <strong>team</strong><br>Thanks</p>"),
+    ).toBe("<p>Hello <strong>team</strong><br>Thanks</p>");
+  });
+
+  it("removes blocked tags and event handlers", () => {
+    expect(
+      sanitizeHtmlPreview(
+        '<script>alert(1)</script><p onclick="evil()">Safe</p>',
+      ),
+    ).toBe("<p>Safe</p>");
+  });
+
+  it("removes unsafe href values", () => {
+    expect(
+      sanitizeHtmlPreview('<a href="javascript:alert(1)">Click</a>'),
+    ).toBe("<a>Click</a>");
+  });
+});

--- a/frontend/src/utils/__tests__/sanitizeHtmlPreview.test.ts
+++ b/frontend/src/utils/__tests__/sanitizeHtmlPreview.test.ts
@@ -18,8 +18,8 @@ describe("sanitizeHtmlPreview", () => {
   });
 
   it("removes unsafe href values", () => {
-    expect(
-      sanitizeHtmlPreview('<a href="javascript:alert(1)">Click</a>'),
-    ).toBe("<a>Click</a>");
+    expect(sanitizeHtmlPreview('<a href="javascript:alert(1)">Click</a>')).toBe(
+      "<a>Click</a>",
+    );
   });
 });

--- a/frontend/src/utils/sanitizeHtmlPreview.ts
+++ b/frontend/src/utils/sanitizeHtmlPreview.ts
@@ -1,0 +1,29 @@
+import DOMPurify from "dompurify";
+
+const PREVIEW_FORBID_TAGS = [
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "input",
+  "button",
+  "textarea",
+  "select",
+];
+
+const PREVIEW_FORBID_ATTR = ["onerror", "onload", "onclick", "onmouseover"];
+
+/**
+ * Sanitizes a model-produced HTML fragment before rendering it inside an email
+ * suggestion preview. This keeps lightweight email formatting while removing
+ * active content and unsafe attributes.
+ */
+export function sanitizeHtmlPreview(html: string): string {
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: PREVIEW_FORBID_TAGS,
+    FORBID_ATTR: PREVIEW_FORBID_ATTR,
+  });
+}

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -19,6 +19,7 @@ import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection"
 import { useOutlookEmailSource } from "../hooks/useOutlookEmailSource";
 import { useOffice } from "../providers/OfficeProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
+import { getComposeBodyType } from "../utils/outlookComposeWrite";
 
 interface AddinChatInputProps {
   onSendMessage: (
@@ -153,6 +154,7 @@ export const AddinChatInput = forwardRef<
     ) => {
       // Build action facet payload: selection-based rewrite or full-body review
       let actionFacet: ActionFacetRequest | undefined;
+      const bodyFormat = mailItem ? await getComposeBodyType() : undefined;
 
       if (hasActiveSelection) {
         actionFacet = {
@@ -160,16 +162,19 @@ export const AddinChatInput = forwardRef<
           args: {
             selected_text: composeSelection.data,
             source_property: composeSelection.sourceProperty,
+            ...(bodyFormat ? { body_format: bodyFormat } : {}),
           },
         };
       } else if (mailItem?.bodyText || mailItem?.bodyHtml) {
-        const fullBody = mailItem.bodyText ?? mailItem.bodyHtml ?? "";
-        const bodyFormat = mailItem.bodyHtml ? "html" : "text";
+        const fullBody =
+          bodyFormat === "html"
+            ? mailItem.bodyHtml ?? mailItem.bodyText ?? ""
+            : mailItem.bodyText ?? mailItem.bodyHtml ?? "";
         actionFacet = {
           id: "outlook_review_draft",
           args: {
             full_body: fullBody,
-            body_format: bodyFormat,
+            body_format: bodyFormat ?? "text",
           },
         };
       }

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -168,8 +168,8 @@ export const AddinChatInput = forwardRef<
       } else if (mailItem?.bodyText || mailItem?.bodyHtml) {
         const fullBody =
           bodyFormat === "html"
-            ? mailItem.bodyHtml ?? mailItem.bodyText ?? ""
-            : mailItem.bodyText ?? mailItem.bodyHtml ?? "";
+            ? (mailItem.bodyHtml ?? mailItem.bodyText ?? "")
+            : (mailItem.bodyText ?? mailItem.bodyHtml ?? "");
         actionFacet = {
           id: "outlook_review_draft",
           args: {
@@ -244,8 +244,7 @@ export const AddinChatInput = forwardRef<
       composeSelection.data,
       composeSelection.sourceProperty,
       hasActiveSelection,
-      mailItem?.bodyText,
-      mailItem?.bodyHtml,
+      mailItem,
       resolveSelectedFilesForSend,
       shouldUseSuggestedEmailSource,
     ],

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from "react";
 import { sanitizeHtmlPreview } from "@erato/frontend/library";
+import { useCallback, useMemo, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
 import { replaceComposeSelection } from "../utils/outlookComposeWrite";
@@ -68,6 +68,8 @@ export function OutlookEratoEmailRenderer({
       {isHtml ? (
         <div
           className="mb-2 text-sm [&_blockquote]:border-l-2 [&_blockquote]:border-theme-border [&_blockquote]:pl-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+          // Sanitized with DOMPurify before rendering.
+          // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: previewHtml ?? "" }}
         />
       ) : (

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { sanitizeHtmlPreview } from "@erato/frontend/library";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
 import { replaceComposeSelection } from "../utils/outlookComposeWrite";
@@ -26,6 +27,10 @@ export function OutlookEratoEmailRenderer({
     "idle" | "inserting" | "done" | "copied" | "error"
   >("idle");
   const isBusy = status === "inserting";
+  const previewHtml = useMemo(
+    () => (isHtml ? sanitizeHtmlPreview(content) : null),
+    [content, isHtml],
+  );
 
   const handleInsert = useCallback(async () => {
     setStatus("inserting");
@@ -60,7 +65,14 @@ export function OutlookEratoEmailRenderer({
 
   return (
     <div className="my-2 rounded-lg border border-theme-border bg-theme-bg-secondary p-3">
-      <div className="mb-2 whitespace-pre-wrap text-sm">{content}</div>
+      {isHtml ? (
+        <div
+          className="mb-2 text-sm [&_blockquote]:border-l-2 [&_blockquote]:border-theme-border [&_blockquote]:pl-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:list-disc [&_ul]:pl-5"
+          dangerouslySetInnerHTML={{ __html: previewHtml ?? "" }}
+        />
+      ) : (
+        <div className="mb-2 whitespace-pre-wrap text-sm">{content}</div>
+      )}
       <div className="flex gap-2">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- make Outlook action-facet prompts branch between plain text and HTML output based on the compose body format
- send `body_format` and the correct draft body content from the add-in when generating rewrite/review suggestions
- render `erato-email-html` previews with shared DOMPurify sanitization in both web chat and the Outlook add-in

## Verification
- `frontend`: `pnpm exec tsc --noEmit`
- `frontend`: `pnpm exec vitest run src/utils/__tests__/sanitizeHtmlPreview.test.ts`
- `office-addin`: `pnpm exec vitest run src/utils/__tests__/outlookComposeWrite.test.ts`
- `office-addin`: `pnpm exec tsc --noEmit`

## Notes
- `frontend/src/components/ui/Message/MessageContent.test.tsx` still has an existing `localStorage` test harness issue in this environment; it was not introduced by this change.
- deployments using an external `erato.toml` override for Outlook action facets still need the same prompt update there, otherwise the runtime config will override the new built-in defaults.