### PR TITLE
Add backend .eml support and tests

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3034,6 +3034,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,6 +3929,7 @@ dependencies = [
  "libc",
  "lopdf",
  "lzma-rust2",
+ "mail-parser",
  "memchr",
  "mime_guess",
  "num_cpus",
@@ -4201,6 +4214,15 @@ checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
  "sha2",
+]
+
+[[package]]
+name = "mail-parser"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
+dependencies = [
+ "hashify",
 ]
 
 [[package]]

--- a/backend/erato/Cargo.toml
+++ b/backend/erato/Cargo.toml
@@ -81,7 +81,7 @@ sha2 = "0.10.9"
 url = "2.5.8"
 # Tokio console for async debugging
 console-subscriber = { version = "0.5.0", optional = true }
-kreuzberg = { version = "=4.3.4",  features = ["bundled-pdfium", "excel", "office", "html", "archives"]}
+kreuzberg = { version = "=4.3.4",  features = ["bundled-pdfium", "excel", "office", "email", "html", "archives"]}
 jemalloc_pprof = { version = "0.8.2", optional = true, features = ["flamegraph", "symbolize"] }
 tikv-jemallocator = { version = "0.6.1", optional = true, features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 

--- a/backend/erato/src/actors/manager.rs
+++ b/backend/erato/src/actors/manager.rs
@@ -10,13 +10,9 @@ impl ActorManager {
     pub async fn new(db: DatabaseConnection, config: AppConfig) -> Self {
         let args = (db, config);
         // Spawn the top-level supervisor
-        let (_supervisor, supervisor_handle) = Actor::spawn(
-            Some("worker_supervisor".to_string()),
-            WorkerSupervisor,
-            args,
-        )
-        .await
-        .expect("Failed to spawn WorkerSupervisor");
+        let (_supervisor, supervisor_handle) = Actor::spawn(None, WorkerSupervisor, args)
+            .await
+            .expect("Failed to spawn WorkerSupervisor");
 
         // We'll spawn the supervisor handle in a background task to ensure it's not dropped
         // and the actor system keeps running.

--- a/backend/erato/src/actors/manager.rs
+++ b/backend/erato/src/actors/manager.rs
@@ -8,11 +8,20 @@ pub struct ActorManager;
 
 impl ActorManager {
     pub async fn new(db: DatabaseConnection, config: AppConfig) -> Self {
+        Self::new_with_name(db, config, Some("worker_supervisor".to_string())).await
+    }
+
+    pub async fn new_with_name(
+        db: DatabaseConnection,
+        config: AppConfig,
+        supervisor_name: Option<String>,
+    ) -> Self {
         let args = (db, config);
         // Spawn the top-level supervisor
-        let (_supervisor, supervisor_handle) = Actor::spawn(None, WorkerSupervisor, args)
-            .await
-            .expect("Failed to spawn WorkerSupervisor");
+        let (_supervisor, supervisor_handle) =
+            Actor::spawn(supervisor_name, WorkerSupervisor, args)
+                .await
+                .expect("Failed to spawn WorkerSupervisor");
 
         // We'll spawn the supervisor handle in a background task to ensure it's not dropped
         // and the actor system keeps running.

--- a/backend/erato/src/models/file_capability.rs
+++ b/backend/erato/src/models/file_capability.rs
@@ -169,6 +169,13 @@ pub fn get_file_capabilities(supports_image_understanding: bool) -> Vec<FileCapa
             ],
             vec![FileOperation::ExtractText],
         ),
+        // Email files - supported by Kreuzberg when parsed as RFC822
+        FileCapability::new(
+            "email",
+            vec!["eml".to_string()],
+            vec!["message/rfc822".to_string()],
+            vec![FileOperation::ExtractText],
+        ),
         // Plain text files - supported by Kreuzberg
         FileCapability::new(
             "text",
@@ -324,6 +331,11 @@ mod tests {
         // Test image
         let cap = find_file_capability_by_filename(&caps, "photo.jpg");
         assert_eq!(cap.id, "image");
+
+        // Test email
+        let cap = find_file_capability_by_filename(&caps, "message.eml");
+        assert_eq!(cap.id, "email");
+        assert_eq!(cap.operations, vec![FileOperation::ExtractText]);
 
         // Test unsupported file
         let cap = find_file_capability_by_filename(&caps, "archive.zip");

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -2442,13 +2442,43 @@ fn preview_content_type(filename: &str) -> &'static str {
     }
 }
 
+fn is_eml_filename(filename: &str) -> bool {
+    filename
+        .rsplit('.')
+        .next()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("eml"))
+}
+
+fn content_type_essence(content_type: &str) -> &str {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+}
+
 fn effective_upload_content_type(
     filename: &str,
     provided_content_type: Option<&str>,
 ) -> Option<String> {
+    let provided_content_type = provided_content_type.map(content_type_essence);
+
+    let needs_eml_override = is_eml_filename(filename)
+        && match provided_content_type {
+            None => true,
+            Some(content_type) => {
+                content_type.eq_ignore_ascii_case("application/octet-stream")
+                    || content_type.eq_ignore_ascii_case("text/plain")
+            }
+        };
+
+    if needs_eml_override {
+        return Some("message/rfc822".to_string());
+    }
+
     match provided_content_type {
-        Some(content_type) if content_type != "application/octet-stream" => {
-            Some(content_type.to_string())
+        Some(content_type) if !content_type.eq_ignore_ascii_case("application/octet-stream") => {
+            Some(content_type.to_ascii_lowercase())
         }
         _ => Some(preview_content_type(filename).to_string()),
     }
@@ -2881,6 +2911,14 @@ mod tests {
     fn effective_upload_content_type_preserves_specific_multipart_type() {
         assert_eq!(
             effective_upload_content_type("message.eml", Some("message/rfc822")),
+            Some("message/rfc822".to_string())
+        );
+    }
+
+    #[test]
+    fn effective_upload_content_type_normalizes_eml_text_plain() {
+        assert_eq!(
+            effective_upload_content_type("message.eml", Some("text/plain; charset=utf-8")),
             Some("message/rfc822".to_string())
         );
     }

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -2428,6 +2428,7 @@ fn preview_content_type(filename: &str) -> &'static str {
         .map(|ext| ext.to_ascii_lowercase())
     {
         Some(ext) => match ext.as_str() {
+            "eml" => "message/rfc822",
             "pdf" => "application/pdf",
             "jpg" | "jpeg" => "image/jpeg",
             "png" => "image/png",
@@ -2857,4 +2858,30 @@ pub async fn file_capabilities(
 pub struct FileCapabilitiesQuery {
     /// Optional model ID to get capabilities specific to that model
     model_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{effective_upload_content_type, preview_content_type};
+
+    #[test]
+    fn preview_content_type_supports_eml() {
+        assert_eq!(preview_content_type("message.eml"), "message/rfc822");
+    }
+
+    #[test]
+    fn effective_upload_content_type_uses_eml_fallback_for_octet_stream() {
+        assert_eq!(
+            effective_upload_content_type("message.eml", Some("application/octet-stream")),
+            Some("message/rfc822".to_string())
+        );
+    }
+
+    #[test]
+    fn effective_upload_content_type_preserves_specific_multipart_type() {
+        assert_eq!(
+            effective_upload_content_type("message.eml", Some("message/rfc822")),
+            Some("message/rfc822".to_string())
+        );
+    }
 }

--- a/backend/erato/src/services/file_parsing.rs
+++ b/backend/erato/src/services/file_parsing.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 pub async fn parse_file(
     file_processor: &dyn FileProcessor,
     file_bytes: Vec<u8>,
+    filename: Option<&str>,
 ) -> Result<String, Report> {
-    file_processor.parse_file(file_bytes).await
+    file_processor.parse_file(file_bytes, filename).await
 }

--- a/backend/erato/src/services/file_parsing.rs
+++ b/backend/erato/src/services/file_parsing.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 pub async fn parse_file(
     file_processor: &dyn FileProcessor,
     file_bytes: Vec<u8>,
-    filename: Option<&str>,
+    mime_type: Option<&str>,
 ) -> Result<String, Report> {
-    file_processor.parse_file(file_bytes, filename).await
+    file_processor.parse_file(file_bytes, mime_type).await
 }

--- a/backend/erato/src/services/file_processing_cached.rs
+++ b/backend/erato/src/services/file_processing_cached.rs
@@ -121,6 +121,7 @@ pub async fn get_file_contents_cached<'a>(
     cache_key: &FileCacheKey,
     file_storage: &FileStorage,
     file_storage_path: &str,
+    filename: &str,
     sharepoint_ctx: Option<&SharepointContext<'a>>,
 ) -> Result<String, Report> {
     let file_id_str = cache_key.file_id.to_string();
@@ -156,7 +157,12 @@ pub async fn get_file_contents_cached<'a>(
                 .acquire()
                 .await
                 .wrap_err("File processing semaphore closed")?;
-            let parsed_content = parse_file(app_state.file_processor.as_ref(), file_bytes).await?;
+            let parsed_content = parse_file(
+                app_state.file_processor.as_ref(),
+                file_bytes,
+                Some(filename),
+            )
+            .await?;
             let content = remove_null_characters(&parsed_content);
 
             tracing::debug!(
@@ -259,6 +265,7 @@ pub fn get_file_cached<'a>(
                 &cache_key,
                 file_storage,
                 file_storage_path,
+                filename,
                 sharepoint_ctx,
             )
             .await?;

--- a/backend/erato/src/services/file_processing_cached.rs
+++ b/backend/erato/src/services/file_processing_cached.rs
@@ -121,7 +121,6 @@ pub async fn get_file_contents_cached<'a>(
     cache_key: &FileCacheKey,
     file_storage: &FileStorage,
     file_storage_path: &str,
-    filename: &str,
     sharepoint_ctx: Option<&SharepointContext<'a>>,
 ) -> Result<String, Report> {
     let file_id_str = cache_key.file_id.to_string();
@@ -150,6 +149,9 @@ pub async fn get_file_contents_cached<'a>(
             .await?;
 
             span.record("file_bytes_length", file_bytes.len());
+            let mime_type = file_storage
+                .get_file_content_type_with_context(file_storage_path, sharepoint_ctx)
+                .await?;
 
             // Parse the file using the configured file processor
             let _permit = app_state
@@ -160,7 +162,7 @@ pub async fn get_file_contents_cached<'a>(
             let parsed_content = parse_file(
                 app_state.file_processor.as_ref(),
                 file_bytes,
-                Some(filename),
+                mime_type.as_deref(),
             )
             .await?;
             let content = remove_null_characters(&parsed_content);
@@ -265,7 +267,6 @@ pub fn get_file_cached<'a>(
                 &cache_key,
                 file_storage,
                 file_storage_path,
-                filename,
                 sharepoint_ctx,
             )
             .await?;

--- a/backend/erato/src/services/file_processor.rs
+++ b/backend/erato/src/services/file_processor.rs
@@ -10,7 +10,7 @@ pub trait FileProcessor: Send + Sync {
     async fn parse_file(
         &self,
         file_bytes: Vec<u8>,
-        filename: Option<&str>,
+        mime_type: Option<&str>,
     ) -> Result<String, Report>;
 }
 
@@ -29,16 +29,26 @@ fn looks_like_docx(file_bytes: &[u8]) -> bool {
         .any(|window| window == needle)
 }
 
-fn mime_type_override_for_filename(filename: &str) -> Option<&'static str> {
-    match filename
-        .rsplit('.')
+fn normalize_mime_type(mime_type: &str) -> String {
+    mime_type
+        .split(';')
         .next()
-        .map(|ext| ext.to_ascii_lowercase())
-        .as_deref()
+        .unwrap_or(mime_type)
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn detect_mime_type(file_bytes: &[u8]) -> Result<String, Report> {
+    let mut mime_type = detect_mime_type_from_bytes(file_bytes)?;
+    tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
+    if matches!(
+        mime_type.as_str(),
+        "application/zip" | "application/x-zip-compressed"
+    ) && looks_like_docx(file_bytes)
     {
-        Some("eml") => Some("message/rfc822"),
-        _ => None,
+        mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
     }
+    Ok(mime_type)
 }
 
 #[async_trait]
@@ -46,9 +56,9 @@ impl FileProcessor for KreuzbergProcessor {
     async fn parse_file(
         &self,
         file_bytes: Vec<u8>,
-        filename: Option<&str>,
+        mime_type: Option<&str>,
     ) -> Result<String, Report> {
-        let filename = filename.map(str::to_owned);
+        let mime_type = mime_type.map(str::to_owned);
         Ok(
             tokio::task::spawn_blocking(move || -> Result<String, Report> {
                 // Check if the file is an image using magic number detection
@@ -57,37 +67,11 @@ impl FileProcessor for KreuzbergProcessor {
                     return Ok(String::new());
                 }
 
-                let mut mime_type = if let Some(filename) = filename.as_deref() {
-                    if let Some(mime_type) = mime_type_override_for_filename(filename) {
-                        tracing::debug!(
-                            filename = %filename,
-                            mime_type = %mime_type,
-                            "Overriding MIME type from filename"
-                        );
-                        mime_type.to_string()
-                    } else {
-                        let mut mime_type = detect_mime_type_from_bytes(&file_bytes)?;
-                        tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
-                        if matches!(
-                            mime_type.as_str(),
-                            "application/zip" | "application/x-zip-compressed"
-                        ) && looks_like_docx(&file_bytes)
-                        {
-                            mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
-                        }
-                        mime_type
-                    }
+                let mut mime_type = if let Some(mime_type) = mime_type.as_deref() {
+                    tracing::debug!(mime_type = %mime_type, "Using provided MIME type");
+                    normalize_mime_type(mime_type)
                 } else {
-                    let mut mime_type = detect_mime_type_from_bytes(&file_bytes)?;
-                    tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
-                    if matches!(
-                        mime_type.as_str(),
-                        "application/zip" | "application/x-zip-compressed"
-                    ) && looks_like_docx(&file_bytes)
-                    {
-                        mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
-                    }
-                    mime_type
+                    detect_mime_type(&file_bytes)?
                 };
 
                 if matches!(
@@ -158,7 +142,7 @@ mod tests {
 
         let processor = KreuzbergProcessor;
         let extracted = processor
-            .parse_file(pdf_bytes, Some("sample-report-compressed.pdf"))
+            .parse_file(pdf_bytes, None)
             .await
             .expect("Failed to extract text from PDF");
 
@@ -174,7 +158,7 @@ mod tests {
 
         let processor = KreuzbergProcessor;
         let extracted = processor
-            .parse_file(eml_bytes, Some("please_review_attached_draft.eml"))
+            .parse_file(eml_bytes, Some("message/rfc822"))
             .await
             .expect("Failed to extract text from EML fixture");
 
@@ -193,7 +177,7 @@ mod tests {
 
         let processor = KreuzbergProcessor;
         let extracted = processor
-            .parse_file(eml_bytes, Some("re_another_doc_you_have_to_check.eml"))
+            .parse_file(eml_bytes, Some("message/rfc822"))
             .await
             .expect("Failed to extract text from EML reply fixture");
 

--- a/backend/erato/src/services/file_processor.rs
+++ b/backend/erato/src/services/file_processor.rs
@@ -7,7 +7,11 @@ use tracing::Instrument;
 /// Trait for file processors that extract text content from file bytes
 #[async_trait]
 pub trait FileProcessor: Send + Sync {
-    async fn parse_file(&self, file_bytes: Vec<u8>) -> Result<String, Report>;
+    async fn parse_file(
+        &self,
+        file_bytes: Vec<u8>,
+        filename: Option<&str>,
+    ) -> Result<String, Report>;
 }
 
 /// Kreuzberg-based file processor with page-aware markdown extraction
@@ -25,9 +29,26 @@ fn looks_like_docx(file_bytes: &[u8]) -> bool {
         .any(|window| window == needle)
 }
 
+fn mime_type_override_for_filename(filename: &str) -> Option<&'static str> {
+    match filename
+        .rsplit('.')
+        .next()
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("eml") => Some("message/rfc822"),
+        _ => None,
+    }
+}
+
 #[async_trait]
 impl FileProcessor for KreuzbergProcessor {
-    async fn parse_file(&self, file_bytes: Vec<u8>) -> Result<String, Report> {
+    async fn parse_file(
+        &self,
+        file_bytes: Vec<u8>,
+        filename: Option<&str>,
+    ) -> Result<String, Report> {
+        let filename = filename.map(str::to_owned);
         Ok(
             tokio::task::spawn_blocking(move || -> Result<String, Report> {
                 // Check if the file is an image using magic number detection
@@ -36,8 +57,39 @@ impl FileProcessor for KreuzbergProcessor {
                     return Ok(String::new());
                 }
 
-                let mut mime_type = detect_mime_type_from_bytes(&file_bytes)?;
-                tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
+                let mut mime_type = if let Some(filename) = filename.as_deref() {
+                    if let Some(mime_type) = mime_type_override_for_filename(filename) {
+                        tracing::debug!(
+                            filename = %filename,
+                            mime_type = %mime_type,
+                            "Overriding MIME type from filename"
+                        );
+                        mime_type.to_string()
+                    } else {
+                        let mut mime_type = detect_mime_type_from_bytes(&file_bytes)?;
+                        tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
+                        if matches!(
+                            mime_type.as_str(),
+                            "application/zip" | "application/x-zip-compressed"
+                        ) && looks_like_docx(&file_bytes)
+                        {
+                            mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
+                        }
+                        mime_type
+                    }
+                } else {
+                    let mut mime_type = detect_mime_type_from_bytes(&file_bytes)?;
+                    tracing::debug!("Detected MIME type from bytes: {:?}", &mime_type);
+                    if matches!(
+                        mime_type.as_str(),
+                        "application/zip" | "application/x-zip-compressed"
+                    ) && looks_like_docx(&file_bytes)
+                    {
+                        mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
+                    }
+                    mime_type
+                };
+
                 if matches!(
                     mime_type.as_str(),
                     "application/zip" | "application/x-zip-compressed"
@@ -84,6 +136,14 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
+    fn read_test_fixture(filename: &str) -> Vec<u8> {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/integration_tests/test_files")
+            .join(filename);
+
+        fs::read(&fixture_path).unwrap_or_else(|_| panic!("Failed to read fixture {}", filename))
+    }
+
     #[test]
     fn test_create_file_processor() {
         let processor = create_file_processor("kreuzberg");
@@ -98,7 +158,7 @@ mod tests {
 
         let processor = KreuzbergProcessor;
         let extracted = processor
-            .parse_file(pdf_bytes)
+            .parse_file(pdf_bytes, Some("sample-report-compressed.pdf"))
             .await
             .expect("Failed to extract text from PDF");
 
@@ -106,5 +166,45 @@ mod tests {
             extracted.contains("<page number=\""),
             "Expected page marker in extracted text, but none was found"
         );
+    }
+
+    #[tokio::test]
+    async fn test_kreuzberg_extracts_structured_content_from_eml_with_attachment() {
+        let eml_bytes = read_test_fixture("please_review_attached_draft.eml");
+
+        let processor = KreuzbergProcessor;
+        let extracted = processor
+            .parse_file(eml_bytes, Some("please_review_attached_draft.eml"))
+            .await
+            .expect("Failed to extract text from EML fixture");
+
+        assert!(extracted.contains("Subject: Please review attached draft"));
+        assert!(extracted.contains("From: daniel@eratolabs.com"));
+        assert!(extracted.contains("To: testuser@maxgoisser.onmicrosoft.com"));
+        assert!(extracted.contains(
+            "could you please take a quick look at the attached draft document and let me know whether it looks fine from your side."
+        ));
+        assert!(extracted.contains("Attachments: internal_review_test_attachment.pdf"));
+    }
+
+    #[tokio::test]
+    async fn test_kreuzberg_extracts_structured_content_from_eml_reply_thread() {
+        let eml_bytes = read_test_fixture("re_another_doc_you_have_to_check.eml");
+
+        let processor = KreuzbergProcessor;
+        let extracted = processor
+            .parse_file(eml_bytes, Some("re_another_doc_you_have_to_check.eml"))
+            .await
+            .expect("Failed to extract text from EML reply fixture");
+
+        assert!(extracted.contains("Subject: Re: Another doc you have to check"));
+        assert!(extracted.contains("From: daniel@eratolabs.com"));
+        assert!(extracted.contains("To: testuser@maxgoisser.onmicrosoft.com"));
+        assert!(
+            extracted.contains("I am referring to the PDF draft I attached to my previous email.")
+        );
+        assert!(extracted.contains(
+            "Please let me know if you have any specific questions or if you cannot see the attachment."
+        ));
     }
 }

--- a/backend/erato/src/services/file_storage.rs
+++ b/backend/erato/src/services/file_storage.rs
@@ -557,6 +557,7 @@ fn preview_content_type_for_filename(filename: &str) -> Option<&'static str> {
         .map(|ext| ext.to_ascii_lowercase())
         .as_deref()
     {
+        Some("eml") => Some("message/rfc822"),
         Some("pdf") => Some("application/pdf"),
         Some("jpg") | Some("jpeg") => Some("image/jpeg"),
         Some("png") => Some("image/png"),
@@ -776,6 +777,7 @@ mod tests {
     use super::SharepointStorage;
     use super::build_content_disposition;
     use super::build_presign_content_disposition;
+    use super::preview_content_type_for_filename;
     use serde_json::json;
 
     #[test]
@@ -858,5 +860,13 @@ mod tests {
 
         assert_eq!(metadata.download_url, "https://example.test/download");
         assert_eq!(metadata.etag.as_deref(), Some("\"abc123\""));
+    }
+
+    #[test]
+    fn preview_content_type_for_filename_supports_eml() {
+        assert_eq!(
+            preview_content_type_for_filename("message.eml"),
+            Some("message/rfc822")
+        );
     }
 }

--- a/backend/erato/src/services/file_storage.rs
+++ b/backend/erato/src/services/file_storage.rs
@@ -92,6 +92,7 @@ pub struct SharepointContext<'a> {
 pub struct SharepointFileMetadata {
     pub download_url: String,
     pub etag: Option<String>,
+    pub content_type: Option<String>,
 }
 
 impl FileStorage {
@@ -286,6 +287,22 @@ impl FileStorage {
             )),
         }
     }
+
+    pub async fn get_file_content_type_with_context(
+        &self,
+        path: &str,
+        context: Option<&SharepointContext<'_>>,
+    ) -> Result<Option<String>, Report> {
+        match self {
+            Self::OpenDal(storage) => storage.get_file_content_type(path).await,
+            Self::Sharepoint(storage) => {
+                let ctx = context.ok_or_else(|| {
+                    eyre::eyre!("Sharepoint storage requires an access token context")
+                })?;
+                Ok(storage.get_file_metadata(path, ctx).await?.content_type)
+            }
+        }
+    }
 }
 
 impl OpenDalStorage {
@@ -374,6 +391,15 @@ impl OpenDalStorage {
         let mut buffer = Vec::new();
         reader.read_into(&mut buffer, ..).await?;
         Ok(buffer)
+    }
+
+    pub async fn get_file_content_type(&self, path: &str) -> Result<Option<String>, Report> {
+        Ok(self
+            .opendal_operator
+            .stat(path)
+            .await?
+            .content_type()
+            .map(ToOwned::to_owned))
     }
 
     /// Generate a pre-signed URL for downloading a file
@@ -740,10 +766,16 @@ impl SharepointStorage {
             .or_else(|| item.get("etag"))
             .and_then(|v| v.as_str())
             .map(ToOwned::to_owned);
+        let content_type = item
+            .get("file")
+            .and_then(|file| file.get("mimeType"))
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
 
         Ok(SharepointFileMetadata {
             download_url: download_url.to_string(),
             etag,
+            content_type,
         })
     }
 }
@@ -860,6 +892,24 @@ mod tests {
 
         assert_eq!(metadata.download_url, "https://example.test/download");
         assert_eq!(metadata.etag.as_deref(), Some("\"abc123\""));
+        assert_eq!(metadata.content_type, None);
+    }
+
+    #[test]
+    fn parse_sharepoint_metadata_extracts_content_type() {
+        let metadata = SharepointStorage::parse_file_metadata_response(
+            &json!({
+                "@microsoft.graph.downloadUrl": "https://example.test/download",
+                "file": {
+                    "mimeType": "message/rfc822"
+                }
+            }),
+            "drive",
+            "item",
+        )
+        .unwrap();
+
+        assert_eq!(metadata.content_type.as_deref(), Some("message/rfc822"));
     }
 
     #[test]

--- a/backend/erato/src/services/prompt_composition/adapters.rs
+++ b/backend/erato/src/services/prompt_composition/adapters.rs
@@ -99,7 +99,7 @@ impl<'a> FileResolver for AppStateFileResolver<'a> {
         let text = self
             .app_state
             .file_processor
-            .parse_file(file_bytes)
+            .parse_file(file_bytes, Some(&file.filename))
             .await
             .wrap_err("Failed to parse file")?;
 

--- a/backend/erato/src/services/prompt_composition/adapters.rs
+++ b/backend/erato/src/services/prompt_composition/adapters.rs
@@ -88,6 +88,10 @@ impl<'a> FileResolver for AppStateFileResolver<'a> {
             .file_storage_providers
             .get(&file.file_storage_provider_id)
             .wrap_err("File storage provider not found")?;
+        let content_type = file_storage
+            .get_file_content_type_with_context(&file.file_storage_path, sharepoint_ctx.as_ref())
+            .await
+            .wrap_err("Failed to read file content type from storage")?;
 
         // Read the file content
         let file_bytes = file_storage
@@ -99,7 +103,7 @@ impl<'a> FileResolver for AppStateFileResolver<'a> {
         let text = self
             .app_state
             .file_processor
-            .parse_file(file_bytes, Some(&file.filename))
+            .parse_file(file_bytes, content_type.as_deref())
             .await
             .wrap_err("Failed to parse file")?;
 

--- a/backend/erato/tests/integration_tests/api/files.rs
+++ b/backend/erato/tests/integration_tests/api/files.rs
@@ -12,7 +12,9 @@ use sqlx::Pool;
 use sqlx::postgres::Postgres;
 
 use crate::test_app_state;
-use crate::test_utils::{TEST_JWT_TOKEN, TestRequestAuthExt, setup_mock_llm_server};
+use crate::test_utils::{
+    TEST_JWT_TOKEN, TestRequestAuthExt, read_integration_test_file_bytes, setup_mock_llm_server,
+};
 
 fn assert_download_url_contains_filename(download_url: &str, filename: &str) {
     assert!(
@@ -23,6 +25,47 @@ fn assert_download_url_contains_filename(download_url: &str, filename: &str) {
         download_url.contains(&format!("filename%3D%22{filename}%22")),
         "Download URL should contain the original filename in content disposition: {download_url}"
     );
+}
+
+async fn create_chat(server: &TestServer) -> String {
+    let create_chat_response = server
+        .post("/api/v1beta/me/chats")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .add_header(http::header::CONTENT_TYPE, "application/json")
+        .json(&json!({}))
+        .await;
+
+    create_chat_response.assert_status_ok();
+
+    let create_chat_json: Value = create_chat_response.json();
+    create_chat_json["chat_id"]
+        .as_str()
+        .expect("Expected chat_id in response")
+        .to_string()
+}
+
+async fn upload_file_to_chat(
+    server: &TestServer,
+    chat_id: &str,
+    file_bytes: Vec<u8>,
+    filename: &str,
+    mime_type: &str,
+) -> Value {
+    let multipart_form = MultipartForm::new().add_part(
+        "file",
+        Part::bytes(file_bytes)
+            .file_name(filename)
+            .mime_type(mime_type),
+    );
+
+    let upload_response = server
+        .post(&format!("/api/v1beta/me/files?chat_id={}", chat_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .multipart(multipart_form)
+        .await;
+
+    upload_response.assert_status_ok();
+    upload_response.json()
 }
 
 /// Test file upload to a chat.
@@ -165,6 +208,137 @@ async fn test_file_upload_endpoint(pool: Pool<Postgres>) {
     }
 }
 
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_file_capabilities_endpoint_includes_email_support(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let response = server
+        .get("/api/v1beta/me/file-capabilities")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status_ok();
+    let capabilities: Value = response.json();
+    let capabilities = capabilities
+        .as_array()
+        .expect("Expected capabilities array");
+
+    let email_capability = capabilities
+        .iter()
+        .find(|cap| cap["id"].as_str() == Some("email"))
+        .expect("Expected email capability");
+
+    assert_eq!(email_capability["extensions"], json!(["eml"]));
+    assert_eq!(email_capability["mime_types"], json!(["message/rfc822"]));
+    assert_eq!(email_capability["operations"], json!(["extract_text"]));
+}
+
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_storage_helpers_support_eml_content_type(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let provider = app_state.default_file_storage_provider();
+    let file_path = format!("eml-storage-test-{}", Uuid::new_v4());
+    let filename = "storage_roundtrip.eml";
+
+    let mut writer = provider
+        .upload_file_writer(&file_path, Some("message/rfc822"))
+        .await
+        .expect("Failed to create upload writer for EML content type");
+    writer
+        .write(read_integration_test_file_bytes(
+            "please_review_attached_draft.eml",
+        ))
+        .await
+        .expect("Failed to write EML fixture to storage");
+    writer
+        .close()
+        .await
+        .expect("Failed to finalize EML upload to storage");
+
+    provider
+        .generate_presigned_download_url(&file_path, None, Some(filename))
+        .await
+        .expect("Failed to generate presigned download URL for EML file");
+    provider
+        .generate_presigned_preview_url(&file_path, None, Some(filename))
+        .await
+        .expect("Failed to generate presigned preview URL for EML file");
+}
+
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_eml_upload_supports_rfc822_and_octet_stream_content_types(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let chat_id = create_chat(&server).await;
+    let test_cases = [
+        ("message/rfc822", "email_rfc822.eml"),
+        ("application/octet-stream", "email_octet_stream.eml"),
+    ];
+
+    for (mime_type, filename) in test_cases {
+        let upload_json = upload_file_to_chat(
+            &server,
+            &chat_id,
+            read_integration_test_file_bytes("please_review_attached_draft.eml"),
+            filename,
+            mime_type,
+        )
+        .await;
+
+        let file = &upload_json["files"][0];
+        let file_id = file["id"].as_str().expect("Expected uploaded file id");
+        let download_url = file["download_url"]
+            .as_str()
+            .expect("Expected download URL");
+
+        assert_eq!(file["filename"], json!(filename));
+        assert_eq!(file["file_capability"]["id"], json!("email"));
+        assert_eq!(
+            file["file_capability"]["operations"],
+            json!(["extract_text"])
+        );
+        assert!(
+            file["preview_url"].as_str().is_some(),
+            "Expected preview URL"
+        );
+        assert_download_url_contains_filename(download_url, filename);
+
+        let get_file_response = server
+            .get(&format!("/api/v1beta/files/{}", file_id))
+            .with_bearer_token(TEST_JWT_TOKEN)
+            .await;
+
+        get_file_response.assert_status_ok();
+        let file_json: Value = get_file_response.json();
+        assert_eq!(file_json["filename"], json!(filename));
+        assert_eq!(file_json["file_capability"]["id"], json!("email"));
+        assert_eq!(
+            file_json["file_capability"]["operations"],
+            json!(["extract_text"])
+        );
+        assert!(
+            file_json["preview_url"].as_str().is_some(),
+            "Expected preview URL"
+        );
+    }
+}
+
 /// Test retrieving file information by ID.
 ///
 /// # Test Categories
@@ -191,19 +365,7 @@ async fn test_get_file_by_id(pool: Pool<Postgres>) {
     let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
 
     // First, create a chat to attach the file to
-    let create_chat_response = server
-        .post("/api/v1beta/me/chats")
-        .with_bearer_token(TEST_JWT_TOKEN)
-        .add_header(http::header::CONTENT_TYPE, "application/json")
-        .json(&json!({}))
-        .await;
-
-    create_chat_response.assert_status_ok();
-
-    let create_chat_json: Value = create_chat_response.json();
-    let chat_id = create_chat_json["chat_id"]
-        .as_str()
-        .expect("Expected chat_id in response");
+    let chat_id = create_chat(&server).await;
 
     // Create a file to upload
     let file_content = json!({"test": "content"}).to_string();

--- a/backend/erato/tests/integration_tests/api/files.rs
+++ b/backend/erato/tests/integration_tests/api/files.rs
@@ -268,6 +268,11 @@ async fn test_storage_helpers_support_eml_content_type(pool: Pool<Postgres>) {
         .generate_presigned_download_url(&file_path, None, Some(filename))
         .await
         .expect("Failed to generate presigned download URL for EML file");
+    let content_type = provider
+        .get_file_content_type_with_context(&file_path, None)
+        .await
+        .expect("Failed to fetch stored EML content type");
+    assert_eq!(content_type.as_deref(), Some("message/rfc822"));
     provider
         .generate_presigned_preview_url(&file_path, None, Some(filename))
         .await
@@ -289,6 +294,7 @@ async fn test_eml_upload_supports_rfc822_and_octet_stream_content_types(pool: Po
     let test_cases = [
         ("message/rfc822", "email_rfc822.eml"),
         ("application/octet-stream", "email_octet_stream.eml"),
+        ("text/plain", "email_text_plain.eml"),
     ];
 
     for (mime_type, filename) in test_cases {

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -21,7 +21,7 @@ use std::env;
 use crate::test_app_state;
 use crate::test_utils::{
     JwtTokenBuilder, TEST_JWT_TOKEN, TEST_USER_ISSUER, TEST_USER_SUBJECT, TestRequestAuthExt,
-    extract_chat_id, parse_sse_events, setup_mock_llm_server,
+    extract_chat_id, parse_sse_events, read_integration_test_file_bytes, setup_mock_llm_server,
 };
 
 fn mock_mcp_base_url() -> String {
@@ -964,6 +964,126 @@ async fn test_token_usage_estimate_with_file(pool: Pool<Postgres>) {
         remaining_tokens,
         max_tokens - total_tokens,
         "Remaining tokens should be max_tokens - total_tokens"
+    );
+}
+
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_token_usage_estimate_with_eml_file(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let message_request = json!({
+        "previous_message_id": null,
+        "user_message": "Test message to create a chat for EML token usage test"
+    });
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .add_header(http::header::CONTENT_TYPE, "application/json")
+        .json(&message_request)
+        .await;
+
+    response.assert_status_ok();
+
+    let body = response.as_bytes();
+    let body_str = String::from_utf8_lossy(body);
+    let lines: Vec<&str> = body_str.lines().collect();
+
+    let mut user_message_id = String::new();
+    let mut chat_id = String::new();
+
+    for i in 0..lines.len() - 1 {
+        if lines[i] == "event: user_message_saved" {
+            let data_line = lines[i + 1];
+            if data_line.starts_with("data: ") {
+                let data_json: Value = serde_json::from_str(&data_line[6..])
+                    .expect("Failed to parse user_message_saved data");
+                user_message_id = data_json["message_id"]
+                    .as_str()
+                    .expect("Expected message_id to be a string")
+                    .to_string();
+            }
+        } else if lines[i] == "event: chat_created" {
+            let data_line = lines[i + 1];
+            if data_line.starts_with("data: ") {
+                let data_json: Value = serde_json::from_str(&data_line[6..])
+                    .expect("Failed to parse chat_created data");
+                chat_id = data_json["chat_id"]
+                    .as_str()
+                    .expect("Expected chat_id to be a string")
+                    .to_string();
+            }
+        }
+    }
+
+    let multipart_form = axum_test::multipart::MultipartForm::new().add_part(
+        "file",
+        axum_test::multipart::Part::bytes(read_integration_test_file_bytes(
+            "please_review_attached_draft.eml",
+        ))
+        .file_name("please_review_attached_draft.eml")
+        .mime_type("application/octet-stream"),
+    );
+
+    let upload_response = server
+        .post(&format!("/api/v1beta/me/files?chat_id={}", chat_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .multipart(multipart_form)
+        .await;
+
+    upload_response.assert_status_ok();
+    let upload_json: Value = upload_response.json();
+    assert_eq!(
+        upload_json["files"][0]["file_capability"]["id"],
+        json!("email")
+    );
+
+    let file_id = upload_json["files"][0]["id"]
+        .as_str()
+        .expect("Expected file ID")
+        .to_string();
+
+    let token_usage_request = json!({
+        "previous_message_id": user_message_id,
+        "user_message": "Can you analyze this email file for me?",
+        "input_files_ids": [file_id]
+    });
+
+    let response = server
+        .post("/api/v1beta/token_usage/estimate")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .add_header(http::header::CONTENT_TYPE, "application/json")
+        .json(&token_usage_request)
+        .await;
+
+    response.assert_status_ok();
+    let token_usage: Value = response.json();
+
+    let file_detail = &token_usage["file_details"][0];
+    assert_eq!(
+        file_detail["filename"],
+        json!("please_review_attached_draft.eml")
+    );
+    assert!(
+        file_detail["token_count"]
+            .as_u64()
+            .expect("Expected token_count")
+            > 0,
+        "Expected extracted email content to produce tokens"
+    );
+    assert!(
+        token_usage["stats"]["file_tokens"]
+            .as_u64()
+            .expect("Expected file_tokens")
+            > 0,
+        "Expected file_tokens to be greater than zero"
     );
 }
 

--- a/backend/erato/tests/integration_tests/main.rs
+++ b/backend/erato/tests/integration_tests/main.rs
@@ -107,7 +107,8 @@ async fn test_app_state_internal(
     }
 
     let actor_manager =
-        erato::actors::manager::ActorManager::new(db.clone(), app_config.clone()).await;
+        erato::actors::manager::ActorManager::new_with_name(db.clone(), app_config.clone(), None)
+            .await;
 
     // Create a disabled Langfuse client for testing
     let langfuse_config = LangfuseConfig {

--- a/backend/erato/tests/integration_tests/test_files/please_review_attached_draft.eml
+++ b/backend/erato/tests/integration_tests/test_files/please_review_attached_draft.eml
@@ -1,0 +1,26 @@
+From: Daniel Person <daniel@eratolabs.com>
+To: testuser@maxgoisser.onmicrosoft.com
+Subject: Please review attached draft
+Date: Fri, 20 Mar 2026 13:28:03 +0100
+Message-ID: <sample-review@eratolabs.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="mix-boundary"
+
+--mix-boundary
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Hi Max,
+
+could you please take a quick look at the attached draft document and let me know whether it looks fine from your side.
+
+Thanks
+Daniel
+
+--mix-boundary
+Content-Type: application/pdf; name="internal_review_test_attachment.pdf"
+Content-Disposition: attachment; filename="internal_review_test_attachment.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQKJUVPRgo=
+--mix-boundary--

--- a/backend/erato/tests/integration_tests/test_files/re_another_doc_you_have_to_check.eml
+++ b/backend/erato/tests/integration_tests/test_files/re_another_doc_you_have_to_check.eml
@@ -1,0 +1,41 @@
+From: Daniel Person <daniel@eratolabs.com>
+To: Max Token <testuser@maxgoisser.onmicrosoft.com>
+Subject: Re: Another doc you have to check
+Date: Sun, 19 Apr 2026 15:40:17 +0200
+Message-ID: <sample-reply@eratolabs.com>
+In-Reply-To: <original-message@eratolabs.com>
+References: <original-message@eratolabs.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="alt-boundary"
+
+--alt-boundary
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Hi Max,
+
+I am referring to the PDF draft I attached to my previous email. I was hoping you could review the content and confirm if you are comfortable with it.
+
+Please let me know if you have any specific questions or if you cannot see the attachment.
+
+Best regards,
+Daniel
+
+On Fri, 20 Mar 2026 at 13:28, Daniel Person <daniel@eratolabs.com> wrote:
+> could you please take a quick look at the attached draft document and let me know whether it looks fine from your side.
+> Thanks
+> Daniel
+
+--alt-boundary
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+<html>
+  <body>
+    <p>Hi Max,</p>
+    <p>I am referring to the PDF draft I attached to my previous email. I was hoping you could review the content and confirm if you are comfortable with it.</p>
+    <p>Please let me know if you have any specific questions or if you cannot see the attachment.</p>
+    <p>Best regards,<br>Daniel</p>
+  </body>
+</html>
+--alt-boundary--

--- a/backend/erato/tests/integration_tests/test_utils.rs
+++ b/backend/erato/tests/integration_tests/test_utils.rs
@@ -12,8 +12,10 @@ use erato::state::AppState;
 use mocktail::prelude::*;
 use mocktail::server::MockServerConfig;
 use serde_json::{Value, json};
+use std::fs;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::PathBuf;
 use std::time::Duration;
 use tempfile::{Builder, NamedTempFile};
 
@@ -54,6 +56,16 @@ pub fn create_temp_config_file(content: &str) -> NamedTempFile {
     temp_file.flush().expect("Failed to flush temporary file");
 
     temp_file
+}
+
+/// Read a fixture from `tests/integration_tests/test_files`.
+pub fn read_integration_test_file_bytes(filename: &str) -> Vec<u8> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/integration_tests/test_files")
+        .join(filename);
+
+    fs::read(&path)
+        .unwrap_or_else(|_| panic!("Failed to read integration test fixture {}", filename))
 }
 
 /// Builds an `AppConfig` from a configuration file path with optional overrides.


### PR DESCRIPTION
## What changed
- enabled backend `.eml` extraction by turning on Kreuzberg email support
- passed filenames into backend parsing so `.eml` files force `message/rfc822`
- added backend file capability and MIME fallback support for email uploads
- added focused `.eml` fixtures and tests for extraction, upload, and token estimation
- removed the fixed actor supervisor registration name used in tests to avoid integration-test collisions

## Why
ERMAIN-250 phase 1 is backend-only. The goal is to make `.eml` files work end-to-end for upload, extraction, and token estimation before any frontend preview or structured rendering work.

## User impact
Backend clients can now upload `.eml` files and get extracted text through the existing file-processing flow. Token estimation and file capability reporting now treat email files as supported backend text-extraction inputs.

## Root cause
Kreuzberg needs the email parser enabled and `.eml` files need an RFC822 MIME hint. Relying on byte-based detection alone was not sufficient for this path.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo clippy --all-targets --no-default-features --locked`
- `cargo clippy --all-targets --no-default-features --features=sentry --locked`
- `cargo run --bin gen-openapi -- --check`
- `cargo run --bin gen-config-reference -- --check`
- `cargo nextest run --retries 2`
- `cargo deny --manifest-path backend/Cargo.toml check licenses`