### PR TITLE
Wire OfficeThemeProvider into App (ERMAIN-267)

### DIFF
--- a/office-addin/src/App.tsx
+++ b/office-addin/src/App.tsx
@@ -9,6 +9,7 @@ import { t } from "@lingui/core/macro";
 import { AddinChatPage } from "./pages/AddinChatPage";
 import { MsalNaaProvider, useMsalNaa } from "./providers/MsalNaaProvider";
 import { OfficeProvider, useOffice } from "./providers/OfficeProvider";
+import { OfficeThemeProvider } from "./providers/OfficeThemeProvider";
 import { OutlookMailItemProvider } from "./providers/OutlookMailItemProvider";
 
 import "./styles.css";
@@ -59,25 +60,23 @@ function OutlookWrapper({ children }: { children: React.ReactNode }) {
 export default function App() {
   return (
     <I18nProvider>
-      <ThemeProvider
-        enableCustomTheme
-        initialThemeMode="light"
-        persistThemeMode={false}
-      >
+      <ThemeProvider enableCustomTheme persistThemeMode={false}>
         <FeatureConfigProvider
           config={{ chatInput: { showUsageAdvisory: false } }}
         >
           <ApiProvider enableDevtools={false}>
             <OfficeProvider>
-              <MsalNaaProvider>
-                <AuthGate>
-                  <OutlookWrapper>
-                    <div className="office-shell">
-                      <AddinChatPage />
-                    </div>
-                  </OutlookWrapper>
-                </AuthGate>
-              </MsalNaaProvider>
+              <OfficeThemeProvider>
+                <MsalNaaProvider>
+                  <AuthGate>
+                    <OutlookWrapper>
+                      <div className="office-shell">
+                        <AddinChatPage />
+                      </div>
+                    </OutlookWrapper>
+                  </AuthGate>
+                </MsalNaaProvider>
+              </OfficeThemeProvider>
             </OfficeProvider>
           </ApiProvider>
         </FeatureConfigProvider>

--- a/office-addin/src/providers/OfficeThemeProvider.tsx
+++ b/office-addin/src/providers/OfficeThemeProvider.tsx
@@ -1,0 +1,24 @@
+/**
+ * Side-effect-only provider — deliberately does not expose its own React
+ * context, unlike the other providers in this directory. It reads the
+ * Office.js theme via `useOfficeTheme` and pushes the resulting mode into
+ * the frontend `ThemeProvider` through `setThemeMode`. The redundant-mode
+ * guard prevents unnecessary re-renders.
+ */
+import { useTheme } from "@erato/frontend/library";
+import { useEffect, type ReactNode } from "react";
+
+import { useOfficeTheme } from "../hooks/useOfficeTheme";
+
+export function OfficeThemeProvider({ children }: { children: ReactNode }) {
+  const { mode } = useOfficeTheme();
+  const { themeMode, setThemeMode } = useTheme();
+
+  useEffect(() => {
+    if (mode && mode !== themeMode) {
+      setThemeMode(mode);
+    }
+  }, [mode, themeMode, setThemeMode]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
This pull request introduces a new `OfficeThemeProvider` component to better synchronize the application's theme with the Office.js theme. The new provider is integrated into the main app component, ensuring that theme changes in Office are reflected in the frontend theme without unnecessary re-renders.

Theme synchronization improvements:

* Added the new `OfficeThemeProvider` component, which listens for theme changes via `useOfficeTheme` and updates the frontend `ThemeProvider` accordingly, while avoiding redundant updates. (`office-addin/src/providers/OfficeThemeProvider.tsx`)
* Integrated `OfficeThemeProvider` into the app's provider hierarchy, wrapping the authentication and Outlook providers to ensure theme synchronization throughout the app. (`office-addin/src/App.tsx`) [[1]](diffhunk://#diff-5e5d2952245e4ff12f457c64c0ee8bca78ba7f3b0151b4297de78098d0b2c324R12) [[2]](diffhunk://#diff-5e5d2952245e4ff12f457c64c0ee8bca78ba7f3b0151b4297de78098d0b2c324L62-R69) [[3]](diffhunk://#diff-5e5d2952245e4ff12f457c64c0ee8bca78ba7f3b0151b4297de78098d0b2c324R79)