### PR TITLE
Add officeTheme utils module (ERMAIN-265)

### DIFF
--- a/office-addin/src/test/setupOffice.ts
+++ b/office-addin/src/test/setupOffice.ts
@@ -19,6 +19,7 @@ const officeMock = {
   },
   EventType: {
     ItemChanged: "itemChanged",
+    OfficeThemeChanged: "officeThemeChanged",
   },
   context: {} as Record<string, unknown>,
 };

--- a/office-addin/src/utils/officeTheme/__tests__/detectTheme.test.ts
+++ b/office-addin/src/utils/officeTheme/__tests__/detectTheme.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { detectTheme } from "../detectTheme";
+
+type OfficeThemeLike = {
+  bodyBackgroundColor: string;
+  bodyForegroundColor: string;
+  controlBackgroundColor: string;
+  controlForegroundColor: string;
+  isDarkTheme: boolean;
+  themeId?: unknown;
+};
+
+function installOfficeTheme(theme: OfficeThemeLike) {
+  (Office.context as unknown as Record<string, unknown>).officeTheme = theme;
+}
+
+function uninstallOfficeTheme() {
+  delete (Office.context as unknown as Record<string, unknown>).officeTheme;
+}
+
+const lightTheme: OfficeThemeLike = {
+  bodyBackgroundColor: "#FFFFFF",
+  bodyForegroundColor: "#000000",
+  controlBackgroundColor: "#F3F3F3",
+  controlForegroundColor: "#222222",
+  isDarkTheme: false,
+};
+
+const darkTheme: OfficeThemeLike = {
+  bodyBackgroundColor: "#1F1F1F",
+  bodyForegroundColor: "#FFFFFF",
+  controlBackgroundColor: "#2B2B2B",
+  controlForegroundColor: "#FFFFFF",
+  isDarkTheme: true,
+};
+
+describe("detectTheme", () => {
+  afterEach(() => {
+    uninstallOfficeTheme();
+  });
+
+  it("returns null when Office.context.officeTheme is unavailable", () => {
+    expect(detectTheme("Outlook")).toBeNull();
+    expect(detectTheme("Excel")).toBeNull();
+    expect(detectTheme(null)).toBeNull();
+  });
+
+  it("derives Outlook mode from bodyBackgroundColor luminance (dark bg → dark)", () => {
+    installOfficeTheme({
+      ...darkTheme,
+      isDarkTheme: false, // Outlook does not populate this; must be ignored
+    });
+
+    const snapshot = detectTheme("Outlook");
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.mode).toBe("dark");
+    expect(snapshot?.colors).toEqual({
+      bodyBackground: "#1F1F1F",
+      bodyForeground: "#FFFFFF",
+      controlBackground: "#2B2B2B",
+      controlForeground: "#FFFFFF",
+    });
+  });
+
+  it("derives Outlook mode from bodyBackgroundColor luminance (light bg → light)", () => {
+    installOfficeTheme({
+      ...lightTheme,
+      isDarkTheme: true, // ignored for Outlook
+    });
+
+    const snapshot = detectTheme("Outlook");
+
+    expect(snapshot?.mode).toBe("light");
+  });
+
+  it("uses isDarkTheme directly for non-Outlook hosts (true → dark)", () => {
+    installOfficeTheme(darkTheme);
+
+    expect(detectTheme("Excel")?.mode).toBe("dark");
+    expect(detectTheme("Word")?.mode).toBe("dark");
+    expect(detectTheme("PowerPoint")?.mode).toBe("dark");
+  });
+
+  it("uses isDarkTheme directly for non-Outlook hosts (false → light)", () => {
+    installOfficeTheme({ ...darkTheme, isDarkTheme: false });
+
+    expect(detectTheme("Excel")?.mode).toBe("light");
+  });
+
+  it("uses isDarkTheme for an unknown or null host (non-Outlook branch)", () => {
+    installOfficeTheme(darkTheme);
+
+    expect(detectTheme(null)?.mode).toBe("dark");
+    expect(detectTheme("Unknown")?.mode).toBe("dark");
+  });
+});

