### PR TITLE
Add fallback for Outlook hosts missing body.getTypeAsync

### DIFF
--- a/office-addin/src/test/mocks/outlook/composeMail.ts
+++ b/office-addin/src/test/mocks/outlook/composeMail.ts
@@ -12,7 +12,7 @@ export function createMockMessageCompose(
     cc: { getAsync: ReturnType<typeof vi.fn> };
     body: {
       getAsync: ReturnType<typeof vi.fn>;
-      getTypeAsync: ReturnType<typeof vi.fn>;
+      getTypeAsync?: ReturnType<typeof vi.fn>;
       setSelectedDataAsync: ReturnType<typeof vi.fn>;
       prependAsync: ReturnType<typeof vi.fn>;
     };

--- a/office-addin/src/utils/__tests__/outlookComposeWrite.test.ts
+++ b/office-addin/src/utils/__tests__/outlookComposeWrite.test.ts
@@ -58,6 +58,63 @@ describe("outlookComposeWrite", () => {
       expect(result).toBe("text");
     });
 
+    it("infers 'html' when getTypeAsync is unavailable", async () => {
+      const getAsync = vi.fn((coercionType, callback) => {
+        if (coercionType === Office.CoercionType.Html) {
+          callback(createMockAsyncResult("<div>Hello</div>"));
+          return;
+        }
+
+        callback(createMockAsyncResult("Hello"));
+      });
+      const item = createMockMessageCompose({
+        body: {
+          getAsync,
+          setSelectedDataAsync: vi.fn(),
+          prependAsync: vi.fn(),
+        },
+      });
+      mailbox.item = item;
+
+      const result = await getComposeBodyType();
+      expect(result).toBe("html");
+      expect(getAsync).toHaveBeenCalledWith(
+        Office.CoercionType.Html,
+        expect.any(Function),
+      );
+      expect(getAsync).toHaveBeenCalledWith(
+        Office.CoercionType.Text,
+        expect.any(Function),
+      );
+    });
+
+    it("falls back to 'text' when html body reads are unavailable", async () => {
+      const getAsync = vi.fn((coercionType, callback) => {
+        if (coercionType === Office.CoercionType.Html) {
+          callback(
+            createMockAsyncResult("", "failed", {
+              message: "HTML body unsupported",
+              code: "UnsupportedDataObject",
+            }),
+          );
+          return;
+        }
+
+        callback(createMockAsyncResult("Hello"));
+      });
+      const item = createMockMessageCompose({
+        body: {
+          getAsync,
+          setSelectedDataAsync: vi.fn(),
+          prependAsync: vi.fn(),
+        },
+      });
+      mailbox.item = item;
+
+      const result = await getComposeBodyType();
+      expect(result).toBe("text");
+    });
+
     it("throws when no compose item is available", async () => {
       mailbox.item = null;
       await expect(getComposeBodyType()).rejects.toThrow(
@@ -158,6 +215,51 @@ describe("outlookComposeWrite", () => {
       await replaceComposeSelection("<b>bold</b> text", true);
       expect(setSelectedDataAsync).toHaveBeenCalledWith(
         "bold text",
+        { coercionType: Office.CoercionType.Text },
+        expect.any(Function),
+      );
+    });
+
+    it("falls back to text insertion when html insertion is rejected", async () => {
+      const setSelectedDataAsync = vi.fn((data, options, callback) => {
+        if (options.coercionType === Office.CoercionType.Html) {
+          callback(
+            createMockAsyncResult(undefined, "failed", {
+              message: "HTML insertion unsupported",
+              code: "InvalidFormatError",
+            }),
+          );
+          return;
+        }
+
+        callback(createMockAsyncResult(undefined));
+      });
+      const item = createMockMessageCompose({
+        body: {
+          getAsync: vi.fn((coercionType, callback) => {
+            if (coercionType === Office.CoercionType.Html) {
+              callback(createMockAsyncResult("plain text"));
+              return;
+            }
+
+            callback(createMockAsyncResult("plain text"));
+          }),
+          setSelectedDataAsync,
+          prependAsync: vi.fn(),
+        },
+      });
+      mailbox.item = item;
+
+      await replaceComposeSelection("<b>bold</b>", true);
+      expect(setSelectedDataAsync).toHaveBeenNthCalledWith(
+        1,
+        "<b>bold</b>",
+        { coercionType: Office.CoercionType.Html },
+        expect.any(Function),
+      );
+      expect(setSelectedDataAsync).toHaveBeenNthCalledWith(
+        2,
+        "bold",
         { coercionType: Office.CoercionType.Text },
         expect.any(Function),
       );

--- a/office-addin/src/utils/outlookComposeWrite.ts
+++ b/office-addin/src/utils/outlookComposeWrite.ts
@@ -4,9 +4,60 @@ import { callOfficeAsync } from "./officeAsync";
 
 export type BodyFormat = "html" | "text";
 
+interface ComposeWriteAttempt {
+  coercionType: Office.CoercionType;
+  data: string;
+}
+
+async function tryReadComposeBody(
+  item: Office.MessageCompose,
+  coercionType: Office.CoercionType,
+): Promise<string | null> {
+  const body = item.body as {
+    getAsync?: (
+      coercionType: Office.CoercionType,
+      callback: (result: Office.AsyncResult<string>) => void,
+    ) => void;
+  };
+  const getAsync = body.getAsync;
+
+  if (typeof getAsync !== "function") {
+    return null;
+  }
+
+  try {
+    return await callOfficeAsync<string>((callback) =>
+      getAsync(coercionType, callback),
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function tryComposeWrite(
+  attempts: ComposeWriteAttempt[],
+  write: (attempt: ComposeWriteAttempt) => Promise<void>,
+): Promise<void> {
+  let lastError: unknown;
+
+  for (const attempt of attempts) {
+    try {
+      await write(attempt);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to write to compose body");
+}
+
 /**
  * Returns the current body format of the compose item ("html" or "text").
- * Must be called before every insertion to match the coercion type.
+ * Some Outlook hosts omit `body.getTypeAsync`, so this falls back to
+ * inspecting body reads instead of throwing.
  */
 export async function getComposeBodyType(): Promise<BodyFormat> {
   const item = Office.context.mailbox.item as Office.MessageCompose | null;
@@ -14,11 +65,35 @@ export async function getComposeBodyType(): Promise<BodyFormat> {
     throw new Error("No compose item available");
   }
 
-  const bodyType = await callOfficeAsync<Office.CoercionType>((callback) =>
-    item.body.getTypeAsync(callback),
-  );
+  const body = item.body as {
+    getTypeAsync?: (
+      callback: (result: Office.AsyncResult<Office.CoercionType>) => void,
+    ) => void;
+  };
+  const getTypeAsync = body.getTypeAsync;
 
-  return bodyType === Office.CoercionType.Html ? "html" : "text";
+  if (typeof getTypeAsync === "function") {
+    const bodyType = await callOfficeAsync<Office.CoercionType>((callback) =>
+      getTypeAsync(callback),
+    );
+
+    return bodyType === Office.CoercionType.Html ? "html" : "text";
+  }
+
+  const [htmlBody, textBody] = await Promise.all([
+    tryReadComposeBody(item, Office.CoercionType.Html),
+    tryReadComposeBody(item, Office.CoercionType.Text),
+  ]);
+
+  if (htmlBody !== null) {
+    return "html";
+  }
+
+  if (textBody !== null) {
+    return "text";
+  }
+
+  return "html";
 }
 
 /**
@@ -45,25 +120,46 @@ export async function replaceComposeSelection(
   }
 
   const bodyFormat = await getComposeBodyType();
+  const writeAttempts: ComposeWriteAttempt[] = isHtml
+    ? bodyFormat === "text"
+      ? [
+          {
+            coercionType: Office.CoercionType.Text,
+            data: stripHtmlTags(data),
+          },
+          { coercionType: Office.CoercionType.Html, data },
+        ]
+      : [
+          { coercionType: Office.CoercionType.Html, data },
+          {
+            coercionType: Office.CoercionType.Text,
+            data: stripHtmlTags(data),
+          },
+        ]
+    : bodyFormat === "html"
+      ? [
+          {
+            coercionType: Office.CoercionType.Html,
+            data: plainTextToHtml(data),
+          },
+          { coercionType: Office.CoercionType.Text, data },
+        ]
+      : [
+          { coercionType: Office.CoercionType.Text, data },
+          {
+            coercionType: Office.CoercionType.Html,
+            data: plainTextToHtml(data),
+          },
+        ];
 
-  let insertData = data;
-  let coercionType: Office.CoercionType;
-
-  if (bodyFormat === "html") {
-    coercionType = Office.CoercionType.Html;
-    if (!isHtml) {
-      // Plain text → HTML: escape special chars and convert newlines to <br>
-      insertData = plainTextToHtml(data);
-    }
-  } else {
-    coercionType = Office.CoercionType.Text;
-    if (isHtml) {
-      insertData = stripHtmlTags(data);
-    }
-  }
-
-  await callOfficeAsync<void>((callback) =>
-    item.body.setSelectedDataAsync(insertData, { coercionType }, callback),
+  await tryComposeWrite(writeAttempts, (attempt) =>
+    callOfficeAsync<void>((callback) =>
+      item.body.setSelectedDataAsync(
+        attempt.data,
+        { coercionType: attempt.coercionType },
+        callback,
+      ),
+    ),
   );
 }
 
@@ -77,10 +173,24 @@ export async function prependComposeBody(data: string): Promise<void> {
   }
 
   const bodyFormat = await getComposeBodyType();
-  const coercionType =
-    bodyFormat === "html" ? Office.CoercionType.Html : Office.CoercionType.Text;
+  const writeAttempts: ComposeWriteAttempt[] =
+    bodyFormat === "html"
+      ? [
+          { coercionType: Office.CoercionType.Html, data },
+          { coercionType: Office.CoercionType.Text, data: stripHtmlTags(data) },
+        ]
+      : [
+          { coercionType: Office.CoercionType.Text, data: stripHtmlTags(data) },
+          { coercionType: Office.CoercionType.Html, data },
+        ];
 
-  await callOfficeAsync<void>((callback) =>
-    item.body.prependAsync(data, { coercionType }, callback),
+  await tryComposeWrite(writeAttempts, (attempt) =>
+    callOfficeAsync<void>((callback) =>
+      item.body.prependAsync(
+        attempt.data,
+        { coercionType: attempt.coercionType },
+        callback,
+      ),
+    ),
   );
 }


### PR DESCRIPTION
## Summary
- Adds resilience for Outlook hosts that omit `body.getTypeAsync` by falling back to reading HTML/text body content to infer the compose format
- Adds retry-with-fallback when HTML insertion or reading is rejected, gracefully degrading to plain text
- Updates mock and tests to cover the new code paths

## Test plan
- [x] Verify existing Outlook compose tests pass
- [x] Test on Outlook hosts that support `getTypeAsync` (no behavior change)
- [x] Test on Outlook hosts that lack `getTypeAsync` (should infer format instead of throwing)