### PR TITLE
Fix linked add-in linked-dev asset rebuilds and startup flow

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -7,10 +7,19 @@
 # It also receives through stdin a series of lines in the format:
 # <local_ref> <local_sha> <remote_ref> <remote_sha>
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+run_from_repo_dir() {
+    local relative_dir=$1
+    shift
+    (
+        cd "$REPO_ROOT/$relative_dir" && "$@"
+    )
+}
+
 check_backend_changes() {
     local changed_files=("$@")
     local backend_files=()
-    local initial_dir=$(pwd)
 
     # Check if any files in backend directory were modified
     for file in "${changed_files[@]}"; do
@@ -47,18 +56,15 @@ check_backend_changes() {
     if [ -n "$selected" ]; then
         if echo "$selected" | grep -q "Run tests"; then
             echo "Running tests..."
-            cd backend && just test
-            cd "$initial_dir"
+            run_from_repo_dir backend just test
         fi
         if echo "$selected" | grep -q "Run lint"; then
             echo "Running lint..."
-            cd backend && just lint
-            cd "$initial_dir"
+            run_from_repo_dir backend just lint
         fi
         if echo "$selected" | grep -q "Check OpenAPI"; then
             echo "Checking if OpenAPI spec is up to date..."
-            cd backend && just generate_open_api_check
-            cd "$initial_dir"
+            run_from_repo_dir backend just generate_open_api_check
         fi
     fi
 
@@ -68,7 +74,6 @@ check_backend_changes() {
 check_frontend_changes() {
     local changed_files=("$@")
     local frontend_files=()
-    local initial_dir=$(pwd)
 
     # Check if any files in frontend directory were modified
     for file in "${changed_files[@]}"; do
@@ -105,7 +110,7 @@ check_frontend_changes() {
     if [ -n "$selected" ]; then
         if echo "$selected" | grep -q "Run standard lint + check"; then
             echo "Running lint and type check..."
-            cd frontend && pnpm run check
+            run_from_repo_dir frontend pnpm run check
             if [ $? -ne 0 ]; then
                 echo "Lint or type check failed. Fix the issues before pushing."
                 return 1
@@ -114,7 +119,7 @@ check_frontend_changes() {
 
         if echo "$selected" | grep -q "Run strict type check"; then
             echo "Running strict type check..."
-            cd frontend && pnpm run lint:strict
+            run_from_repo_dir frontend pnpm run lint:strict
             if [ $? -ne 0 ]; then
                 echo "Strict type check failed. You can try 'cd frontend && pnpm run lint:fix' to automatically fix some issues."
                 echo "For Type errors, you'll need to fix them manually."
@@ -124,7 +129,7 @@ check_frontend_changes() {
 
         if echo "$selected" | grep -q "Check format"; then
             echo "Checking formatting..."
-            cd frontend && just check-format
+            run_from_repo_dir frontend just check-format
             if [ $? -ne 0 ]; then
                 echo "Formatting check failed. Run 'cd frontend && just format' to fix."
                 return 1
@@ -138,7 +143,6 @@ check_frontend_changes() {
 check_office_addin_changes() {
     local changed_files=("$@")
     local addin_files=()
-    local initial_dir=$(pwd)
 
     # Check if any files in office-addin directory were modified
     for file in "${changed_files[@]}"; do
@@ -175,22 +179,20 @@ check_office_addin_changes() {
     if [ -n "$selected" ]; then
         if echo "$selected" | grep -q "Run check"; then
             echo "Running format, lint, and type check..."
-            cd office-addin && pnpm run check
+            run_from_repo_dir office-addin pnpm run check
             if [ $? -ne 0 ]; then
                 echo "Check failed. Fix the issues before pushing."
                 return 1
             fi
-            cd "$initial_dir"
         fi
 
         if echo "$selected" | grep -q "Run tests"; then
             echo "Running tests..."
-            cd office-addin && pnpm run test
+            run_from_repo_dir office-addin pnpm run test
             if [ $? -ne 0 ]; then
                 echo "Tests failed. Fix the issues before pushing."
                 return 1
             fi
-            cd "$initial_dir"
         fi
     fi
 

--- a/frontend/scripts/watch-library.mjs
+++ b/frontend/scripts/watch-library.mjs
@@ -15,6 +15,7 @@ function shouldSuppressLine(line) {
       line.includes("downloaded") &&
       line.includes("added")) ||
     line.includes("transforming (") ||
+    line.endsWith("modules transformed.") ||
     line === "transforming..." ||
     line === "rendering chunks..." ||
     line === "computing gzip size..." ||
@@ -59,6 +60,14 @@ function emitLine(name, line) {
 
   if (name === "bundle" && trimmed.includes("watching for file changes")) {
     logLine("[watch-library] library bundle watching");
+    return;
+  }
+
+  if (
+    name === "pack" &&
+    trimmed.includes("wrote dist-package/erato-frontend.tgz")
+  ) {
+    logLine("[watch-library] package archive ready");
     return;
   }
 

--- a/frontend/scripts/watch-library.mjs
+++ b/frontend/scripts/watch-library.mjs
@@ -14,7 +14,11 @@ function shouldSuppressLine(line) {
     (line.includes("reused") &&
       line.includes("downloaded") &&
       line.includes("added")) ||
-    line.includes("transforming (")
+    line.includes("transforming (") ||
+    line === "transforming..." ||
+    line === "rendering chunks..." ||
+    line === "computing gzip size..." ||
+    line === "build started..."
   );
 }
 
@@ -55,6 +59,18 @@ function emitLine(name, line) {
 
   if (name === "bundle" && trimmed.includes("watching for file changes")) {
     logLine("[watch-library] library bundle watching");
+    return;
+  }
+
+  if (
+    name === "bundle" &&
+    (trimmed.startsWith("vite v") ||
+      trimmed.startsWith("dist-library/") ||
+      trimmed.startsWith("built in "))
+  ) {
+    if (trimmed.startsWith("built in ")) {
+      logLine("[watch-library] library bundle ready");
+    }
     return;
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,10 +5,16 @@ import { Readable } from "node:stream";
 
 import { lingui } from "@lingui/vite-plugin";
 import react from "@vitejs/plugin-react";
-import { defineConfig, type Plugin, type ViteDevServer } from "vite";
+import {
+  createLogger,
+  defineConfig,
+  type Logger,
+  type Plugin,
+  type ViteDevServer,
+} from "vite";
 
 // Custom plugin to copy index.html as 404.html for SPA routing
-const copy404Plugin = () => {
+const copy404Plugin = ({ silent = false }: { silent?: boolean } = {}) => {
   return {
     name: "copy-404",
     writeBundle(options: any) {
@@ -18,10 +24,34 @@ const copy404Plugin = () => {
 
       if (fs.existsSync(indexPath)) {
         fs.copyFileSync(indexPath, notFoundPath);
-        console.log("✓ Copied index.html to 404.html");
+        if (!silent) {
+          console.log("✓ Copied index.html to 404.html");
+        }
       }
     },
   };
+};
+
+const createDevLinkedBuildLogger = (enabled: boolean): Logger | undefined => {
+  if (!enabled) {
+    return undefined;
+  }
+
+  const logger = createLogger();
+  const originalWarn = logger.warn;
+
+  logger.warn = (msg, options) => {
+    if (
+      msg.includes("date-fns/locale/en-US.js is dynamically imported") ||
+      msg.includes("Some chunks are larger than 500 kB after minification.")
+    ) {
+      return;
+    }
+
+    originalWarn(msg, options);
+  };
+
+  return logger;
 };
 
 const contentTypeForPath = (filePath: string): string => {
@@ -205,28 +235,34 @@ const stagePublicLayoutPlugin = (): Plugin => {
 };
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: ["@lingui/babel-plugin-lingui-macro"],
-      },
-    }),
-    lingui(),
-    stagePublicLayoutPlugin(),
-    copy404Plugin(),
-  ],
-  publicDir: false,
-  server: {
-    port: 3000, // You can change this if needed
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const silentLinkedBuildOutput = mode === "dev-linked";
+
+  return {
+    customLogger: createDevLinkedBuildLogger(silentLinkedBuildOutput),
+    plugins: [
+      react({
+        babel: {
+          plugins: ["@lingui/babel-plugin-lingui-macro"],
+        },
+      }),
+      lingui(),
+      stagePublicLayoutPlugin(),
+      copy404Plugin({ silent: silentLinkedBuildOutput }),
+    ],
+    publicDir: false,
+    server: {
+      port: 3000, // You can change this if needed
     },
-  },
-  build: {
-    outDir: "out",
-    assetsDir: "public/common/assets",
-  },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    build: {
+      outDir: "out",
+      assetsDir: "public/common/assets",
+      reportCompressedSize: !silentLinkedBuildOutput,
+    },
+  };
 });

--- a/office-addin/local-auth/docker-compose.yml
+++ b/office-addin/local-auth/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   oauth2-proxy:
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.14.2

--- a/office-addin/scripts/dev.py
+++ b/office-addin/scripts/dev.py
@@ -56,7 +56,7 @@ MANIFEST_LOCAL_PATH = OFFICE_ADDIN_DIR / "manifests" / "manifest-local.xml"
 MANIFEST_FUNNEL_PATH = OFFICE_ADDIN_DIR / "manifests" / "manifest-funnel.xml"
 ENTRA_TEMPLATE_PATH = LOCAL_AUTH_DIR / "oauth2-proxy-entra-id.template.cfg"
 ENTRA_CONFIG_PATH = LOCAL_AUTH_DIR / "oauth2-proxy-entra-id.cfg"
-REQUIRED_COMMANDS = ("docker", "pnpm", "tailscale")
+REQUIRED_COMMANDS = ("docker", "node", "pnpm", "tailscale")
 EXPECTED_OAUTH2_PROXY_UPSTREAMS = """upstreams = [
     "http://localhost:3130/public/common/#/public/common/",
     "http://localhost:3002/office-addin/#/",
@@ -473,7 +473,7 @@ def build_frontend_app() -> None:
     run_quiet_command(
         ["pnpm", "exec", "vite", "build", "--mode", "dev-linked", "--logLevel", "warn"],
         cwd=FRONTEND_DIR,
-        print_stdout_on_success=True,
+        print_stdout_on_success=False,
         print_stderr_on_success=True,
         success_message="Frontend app output ready",
     )
@@ -574,7 +574,7 @@ class FrontendAppBuildWatcher:
 
 def spawn_frontend_watch() -> subprocess.Popen[str]:
     return subprocess.Popen(
-        ["pnpm", "run", "build:lib:watch"],
+        ["node", "scripts/watch-library.mjs"],
         cwd=FRONTEND_DIR,
         text=True,
         start_new_session=True,

--- a/office-addin/scripts/dev.py
+++ b/office-addin/scripts/dev.py
@@ -14,6 +14,7 @@ import re
 import secrets
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -369,6 +370,21 @@ def clear_vite_cache() -> None:
     shutil.rmtree(VITE_CACHE_DIR, ignore_errors=True)
 
 
+def can_connect_to_port(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as connection:
+        connection.settimeout(0.2)
+        return connection.connect_ex(("127.0.0.1", port)) == 0
+
+
+def ensure_port_is_free(port: int, *, label: str) -> None:
+    if can_connect_to_port(port):
+        print(
+            f"{label} port {port} is already in use; stop the existing process and retry",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def wait_for_generated_path(
     path: Path,
     producer: subprocess.Popen[str],
@@ -392,6 +408,34 @@ def wait_for_generated_path(
 
     print(
         f"Timed out waiting for {path.relative_to(FRONTEND_DIR.parent)}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def wait_for_listening_port(
+    port: int,
+    producer: subprocess.Popen[str],
+    *,
+    timeout_seconds: int = 60,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if can_connect_to_port(port):
+            return
+
+        return_code = producer.poll()
+        if return_code is not None:
+            print(
+                f"Process exited with code {return_code}: {producer.args}",
+                file=sys.stderr,
+            )
+            sys.exit(return_code or 1)
+
+        time.sleep(0.25)
+
+    print(
+        f"Timed out waiting for localhost:{port} to accept connections",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -596,6 +640,65 @@ def spawn_app_dev(mode: str, *, force_optimize: bool = False) -> subprocess.Pope
     )
 
 
+def print_status_block(title: str, lines: list[tuple[str, str]]) -> None:
+    print(title)
+    label_width = max(len(label) for label, _ in lines)
+    for label, value in lines:
+        print(f"- {label.ljust(label_width)}  {value}")
+
+
+def print_linked_long_running_processes() -> None:
+    print_status_block(
+        "Linked long-running processes",
+        [
+            (
+                "frontend library build watch",
+                "running via node scripts/watch-library.mjs",
+            ),
+            (
+                "frontend public/locales watcher",
+                "running inside scripts/dev.py",
+            ),
+            (
+                "add-in dev server",
+                "starting via vite --host --mode linked",
+            ),
+        ],
+    )
+
+
+def print_linked_watch_mode_ready() -> None:
+    print_status_block(
+        "Linked watch mode ready",
+        [
+            (
+                "add-in dev server",
+                f"http://localhost:{OFFICE_ADDIN_PORT}/office-addin/",
+            ),
+            (
+                "frontend app assets",
+                "ready for backend serving",
+            ),
+            (
+                "frontend library outputs",
+                "ready for linked imports",
+            ),
+            (
+                "frontend public/locales changes",
+                "rebuild backend-served assets",
+            ),
+            (
+                "frontend library changes",
+                "rebuild linked library outputs",
+            ),
+            (
+                "office-addin changes",
+                "Vite HMR or full reload",
+            ),
+        ],
+    )
+
+
 def terminate_process(process: subprocess.Popen[str]) -> None:
     if process.poll() is not None:
         return
@@ -736,6 +839,10 @@ def main() -> int:
             wait_for_packaged_frontend(frontend_watch)
             install_packaged_frontend()
             clear_vite_cache()
+            ensure_port_is_free(
+                OFFICE_ADDIN_PORT,
+                label="Office add-in dev server",
+            )
             app_dev = spawn_app_dev(args.mode, force_optimize=True)
         else:
             build_frontend_app()
@@ -743,7 +850,14 @@ def main() -> int:
             wait_for_linked_frontend(frontend_watch)
             frontend_app_build_watcher = FrontendAppBuildWatcher()
             frontend_app_build_watcher.start()
+            print_linked_long_running_processes()
+            ensure_port_is_free(
+                OFFICE_ADDIN_PORT,
+                label="Office add-in dev server",
+            )
             app_dev = spawn_app_dev(args.mode)
+            wait_for_listening_port(OFFICE_ADDIN_PORT, app_dev)
+            print_linked_watch_mode_ready()
 
         assert frontend_watch is not None
         assert app_dev is not None

--- a/office-addin/scripts/dev.py
+++ b/office-addin/scripts/dev.py
@@ -16,6 +16,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from urllib.parse import urlparse
@@ -27,12 +28,19 @@ FUNNEL_TARGET_PORT = AUTH_PROXY_PORT
 SCRIPT_PATH = Path(__file__).resolve()
 OFFICE_ADDIN_DIR = SCRIPT_PATH.parent.parent
 FRONTEND_DIR = OFFICE_ADDIN_DIR.parent / "frontend"
+FRONTEND_PUBLIC_DIR = FRONTEND_DIR / "public"
+FRONTEND_SOURCE_LOCALES_DIR = FRONTEND_DIR / "src" / "locales"
 FRONTEND_TARBALL_PATH = FRONTEND_DIR / "dist-package" / "erato-frontend.tgz"
 FRONTEND_PACKAGE_STATE_PATH = (
     FRONTEND_DIR / "dist-package" / "erato-frontend.state.json"
 )
 FRONTEND_LIBRARY_ENTRY_PATH = FRONTEND_DIR / "dist-library" / "library.js"
 FRONTEND_LIBRARY_CSS_PATH = FRONTEND_DIR / "dist-library" / "style.css"
+FRONTEND_APP_BUILD_WATCH_POLL_SECONDS = 1.0
+FRONTEND_APP_BUILD_WATCH_FILES = (
+    FRONTEND_DIR / "lingui.config.ts",
+    FRONTEND_DIR / "vite.config.ts",
+)
 INSTALLED_FRONTEND_LIBRARY_ENTRY_PATH = (
     OFFICE_ADDIN_DIR
     / "node_modules"
@@ -278,10 +286,7 @@ def print_funnel_url() -> None:
         "",
         redirect_status,
         "",
-        (
-            "Upload manifests/manifest-funnel.xml via "
-            "https://aka.ms/olksideload"
-        ),
+        ("Upload manifests/manifest-funnel.xml via https://aka.ms/olksideload"),
     ]
     width = max(len(line) for line in lines) + 4
     border = "#" * width
@@ -312,11 +317,25 @@ def clear_vite_cache() -> None:
     shutil.rmtree(VITE_CACHE_DIR, ignore_errors=True)
 
 
-def wait_for_path(path: Path, timeout_seconds: int = 60) -> None:
+def wait_for_generated_path(
+    path: Path,
+    producer: subprocess.Popen[str],
+    *,
+    timeout_seconds: int = 60,
+) -> None:
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         if path.exists():
             return
+
+        return_code = producer.poll()
+        if return_code is not None:
+            print(
+                f"Process exited with code {return_code}: {producer.args}",
+                file=sys.stderr,
+            )
+            sys.exit(return_code or 1)
+
         time.sleep(0.5)
 
     print(
@@ -326,13 +345,43 @@ def wait_for_path(path: Path, timeout_seconds: int = 60) -> None:
     sys.exit(1)
 
 
-def wait_for_packaged_frontend(timeout_seconds: int = 60) -> None:
-    wait_for_path(FRONTEND_PACKAGE_STATE_PATH, timeout_seconds=timeout_seconds)
+def wait_for_packaged_frontend(
+    frontend_watch: subprocess.Popen[str],
+    timeout_seconds: int = 60,
+) -> None:
+    wait_for_generated_path(
+        FRONTEND_PACKAGE_STATE_PATH,
+        frontend_watch,
+        timeout_seconds=timeout_seconds,
+    )
+    wait_for_generated_path(
+        FRONTEND_TARBALL_PATH,
+        frontend_watch,
+        timeout_seconds=timeout_seconds,
+    )
 
 
-def wait_for_linked_frontend(timeout_seconds: int = 60) -> None:
-    wait_for_path(FRONTEND_LIBRARY_ENTRY_PATH, timeout_seconds=timeout_seconds)
-    wait_for_path(FRONTEND_LIBRARY_CSS_PATH, timeout_seconds=timeout_seconds)
+def wait_for_linked_frontend(
+    frontend_watch: subprocess.Popen[str],
+    timeout_seconds: int = 60,
+) -> None:
+    wait_for_generated_path(
+        FRONTEND_LIBRARY_ENTRY_PATH,
+        frontend_watch,
+        timeout_seconds=timeout_seconds,
+    )
+    wait_for_generated_path(
+        FRONTEND_LIBRARY_CSS_PATH,
+        frontend_watch,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def clear_frontend_watch_outputs() -> None:
+    FRONTEND_LIBRARY_ENTRY_PATH.unlink(missing_ok=True)
+    FRONTEND_LIBRARY_CSS_PATH.unlink(missing_ok=True)
+    FRONTEND_PACKAGE_STATE_PATH.unlink(missing_ok=True)
+    FRONTEND_TARBALL_PATH.unlink(missing_ok=True)
 
 
 def read_package_state() -> dict[str, str] | None:
@@ -355,6 +404,104 @@ def compute_file_sha256(path: Path) -> str | None:
             digest.update(chunk)
 
     return digest.hexdigest()
+
+
+def build_frontend_app() -> None:
+    print("Building frontend app output for backend-served assets")
+    run_command(["pnpm", "run", "build:app"], cwd=FRONTEND_DIR)
+
+
+def path_has_hidden_segment(path: Path) -> bool:
+    return any(part.startswith(".") for part in path.parts)
+
+
+def should_watch_frontend_app_file(path: Path) -> bool:
+    if path_has_hidden_segment(path.relative_to(FRONTEND_DIR)):
+        return False
+
+    if (
+        path.name == "messages.json"
+        and "locales" in path.parts
+    ):
+        return False
+
+    return path.is_file()
+
+
+def iter_frontend_app_watch_files() -> list[Path]:
+    files: list[Path] = []
+
+    for watch_file in FRONTEND_APP_BUILD_WATCH_FILES:
+        if watch_file.exists():
+            files.append(watch_file)
+
+    for root in (FRONTEND_PUBLIC_DIR, FRONTEND_SOURCE_LOCALES_DIR):
+        if not root.exists():
+            continue
+
+        for path in root.rglob("*"):
+            if should_watch_frontend_app_file(path):
+                files.append(path)
+
+    return sorted(files)
+
+
+def capture_frontend_app_watch_snapshot() -> dict[str, tuple[int, int]]:
+    snapshot: dict[str, tuple[int, int]] = {}
+    for file_path in iter_frontend_app_watch_files():
+        stat_result = file_path.stat()
+        snapshot[str(file_path.relative_to(FRONTEND_DIR))] = (
+            stat_result.st_mtime_ns,
+            stat_result.st_size,
+        )
+
+    return snapshot
+
+
+class FrontendAppBuildWatcher:
+    def __init__(self) -> None:
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=5)
+
+    def _run(self) -> None:
+        baseline_snapshot = capture_frontend_app_watch_snapshot()
+
+        while not self._stop_event.wait(FRONTEND_APP_BUILD_WATCH_POLL_SECONDS):
+            current_snapshot = capture_frontend_app_watch_snapshot()
+            if current_snapshot == baseline_snapshot:
+                continue
+
+            print(
+                "Detected frontend public or locale source change, rebuilding frontend app",
+            )
+            snapshot_before_build = current_snapshot
+
+            try:
+                build_frontend_app()
+            except subprocess.CalledProcessError as error:
+                print(
+                    f"Frontend app build failed with code {error.returncode}; waiting for more changes",
+                    file=sys.stderr,
+                )
+                baseline_snapshot = snapshot_before_build
+                continue
+
+            snapshot_after_build = capture_frontend_app_watch_snapshot()
+            if snapshot_after_build != snapshot_before_build:
+                print(
+                    "Frontend public or locale source changed during rebuild, scheduling another frontend app build",
+                )
+                baseline_snapshot = snapshot_before_build
+                continue
+
+            baseline_snapshot = snapshot_after_build
 
 
 def spawn_frontend_watch() -> subprocess.Popen[str]:
@@ -427,9 +574,13 @@ def wait_for_processes(
 
             if mode == "packaged":
                 package_state = read_package_state()
-                next_package_sha = package_state.get("sha256") if package_state else None
+                next_package_sha = (
+                    package_state.get("sha256") if package_state else None
+                )
                 if next_package_sha and next_package_sha != current_package_sha:
-                    print("Detected packaged frontend update, reinstalling office-addin")
+                    print(
+                        "Detected packaged frontend update, reinstalling office-addin"
+                    )
                     install_packaged_frontend()
                     clear_vite_cache()
                     terminate_process(app_dev)
@@ -491,25 +642,51 @@ def main() -> int:
     ensure_funnel()
     print_funnel_url()
 
-    frontend_watch = spawn_frontend_watch()
-    if args.mode == "packaged":
-        wait_for_packaged_frontend()
-        install_packaged_frontend()
-        clear_vite_cache()
-        app_dev = spawn_app_dev(args.mode, force_optimize=True)
-    else:
-        wait_for_linked_frontend()
-        app_dev = spawn_app_dev(args.mode)
+    frontend_watch: subprocess.Popen[str] | None = None
+    frontend_app_build_watcher: FrontendAppBuildWatcher | None = None
+    app_dev: subprocess.Popen[str] | None = None
+
+    def cleanup() -> None:
+        if frontend_watch is not None:
+            terminate_process(frontend_watch)
+        if frontend_app_build_watcher is not None:
+            frontend_app_build_watcher.stop()
+        if app_dev is not None:
+            terminate_process(app_dev)
 
     def handle_signal(signum: int, _frame: object) -> None:
-        terminate_process(frontend_watch)
-        terminate_process(app_dev)
+        cleanup()
         raise SystemExit(128 + signum)
 
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
-    return wait_for_processes(frontend_watch, app_dev, mode=args.mode)
+    try:
+        clear_frontend_watch_outputs()
+        if args.mode == "packaged":
+            frontend_watch = spawn_frontend_watch()
+            wait_for_packaged_frontend(frontend_watch)
+            install_packaged_frontend()
+            clear_vite_cache()
+            app_dev = spawn_app_dev(args.mode, force_optimize=True)
+        else:
+            build_frontend_app()
+            frontend_watch = spawn_frontend_watch()
+            wait_for_linked_frontend(frontend_watch)
+            frontend_app_build_watcher = FrontendAppBuildWatcher()
+            frontend_app_build_watcher.start()
+            app_dev = spawn_app_dev(args.mode)
+
+        assert frontend_watch is not None
+        assert app_dev is not None
+        return wait_for_processes(
+            frontend_watch,
+            app_dev,
+            mode=args.mode,
+        )
+    except BaseException:
+        cleanup()
+        raise
 
 
 if __name__ == "__main__":

--- a/office-addin/scripts/dev.py
+++ b/office-addin/scripts/dev.py
@@ -81,6 +81,50 @@ def run_command(
     )
 
 
+def print_process_output(output: str | None) -> None:
+    if not output:
+        return
+
+    for line in output.splitlines():
+        if line.strip():
+            print(line)
+
+
+def run_quiet_command(
+    command: list[str],
+    *,
+    cwd: Path | None = None,
+    success_message: str | None = None,
+    print_stdout_on_success: bool = False,
+    print_stderr_on_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = run_command(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        print_process_output(result.stdout)
+        print_process_output(result.stderr)
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+    if print_stdout_on_success:
+        print_process_output(result.stdout)
+    if print_stderr_on_success:
+        print_process_output(result.stderr)
+    if success_message:
+        print(success_message)
+
+    return result
+
+
 def require_command(name: str) -> None:
     if shutil.which(name) is None:
         print(f"Missing required command: {name}", file=sys.stderr)
@@ -158,9 +202,17 @@ def sync_entra_proxy_upstreams() -> None:
 
 
 def start_auth_proxy() -> None:
-    run_command(
-        ["docker", "compose", "up", "--force-recreate", "--detach"],
+    run_quiet_command(
+        [
+            "docker",
+            "compose",
+            "up",
+            "--force-recreate",
+            "--detach",
+            "--remove-orphans",
+        ],
         cwd=LOCAL_AUTH_DIR,
+        print_stderr_on_success=False,
     )
     print(f"Auth proxy available at http://localhost:{AUTH_PROXY_PORT}")
 
@@ -408,7 +460,23 @@ def compute_file_sha256(path: Path) -> str | None:
 
 def build_frontend_app() -> None:
     print("Building frontend app output for backend-served assets")
-    run_command(["pnpm", "run", "build:app"], cwd=FRONTEND_DIR)
+    run_quiet_command(
+        ["pnpm", "exec", "lingui", "compile"],
+        cwd=FRONTEND_DIR,
+        print_stderr_on_success=False,
+    )
+    run_quiet_command(
+        ["pnpm", "exec", "tsc"],
+        cwd=FRONTEND_DIR,
+        print_stderr_on_success=False,
+    )
+    run_quiet_command(
+        ["pnpm", "exec", "vite", "build", "--mode", "dev-linked", "--logLevel", "warn"],
+        cwd=FRONTEND_DIR,
+        print_stdout_on_success=True,
+        print_stderr_on_success=True,
+        success_message="Frontend app output ready",
+    )
 
 
 def path_has_hidden_segment(path: Path) -> bool:
@@ -656,7 +724,7 @@ def main() -> int:
 
     def handle_signal(signum: int, _frame: object) -> None:
         cleanup()
-        raise SystemExit(128 + signum)
+        raise SystemExit(0)
 
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)

--- a/office-addin/vite.config.ts
+++ b/office-addin/vite.config.ts
@@ -145,6 +145,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: isDevServer ? "/office-addin/" : "/public/platform-office-addin/",
+    clearScreen: false,
     define,
     plugins: [
       react({
@@ -175,6 +176,7 @@ export default defineConfig(({ mode }) => {
       host: true,
       allowedHosts: [".ts.net"],
       port: 3002,
+      strictPort: true,
       proxy: apiProxy,
       fs: {
         allow: [path.resolve(__dirname, "..")],

--- a/office-addin/vite.config.ts
+++ b/office-addin/vite.config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { lingui } from "@lingui/vite-plugin";
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig, loadEnv, type ViteDevServer } from "vite";
 
 const loadOfficeAddinEnv = (mode: string) => {
   const developmentEnv =
@@ -64,6 +64,58 @@ const stagePlatformLocalesPlugin = () => {
   };
 };
 
+const watchLinkedFrontendPublicOutputPlugin = (enabled: boolean) => {
+  if (!enabled) {
+    return {
+      name: "watch-linked-frontend-public-output",
+    };
+  }
+
+  const frontendPublicOutputDir = path.resolve(
+    __dirname,
+    "../frontend/out/public",
+  );
+  let reloadTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleReload = (server: ViteDevServer, changedFile: string) => {
+    if (reloadTimer) {
+      clearTimeout(reloadTimer);
+    }
+
+    reloadTimer = setTimeout(() => {
+      console.log(
+        `[linked-frontend-public-output] Detected rebuilt asset: ${path.relative(
+          __dirname,
+          changedFile,
+        )}; reloading add-in clients`,
+      );
+      server.ws.send({ type: "full-reload" });
+    }, 150);
+  };
+
+  return {
+    name: "watch-linked-frontend-public-output",
+    configureServer(server: ViteDevServer) {
+      const onOutputChange = (filePath: string) => {
+        const resolvedFilePath = path.resolve(filePath);
+        if (
+          resolvedFilePath !== frontendPublicOutputDir &&
+          !resolvedFilePath.startsWith(`${frontendPublicOutputDir}${path.sep}`)
+        ) {
+          return;
+        }
+
+        scheduleReload(server, resolvedFilePath);
+      };
+
+      server.watcher.add(frontendPublicOutputDir);
+      server.watcher.on("add", onOutputChange);
+      server.watcher.on("change", onOutputChange);
+      server.watcher.on("unlink", onOutputChange);
+    },
+  };
+};
+
 export default defineConfig(({ mode }) => {
   const env = loadOfficeAddinEnv(mode);
   const apiRootUrl = env.VITE_API_ROOT_URL;
@@ -102,6 +154,7 @@ export default defineConfig(({ mode }) => {
       }),
       lingui(),
       stagePlatformLocalesPlugin(),
+      watchLinkedFrontendPublicOutputPlugin(linkedFrontend),
       copy404Plugin(),
     ],
     resolve: linkedFrontend


### PR DESCRIPTION
## What changed
- make `office-addin` linked dev mode build the frontend app output up front before starting the add-in dev server
- watch frontend public assets and locales during linked dev so backend-served theme and locale files rebuild after saves
- reload add-in clients when rebuilt frontend public output changes
- reduce linked-dev startup log noise and add a clearer watch-mode readiness summary
- force the add-in dev server to stay on port `3002` instead of silently switching ports
- remove the obsolete Compose `version` field warning from the local auth stack
- fix the tracked pre-push hook so frontend checks do not leave the shell in the wrong directory before office-addin checks run

## Why
Linked add-in dev mode depended on frontend outputs that were not being built or refreshed reliably from a clean start. That caused missing theme assets and 404s until a manual `frontend` build was run. The startup logs also made it hard to tell which long-running processes were active and whether the add-in server was actually ready.

## Impact
- `just dev-linked` now produces the backend-served frontend assets needed by the add-in from a clean start
- saves in frontend theme/public/locale inputs trigger rebuilds of backend-served assets during linked dev
- linked frontend library changes continue to rebuild for add-in imports
- startup output is quieter and explicitly shows when linked watch mode is ready
- local pre-push checks for mixed frontend and office-addin changes no longer fail because of a bad working directory transition

## Root cause
The linked dev flow only started the frontend library watcher. It did not run the canonical frontend app build that populates `frontend/out/public`, so the backend had no current theme assets to serve. After a manual frontend build, the assets existed and the add-in worked, which is why the problem appeared to fix itself.

## Validation
- reviewed the branch diff against `main`
- ran `python3 -m py_compile office-addin/scripts/dev.py`
- ran `pnpm exec prettier --check office-addin/vite.config.ts`
- ran `pnpm exec prettier --check frontend/scripts/watch-library.mjs`
- ran `pnpm exec tsc --noEmit` in `frontend`
- ran `pnpm exec tsc --noEmit` in `office-addin`
- cleared linked-dev outputs and reran `just dev-linked` to validate clean-start behavior
- verified frontend public/theme changes rebuilt `frontend/out/public` and triggered add-in reload logging
- reran linked dev after the startup-status/logging changes and confirmed the improved output
- validated the pre-push hook shell syntax with `bash -n .hooks/pre-push`