--- a/office-addin/src/utils/officeTheme/__tests__/luminance.test.ts
+++ b/office-addin/src/utils/officeTheme/__tests__/luminance.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+
+import { isHexDark } from "../luminance";
+
+describe("isHexDark", () => {
+  it("classifies white as light", () => {
+    expect(isHexDark("#FFFFFF")).toBe(false);
+  });
+
+  it("classifies black as dark", () => {
+    expect(isHexDark("#000000")).toBe(true);
+  });
+
+  it("treats mid-grey #808080 as light (brightness just above 0.5)", () => {
+    expect(isHexDark("#808080")).toBe(false);
+  });
+
+  it("treats #7F7F7F as dark (brightness just below 0.5)", () => {
+    expect(isHexDark("#7F7F7F")).toBe(true);
+  });
+
+  it("expands the 3-char form (#FFF)", () => {
+    expect(isHexDark("#FFF")).toBe(false);
+    expect(isHexDark("#000")).toBe(true);
+  });
+
+  it("accepts hex values without a leading hash", () => {
+    expect(isHexDark("FFFFFF")).toBe(false);
+  });
+
+  it("returns false for malformed input rather than throwing", () => {
+    expect(isHexDark("not-a-color")).toBe(false);
+  });
+});

--- a/office-addin/src/utils/officeTheme/__tests__/subscribeThemeChanges.test.ts
+++ b/office-addin/src/utils/officeTheme/__tests__/subscribeThemeChanges.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  installMockMailbox,
+  uninstallMockMailbox,
+} from "../../../test/mocks/outlook/mailbox";
+import { subscribeThemeChanges } from "../subscribeThemeChanges";
+
+type OfficeThemeLike = {
+  bodyBackgroundColor: string;
+  bodyForegroundColor: string;
+  controlBackgroundColor: string;
+  controlForegroundColor: string;
+  isDarkTheme: boolean;
+};
+
+const darkTheme: OfficeThemeLike = {
+  bodyBackgroundColor: "#1F1F1F",
+  bodyForegroundColor: "#FFFFFF",
+  controlBackgroundColor: "#2B2B2B",
+  controlForegroundColor: "#FFFFFF",
+  isDarkTheme: true,
+};
+
+function installOfficeTheme(theme: OfficeThemeLike) {
+  (Office.context as unknown as Record<string, unknown>).officeTheme = theme;
+}
+
+function uninstallOfficeTheme() {
+  delete (Office.context as unknown as Record<string, unknown>).officeTheme;
+}
+
+describe("subscribeThemeChanges", () => {
+  describe("Outlook host", () => {
+    beforeEach(() => {
+      installMockMailbox();
+      installOfficeTheme(darkTheme);
+    });
+
+    afterEach(() => {
+      uninstallOfficeTheme();
+      uninstallMockMailbox();
+    });
+
+    it("registers an OfficeThemeChanged handler on the mailbox", () => {
+      const handler = vi.fn();
+
+      subscribeThemeChanges("Outlook", handler);
+
+      expect(Office.context.mailbox.addHandlerAsync).toHaveBeenCalledTimes(1);
+      const [eventType, registered, callback] = (
+        Office.context.mailbox.addHandlerAsync as unknown as {
+          mock: { calls: unknown[][] };
+        }
+      ).mock.calls[0];
+      expect(eventType).toBe(Office.EventType.OfficeThemeChanged);
+      expect(typeof registered).toBe("function");
+      expect(typeof callback).toBe("function");
+    });
+
+    it("invokes the consumer handler with a parsed snapshot when the event fires", () => {
+      const handler = vi.fn();
+
+      subscribeThemeChanges("Outlook", handler);
+
+      const [, registered] = (
+        Office.context.mailbox.addHandlerAsync as unknown as {
+          mock: { calls: [unknown, (args: unknown) => void, unknown][] };
+        }
+      ).mock.calls[0];
+
+      registered({
+        officeTheme: darkTheme,
+        type: "officeThemeChanged",
+      });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({
+        mode: "dark",
+        colors: {
+          bodyBackground: "#1F1F1F",
+          bodyForeground: "#FFFFFF",
+          controlBackground: "#2B2B2B",
+          controlForeground: "#FFFFFF",
+        },
+      });
+    });
+
+    it("calls removeHandlerAsync when the returned unsubscribe runs", () => {
+      const unsubscribe = subscribeThemeChanges("Outlook", vi.fn());
+
+      expect(Office.context.mailbox.removeHandlerAsync).not.toHaveBeenCalled();
+
+      unsubscribe();
+
+      expect(Office.context.mailbox.removeHandlerAsync).toHaveBeenCalledTimes(
+        1,
+      );
+      const [eventType] = (
+        Office.context.mailbox.removeHandlerAsync as unknown as {
+          mock: { calls: unknown[][] };
+        }
+      ).mock.calls[0];
+      expect(eventType).toBe(Office.EventType.OfficeThemeChanged);
+    });
+  });
+
+  describe("non-Outlook hosts", () => {
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    beforeEach(() => {
+      debugSpy.mockClear();
+    });
+
+    afterEach(() => {
+      // Ensure no mailbox stub leaked in from another test.
+      uninstallMockMailbox();
+    });
+
+    it("returns a no-op unsubscribe and does not touch Office for Excel", () => {
+      const handler = vi.fn();
+
+      const unsubscribe = subscribeThemeChanges("Excel", handler);
+
+      expect(typeof unsubscribe).toBe("function");
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+
+      // Unsubscribe should be safe even without any registered handler.
+      expect(() => unsubscribe()).not.toThrow();
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("returns a no-op for null host", () => {
+      const unsubscribe = subscribeThemeChanges(null, vi.fn());
+
+      expect(typeof unsubscribe).toBe("function");
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+});

--- a/office-addin/src/utils/officeTheme/detectTheme.ts
+++ b/office-addin/src/utils/officeTheme/detectTheme.ts
@@ -1,0 +1,53 @@
+import { isHexDark } from "./luminance";
+
+export type OfficeThemeSnapshot = {
+  mode: "light" | "dark";
+  colors: {
+    bodyBackground: string;
+    bodyForeground: string;
+    controlBackground: string;
+    controlForeground: string;
+  };
+};
+
+/**
+ * Reads the current Office theme and returns a host-normalized snapshot.
+ *
+ * Outlook does not populate `officeTheme.isDarkTheme`, so for that host the
+ * mode is derived from the luminance of `bodyBackgroundColor`. Other hosts
+ * (Excel, Word, PowerPoint) read `isDarkTheme` directly.
+ *
+ * The caller passes `host` — this module deliberately does not read
+ * `Office.context.host` itself, so it stays pure and easy to test.
+ */
+export function detectTheme(host: string | null): OfficeThemeSnapshot | null {
+  const officeTheme = getOfficeTheme();
+  if (!officeTheme) {
+    return null;
+  }
+
+  const colors = {
+    bodyBackground: officeTheme.bodyBackgroundColor,
+    bodyForeground: officeTheme.bodyForegroundColor,
+    controlBackground: officeTheme.controlBackgroundColor,
+    controlForeground: officeTheme.controlForegroundColor,
+  };
+
+  const mode: "light" | "dark" =
+    host === "Outlook"
+      ? isHexDark(colors.bodyBackground)
+        ? "dark"
+        : "light"
+      : officeTheme.isDarkTheme
+        ? "dark"
+        : "light";
+
+  return { mode, colors };
+}
+
+function getOfficeTheme(): Office.OfficeTheme | undefined {
+  if (typeof Office === "undefined") {
+    return undefined;
+  }
+  return Office?.context?.officeTheme;
+}

--- a/office-addin/src/utils/officeTheme/luminance.ts
+++ b/office-addin/src/utils/officeTheme/luminance.ts
@@ -1,0 +1,31 @@
+/**
+ * Returns true when the given hex color is perceptually dark.
+ *
+ * Accepts `#RGB` or `#RRGGBB`. Uses HSP perceived brightness with a 0.5
+ * threshold: sqrt(0.299·R² + 0.587·G² + 0.114·B²) / 255.
+ *
+ * Used to infer Outlook theme mode, where `Office.context.officeTheme.isDarkTheme`
+ * is not populated and callers must derive mode from `bodyBackgroundColor`.
+ */
+export function isHexDark(hex: string): boolean {
+  const cleaned = hex.replace(/^#/, "");
+  const expanded =
+    cleaned.length === 3
+      ? cleaned
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : cleaned;
+
+  if (!/^[0-9a-f]{6}$/i.test(expanded)) {
+    return false;
+  }
+
+  const r = parseInt(expanded.slice(0, 2), 16);
+  const g = parseInt(expanded.slice(2, 4), 16);
+  const b = parseInt(expanded.slice(4, 6), 16);
+
+  const brightness =
+    Math.sqrt(0.299 * r * r + 0.587 * g * g + 0.114 * b * b) / 255;
+  return brightness < 0.5;
+}

--- a/office-addin/src/utils/officeTheme/subscribeThemeChanges.ts
+++ b/office-addin/src/utils/officeTheme/subscribeThemeChanges.ts
@@ -1,0 +1,53 @@
+import { callOfficeAsync } from "../officeAsync";
+import { detectTheme, type OfficeThemeSnapshot } from "./detectTheme";
+
+/**
+ * Subscribes to Office theme changes. Returns an unsubscribe function.
+ *
+ * Only Outlook exposes an event in `@types/office-js@1.0.581` — other hosts
+ * fall back to a no-op unsubscribe. The handler receives a parsed
+ * `OfficeThemeSnapshot` so callers never touch the raw event args.
+ */
+export function subscribeThemeChanges(
+  host: string | null,
+  handler: (snapshot: OfficeThemeSnapshot) => void,
+): () => void {
+  if (host !== "Outlook") {
+    console.debug(
+      `[officeTheme] subscribeThemeChanges: no-op for host "${host ?? "null"}" — ` +
+        "no theme-change event surface available in @types/office-js",
+    );
+    return () => {};
+  }
+
+  const mailbox =
+    typeof Office !== "undefined" ? Office?.context?.mailbox : undefined;
+  if (!mailbox) {
+    return () => {};
+  }
+
+  const eventHandler = () => {
+    const snapshot = detectTheme(host);
+    if (snapshot) {
+      handler(snapshot);
+    }
+  };
+
+  callOfficeAsync<void>((callback) => {
+    mailbox.addHandlerAsync(
+      Office.EventType.OfficeThemeChanged,
+      eventHandler,
+      callback,
+    );
+  }).catch((err: unknown) => {
+    console.warn("[officeTheme] failed to register theme-change handler", err);
+  });
+
+  return () => {
+    callOfficeAsync<void>((callback) => {
+      mailbox.removeHandlerAsync(Office.EventType.OfficeThemeChanged, callback);
+    }).catch((err: unknown) => {
+      console.warn("[officeTheme] failed to remove theme-change handler", err);
+    });
+  };
+}


### PR DESCRIPTION
This pull request introduces a new, well-tested utility for detecting and subscribing to Office theme changes, with special handling for Outlook's unique behavior. The changes include robust theme detection logic, a luminance-based helper for inferring dark mode, and a subscription mechanism for theme change events, all with comprehensive Vitest coverage.

**New Office theme detection and subscription utilities:**

* Added `detectTheme` function in `detectTheme.ts` to normalize Office theme data across hosts, using luminance for Outlook and `isDarkTheme` elsewhere.
* Implemented `subscribeThemeChanges` in `subscribeThemeChanges.ts`, allowing consumers to subscribe to theme changes (works for Outlook, no-ops for other hosts).
* Added `isHexDark` utility in `luminance.ts` to determine if a hex color is perceptually dark, used for Outlook mode inference.
* Updated the Office mock in `setupOffice.ts` to include the new `OfficeThemeChanged` event type required for theme change subscriptions.

**Comprehensive testing:**

* Added Vitest test suites for `detectTheme`, `isHexDark`, and `subscribeThemeChanges`, ensuring correct behavior for all supported scenarios and edge cases. [[1]](diffhunk://#diff-d58234ad2d8437322f08bc9facc3d8e84f08717dc26e2a623bf42bfd1d2a672cR1-R98) [[2]](diffhunk://#diff-5b4be5fced38d2bd1a305d8e9c47add41cff07d6e8c543ac7f448a99fc8b5302R1-R34) [[3]](diffhunk://#diff-9819292bdbf98d80b3dd35b4e9ac1eaf5820e9440ca2f1b9e53a3c1a7b04c3c7R1-R141)