### PR TITLE
Extended mail utilities support

### DIFF
--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -125,6 +125,7 @@ vi.mock("@/hooks/chat", () => ({
     modelsError: null,
     isSelectionReady: false,
   }),
+  useStandardMessageActions: () => vi.fn().mockResolvedValue(false),
 }));
 
 // Mock the actual components that are used

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -10,7 +10,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { useDropzone } from "react-dropzone";
 
 import { FilePreviewModal } from "@/components/ui/Modal/FilePreviewModal";
 import {
@@ -23,6 +22,7 @@ import {
   useStandardMessageActions,
 } from "@/hooks/chat";
 import { useMessageFeedback } from "@/hooks/chat/useMessageFeedback";
+import { useConversationDropzone } from "@/hooks/files/useConversationDropzone";
 import { useFileUploadWithTokenCheck } from "@/hooks/files/useFileUploadWithTokenCheck";
 import { useSidebar, useFilePreviewModal } from "@/hooks/ui";
 import { useChatShareLink } from "@/hooks/useChatShareLink";
@@ -35,7 +35,6 @@ import {
   useSidebarFeature,
 } from "@/providers/FeatureConfigProvider";
 import { createLogger } from "@/utils/debugLogger";
-import { FileTypeUtil } from "@/utils/fileTypes";
 
 import { ChatHistorySidebar } from "./ChatHistorySidebar";
 import { ChatInput } from "./ChatInput";
@@ -585,36 +584,20 @@ export const Chat = ({
     // For now, its presence enables the button in ChatInput.
   }, []);
 
-  const handleConversationDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      if (acceptedFiles.length === 0) {
-        return;
-      }
-
-      void uploadFiles(acceptedFiles).then((uploadedFiles) => {
-        if (uploadedFiles && uploadedFiles.length > 0) {
-          chatInputControlsRef.current?.addUploadedFiles(uploadedFiles);
-        }
-      });
-    },
-    [uploadFiles],
-  );
+  const handleDropUploaded = useCallback((uploaded: FileUploadItem[]) => {
+    chatInputControlsRef.current?.addUploadedFiles(uploaded);
+  }, []);
 
   const {
     getRootProps: getConversationDropzoneRootProps,
     getInputProps: getConversationDropzoneInputProps,
     isDragActive,
     isDragAccept,
-  } = useDropzone({
-    onDrop: handleConversationDrop,
-    accept:
-      acceptedFileTypes && acceptedFileTypes.length > 0
-        ? FileTypeUtil.getAcceptObject(acceptedFileTypes)
-        : undefined,
-    multiple: true,
-    disabled: isUploading,
-    noClick: true,
-    noKeyboard: true,
+  } = useConversationDropzone({
+    uploadFiles,
+    onUploaded: handleDropUploaded,
+    acceptedFileTypes,
+    isUploading,
   });
 
   if (process.env.NODE_ENV === "development") {

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -17,7 +17,11 @@ import {
   componentRegistry,
   resolveComponentOverride,
 } from "@/config/componentRegistry";
-import { useActiveModelSelection, useChatActions } from "@/hooks/chat";
+import {
+  useActiveModelSelection,
+  useChatActions,
+  useStandardMessageActions,
+} from "@/hooks/chat";
 import { useMessageFeedback } from "@/hooks/chat/useMessageFeedback";
 import { useFileUploadWithTokenCheck } from "@/hooks/files/useFileUploadWithTokenCheck";
 import { useSidebar, useFilePreviewModal } from "@/hooks/ui";
@@ -30,7 +34,6 @@ import {
   useChatSharingFeature,
   useSidebarFeature,
 } from "@/providers/FeatureConfigProvider";
-import { extractTextFromContent } from "@/utils/adapters/contentPartAdapter";
 import { createLogger } from "@/utils/debugLogger";
 import { FileTypeUtil } from "@/utils/fileTypes";
 
@@ -556,6 +559,16 @@ export const Chat = ({
     onFeedbackSuccess: handleFeedbackSuccess,
   });
 
+  const standardMessageActionHandler = useStandardMessageActions({
+    messages,
+    setEditState,
+    handleRegenerate,
+    handleFeedbackSubmit,
+    feedbackConfig,
+    openFeedbackDialog,
+    onUnhandledAction: handleMessageAction,
+  });
+
   // Restore placeholder definitions for props passed to MessageList
   const hasOlderMessages = false;
   const loadOlderMessages = () => {
@@ -833,79 +846,7 @@ export const Chat = ({
                     ...controlsContext,
                     canEdit: canEditForCurrentChat,
                   }}
-                  onMessageAction={async (action: MessageAction) => {
-                    // Intercept edit/regenerate here to route to local handlers
-                    if (action.type === "edit") {
-                      logger.log(
-                        `Edit action called with messageId: ${action.messageId}`,
-                      );
-
-                      // Find the message directly from the messages object
-                      const messageToEdit = messages[action.messageId];
-                      logger.log(
-                        `Available message keys:`,
-                        Object.keys(messages),
-                      );
-                      logger.log(`Looking up message:`, messageToEdit);
-
-                      if (messageToEdit.role === "user") {
-                        const messageFiles = (
-                          messageToEdit as ChatMessage & {
-                            files?: FileUploadItem[];
-                          }
-                        ).files;
-                        const initialFiles = Array.isArray(messageFiles)
-                          ? messageFiles
-                          : [];
-                        logger.log(
-                          `Setting editState: messageId=${action.messageId}, content="${extractTextFromContent(messageToEdit.content)}"`,
-                        );
-
-                        // Use React's functional update to ensure we get the latest state
-                        setEditState(() => ({
-                          mode: "edit",
-                          messageId: action.messageId,
-                          initialContent: messageToEdit.content,
-                          initialFiles,
-                        }));
-
-                        logger.log(`editState set successfully`);
-                      } else {
-                        logger.log(
-                          `Cannot edit message ${action.messageId}: not found or not a user message`,
-                          {
-                            messageToEdit,
-                            role: messageToEdit.role,
-                            available: Object.keys(messages),
-                          },
-                        );
-                      }
-                      return true;
-                    }
-                    if (action.type === "regenerate") {
-                      handleRegenerate(action.messageId);
-                      return true;
-                    }
-                    // Handle like/dislike feedback actions
-                    if (action.type === "like" || action.type === "dislike") {
-                      const sentiment =
-                        action.type === "like" ? "positive" : "negative";
-
-                      // Submit feedback immediately (cache invalidation handled by onFeedbackSuccess callback)
-                      const result = await handleFeedbackSubmit(
-                        action.messageId,
-                        sentiment,
-                      );
-
-                      // If comments are enabled, open the dialog for additional comment
-                      if (result.success && feedbackConfig.commentsEnabled) {
-                        openFeedbackDialog(action.messageId, sentiment);
-                      }
-
-                      return result.success;
-                    }
-                    return handleMessageAction(action);
-                  }}
+                  onMessageAction={standardMessageActionHandler}
                   className={clsx(
                     layout,
                     canShareCurrentChat && "pt-12 sm:pt-14",

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -17,6 +17,14 @@ export interface FileAttachmentGroupItem {
   id: string;
   file: FileResource;
   isLoading?: boolean;
+  /**
+   * Optional display label for the item's metadata row. When set, renderers
+   * should show this verbatim instead of deriving a label from the file's
+   * capability / extension. Useful for items synthesised client-side whose
+   * backend capability id would not read well (e.g. email body rendered as
+   * `.html` but meant to be labelled "Email").
+   */
+  labelOverride?: string;
 }
 
 export interface FileAttachmentGroup {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -2,6 +2,8 @@ import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { useState } from "react";
 
+import { componentRegistry } from "@/config/componentRegistry";
+
 import { getFileName, type FileResource } from "./FilePreviewBase";
 import { FilePreviewButton } from "./FilePreviewButton";
 import { FilePreviewLoading } from "./FilePreviewLoading";
@@ -52,7 +54,7 @@ function getFileId(item: FileAttachmentGroupItem): string {
   return item.id;
 }
 
-export const GroupedFileAttachmentsPreview: React.FC<
+const DefaultGroupedFileAttachmentsPreview: React.FC<
   GroupedFileAttachmentsPreviewProps
 > = ({
   groups,
@@ -187,4 +189,14 @@ export const GroupedFileAttachmentsPreview: React.FC<
       })}
     </div>
   );
+};
+
+export const GroupedFileAttachmentsPreview: React.FC<
+  GroupedFileAttachmentsPreviewProps
+> = (props) => {
+  const Override = componentRegistry.ChatGroupedAttachmentsPreview;
+  if (Override) {
+    return <Override {...props} />;
+  }
+  return <DefaultGroupedFileAttachmentsPreview {...props} />;
 };

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -23,6 +23,13 @@
  * ```
  */
 
+import { OpenWebUIChatHistoryList } from "@/customer/components/OpenWebUIChatHistoryList";
+import { OpenWebUIChatInputAttachmentPreview } from "@/customer/components/OpenWebUIChatInputAttachmentPreview";
+import { OpenWebUIChatMessageRenderer } from "@/customer/components/OpenWebUIChatMessageRenderer";
+import { OpenWebUITopLeftAccessory } from "@/customer/components/OpenWebUITopLeftAccessory";
+import { OpenWebUIAssistantWelcomeScreen } from "@/customer/components/OpenWebUIWelcomeScreens"; // eslint-disable-next-line import/order
+import { OpenWebUIStarterPrompts } from "@/customer/components/OpenWebUIStarterPrompts";
+
 import type { AssistantWelcomeScreenProps } from "@/components/ui/Assistant/AssistantWelcomeScreen";
 import type { ChatHistoryListProps } from "@/components/ui/Chat/ChatHistoryList";
 import type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
@@ -155,13 +162,13 @@ export const resolveComponentOverride = <TProps>(
 export const componentRegistry: ComponentRegistry = {
   AssistantFileSourceSelector: null,
   ChatFileSourceSelector: null,
-  ChatInputAttachmentPreview: null,
-  ChatHistoryList: null,
+  ChatInputAttachmentPreview: OpenWebUIChatInputAttachmentPreview,
+  ChatHistoryList: OpenWebUIChatHistoryList,
   ChatWelcomeScreen: null,
-  StarterPrompts: null,
-  AssistantWelcomeScreen: null,
+  StarterPrompts: OpenWebUIStarterPrompts,
+  AssistantWelcomeScreen: OpenWebUIAssistantWelcomeScreen,
   MessageControls: null,
-  ChatMessageRenderer: null,
-  ChatTopLeftAccessory: null,
+  ChatMessageRenderer: OpenWebUIChatMessageRenderer,
+  ChatTopLeftAccessory: OpenWebUITopLeftAccessory,
   EratoEmailCodeBlock: null,
 };

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -23,13 +23,6 @@
  * ```
  */
 
-import { OpenWebUIChatHistoryList } from "@/customer/components/OpenWebUIChatHistoryList";
-import { OpenWebUIChatInputAttachmentPreview } from "@/customer/components/OpenWebUIChatInputAttachmentPreview";
-import { OpenWebUIChatMessageRenderer } from "@/customer/components/OpenWebUIChatMessageRenderer";
-import { OpenWebUITopLeftAccessory } from "@/customer/components/OpenWebUITopLeftAccessory";
-import { OpenWebUIAssistantWelcomeScreen } from "@/customer/components/OpenWebUIWelcomeScreens"; // eslint-disable-next-line import/order
-import { OpenWebUIStarterPrompts } from "@/customer/components/OpenWebUIStarterPrompts";
-
 import type { AssistantWelcomeScreenProps } from "@/components/ui/Assistant/AssistantWelcomeScreen";
 import type { ChatHistoryListProps } from "@/components/ui/Chat/ChatHistoryList";
 import type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
@@ -162,13 +155,13 @@ export const resolveComponentOverride = <TProps>(
 export const componentRegistry: ComponentRegistry = {
   AssistantFileSourceSelector: null,
   ChatFileSourceSelector: null,
-  ChatInputAttachmentPreview: OpenWebUIChatInputAttachmentPreview,
-  ChatHistoryList: OpenWebUIChatHistoryList,
+  ChatInputAttachmentPreview: null,
+  ChatHistoryList: null,
   ChatWelcomeScreen: null,
-  StarterPrompts: OpenWebUIStarterPrompts,
-  AssistantWelcomeScreen: OpenWebUIAssistantWelcomeScreen,
+  StarterPrompts: null,
+  AssistantWelcomeScreen: null,
   MessageControls: null,
-  ChatMessageRenderer: OpenWebUIChatMessageRenderer,
-  ChatTopLeftAccessory: OpenWebUITopLeftAccessory,
+  ChatMessageRenderer: null,
+  ChatTopLeftAccessory: null,
   EratoEmailCodeBlock: null,
 };

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -29,6 +29,7 @@ import type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
 import type { ChatTopLeftAccessoryProps } from "@/components/ui/Chat/ChatTopLeftAccessory";
 import type { StarterPromptsRendererProps } from "@/components/ui/Chat/StarterPromptsSection";
 import type { FileSourceSelectorProps } from "@/components/ui/FileUpload/FileSourceSelector";
+import type { GroupedFileAttachmentsPreviewProps } from "@/components/ui/FileUpload/GroupedFileAttachmentsPreview";
 import type { WelcomeScreenProps } from "@/components/ui/WelcomeScreen";
 import type { ChatInputAttachmentPreviewProps } from "@/types/chat-input-attachment-preview";
 import type { MessageControlsProps } from "@/types/message-controls";
@@ -68,6 +69,17 @@ export interface ComponentRegistry {
    * Used to render custom attachment chips/thumbnails inside the chat input shell.
    */
   ChatInputAttachmentPreview: ComponentType<ChatInputAttachmentPreviewProps> | null;
+
+  /**
+   * Override for the grouped attachments preview.
+   * Used by the Office addin's Outlook email-source suggestion and by any
+   * callsite that renders grouped attachment cards.
+   *
+   * When set, replaces the default rounded-md card layout with a theme-specific
+   * presentation (e.g. the OpenWebUI chip look) so grouped previews stay visually
+   * consistent with composer attachments.
+   */
+  ChatGroupedAttachmentsPreview: ComponentType<GroupedFileAttachmentsPreviewProps> | null;
 
   /**
    * Override for the chat history list shown in the sidebar.
@@ -156,6 +168,7 @@ export const componentRegistry: ComponentRegistry = {
   AssistantFileSourceSelector: null,
   ChatFileSourceSelector: null,
   ChatInputAttachmentPreview: null,
+  ChatGroupedAttachmentsPreview: null,
   ChatHistoryList: null,
   ChatWelcomeScreen: null,
   StarterPrompts: null,

--- a/frontend/src/hooks/chat/index.ts
+++ b/frontend/src/hooks/chat/index.ts
@@ -8,6 +8,7 @@ export * from "./useChat";
 export * from "./useChatHistory";
 export * from "./useChatMessaging";
 export * from "./useChatActions";
+export * from "./useStandardMessageActions";
 export * from "./useTokenManagement";
 export * from "./useModelHistory";
 export * from "./useActiveModelSelection";

--- a/frontend/src/hooks/chat/useStandardMessageActions.ts
+++ b/frontend/src/hooks/chat/useStandardMessageActions.ts
@@ -75,8 +75,7 @@ export function useStandardMessageActions({
       }
 
       if (action.type === "like" || action.type === "dislike") {
-        const sentiment =
-          action.type === "like" ? "positive" : "negative";
+        const sentiment = action.type === "like" ? "positive" : "negative";
         const result = await handleFeedbackSubmit(action.messageId, sentiment);
         if (result.success && feedbackConfig.commentsEnabled) {
           openFeedbackDialog(action.messageId, sentiment);

--- a/frontend/src/hooks/chat/useStandardMessageActions.ts
+++ b/frontend/src/hooks/chat/useStandardMessageActions.ts
@@ -1,0 +1,102 @@
+import { useCallback } from "react";
+
+import type { ChatMessage } from "@/components/ui/MessageList/MessageList";
+import type {
+  ContentPart,
+  FileUploadItem,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { MessageAction } from "@/types/message-controls";
+
+export type EditMessageState =
+  | { mode: "compose" }
+  | {
+      mode: "edit";
+      messageId: string;
+      initialContent: ContentPart[];
+      initialFiles: FileUploadItem[];
+    };
+
+interface UseStandardMessageActionsOptions {
+  messages: Record<string, ChatMessage>;
+  setEditState: (state: EditMessageState) => void;
+  handleRegenerate: (messageId: string) => void;
+  handleFeedbackSubmit: (
+    messageId: string,
+    sentiment: "positive" | "negative",
+  ) => Promise<{ success: boolean; errorType?: string }>;
+  feedbackConfig: { commentsEnabled: boolean };
+  openFeedbackDialog: (
+    messageId: string,
+    sentiment: "positive" | "negative",
+  ) => void;
+  /**
+   * Called for actions the hook does not handle (e.g. "copy"). Return value is
+   * propagated to the MessageList caller.
+   */
+  onUnhandledAction?: (action: MessageAction) => Promise<boolean>;
+}
+
+/**
+ * Returns an onMessageAction handler that covers the intrinsic chat actions
+ * (edit, regenerate, like, dislike) shared by the main Chat and AddinChat
+ * components. Caller-specific actions (copy policy, etc.) are delegated via
+ * onUnhandledAction.
+ */
+export function useStandardMessageActions({
+  messages,
+  setEditState,
+  handleRegenerate,
+  handleFeedbackSubmit,
+  feedbackConfig,
+  openFeedbackDialog,
+  onUnhandledAction,
+}: UseStandardMessageActionsOptions) {
+  return useCallback(
+    async (action: MessageAction): Promise<boolean> => {
+      if (action.type === "edit") {
+        const messageToEdit = messages[action.messageId];
+        if (messageToEdit.role === "user") {
+          const messageFiles = (
+            messageToEdit as ChatMessage & { files?: FileUploadItem[] }
+          ).files;
+          setEditState({
+            mode: "edit",
+            messageId: action.messageId,
+            initialContent: messageToEdit.content,
+            initialFiles: Array.isArray(messageFiles) ? messageFiles : [],
+          });
+        }
+        return true;
+      }
+
+      if (action.type === "regenerate") {
+        handleRegenerate(action.messageId);
+        return true;
+      }
+
+      if (action.type === "like" || action.type === "dislike") {
+        const sentiment =
+          action.type === "like" ? "positive" : "negative";
+        const result = await handleFeedbackSubmit(action.messageId, sentiment);
+        if (result.success && feedbackConfig.commentsEnabled) {
+          openFeedbackDialog(action.messageId, sentiment);
+        }
+        return result.success;
+      }
+
+      if (onUnhandledAction) {
+        return onUnhandledAction(action);
+      }
+      return false;
+    },
+    [
+      messages,
+      setEditState,
+      handleRegenerate,
+      handleFeedbackSubmit,
+      feedbackConfig,
+      openFeedbackDialog,
+      onUnhandledAction,
+    ],
+  );
+}

--- a/frontend/src/hooks/files/index.ts
+++ b/frontend/src/hooks/files/index.ts
@@ -1,3 +1,4 @@
 export * from "./useFileDropzone";
 export * from "./useFileUploadStore";
+export * from "./useFileUploadWithTokenCheck";
 export * from "./useStandaloneFileUpload";

--- a/frontend/src/hooks/files/index.ts
+++ b/frontend/src/hooks/files/index.ts
@@ -1,3 +1,4 @@
+export * from "./useConversationDropzone";
 export * from "./useFileDropzone";
 export * from "./useFileUploadStore";
 export * from "./useFileUploadWithTokenCheck";

--- a/frontend/src/hooks/files/useConversationDropzone.ts
+++ b/frontend/src/hooks/files/useConversationDropzone.ts
@@ -62,7 +62,10 @@ export function useConversationDropzone({
       acceptedFileTypes && acceptedFileTypes.length > 0
         ? FileTypeUtil.getAcceptObject(acceptedFileTypes)
         : undefined;
-    if (!extraAcceptMimeTypes || Object.keys(extraAcceptMimeTypes).length === 0) {
+    if (
+      !extraAcceptMimeTypes ||
+      Object.keys(extraAcceptMimeTypes).length === 0
+    ) {
       return base;
     }
     return { ...(base ?? {}), ...extraAcceptMimeTypes };

--- a/frontend/src/hooks/files/useConversationDropzone.ts
+++ b/frontend/src/hooks/files/useConversationDropzone.ts
@@ -1,0 +1,82 @@
+import { useCallback, useMemo } from "react";
+import { useDropzone } from "react-dropzone";
+
+import { FileTypeUtil } from "@/utils/fileTypes";
+
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { FileType } from "@/utils/fileTypes";
+
+interface UseConversationDropzoneOptions {
+  uploadFiles: (files: File[]) => Promise<FileUploadItem[] | undefined>;
+  /** Called after a successful drop-upload with the resulting items. */
+  onUploaded: (items: FileUploadItem[]) => void;
+  acceptedFileTypes?: FileType[];
+  /**
+   * Extra MIME-keyed entries merged into the dropzone accept map. Useful for
+   * surfaces that accept file types not declared by backend capabilities —
+   * e.g. the Outlook add-in accepting `.eml`/`.msg` drops of email messages.
+   */
+  extraAcceptMimeTypes?: Record<string, string[]>;
+  isUploading?: boolean;
+}
+
+interface ConversationDropzoneBindings {
+  getRootProps: () => Record<string, unknown>;
+  getInputProps: () => Record<string, unknown>;
+  isDragActive: boolean;
+  isDragAccept: boolean;
+}
+
+/**
+ * Shared desktop-file drop-to-upload wiring for the conversation area. Used
+ * by both the main Chat component and the Outlook add-in's AddinChat — the
+ * caller owns the overlay JSX since task-pane and full-app layouts differ.
+ *
+ * Root/input props are returned as plain records so consumers in a different
+ * workspace (with its own React/csstype pins) can spread them without type
+ * collisions across package boundaries.
+ */
+export function useConversationDropzone({
+  uploadFiles,
+  onUploaded,
+  acceptedFileTypes,
+  extraAcceptMimeTypes,
+  isUploading = false,
+}: UseConversationDropzoneOptions): ConversationDropzoneBindings {
+  const handleDrop = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      void uploadFiles(files).then((uploaded) => {
+        if (uploaded && uploaded.length > 0) {
+          onUploaded(uploaded);
+        }
+      });
+    },
+    [onUploaded, uploadFiles],
+  );
+
+  const accept = useMemo(() => {
+    const base =
+      acceptedFileTypes && acceptedFileTypes.length > 0
+        ? FileTypeUtil.getAcceptObject(acceptedFileTypes)
+        : undefined;
+    if (!extraAcceptMimeTypes || Object.keys(extraAcceptMimeTypes).length === 0) {
+      return base;
+    }
+    return { ...(base ?? {}), ...extraAcceptMimeTypes };
+  }, [acceptedFileTypes, extraAcceptMimeTypes]);
+
+  const { getRootProps, getInputProps, isDragActive, isDragAccept } =
+    useDropzone({
+      onDrop: handleDrop,
+      accept,
+      multiple: true,
+      disabled: isUploading,
+      noClick: true,
+      noKeyboard: true,
+    });
+
+  return { getRootProps, getInputProps, isDragActive, isDragAccept };
+}

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -52,13 +52,16 @@ export {
   useChatHistory,
   useChatMessaging,
   useModelHistory,
+  useStandardMessageActions,
   useTokenManagement,
   useActiveModelSelection,
+  type EditMessageState,
 } from "@/hooks/chat";
 export { useBudgetStatus } from "@/hooks/budget/useBudgetStatus";
 export {
   useFileDropzone,
   useFileUploadStore,
+  useFileUploadWithTokenCheck,
   useStandaloneFileUpload,
 } from "@/hooks/files";
 export {

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -59,11 +59,13 @@ export {
 } from "@/hooks/chat";
 export { useBudgetStatus } from "@/hooks/budget/useBudgetStatus";
 export {
+  useConversationDropzone,
   useFileDropzone,
   useFileUploadStore,
   useFileUploadWithTokenCheck,
   useStandaloneFileUpload,
 } from "@/hooks/files";
+export { DocumentIcon } from "@/components/ui/icons";
 export {
   useChatInputHandlers,
   useSidebar,

--- a/office-addin/eslint.config.mjs
+++ b/office-addin/eslint.config.mjs
@@ -36,6 +36,8 @@ const eslintConfig = [
         React: "readonly",
         JSX: "readonly",
         URL: "readonly",
+        atob: "readonly",
+        btoa: "readonly",
         console: "readonly",
         document: "readonly",
         fetch: "readonly",

--- a/office-addin/package.json
+++ b/office-addin/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-query": "5.75.7",
     "@tanstack/react-query-devtools": "5.75.7",
     "@tanstack/react-query-persist-client": "5.75.7",
+    "cfb": "^1.2.2",
     "postal-mime": "2.7.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/office-addin/package.json
+++ b/office-addin/package.json
@@ -37,6 +37,7 @@
     "@tanstack/react-query-devtools": "5.75.7",
     "@tanstack/react-query-persist-client": "5.75.7",
     "cfb": "^1.2.2",
+    "dompurify": "^3.3.3",
     "postal-mime": "2.7.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/office-addin/package.json
+++ b/office-addin/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-query": "5.75.7",
     "@tanstack/react-query-devtools": "5.75.7",
     "@tanstack/react-query-persist-client": "5.75.7",
+    "postal-mime": "2.7.4",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router": "6.30.3",

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tanstack/react-query-persist-client':
         specifier: 5.75.7
         version: 5.75.7(@tanstack/react-query@5.75.7(react@19.0.0))(react@19.0.0)
+      postal-mime:
+        specifier: 2.7.4
+        version: 2.7.4
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -308,7 +311,7 @@ packages:
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-hnLkU6/2zAvelKPvkicJFnZEkMoiaHaDm44ABiGWnZf8qr7sKskIOYG7jLDwQKaf1zxvVxm1rnbswNBx5BdE/g==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-LdGuZLEQvGpGHFAADnKe+Sv7C3R8r3hLPjio3akYZnqvZuX85wafUrMRakK4ZWBiEoemt/yzNvfUQVwII3E9jQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -2839,6 +2842,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -6795,6 +6801,8 @@ snapshots:
   pofile@1.1.4: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postal-mime@2.7.4: {}
 
   postcss-import@15.1.0(postcss@8.5.8):
     dependencies:

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       cfb:
         specifier: ^1.2.2
         version: 1.2.2
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.4.0
       postal-mime:
         specifier: 2.7.4
         version: 2.7.4
@@ -314,7 +317,7 @@ packages:
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-LdGuZLEQvGpGHFAADnKe+Sv7C3R8r3hLPjio3akYZnqvZuX85wafUrMRakK4ZWBiEoemt/yzNvfUQVwII3E9jQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-44YjLHHjvxe7NLgfaOIMouS7/CIuBX3iA+sploZ1DIZVUDl5k/Fyi+Xtka03BQ64t9xus0SEhOaBKpPaCF2QxA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tanstack/react-query-persist-client':
         specifier: 5.75.7
         version: 5.75.7(@tanstack/react-query@5.75.7(react@19.0.0))(react@19.0.0)
+      cfb:
+        specifier: ^1.2.2
+        version: 1.2.2
       postal-mime:
         specifier: 2.7.4
         version: 2.7.4
@@ -1206,6 +1209,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
     engines: {node: '>=12.0'}
@@ -1421,6 +1428,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1545,6 +1556,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4769,6 +4785,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   adm-zip@0.5.16: {}
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
@@ -5006,6 +5024,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -5126,6 +5149,8 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.9.3
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/office-addin/src/App.tsx
+++ b/office-addin/src/App.tsx
@@ -10,6 +10,7 @@ import { AddinChatPage } from "./pages/AddinChatPage";
 import { MsalNaaProvider, useMsalNaa } from "./providers/MsalNaaProvider";
 import { OfficeProvider, useOffice } from "./providers/OfficeProvider";
 import { OfficeThemeProvider } from "./providers/OfficeThemeProvider";
+import { OutlookEmailSourceProvider } from "./providers/OutlookEmailSourceProvider";
 import { OutlookMailItemProvider } from "./providers/OutlookMailItemProvider";
 
 import "./styles.css";
@@ -51,7 +52,11 @@ function OutlookWrapper({ children }: { children: React.ReactNode }) {
   const { host } = useOffice();
 
   if (host === "Outlook") {
-    return <OutlookMailItemProvider>{children}</OutlookMailItemProvider>;
+    return (
+      <OutlookMailItemProvider>
+        <OutlookEmailSourceProvider>{children}</OutlookEmailSourceProvider>
+      </OutlookMailItemProvider>
+    );
   }
 
   return <>{children}</>;

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -3,6 +3,7 @@ import {
   ChatInputControlsProvider,
   ChatMessage,
   DefaultMessageControls,
+  DocumentIcon,
   FeedbackCommentDialog,
   FeedbackViewDialog,
   FilePreviewModal,
@@ -14,6 +15,7 @@ import {
   resolveComponentOverride,
   useActiveModelSelection,
   useChatContext,
+  useConversationDropzone,
   useFileCapabilitiesContext,
   useFilePreviewModal,
   useFileUploadWithTokenCheck,
@@ -33,6 +35,20 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
+import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
+import { expandDroppedEmailFiles } from "../utils/expandDroppedEmailFiles";
+import { fetchOutlookMessageFiles } from "../utils/fetchOutlookMessage";
+
+import type { OutlookMailListDragItem } from "../utils/outlookMailListDragParse";
+
+// Accept real `.eml` / `.msg` files dropped by Outlook clients that expose
+// emails as native file drags (Outlook Mac, Classic Outlook on Windows). OWA
+// and New Outlook use the custom `maillistrow` path handled separately via
+// `useOutlookMailListDrag`.
+const EMAIL_MIME_TYPES: Record<string, string[]> = {
+  "message/rfc822": [".eml"],
+  "application/vnd.ms-outlook": [".msg"],
+};
 
 interface AddinChatProps {
   assistantId?: string;
@@ -89,14 +105,74 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     [capabilities],
   );
 
-  const { uploadFiles, uploadError } = useFileUploadWithTokenCheck({
-    message: "",
-    chatId: currentChatId,
-    assistantId,
-    chatProviderId: selectedModel?.chat_provider_id ?? undefined,
+  const { uploadFiles, uploadError, isUploading } = useFileUploadWithTokenCheck(
+    {
+      message: "",
+      chatId: currentChatId,
+      assistantId,
+      chatProviderId: selectedModel?.chat_provider_id ?? undefined,
+      acceptedFileTypes,
+      multiple: true,
+    },
+  );
+
+  const handleDropUploaded = useCallback((uploaded: FileUploadItem[]) => {
+    chatInputControlsRef.current?.addUploadedFiles(uploaded);
+  }, []);
+
+  const uploadFilesWithEmailExpansion = useCallback(
+    async (files: File[]) => {
+      const expanded = await expandDroppedEmailFiles(files);
+      return uploadFiles(expanded);
+    },
+    [uploadFiles],
+  );
+
+  const {
+    getRootProps: getConversationDropzoneRootProps,
+    getInputProps: getConversationDropzoneInputProps,
+    isDragActive,
+    isDragAccept,
+  } = useConversationDropzone({
+    uploadFiles: uploadFilesWithEmailExpansion,
+    onUploaded: handleDropUploaded,
     acceptedFileTypes,
-    multiple: true,
+    extraAcceptMimeTypes: EMAIL_MIME_TYPES,
+    isUploading,
   });
+
+  const handleOutlookMailListDrop = useCallback(
+    async (items: OutlookMailListDragItem[]) => {
+      const collected: File[] = [];
+      for (const item of items) {
+        try {
+          const { files } = await fetchOutlookMessageFiles(item.itemId);
+          collected.push(...files);
+        } catch (error) {
+          console.warn(
+            "Failed to fetch dropped Outlook email, skipping:",
+            item.subject || item.itemId,
+            error,
+          );
+        }
+      }
+      if (collected.length === 0) {
+        return;
+      }
+      const uploaded = await uploadFiles(collected);
+      if (uploaded && uploaded.length > 0) {
+        chatInputControlsRef.current?.addUploadedFiles(uploaded);
+      }
+    },
+    [uploadFiles],
+  );
+
+  const { isDragActive: isOutlookMailDragActive } = useOutlookMailListDrag({
+    onDrop: handleOutlookMailListDrop,
+  });
+
+  const showDropOverlay =
+    (isDragActive && isDragAccept) || isOutlookMailDragActive;
 
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
 
@@ -307,7 +383,39 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         </div>
 
         <ChatErrorBoundary onReset={() => void refetchHistory()}>
-          <div className="relative flex min-h-0 min-w-0 flex-1 flex-col bg-theme-bg-secondary">
+          <div
+            {...getConversationDropzoneRootProps()}
+            className="relative flex min-h-0 min-w-0 flex-1 flex-col bg-theme-bg-secondary"
+            role="region"
+            aria-label={t({
+              id: "officeAddin.chat.conversation.aria",
+              message: "Chat conversation",
+            })}
+            data-ui="addin-chat-conversation-dropzone"
+          >
+            <input
+              {...getConversationDropzoneInputProps()}
+              aria-label={t({
+                id: "officeAddin.chat.conversation.dropzone.ariaLabel",
+                message: "Drop files anywhere in the conversation to upload",
+              })}
+            />
+            {showDropOverlay && (
+              <div
+                className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center overflow-hidden bg-[color:color-mix(in_srgb,var(--theme-shell-chat-body)_75%,transparent)]"
+                data-testid="addin-chat-drop-overlay"
+              >
+                <div className="relative flex flex-col items-center gap-2 px-6 py-5 text-center">
+                  <DocumentIcon className="size-10 text-[var(--theme-fg-primary)] drop-shadow-[0_8px_24px_rgba(0,0,0,0.18)]" />
+                  <p className="text-sm font-medium text-[var(--theme-fg-primary)]">
+                    {t({
+                      id: "officeAddin.chat.fileDrop.overlay.label",
+                      message: "Drop to upload",
+                    })}
+                  </p>
+                </div>
+              </div>
+            )}
             {TopLeftAccessory ? (
               <TopLeftAccessory
                 availableModels={availableModels}

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -36,10 +36,13 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
+import { useMsalNaa } from "../providers/MsalNaaProvider";
 import { expandDroppedEmailFiles } from "../utils/expandDroppedEmailFiles";
 import { fetchOutlookMessageFiles } from "../utils/fetchOutlookMessage";
 
 import type { OutlookMailListDragItem } from "../utils/outlookMailListDragParse";
+
+const GRAPH_MAIL_SCOPES = ["Mail.Read"];
 
 // Accept real `.eml` / `.msg` files dropped by Outlook clients that expose
 // emails as native file drags (Outlook Mac, Classic Outlook on Windows). OWA
@@ -120,12 +123,20 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     chatInputControlsRef.current?.addUploadedFiles(uploaded);
   }, []);
 
+  const { acquireToken } = useMsalNaa();
+  const acquireGraphToken = useCallback(
+    () => acquireToken(GRAPH_MAIL_SCOPES),
+    [acquireToken],
+  );
+
   const uploadFilesWithEmailExpansion = useCallback(
     async (files: File[]) => {
-      const expanded = await expandDroppedEmailFiles(files);
+      const expanded = await expandDroppedEmailFiles(files, {
+        acquireGraphToken,
+      });
       return uploadFiles(expanded);
     },
-    [uploadFiles],
+    [acquireGraphToken, uploadFiles],
   );
 
   const {
@@ -146,7 +157,10 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       const collected: File[] = [];
       for (const item of items) {
         try {
-          const { files } = await fetchOutlookMessageFiles(item.itemId);
+          const { files } = await fetchOutlookMessageFiles(
+            item.itemId,
+            acquireGraphToken,
+          );
           collected.push(...files);
         } catch (error) {
           console.warn(
@@ -164,7 +178,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         chatInputControlsRef.current?.addUploadedFiles(uploaded);
       }
     },
-    [uploadFiles],
+    [acquireGraphToken, uploadFiles],
   );
 
   const { isDragActive: isOutlookMailDragActive } = useOutlookMailListDrag({

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -38,6 +38,8 @@ import { AddinChatInput } from "./AddinChatInput";
 import { useOfficeDragAndDrop } from "../hooks/useOfficeDragAndDrop";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
 import { useMsalNaa } from "../providers/MsalNaaProvider";
+import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
+import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { expandDroppedEmailFiles } from "../utils/expandDroppedEmailFiles";
 import { fetchOutlookMessageFiles } from "../utils/fetchOutlookMessage";
 
@@ -130,14 +132,28 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     [acquireToken],
   );
 
+  const { mailItem } = useOutlookMailItem();
+  const { hasSelectedEmailSource, isEmailBodyIncluded } =
+    useOutlookEmailSource();
+  const previewEmailMessageIdRef = useRef<string | null>(null);
+
+  const shouldSkipEmailDuplicateOfPreview = useCallback(
+    (messageId: string) => {
+      const previewMessageId = previewEmailMessageIdRef.current;
+      return previewMessageId !== null && messageId === previewMessageId;
+    },
+    [],
+  );
+
   const uploadFilesWithEmailExpansion = useCallback(
     async (files: File[]) => {
       const expanded = await expandDroppedEmailFiles(files, {
         acquireGraphToken,
+        shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
       });
       return uploadFiles(expanded);
     },
-    [acquireGraphToken, uploadFiles],
+    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
   );
 
   const {
@@ -158,10 +174,21 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       const collected: File[] = [];
       for (const item of items) {
         try {
-          const { files } = await fetchOutlookMessageFiles(
+          const { files, internetMessageId } = await fetchOutlookMessageFiles(
             item.itemId,
             acquireGraphToken,
           );
+          if (
+            internetMessageId &&
+            shouldSkipEmailDuplicateOfPreview(internetMessageId)
+          ) {
+            console.log(
+              "[AddinChat] skipping dropped Outlook email already represented by the current-email preview:",
+              item.subject || item.itemId,
+              internetMessageId,
+            );
+            continue;
+          }
           collected.push(...files);
         } catch (error) {
           console.warn(
@@ -179,7 +206,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         chatInputControlsRef.current?.addUploadedFiles(uploaded);
       }
     },
-    [acquireGraphToken, uploadFiles],
+    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
   );
 
   const { isDragActive: isOutlookMailDragActive } = useOutlookMailListDrag({
@@ -193,6 +220,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       }
       const expanded = await expandDroppedEmailFiles(files, {
         acquireGraphToken,
+        shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
       });
       if (expanded.length === 0) {
         return;
@@ -202,7 +230,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         chatInputControlsRef.current?.addUploadedFiles(uploaded);
       }
     },
-    [acquireGraphToken, uploadFiles],
+    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
   );
 
   const { isDragActive: isOfficeDragActive } = useOfficeDragAndDrop({
@@ -246,6 +274,14 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     messageOrder.length === 0 &&
     !isPendingResponse &&
     editState.mode === "compose";
+
+  // Keep the preview's Message-ID fresh for the drop-dedup predicate. The
+  // ref is read by `shouldSkipEmailDuplicateOfPreview` at drop time, so we
+  // write here on every render once `shouldSuggestCurrentEmail` is known.
+  previewEmailMessageIdRef.current =
+    shouldSuggestCurrentEmail && hasSelectedEmailSource && isEmailBodyIncluded
+      ? (mailItem?.internetMessageId ?? null)
+      : null;
 
   const handleSendMessage = useCallback(
     (

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -137,12 +137,33 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     useOutlookEmailSource();
   const previewEmailMessageIdRef = useRef<string | null>(null);
 
+  // Tracks the RFC 5322 Message-IDs of emails already attached via any drop
+  // path in this session. Used to (a) suppress the current-email preview
+  // when the open email is already represented in the attachments and
+  // (b) short-circuit subsequent drops of the same email.
+  const [attachedEmailMessageIds, setAttachedEmailMessageIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const noteAttachedEmail = useCallback((messageId: string) => {
+    setAttachedEmailMessageIds((previous) => {
+      if (previous.has(messageId)) {
+        return previous;
+      }
+      const next = new Set(previous);
+      next.add(messageId);
+      return next;
+    });
+  }, []);
+
   const shouldSkipEmailDuplicateOfPreview = useCallback(
     (messageId: string) => {
       const previewMessageId = previewEmailMessageIdRef.current;
-      return previewMessageId !== null && messageId === previewMessageId;
+      if (previewMessageId !== null && messageId === previewMessageId) {
+        return true;
+      }
+      return attachedEmailMessageIds.has(messageId);
     },
-    [],
+    [attachedEmailMessageIds],
   );
 
   const uploadFilesWithEmailExpansion = useCallback(
@@ -150,10 +171,16 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       const expanded = await expandDroppedEmailFiles(files, {
         acquireGraphToken,
         shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
+        onAttachedEmail: noteAttachedEmail,
       });
       return uploadFiles(expanded);
     },
-    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
+    [
+      acquireGraphToken,
+      noteAttachedEmail,
+      shouldSkipEmailDuplicateOfPreview,
+      uploadFiles,
+    ],
   );
 
   const {
@@ -189,6 +216,9 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
             );
             continue;
           }
+          if (internetMessageId && files.length > 0) {
+            noteAttachedEmail(internetMessageId);
+          }
           collected.push(...files);
         } catch (error) {
           console.warn(
@@ -206,7 +236,12 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         chatInputControlsRef.current?.addUploadedFiles(uploaded);
       }
     },
-    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
+    [
+      acquireGraphToken,
+      noteAttachedEmail,
+      shouldSkipEmailDuplicateOfPreview,
+      uploadFiles,
+    ],
   );
 
   const { isDragActive: isOutlookMailDragActive } = useOutlookMailListDrag({
@@ -221,6 +256,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       const expanded = await expandDroppedEmailFiles(files, {
         acquireGraphToken,
         shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
+        onAttachedEmail: noteAttachedEmail,
       });
       if (expanded.length === 0) {
         return;
@@ -230,7 +266,12 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         chatInputControlsRef.current?.addUploadedFiles(uploaded);
       }
     },
-    [acquireGraphToken, shouldSkipEmailDuplicateOfPreview, uploadFiles],
+    [
+      acquireGraphToken,
+      noteAttachedEmail,
+      shouldSkipEmailDuplicateOfPreview,
+      uploadFiles,
+    ],
   );
 
   const { isDragActive: isOfficeDragActive } = useOfficeDragAndDrop({
@@ -269,18 +310,23 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         initialFiles: FileUploadItem[];
       }
   >({ mode: "compose" });
+  const currentEmailMessageId = mailItem?.internetMessageId ?? null;
+  const currentEmailAlreadyAttached =
+    currentEmailMessageId !== null &&
+    attachedEmailMessageIds.has(currentEmailMessageId);
   const shouldSuggestCurrentEmail =
     currentChatId === null &&
     messageOrder.length === 0 &&
     !isPendingResponse &&
-    editState.mode === "compose";
+    editState.mode === "compose" &&
+    !currentEmailAlreadyAttached;
 
   // Keep the preview's Message-ID fresh for the drop-dedup predicate. The
   // ref is read by `shouldSkipEmailDuplicateOfPreview` at drop time, so we
   // write here on every render once `shouldSuggestCurrentEmail` is known.
   previewEmailMessageIdRef.current =
     shouldSuggestCurrentEmail && hasSelectedEmailSource && isEmailBodyIncluded
-      ? (mailItem?.internetMessageId ?? null)
+      ? currentEmailMessageId
       : null;
 
   const handleSendMessage = useCallback(

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -35,6 +35,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
+import { useOfficeDragAndDrop } from "../hooks/useOfficeDragAndDrop";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
 import { useMsalNaa } from "../providers/MsalNaaProvider";
 import { expandDroppedEmailFiles } from "../utils/expandDroppedEmailFiles";
@@ -185,8 +186,33 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     onDrop: handleOutlookMailListDrop,
   });
 
+  const handleOfficeDragAndDrop = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
+      const expanded = await expandDroppedEmailFiles(files, {
+        acquireGraphToken,
+      });
+      if (expanded.length === 0) {
+        return;
+      }
+      const uploaded = await uploadFiles(expanded);
+      if (uploaded && uploaded.length > 0) {
+        chatInputControlsRef.current?.addUploadedFiles(uploaded);
+      }
+    },
+    [acquireGraphToken, uploadFiles],
+  );
+
+  const { isDragActive: isOfficeDragActive } = useOfficeDragAndDrop({
+    onDrop: handleOfficeDragAndDrop,
+  });
+
   const showDropOverlay =
-    (isDragActive && isDragAccept) || isOutlookMailDragActive;
+    (isDragActive && isDragAccept) ||
+    isOutlookMailDragActive ||
+    isOfficeDragActive;
 
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
 

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -10,13 +10,16 @@ import {
   chatMessagesQuery,
   componentRegistry,
   extractTextFromContent,
+  getSupportedFileTypes,
   resolveComponentOverride,
   useActiveModelSelection,
-  useChatActions,
   useChatContext,
+  useFileCapabilitiesContext,
   useFilePreviewModal,
+  useFileUploadWithTokenCheck,
   useMessageFeedback,
   useProfile,
+  useStandardMessageActions,
   type ActionFacetRequest,
   type ChatInputControlsHandle,
   type ContentPart,
@@ -31,7 +34,11 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
 
-export function AddinChat() {
+interface AddinChatProps {
+  assistantId?: string;
+}
+
+export function AddinChat({ assistantId }: AddinChatProps = {}) {
   const chatInputControlsRef = useRef<ChatInputControlsHandle | null>(null);
   const chatInputControls = useMemo(
     () => ({
@@ -64,19 +71,32 @@ export function AddinChat() {
     editMessage,
     regenerateMessage,
     isMessagingLoading,
+    isPendingResponse,
     chats,
     currentChatId,
-    navigateToChat,
     createNewChat,
     refetchHistory,
     currentChatLastModel,
-    uploadFiles,
-    uploadError,
   } = useChatContext();
   const { profile } = useProfile();
+  const { capabilities } = useFileCapabilitiesContext();
 
   const { availableModels, selectedModel, setSelectedModel, isSelectionReady } =
     useActiveModelSelection({ initialModel: currentChatLastModel });
+
+  const acceptedFileTypes = useMemo(
+    () => getSupportedFileTypes(capabilities),
+    [capabilities],
+  );
+
+  const { uploadFiles, uploadError } = useFileUploadWithTokenCheck({
+    message: "",
+    chatId: currentChatId,
+    assistantId,
+    chatProviderId: selectedModel?.chat_provider_id ?? undefined,
+    acceptedFileTypes,
+    multiple: true,
+  });
 
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
 
@@ -98,17 +118,18 @@ export function AddinChat() {
   >(currentChatLastSelectedFacets ?? []);
   const [editState, setEditState] = useState<
     | { mode: "compose" }
-    | { mode: "edit"; messageId: string; initialContent: ContentPart[] }
+    | {
+        mode: "edit";
+        messageId: string;
+        initialContent: ContentPart[];
+        initialFiles: FileUploadItem[];
+      }
   >({ mode: "compose" });
   const shouldSuggestCurrentEmail =
     currentChatId === null &&
     messageOrder.length === 0 &&
+    !isPendingResponse &&
     editState.mode === "compose";
-
-  const { handleMessageAction } = useChatActions({
-    switchSession: navigateToChat,
-    sendMessage,
-  });
 
   const handleSendMessage = useCallback(
     (
@@ -122,12 +143,12 @@ export function AddinChat() {
         message,
         inputFileIds,
         modelId,
-        undefined,
+        assistantId,
         selectedFacetIds,
         actionFacet,
       ).then(() => refetchHistory());
     },
-    [refetchHistory, sendMessage],
+    [assistantId, refetchHistory, sendMessage],
   );
 
   const cancelEdit = useCallback(() => setEditState({ mode: "compose" }), []);
@@ -188,6 +209,54 @@ export function AddinChat() {
     switchToEditMode,
     canEditFeedback,
   } = useMessageFeedback({ onFeedbackSuccess: handleFeedbackSuccess });
+
+  const handleCopyAction = useCallback(
+    async (action: MessageAction): Promise<boolean> => {
+      if (action.type !== "copy") {
+        return false;
+      }
+      const messageToCopy = messages[action.messageId];
+      const textContent = extractTextFromContent(messageToCopy?.content);
+      if (!textContent) {
+        return false;
+      }
+
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(textContent);
+        } else {
+          throw new Error("clipboard API unavailable");
+        }
+        return true;
+      } catch {
+        try {
+          const textarea = document.createElement("textarea");
+          textarea.value = textContent;
+          textarea.style.position = "fixed";
+          textarea.style.opacity = "0";
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand("copy");
+          document.body.removeChild(textarea);
+          return true;
+        } catch (fallbackError) {
+          console.warn("Failed to copy message content:", fallbackError);
+          return false;
+        }
+      }
+    },
+    [messages],
+  );
+
+  const standardMessageActionHandler = useStandardMessageActions({
+    messages,
+    setEditState,
+    handleRegenerate,
+    handleFeedbackSubmit,
+    feedbackConfig,
+    openFeedbackDialog,
+    onUnhandledAction: handleCopyAction,
+  });
 
   const controlsContext: MessageControlsContext = useMemo(
     () => ({
@@ -262,76 +331,7 @@ export function AddinChat() {
               controls={resolvedMessageControls}
               messageRenderer={resolvedMessageRenderer}
               controlsContext={controlsContext}
-              onMessageAction={async (action: MessageAction) => {
-                if (action.type === "edit") {
-                  const messageToEdit = messages[action.messageId];
-                  if (messageToEdit?.role === "user") {
-                    setEditState({
-                      mode: "edit",
-                      messageId: action.messageId,
-                      initialContent: messageToEdit.content,
-                    });
-                  }
-                  return true;
-                }
-
-                if (action.type === "regenerate") {
-                  handleRegenerate(action.messageId);
-                  return true;
-                }
-
-                if (action.type === "copy") {
-                  const messageToCopy = messages[action.messageId];
-                  const textContent = extractTextFromContent(
-                    messageToCopy?.content,
-                  );
-                  if (!textContent) {
-                    return false;
-                  }
-
-                  try {
-                    if (navigator.clipboard?.writeText) {
-                      await navigator.clipboard.writeText(textContent);
-                    } else {
-                      throw new Error("clipboard API unavailable");
-                    }
-                    return true;
-                  } catch {
-                    try {
-                      const textarea = document.createElement("textarea");
-                      textarea.value = textContent;
-                      textarea.style.position = "fixed";
-                      textarea.style.opacity = "0";
-                      document.body.appendChild(textarea);
-                      textarea.select();
-                      document.execCommand("copy");
-                      document.body.removeChild(textarea);
-                      return true;
-                    } catch (fallbackError) {
-                      console.warn(
-                        "Failed to copy message content:",
-                        fallbackError,
-                      );
-                      return false;
-                    }
-                  }
-                }
-
-                if (action.type === "like" || action.type === "dislike") {
-                  const sentiment =
-                    action.type === "like" ? "positive" : "negative";
-                  const result = await handleFeedbackSubmit(
-                    action.messageId,
-                    sentiment,
-                  );
-                  if (result.success && feedbackConfig.commentsEnabled) {
-                    openFeedbackDialog(action.messageId, sentiment);
-                  }
-                  return result.success;
-                }
-
-                return handleMessageAction(action);
-              }}
+              onMessageAction={standardMessageActionHandler}
               useVirtualization={messageOrder.length > 30}
               virtualizationThreshold={30}
               onFilePreview={openPreviewModal}
@@ -346,6 +346,7 @@ export function AddinChat() {
               onFilePreview={openPreviewModal}
               handleFileAttachments={(_files: FileUploadItem[]) => {}}
               chatId={currentChatId}
+              assistantId={assistantId}
               isLoading={isMessagingLoading}
               mode={editState.mode}
               editMessageId={
@@ -353,6 +354,9 @@ export function AddinChat() {
               }
               editInitialContent={
                 editState.mode === "edit" ? editState.initialContent : undefined
+              }
+              editInitialFiles={
+                editState.mode === "edit" ? editState.initialFiles : undefined
               }
               controlledAvailableModels={availableModels}
               controlledSelectedModel={selectedModel}

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -8,7 +8,10 @@ import {
   FilePreviewModal,
   MessageList,
   chatMessagesQuery,
+  componentRegistry,
   extractTextFromContent,
+  resolveComponentOverride,
+  useActiveModelSelection,
   useChatActions,
   useChatContext,
   useFilePreviewModal,
@@ -19,6 +22,7 @@ import {
   type ContentPart,
   type FileUploadItem,
   type MessageAction,
+  type MessageControlsComponent,
   type MessageControlsContext,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
@@ -70,6 +74,11 @@ export function AddinChat() {
     uploadError,
   } = useChatContext();
   const { profile } = useProfile();
+
+  const { availableModels, selectedModel, setSelectedModel, isSelectionReady } =
+    useActiveModelSelection({ initialModel: currentChatLastModel });
+
+  const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
 
   const canEditForCurrentChat = Array.isArray(chats)
     ? !!chats.find((chat) => chat.id === (currentChatId ?? ""))?.can_edit
@@ -188,6 +197,24 @@ export function AddinChat() {
     [canEditForCurrentChat, profile?.id],
   );
 
+  const resolvedMessageControls = useMemo(
+    () =>
+      resolveComponentOverride(
+        componentRegistry.MessageControls,
+        DefaultMessageControls,
+      ) as MessageControlsComponent,
+    [],
+  );
+
+  const resolvedMessageRenderer = useMemo(
+    () =>
+      resolveComponentOverride(
+        componentRegistry.ChatMessageRenderer,
+        ChatMessage,
+      ),
+    [],
+  );
+
   return (
     <ChatInputControlsProvider value={chatInputControls}>
       <div className="flex size-full min-w-0 flex-col">
@@ -211,7 +238,15 @@ export function AddinChat() {
         </div>
 
         <ChatErrorBoundary onReset={() => void refetchHistory()}>
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-theme-bg-secondary">
+          <div className="relative flex min-h-0 min-w-0 flex-1 flex-col bg-theme-bg-secondary">
+            {TopLeftAccessory ? (
+              <TopLeftAccessory
+                availableModels={availableModels}
+                selectedModel={selectedModel}
+                onModelChange={setSelectedModel}
+                isModelSelectionReady={isSelectionReady}
+              />
+            ) : null}
             <MessageList
               messages={messages}
               messageOrder={messageOrder}
@@ -224,8 +259,8 @@ export function AddinChat() {
               showTimestamps={true}
               showAvatars={false}
               userProfile={profile ?? undefined}
-              controls={DefaultMessageControls}
-              messageRenderer={ChatMessage}
+              controls={resolvedMessageControls}
+              messageRenderer={resolvedMessageRenderer}
               controlsContext={controlsContext}
               onMessageAction={async (action: MessageAction) => {
                 if (action.type === "edit") {
@@ -319,7 +354,10 @@ export function AddinChat() {
               editInitialContent={
                 editState.mode === "edit" ? editState.initialContent : undefined
               }
-              initialModel={currentChatLastModel}
+              controlledAvailableModels={availableModels}
+              controlledSelectedModel={selectedModel}
+              onControlledSelectedModelChange={setSelectedModel}
+              controlledIsModelSelectionReady={isSelectionReady}
               initialSelectedFacetIds={currentChatLastSelectedFacets}
               onFacetSelectionChange={setActiveSelectedFacetIds}
               showSuggestedEmailSource={shouldSuggestCurrentEmail}

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -24,7 +24,7 @@ import {
   useStandardMessageActions,
   type ActionFacetRequest,
   type ChatInputControlsHandle,
-  type ContentPart,
+  type EditMessageState,
   type FileUploadItem,
   type MessageAction,
   type MessageControlsComponent,
@@ -35,6 +35,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
+import { useEmailDedupSet } from "../hooks/useEmailDedupSet";
 import { useOfficeDragAndDrop } from "../hooks/useOfficeDragAndDrop";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
 import { useMsalNaa } from "../providers/MsalNaaProvider";
@@ -43,9 +44,13 @@ import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { expandDroppedEmailFiles } from "../utils/expandDroppedEmailFiles";
 import { fetchOutlookMessageFiles } from "../utils/fetchOutlookMessage";
 
+import type { FetchOutlookMessageResult } from "../utils/fetchOutlookMessage";
 import type { OutlookMailListDragItem } from "../utils/outlookMailListDragParse";
 
 const GRAPH_MAIL_SCOPES = ["Mail.Read"];
+// Upper bound for a single Outlook item's Graph fetch. Beyond this we drop
+// the item from the drop batch so the send button isn't held hostage.
+const OUTLOOK_FETCH_TIMEOUT_MS = 10_000;
 
 // Accept real `.eml` / `.msg` files dropped by Outlook clients that expose
 // emails as native file drags (Outlook Mac, Classic Outlook on Windows). OWA
@@ -138,47 +143,114 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   const previewEmailMessageIdRef = useRef<string | null>(null);
 
   // Tracks the RFC 5322 Message-IDs of emails already attached via any drop
-  // path in this session. Used to (a) suppress the current-email preview
-  // when the open email is already represented in the attachments and
-  // (b) short-circuit subsequent drops of the same email.
-  const [attachedEmailMessageIds, setAttachedEmailMessageIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  const noteAttachedEmail = useCallback((messageId: string) => {
-    setAttachedEmailMessageIds((previous) => {
-      if (previous.has(messageId)) {
-        return previous;
-      }
-      const next = new Set(previous);
-      next.add(messageId);
-      return next;
-    });
-  }, []);
+  // path in this session. The hook keeps a ref as the synchronous source of
+  // truth (safe across awaits in concurrent drop handlers) plus a mirrored
+  // state so render-time predicates — e.g. the current-email preview
+  // suppression below — still see updates.
+  const dedup = useEmailDedupSet();
 
-  const shouldSkipEmailDuplicateOfPreview = useCallback(
-    (messageId: string) => {
-      const previewMessageId = previewEmailMessageIdRef.current;
-      if (previewMessageId !== null && messageId === previewMessageId) {
-        return true;
+  // Atomic claim across the preview-dup check + the session dedup. Returns
+  // false when the email is already represented by the preview or was
+  // previously claimed by another drop; callers must treat a `false` result
+  // as "skip this email, do not upload". The combined claim closes a race
+  // where two concurrent drops both saw an empty state.
+  const tryClaimEmailAttachment = useCallback(
+    (messageId: string): boolean => {
+      if (previewEmailMessageIdRef.current === messageId) {
+        return false;
       }
-      return attachedEmailMessageIds.has(messageId);
+      return dedup.tryAdd(messageId);
     },
-    [attachedEmailMessageIds],
+    [dedup],
+  );
+
+  // Coalesce duplicate Outlook Graph fetches for the same item id. Two
+  // rapid drops of the same mail-list row now share a single Graph call
+  // instead of burning quota on both. A 10s timeout keeps a hung fetch
+  // from locking the send button indefinitely — the coalesced promise
+  // rejects and its entry is cleared so a later retry can start fresh.
+  const pendingOutlookFetchesRef = useRef<
+    Map<string, Promise<FetchOutlookMessageResult>>
+  >(new Map());
+  const fetchOutlookMessageFilesCoalesced = useCallback(
+    (itemId: string): Promise<FetchOutlookMessageResult> => {
+      const existing = pendingOutlookFetchesRef.current.get(itemId);
+      if (existing) {
+        return existing;
+      }
+      const fetchPromise = (async () => {
+        try {
+          return await Promise.race([
+            fetchOutlookMessageFiles(itemId, acquireGraphToken),
+            new Promise<FetchOutlookMessageResult>((_, reject) => {
+              setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      `Outlook fetch timed out after ${OUTLOOK_FETCH_TIMEOUT_MS}ms`,
+                    ),
+                  ),
+                OUTLOOK_FETCH_TIMEOUT_MS,
+              );
+            }),
+          ]);
+        } finally {
+          pendingOutlookFetchesRef.current.delete(itemId);
+        }
+      })();
+      pendingOutlookFetchesRef.current.set(itemId, fetchPromise);
+      return fetchPromise;
+    },
+    [acquireGraphToken],
+  );
+
+  // Counter for in-flight drop batches. Drives the "processing dropped
+  // emails" indicator and disables send while the user is still seeing
+  // files appear. Incremented on drop entry and decremented in a finally
+  // so timeouts and failures always release the gate.
+  const [pendingExpansionCount, setPendingExpansionCount] = useState(0);
+  const isExpandingDroppedEmails = pendingExpansionCount > 0;
+  const trackExpansion = useCallback(
+    async <T,>(work: () => Promise<T>): Promise<T> => {
+      setPendingExpansionCount((n) => n + 1);
+      try {
+        return await work();
+      } finally {
+        setPendingExpansionCount((n) => n - 1);
+      }
+    },
+    [],
   );
 
   const uploadFilesWithEmailExpansion = useCallback(
     async (files: File[]) => {
-      const expanded = await expandDroppedEmailFiles(files, {
-        acquireGraphToken,
-        shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
-        onAttachedEmail: noteAttachedEmail,
+      return trackExpansion(async () => {
+        const claimedIds: string[] = [];
+        const expanded = await expandDroppedEmailFiles(files, {
+          acquireGraphToken,
+          tryAttachEmail: (messageId) => {
+            if (!tryClaimEmailAttachment(messageId)) {
+              return false;
+            }
+            claimedIds.push(messageId);
+            return true;
+          },
+        });
+        if (expanded.length === 0) {
+          return undefined;
+        }
+        const uploaded = await uploadFiles(expanded);
+        if (uploaded === undefined) {
+          claimedIds.forEach((id) => dedup.remove(id));
+        }
+        return uploaded;
       });
-      return uploadFiles(expanded);
     },
     [
       acquireGraphToken,
-      noteAttachedEmail,
-      shouldSkipEmailDuplicateOfPreview,
+      dedup,
+      trackExpansion,
+      tryClaimEmailAttachment,
       uploadFiles,
     ],
   );
@@ -198,48 +270,53 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
 
   const handleOutlookMailListDrop = useCallback(
     async (items: OutlookMailListDragItem[]) => {
-      const collected: File[] = [];
-      for (const item of items) {
-        try {
-          const { files, internetMessageId } = await fetchOutlookMessageFiles(
-            item.itemId,
-            acquireGraphToken,
-          );
-          if (
-            internetMessageId &&
-            shouldSkipEmailDuplicateOfPreview(internetMessageId)
-          ) {
-            console.log(
-              "[AddinChat] skipping dropped Outlook email already represented by the current-email preview:",
+      return trackExpansion(async () => {
+        const collected: File[] = [];
+        const claimedIds: string[] = [];
+        for (const item of items) {
+          try {
+            const { files, internetMessageId } =
+              await fetchOutlookMessageFilesCoalesced(item.itemId);
+            if (!internetMessageId || files.length === 0) {
+              collected.push(...files);
+              continue;
+            }
+            if (!tryClaimEmailAttachment(internetMessageId)) {
+              console.log(
+                "[AddinChat] skipping dropped Outlook email already claimed:",
+                item.subject || item.itemId,
+                internetMessageId,
+              );
+              continue;
+            }
+            claimedIds.push(internetMessageId);
+            collected.push(...files);
+          } catch (error) {
+            console.warn(
+              "Failed to fetch dropped Outlook email, skipping:",
               item.subject || item.itemId,
-              internetMessageId,
+              error,
             );
-            continue;
           }
-          if (internetMessageId && files.length > 0) {
-            noteAttachedEmail(internetMessageId);
-          }
-          collected.push(...files);
-        } catch (error) {
-          console.warn(
-            "Failed to fetch dropped Outlook email, skipping:",
-            item.subject || item.itemId,
-            error,
-          );
         }
-      }
-      if (collected.length === 0) {
-        return;
-      }
-      const uploaded = await uploadFiles(collected);
-      if (uploaded && uploaded.length > 0) {
-        chatInputControlsRef.current?.addUploadedFiles(uploaded);
-      }
+        if (collected.length === 0) {
+          return;
+        }
+        const uploaded = await uploadFiles(collected);
+        if (uploaded === undefined) {
+          claimedIds.forEach((id) => dedup.remove(id));
+          return;
+        }
+        if (uploaded.length > 0) {
+          chatInputControlsRef.current?.addUploadedFiles(uploaded);
+        }
+      });
     },
     [
-      acquireGraphToken,
-      noteAttachedEmail,
-      shouldSkipEmailDuplicateOfPreview,
+      dedup,
+      fetchOutlookMessageFilesCoalesced,
+      trackExpansion,
+      tryClaimEmailAttachment,
       uploadFiles,
     ],
   );
@@ -253,23 +330,36 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       if (files.length === 0) {
         return;
       }
-      const expanded = await expandDroppedEmailFiles(files, {
-        acquireGraphToken,
-        shouldSkipEmail: shouldSkipEmailDuplicateOfPreview,
-        onAttachedEmail: noteAttachedEmail,
+      return trackExpansion(async () => {
+        const claimedIds: string[] = [];
+        const expanded = await expandDroppedEmailFiles(files, {
+          acquireGraphToken,
+          tryAttachEmail: (messageId) => {
+            if (!tryClaimEmailAttachment(messageId)) {
+              return false;
+            }
+            claimedIds.push(messageId);
+            return true;
+          },
+        });
+        if (expanded.length === 0) {
+          return;
+        }
+        const uploaded = await uploadFiles(expanded);
+        if (uploaded === undefined) {
+          claimedIds.forEach((id) => dedup.remove(id));
+          return;
+        }
+        if (uploaded.length > 0) {
+          chatInputControlsRef.current?.addUploadedFiles(uploaded);
+        }
       });
-      if (expanded.length === 0) {
-        return;
-      }
-      const uploaded = await uploadFiles(expanded);
-      if (uploaded && uploaded.length > 0) {
-        chatInputControlsRef.current?.addUploadedFiles(uploaded);
-      }
     },
     [
       acquireGraphToken,
-      noteAttachedEmail,
-      shouldSkipEmailDuplicateOfPreview,
+      dedup,
+      trackExpansion,
+      tryClaimEmailAttachment,
       uploadFiles,
     ],
   );
@@ -301,19 +391,12 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   const [activeSelectedFacetIds, setActiveSelectedFacetIds] = useState<
     string[]
   >(currentChatLastSelectedFacets ?? []);
-  const [editState, setEditState] = useState<
-    | { mode: "compose" }
-    | {
-        mode: "edit";
-        messageId: string;
-        initialContent: ContentPart[];
-        initialFiles: FileUploadItem[];
-      }
-  >({ mode: "compose" });
+  const [editState, setEditState] = useState<EditMessageState>({
+    mode: "compose",
+  });
   const currentEmailMessageId = mailItem?.internetMessageId ?? null;
   const currentEmailAlreadyAttached =
-    currentEmailMessageId !== null &&
-    attachedEmailMessageIds.has(currentEmailMessageId);
+    currentEmailMessageId !== null && dedup.ids.has(currentEmailMessageId);
   const shouldSuggestCurrentEmail =
     currentChatId === null &&
     messageOrder.length === 0 &&
@@ -322,8 +405,8 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     !currentEmailAlreadyAttached;
 
   // Keep the preview's Message-ID fresh for the drop-dedup predicate. The
-  // ref is read by `shouldSkipEmailDuplicateOfPreview` at drop time, so we
-  // write here on every render once `shouldSuggestCurrentEmail` is known.
+  // ref is read by `tryClaimEmailAttachment` at drop time, so we write here
+  // on every render once `shouldSuggestCurrentEmail` is known.
   previewEmailMessageIdRef.current =
     shouldSuggestCurrentEmail && hasSelectedEmailSource && isEmailBodyIncluded
       ? currentEmailMessageId
@@ -597,6 +680,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
               showSuggestedEmailSource={shouldSuggestCurrentEmail}
               uploadFiles={uploadFiles}
               uploadError={uploadError}
+              isExpandingDroppedEmails={isExpandingDroppedEmails}
             />
           </div>
         </ChatErrorBoundary>

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -17,8 +17,8 @@ import { t } from "@lingui/core/macro";
 import { forwardRef, useCallback, useMemo, useRef, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
-import { useOutlookEmailSource } from "../hooks/useOutlookEmailSource";
 import { useOffice } from "../providers/OfficeProvider";
+import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { getComposeBodyType } from "../utils/outlookComposeWrite";
 

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -1,7 +1,5 @@
 import {
   ChatInput,
-  FilePreviewButton,
-  FilePreviewLoading,
   GroupedFileAttachmentsPreview,
   fetchUploadFile,
   getIdToken,
@@ -267,50 +265,26 @@ export const AddinChatInput = forwardRef<
         showSuggestedEmailSource &&
         (hasSelectedEmailSource || isLoadingAttachments) && (
           <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
-            {emailSourceItems.length === 1 ? (
-              emailSourceItems[0].isLoading ? (
-                <FilePreviewLoading
-                  className="w-full"
-                  label={t({
-                    id: "officeAddin.chatInput.loadingAttachments",
-                    message: "Loading attachments...",
-                  })}
-                />
-              ) : (
-                <FilePreviewButton
-                  file={emailSourceItems[0].file}
-                  onRemove={() =>
-                    handleRemoveEmailSourceFile(emailSourceItems[0].id)
-                  }
-                  disabled={isUploadingEmail}
-                  className="w-full"
-                  showFileType={true}
-                  showSize={true}
-                  filenameClassName="max-w-full"
-                />
-              )
-            ) : (
-              <GroupedFileAttachmentsPreview
-                groups={[
-                  {
-                    id: "current-email",
-                    label:
-                      emailSubject ||
-                      t({
-                        id: "officeAddin.chatInput.emailFallback",
-                        message: "Email",
-                      }),
-                    metaLabel: "",
-                    items: emailSourceItems,
-                  },
-                ]}
-                onRemoveFile={handleRemoveEmailSourceFile}
-                disabled={isUploadingEmail}
-                showFileTypes={true}
-                showFileSizes={true}
-                defaultVisibleItems={3}
-              />
-            )}
+            <GroupedFileAttachmentsPreview
+              groups={[
+                {
+                  id: "current-email",
+                  label:
+                    emailSubject ||
+                    t({
+                      id: "officeAddin.chatInput.emailFallback",
+                      message: "Email",
+                    }),
+                  metaLabel: "",
+                  items: emailSourceItems,
+                },
+              ]}
+              onRemoveFile={handleRemoveEmailSourceFile}
+              disabled={isUploadingEmail}
+              showFileTypes={true}
+              showFileSizes={true}
+              defaultVisibleItems={3}
+            />
           </div>
         )}
 

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -108,6 +108,10 @@ export const AddinChatInput = forwardRef<
                 size: emailBodyFile.size,
               },
               isLoading: false,
+              labelOverride: t({
+                id: "officeAddin.chatInput.emailLabel",
+                message: "Email",
+              }),
             },
           ]
         : []),

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -53,6 +53,12 @@ interface AddinChatInputProps {
   showSuggestedEmailSource?: boolean;
   uploadFiles?: (files: File[]) => Promise<FileUploadItem[] | undefined>;
   uploadError?: Error | string | null;
+  /**
+   * `true` while one or more dropped emails are being expanded or
+   * deduplicated. Gates the send button and renders a non-blocking inline
+   * indicator so the user knows attachments are still materializing.
+   */
+  isExpandingDroppedEmails?: boolean;
   controlledAvailableModels?: ChatModel[];
   controlledSelectedModel?: ChatModel | null;
   onControlledSelectedModelChange?: (model: ChatModel) => void;
@@ -68,6 +74,7 @@ export const AddinChatInput = forwardRef<
     className,
     showSuggestedEmailSource = false,
     editInitialFiles,
+    isExpandingDroppedEmails = false,
     ...chatInputProps
   },
   ref,
@@ -299,6 +306,28 @@ export const AddinChatInput = forwardRef<
           </div>
         )}
 
+      {isExpandingDroppedEmails && (
+        <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
+          <div
+            className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary"
+            role="status"
+            aria-live="polite"
+            data-testid="addin-chat-email-expansion-indicator"
+          >
+            <span
+              aria-hidden="true"
+              className="inline-block size-3 animate-spin rounded-full border-2 border-theme-border border-t-theme-fg-primary"
+            />
+            <span className="min-w-0 truncate">
+              {t({
+                id: "officeAddin.chatInput.expandingDroppedEmails",
+                message: "Processing dropped emails…",
+              })}
+            </span>
+          </div>
+        </div>
+      )}
+
       {host === "Outlook" && hasActiveSelection && (
         <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
           <div className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary">
@@ -340,7 +369,11 @@ export const AddinChatInput = forwardRef<
             selectedFacetIds,
           );
         }}
-        disabled={isUploadingEmail || chatInputProps.disabled}
+        disabled={
+          isUploadingEmail ||
+          isExpandingDroppedEmails ||
+          chatInputProps.disabled
+        }
       />
     </div>
   );

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -54,6 +54,10 @@ interface AddinChatInputProps {
   showSuggestedEmailSource?: boolean;
   uploadFiles?: (files: File[]) => Promise<FileUploadItem[] | undefined>;
   uploadError?: Error | string | null;
+  controlledAvailableModels?: ChatModel[];
+  controlledSelectedModel?: ChatModel | null;
+  onControlledSelectedModelChange?: (model: ChatModel) => void;
+  controlledIsModelSelectionReady?: boolean;
 }
 
 export const AddinChatInput = forwardRef<

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -46,6 +46,7 @@ interface AddinChatInputProps {
   mode?: "compose" | "edit";
   editMessageId?: string;
   editInitialContent?: ContentPart[];
+  editInitialFiles?: FileUploadItem[];
   initialModel?: ChatModel | null;
   initialSelectedFacetIds?: string[];
   onFacetSelectionChange?: (selectedFacetIds: string[]) => void;
@@ -62,7 +63,13 @@ export const AddinChatInput = forwardRef<
   ChatInputControlsHandle,
   AddinChatInputProps
 >(function AddinChatInput(
-  { chatId, className, showSuggestedEmailSource = false, ...chatInputProps },
+  {
+    chatId,
+    className,
+    showSuggestedEmailSource = false,
+    editInitialFiles,
+    ...chatInputProps
+  },
   ref,
 ) {
   const { host } = useOffice();
@@ -320,7 +327,7 @@ export const AddinChatInput = forwardRef<
         className="p-2 sm:p-4"
         showControls={true}
         showFileTypes={true}
-        initialFiles={[]}
+        initialFiles={editInitialFiles ?? []}
         chatId={chatId}
         {...chatInputProps}
         uploadFiles={chatInputProps.uploadFiles}

--- a/office-addin/src/components/AddinFileSourceSelector.tsx
+++ b/office-addin/src/components/AddinFileSourceSelector.tsx
@@ -1,8 +1,9 @@
-import { AnchoredPopover } from "@erato/frontend/library";
+import { AnchoredPopover, useChatContext } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { useCallback, useMemo, useState } from "react";
 
 import { useOffice } from "../providers/OfficeProvider";
+import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { emailToHtmlFile } from "../utils/emailToFile";
 
@@ -46,9 +47,19 @@ export function AddinFileSourceSelector({
   const { host } = useOffice();
   const { mailItem, attachments, isLoadingAttachments, getAttachmentFile } =
     useOutlookMailItem();
+  const {
+    isEmailBodyDismissed,
+    dismissedAttachmentIds,
+    restoreEmailBody,
+    restoreAttachment,
+  } = useOutlookEmailSource();
+  const { currentChatId, messageOrder } = useChatContext();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isEmailContentOpen, setIsEmailContentOpen] = useState(false);
   const [isUploadingEmailContent, setIsUploadingEmailContent] = useState(false);
+
+  const isSuggestionEligible =
+    host === "Outlook" && currentChatId === null && messageOrder.length === 0;
 
   const isBusy = disabled || isProcessing || isUploadingEmailContent;
   const canShowEmailContent = host === "Outlook";
@@ -113,11 +124,29 @@ export function AddinFileSourceSelector({
       return;
     }
 
+    if (isSuggestionEligible) {
+      restoreEmailBody();
+      closeMenus();
+      return;
+    }
+
     void handleUploadResolvedFiles([emailBodyFile]);
-  }, [emailBodyFile, handleUploadResolvedFiles]);
+  }, [
+    closeMenus,
+    emailBodyFile,
+    handleUploadResolvedFiles,
+    isSuggestionEligible,
+    restoreEmailBody,
+  ]);
 
   const handleSelectAttachment = useCallback(
     (attachmentId: string) => {
+      if (isSuggestionEligible) {
+        restoreAttachment(attachmentId);
+        closeMenus();
+        return;
+      }
+
       void (async () => {
         try {
           const file = await getAttachmentFile(attachmentId);
@@ -130,7 +159,13 @@ export function AddinFileSourceSelector({
         }
       })();
     },
-    [getAttachmentFile, handleUploadResolvedFiles],
+    [
+      closeMenus,
+      getAttachmentFile,
+      handleUploadResolvedFiles,
+      isSuggestionEligible,
+      restoreAttachment,
+    ],
   );
 
   const hasAnyEmailContent =
@@ -252,30 +287,40 @@ export function AddinFileSourceSelector({
                   </div>
                 )}
 
-                {emailBodyFile && (
-                  <button
-                    type="button"
-                    onClick={handleSelectEmailBody}
-                    disabled={isBusy}
-                    title={emailBodyFile.name}
-                    className="flex w-full items-start justify-between gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-theme-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <div className="min-w-0">
-                      <div className="truncate text-sm font-medium text-theme-fg-primary">
-                        {t({
-                          id: "officeAddin.fileSource.emailThread",
-                          message: "Email thread",
-                        })}
-                      </div>
-                      <div className="truncate text-xs text-theme-fg-muted">
-                        {emailBodyFile.name}
-                      </div>
-                    </div>
-                    <span className="shrink-0 text-xs text-theme-fg-muted">
-                      {formatFileSize(emailBodyFile.size)}
-                    </span>
-                  </button>
-                )}
+                {emailBodyFile &&
+                  (() => {
+                    const isAlreadyAdded =
+                      isSuggestionEligible && !isEmailBodyDismissed;
+                    return (
+                      <button
+                        type="button"
+                        onClick={handleSelectEmailBody}
+                        disabled={isBusy || isAlreadyAdded}
+                        title={emailBodyFile.name}
+                        className="flex w-full items-start justify-between gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-theme-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-theme-fg-primary">
+                            {t({
+                              id: "officeAddin.fileSource.emailThread",
+                              message: "Email thread",
+                            })}
+                          </div>
+                          <div className="truncate text-xs text-theme-fg-muted">
+                            {isAlreadyAdded
+                              ? t({
+                                  id: "officeAddin.fileSource.alreadyAdded",
+                                  message: "Already added",
+                                })
+                              : emailBodyFile.name}
+                          </div>
+                        </div>
+                        <span className="shrink-0 text-xs text-theme-fg-muted">
+                          {formatFileSize(emailBodyFile.size)}
+                        </span>
+                      </button>
+                    );
+                  })()}
 
                 {isLoadingAttachments && (
                   <div className="px-3 py-2 text-xs text-theme-fg-muted">
@@ -289,13 +334,16 @@ export function AddinFileSourceSelector({
                 {selectableAttachments.map((attachment) => {
                   const isCloudAttachment =
                     String(attachment.attachmentType).toLowerCase() === "cloud";
+                  const isAlreadyAdded =
+                    isSuggestionEligible &&
+                    !dismissedAttachmentIds.includes(attachment.id);
 
                   return (
                     <button
                       key={attachment.id}
                       type="button"
                       onClick={() => handleSelectAttachment(attachment.id)}
-                      disabled={isBusy || isCloudAttachment}
+                      disabled={isBusy || isCloudAttachment || isAlreadyAdded}
                       title={attachment.name}
                       className="flex w-full items-start justify-between gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-theme-bg-hover disabled:cursor-not-allowed disabled:opacity-50"
                     >
@@ -310,11 +358,16 @@ export function AddinFileSourceSelector({
                                 message:
                                   "Cloud attachment cannot be uploaded from Outlook",
                               })
-                            : attachment.contentType ||
-                              t({
-                                id: "officeAddin.fileSource.attachmentFallback",
-                                message: "Attachment",
-                              })}
+                            : isAlreadyAdded
+                              ? t({
+                                  id: "officeAddin.fileSource.alreadyAdded",
+                                  message: "Already added",
+                                })
+                              : attachment.contentType ||
+                                t({
+                                  id: "officeAddin.fileSource.attachmentFallback",
+                                  message: "Attachment",
+                                })}
                         </div>
                       </div>
                       <span className="shrink-0 text-xs text-theme-fg-muted">

--- a/office-addin/src/hooks/__tests__/officeDragAndDropBroker.test.ts
+++ b/office-addin/src/hooks/__tests__/officeDragAndDropBroker.test.ts
@@ -16,7 +16,9 @@ let capturedHandler: ((event: Office.DragAndDropEventArgs) => void) | null =
   null;
 let deferredRegistration: (() => void) | null = null;
 
-function setupOffice(options: { deferRegistration?: boolean } = {}): MailboxMock {
+function setupOffice(
+  options: { deferRegistration?: boolean } = {},
+): MailboxMock {
   const mailbox = installMockMailbox();
   (Office.EventType as unknown as Record<string, string>).DragAndDropEvent =
     "olkDragAndDropEvent";

--- a/office-addin/src/hooks/__tests__/officeDragAndDropBroker.test.ts
+++ b/office-addin/src/hooks/__tests__/officeDragAndDropBroker.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installMockMailbox,
+  uninstallMockMailbox,
+} from "../../test/mocks/outlook/mailbox";
+import {
+  __resetOfficeDragAndDropBrokerForTests,
+  subscribeToOfficeDragAndDrop,
+} from "../officeDragAndDropBroker";
+
+type MailboxMock = ReturnType<typeof installMockMailbox>;
+
+let requirementsSupported = true;
+let capturedHandler: ((event: Office.DragAndDropEventArgs) => void) | null =
+  null;
+let deferredRegistration: (() => void) | null = null;
+
+function setupOffice(options: { deferRegistration?: boolean } = {}): MailboxMock {
+  const mailbox = installMockMailbox();
+  (Office.EventType as unknown as Record<string, string>).DragAndDropEvent =
+    "olkDragAndDropEvent";
+  (Office.context as unknown as Record<string, unknown>).requirements = {
+    isSetSupported: () => requirementsSupported,
+  };
+
+  (mailbox.addHandlerAsync as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+    (
+      _eventType: unknown,
+      handler: (event: Office.DragAndDropEventArgs) => void,
+      callback?: (result: unknown) => void,
+    ) => {
+      capturedHandler = handler;
+      const resolve = () =>
+        callback?.({ status: Office.AsyncResultStatus.Succeeded });
+      if (options.deferRegistration) {
+        deferredRegistration = resolve;
+      } else {
+        resolve();
+      }
+    },
+  );
+  (mailbox.removeHandlerAsync as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+    (_eventType: unknown, callback?: (result: unknown) => void) => {
+      capturedHandler = null;
+      callback?.({ status: Office.AsyncResultStatus.Succeeded });
+    },
+  );
+  return mailbox;
+}
+
+function fireDragover(): void {
+  if (!capturedHandler) throw new Error("no handler registered");
+  capturedHandler({
+    type: "olkDragAndDropEvent",
+    dragAndDropEventData: {
+      type: "dragover",
+      pageX: 0,
+      pageY: 0,
+      taskPaneX: 0,
+      taskPaneY: 0,
+    },
+  });
+}
+
+function fireDrop(
+  files: { name: string; type: string; fileContent: Blob }[],
+): void {
+  if (!capturedHandler) throw new Error("no handler registered");
+  capturedHandler({
+    type: "olkDragAndDropEvent",
+    dragAndDropEventData: {
+      type: "drop",
+      pageX: 0,
+      pageY: 0,
+      taskPaneX: 0,
+      taskPaneY: 0,
+      dataTransfer: { files },
+    },
+  });
+}
+
+describe("officeDragAndDropBroker", () => {
+  beforeEach(() => {
+    requirementsSupported = true;
+    capturedHandler = null;
+    deferredRegistration = null;
+    __resetOfficeDragAndDropBrokerForTests();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    delete (Office.EventType as unknown as Record<string, string>)
+      .DragAndDropEvent;
+    delete (Office.context as unknown as Record<string, unknown>).requirements;
+  });
+
+  it("installs the Office.js handler on the first subscribe", () => {
+    const mailbox = setupOffice();
+    const onDrop = vi.fn();
+
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop });
+
+    expect(mailbox.addHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-install when a second subscriber joins", () => {
+    const mailbox = setupOffice();
+
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: vi.fn() });
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: vi.fn() });
+
+    expect(mailbox.addHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("tears down only when the last subscriber leaves", () => {
+    const mailbox = setupOffice();
+
+    const unsubA = subscribeToOfficeDragAndDrop({
+      onDragover: vi.fn(),
+      onDrop: vi.fn(),
+    });
+    const unsubB = subscribeToOfficeDragAndDrop({
+      onDragover: vi.fn(),
+      onDrop: vi.fn(),
+    });
+
+    unsubA();
+    expect(mailbox.removeHandlerAsync).not.toHaveBeenCalled();
+
+    unsubB();
+    expect(mailbox.removeHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("fans a single drop event out to every active subscriber exactly once", async () => {
+    setupOffice();
+    const dropA = vi.fn();
+    const dropB = vi.fn();
+
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: dropA });
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: dropB });
+
+    const blob = new Blob(["body"], { type: "message/rfc822" });
+    fireDrop([{ name: "m.eml", type: "message/rfc822", fileContent: blob }]);
+
+    expect(dropA).toHaveBeenCalledTimes(1);
+    expect(dropB).toHaveBeenCalledTimes(1);
+    const aFiles = dropA.mock.calls[0][0] as File[];
+    expect(aFiles[0].name).toBe("m.eml");
+    expect(await aFiles[0].text()).toBe("body");
+  });
+
+  it("skips notifying an unsubscribed listener", () => {
+    setupOffice();
+    const dropA = vi.fn();
+    const dropB = vi.fn();
+
+    const unsubA = subscribeToOfficeDragAndDrop({
+      onDragover: vi.fn(),
+      onDrop: dropA,
+    });
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: dropB });
+    unsubA();
+
+    fireDrop([
+      { name: "x.eml", type: "message/rfc822", fileContent: new Blob(["x"]) },
+    ]);
+
+    expect(dropA).not.toHaveBeenCalled();
+    expect(dropB).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates a throwing subscriber so sibling subscribers still fire", () => {
+    setupOffice();
+    const dropA = vi.fn().mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const dropB = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: dropA });
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: dropB });
+
+    fireDrop([
+      { name: "x.eml", type: "message/rfc822", fileContent: new Blob(["x"]) },
+    ]);
+
+    expect(dropA).toHaveBeenCalledTimes(1);
+    expect(dropB).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("fans dragover events out to every subscriber", () => {
+    setupOffice();
+    const dragA = vi.fn();
+    const dragB = vi.fn();
+
+    subscribeToOfficeDragAndDrop({ onDragover: dragA, onDrop: vi.fn() });
+    subscribeToOfficeDragAndDrop({ onDragover: dragB, onDrop: vi.fn() });
+
+    fireDragover();
+
+    expect(dragA).toHaveBeenCalledTimes(1);
+    expect(dragB).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not install when Mailbox 1.5 requirement set is unsupported", () => {
+    requirementsSupported = false;
+    const mailbox = setupOffice();
+
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: vi.fn() });
+
+    expect(mailbox.addHandlerAsync).not.toHaveBeenCalled();
+  });
+
+  it("handles StrictMode-style subscribe/unsubscribe/subscribe with one Office.js install", () => {
+    const mailbox = setupOffice();
+
+    // First mount
+    const unsubA = subscribeToOfficeDragAndDrop({
+      onDragover: vi.fn(),
+      onDrop: vi.fn(),
+    });
+    expect(mailbox.addHandlerAsync).toHaveBeenCalledTimes(1);
+    // Cleanup
+    unsubA();
+    // Second mount
+    subscribeToOfficeDragAndDrop({ onDragover: vi.fn(), onDrop: vi.fn() });
+
+    // Idle path: unsubA tore down, second subscribe re-installs. So two
+    // addHandlerAsync calls but one installed handler at any time.
+    expect(mailbox.addHandlerAsync).toHaveBeenCalledTimes(2);
+    expect(mailbox.removeHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not leak a handler when subscribe is torn down before addHandlerAsync completes", () => {
+    const mailbox = setupOffice({ deferRegistration: true });
+
+    const unsub = subscribeToOfficeDragAndDrop({
+      onDragover: vi.fn(),
+      onDrop: vi.fn(),
+    });
+    // Unsubscribe while registration is still pending.
+    unsub();
+
+    // Now resolve the deferred addHandlerAsync callback.
+    deferredRegistration?.();
+
+    // Broker should detect subscribers.size === 0 and tear down immediately.
+    expect(mailbox.removeHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/office-addin/src/hooks/__tests__/useEmailDedupSet.test.ts
+++ b/office-addin/src/hooks/__tests__/useEmailDedupSet.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useEmailDedupSet } from "../useEmailDedupSet";
+
+describe("useEmailDedupSet", () => {
+  it("tryAdd returns true on first call and false on duplicate", () => {
+    const { result } = renderHook(() => useEmailDedupSet());
+
+    let first = false;
+    let second = false;
+    act(() => {
+      first = result.current.tryAdd("msg1@example.com");
+      second = result.current.tryAdd("msg1@example.com");
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(result.current.has("msg1@example.com")).toBe(true);
+    expect(result.current.ids.has("msg1@example.com")).toBe(true);
+  });
+
+  // Reproduces the cross-await race that motivated this hook: two async
+  // handlers each crossed an `await`, then both call into the dedup. With a
+  // `useState<Set>` the second call would see stale state and also pass.
+  // Here, the captured callback writes to the ref synchronously, so the
+  // second call sees the first call's mutation regardless of render cycle.
+  it("survives the stale-closure race across awaits", async () => {
+    const { result } = renderHook(() => useEmailDedupSet());
+    const tryAddBeforeAwait = result.current.tryAdd;
+
+    let addedA = false;
+    let addedB = false;
+    await act(async () => {
+      await Promise.resolve();
+      addedA = tryAddBeforeAwait("shared-id");
+      await Promise.resolve();
+      addedB = tryAddBeforeAwait("shared-id");
+    });
+
+    expect(addedA).toBe(true);
+    expect(addedB).toBe(false);
+  });
+
+  it("remove rolls back tryAdd so the same id can be re-added", () => {
+    const { result } = renderHook(() => useEmailDedupSet());
+
+    act(() => {
+      result.current.tryAdd("msg1");
+    });
+    expect(result.current.ids.has("msg1")).toBe(true);
+
+    act(() => {
+      result.current.remove("msg1");
+    });
+    expect(result.current.ids.has("msg1")).toBe(false);
+    expect(result.current.has("msg1")).toBe(false);
+
+    let readded = false;
+    act(() => {
+      readded = result.current.tryAdd("msg1");
+    });
+    expect(readded).toBe(true);
+  });
+
+  it("remove on an absent id is a no-op", () => {
+    const { result } = renderHook(() => useEmailDedupSet());
+    const initialIds = result.current.ids;
+
+    act(() => {
+      result.current.remove("never-added");
+    });
+
+    expect(result.current.ids).toBe(initialIds);
+  });
+
+  it("ids state mirrors the ref after multiple adds", () => {
+    const { result } = renderHook(() => useEmailDedupSet());
+
+    act(() => {
+      result.current.tryAdd("a");
+      result.current.tryAdd("b");
+      result.current.tryAdd("c");
+    });
+
+    expect(Array.from(result.current.ids).sort()).toEqual(["a", "b", "c"]);
+  });
+});

--- a/office-addin/src/hooks/__tests__/useOfficeDragAndDrop.test.ts
+++ b/office-addin/src/hooks/__tests__/useOfficeDragAndDrop.test.ts
@@ -1,0 +1,196 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installMockMailbox,
+  uninstallMockMailbox,
+} from "../../test/mocks/outlook/mailbox";
+import { __resetOfficeDragAndDropBrokerForTests } from "../officeDragAndDropBroker";
+import { useOfficeDragAndDrop } from "../useOfficeDragAndDrop";
+
+type MailboxMock = ReturnType<typeof installMockMailbox>;
+
+let requirementsSupported = true;
+let capturedHandler: ((event: Office.DragAndDropEventArgs) => void) | null =
+  null;
+
+function setupOffice(): MailboxMock {
+  const mailbox = installMockMailbox();
+  (Office.EventType as unknown as Record<string, string>).DragAndDropEvent =
+    "olkDragAndDropEvent";
+  (Office.context as unknown as Record<string, unknown>).requirements = {
+    isSetSupported: () => requirementsSupported,
+  };
+  (mailbox.addHandlerAsync as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+    (
+      _eventType: unknown,
+      handler: (event: Office.DragAndDropEventArgs) => void,
+      callback?: (result: unknown) => void,
+    ) => {
+      capturedHandler = handler;
+      callback?.({ status: Office.AsyncResultStatus.Succeeded });
+    },
+  );
+  (mailbox.removeHandlerAsync as unknown as ReturnType<typeof vi.fn>) = vi.fn(
+    (_eventType: unknown, callback?: (result: unknown) => void) => {
+      capturedHandler = null;
+      callback?.({ status: Office.AsyncResultStatus.Succeeded });
+    },
+  );
+  return mailbox;
+}
+
+function fireDragover(): void {
+  if (!capturedHandler) throw new Error("no handler registered");
+  capturedHandler({
+    type: "olkDragAndDropEvent",
+    dragAndDropEventData: {
+      type: "dragover",
+      pageX: 0,
+      pageY: 0,
+      taskPaneX: 0,
+      taskPaneY: 0,
+    },
+  });
+}
+
+function fireDrop(
+  files: { name: string; type: string; fileContent: Blob }[],
+): void {
+  if (!capturedHandler) throw new Error("no handler registered");
+  capturedHandler({
+    type: "olkDragAndDropEvent",
+    dragAndDropEventData: {
+      type: "drop",
+      pageX: 0,
+      pageY: 0,
+      taskPaneX: 0,
+      taskPaneY: 0,
+      dataTransfer: { files },
+    },
+  });
+}
+
+describe("useOfficeDragAndDrop", () => {
+  beforeEach(() => {
+    requirementsSupported = true;
+    capturedHandler = null;
+    __resetOfficeDragAndDropBrokerForTests();
+    setupOffice();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    delete (Office.EventType as unknown as Record<string, string>)
+      .DragAndDropEvent;
+    delete (Office.context as unknown as Record<string, unknown>).requirements;
+  });
+
+  it("flips isDragActive true on dragover and false on drop", () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useOfficeDragAndDrop({ onDrop }));
+
+    expect(result.current.isDragActive).toBe(false);
+
+    act(() => fireDragover());
+    expect(result.current.isDragActive).toBe(true);
+
+    act(() =>
+      fireDrop([
+        {
+          name: "item.eml",
+          type: "message/rfc822",
+          fileContent: new Blob(["x"]),
+        },
+      ]),
+    );
+    expect(result.current.isDragActive).toBe(false);
+  });
+
+  it("delivers dropped items to onDrop as File objects with name and type preserved", async () => {
+    const onDrop = vi.fn();
+    renderHook(() => useOfficeDragAndDrop({ onDrop }));
+
+    const emlBlob = new Blob(["rfc822 content"], { type: "message/rfc822" });
+    const pdfBlob = new Blob(["pdf bytes"], { type: "application/pdf" });
+
+    await act(async () => {
+      fireDrop([
+        {
+          name: "Hey how are you.eml",
+          type: "message/rfc822",
+          fileContent: emlBlob,
+        },
+        { name: "doc.pdf", type: "application/pdf", fileContent: pdfBlob },
+      ]);
+    });
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    const files = onDrop.mock.calls[0][0] as File[];
+    expect(files).toHaveLength(2);
+    expect(files[0].name).toBe("Hey how are you.eml");
+    expect(files[0].type).toBe("message/rfc822");
+    expect(await files[0].text()).toBe("rfc822 content");
+    expect(files[1].name).toBe("doc.pdf");
+    expect(files[1].type).toBe("application/pdf");
+  });
+
+  it("does not fire onDrop when the drop event has no files", () => {
+    const onDrop = vi.fn();
+    renderHook(() => useOfficeDragAndDrop({ onDrop }));
+
+    act(() => fireDrop([]));
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not subscribe when disabled", () => {
+    const mailbox = Office.context.mailbox as unknown as MailboxMock;
+    const onDrop = vi.fn();
+
+    renderHook(() => useOfficeDragAndDrop({ onDrop, disabled: true }));
+
+    expect(mailbox.addHandlerAsync).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes on unmount", () => {
+    const mailbox = Office.context.mailbox as unknown as MailboxMock;
+    const onDrop = vi.fn();
+
+    const { unmount } = renderHook(() => useOfficeDragAndDrop({ onDrop }));
+    unmount();
+
+    expect(mailbox.removeHandlerAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onDrop exactly once per drop when two instances of the hook are mounted", async () => {
+    const onDropA = vi.fn();
+    const onDropB = vi.fn();
+    renderHook(() => useOfficeDragAndDrop({ onDrop: onDropA }));
+    renderHook(() => useOfficeDragAndDrop({ onDrop: onDropB }));
+
+    await act(async () => {
+      fireDrop([
+        {
+          name: "m.eml",
+          type: "message/rfc822",
+          fileContent: new Blob(["body"]),
+        },
+      ]);
+    });
+
+    // Each hook invokes its own onDrop once — no duplication.
+    expect(onDropA).toHaveBeenCalledTimes(1);
+    expect(onDropB).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays inert (no registration, no drop) when Mailbox 1.5 is unsupported", () => {
+    requirementsSupported = false;
+    const mailbox = Office.context.mailbox as unknown as MailboxMock;
+    const onDrop = vi.fn();
+
+    renderHook(() => useOfficeDragAndDrop({ onDrop }));
+
+    expect(mailbox.addHandlerAsync).not.toHaveBeenCalled();
+  });
+});

--- a/office-addin/src/hooks/__tests__/useOutlookMailListDrag.test.ts
+++ b/office-addin/src/hooks/__tests__/useOutlookMailListDrag.test.ts
@@ -1,0 +1,187 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MAILLISTROW_TRANSFER_TYPE } from "../../utils/outlookMailListDragParse";
+import { useOutlookMailListDrag } from "../useOutlookMailListDrag";
+
+function buildDragEvent(
+  type: "dragenter" | "dragover" | "dragleave" | "drop",
+  init: {
+    transferTypes?: string[];
+    payloadByType?: Record<string, string>;
+    relatedTarget?: EventTarget | null;
+  } = {},
+): DragEvent {
+  const { transferTypes = [], payloadByType = {}, relatedTarget = null } = init;
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+  const dataTransfer = {
+    types: transferTypes,
+    getData: (key: string) => payloadByType[key] ?? "",
+  } as unknown as DataTransfer;
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  Object.defineProperty(event, "relatedTarget", { value: relatedTarget });
+  return event;
+}
+
+const validPayload = JSON.stringify({
+  itemType: MAILLISTROW_TRANSFER_TYPE,
+  itemIds: ["id-1"],
+  subjects: ["Hello"],
+  sizes: [42],
+  mailboxInfos: [{ mailboxSmtpAddress: "u@x" }],
+});
+
+describe("useOutlookMailListDrag", () => {
+  it("flips isDragActive when a maillistrow drag enters the window", () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useOutlookMailListDrag({ onDrop }));
+    expect(result.current.isDragActive).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+        }),
+      );
+    });
+    expect(result.current.isDragActive).toBe(true);
+  });
+
+  it("ignores drags that do not carry a maillistrow type", () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useOutlookMailListDrag({ onDrop }));
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", { transferTypes: ["Files"] }),
+      );
+    });
+    expect(result.current.isDragActive).toBe(false);
+  });
+
+  it("calls preventDefault on dragover for maillistrow to enable the subsequent drop", () => {
+    const onDrop = vi.fn();
+    renderHook(() => useOutlookMailListDrag({ onDrop }));
+
+    const event = buildDragEvent("dragover", {
+      transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+    });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("clears isDragActive when the drag leaves the document (relatedTarget null)", () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useOutlookMailListDrag({ onDrop }));
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+        }),
+      );
+    });
+    expect(result.current.isDragActive).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragleave", { relatedTarget: null }),
+      );
+    });
+    expect(result.current.isDragActive).toBe(false);
+  });
+
+  it("calls onDrop with parsed items and clears isDragActive on drop", async () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useOutlookMailListDrag({ onDrop }));
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+        }),
+      );
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        buildDragEvent("drop", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+          payloadByType: { [MAILLISTROW_TRANSFER_TYPE]: validPayload },
+        }),
+      );
+    });
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(onDrop).toHaveBeenCalledWith([
+      {
+        itemId: "id-1",
+        subject: "Hello",
+        size: 42,
+        mailboxSmtpAddress: "u@x",
+      },
+    ]);
+    expect(result.current.isDragActive).toBe(false);
+  });
+
+  it("does not call onDrop when the payload fails to parse", () => {
+    const onDrop = vi.fn();
+    renderHook(() => useOutlookMailListDrag({ onDrop }));
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("drop", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+          payloadByType: { [MAILLISTROW_TRANSFER_TYPE]: "not-json" },
+        }),
+      );
+    });
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not register listeners when disabled", () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() =>
+      useOutlookMailListDrag({ onDrop, disabled: true }),
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+        }),
+      );
+      window.dispatchEvent(
+        buildDragEvent("drop", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+          payloadByType: { [MAILLISTROW_TRANSFER_TYPE]: validPayload },
+        }),
+      );
+    });
+
+    expect(result.current.isDragActive).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("tears down listeners on unmount", () => {
+    const onDrop = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useOutlookMailListDrag({ onDrop }),
+    );
+
+    unmount();
+    act(() => {
+      window.dispatchEvent(
+        buildDragEvent("dragenter", {
+          transferTypes: [MAILLISTROW_TRANSFER_TYPE],
+        }),
+      );
+    });
+    expect(result.current.isDragActive).toBe(false);
+  });
+});

--- a/office-addin/src/hooks/__tests__/useOutlookMailListDrag.test.ts
+++ b/office-addin/src/hooks/__tests__/useOutlookMailListDrag.test.ts
@@ -13,7 +13,10 @@ function buildDragEvent(
   } = {},
 ): DragEvent {
   const { transferTypes = [], payloadByType = {}, relatedTarget = null } = init;
-  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent;
   const dataTransfer = {
     types: transferTypes,
     getData: (key: string) => payloadByType[key] ?? "",

--- a/office-addin/src/hooks/officeDragAndDropBroker.ts
+++ b/office-addin/src/hooks/officeDragAndDropBroker.ts
@@ -1,0 +1,157 @@
+/**
+ * Module-level singleton that registers exactly one Office.js
+ * `DragAndDropEvent` handler regardless of how many React components
+ * subscribe. This is the canonical early-2026 pattern for binding a single
+ * Office.js event across React 18/19 StrictMode mounts, where effect
+ * double-invocation would otherwise race `addHandlerAsync`/`removeHandlerAsync`
+ * and leave two handlers registered (the root cause of visible drops being
+ * processed twice).
+ *
+ * Design:
+ *   - Subscribers register via `subscribe({ onDragover, onDrop })` and get
+ *     back an idempotent `unsubscribe` callback.
+ *   - The Office.js handler is installed lazily on the first subscriber and
+ *     removed only when the last subscriber leaves.
+ *   - An internal `installState` (`idle | pending | installed | failed`)
+ *     gates the async registration so that a `subscribe`/`unsubscribe` pair
+ *     occurring during a pending `addHandlerAsync` resolves deterministically:
+ *     the registration callback tears down immediately if the subscriber set
+ *     went empty while it was in flight.
+ *   - Subscriber callbacks are isolated — one throwing doesn't break others.
+ */
+
+export interface OfficeDragAndDropSubscriber {
+  onDragover: () => void;
+  onDrop: (files: File[]) => void;
+}
+
+type InstallState = "idle" | "pending" | "installed" | "failed";
+
+const subscribers = new Set<OfficeDragAndDropSubscriber>();
+let installState: InstallState = "idle";
+
+export function subscribeToOfficeDragAndDrop(
+  subscriber: OfficeDragAndDropSubscriber,
+): () => void {
+  subscribers.add(subscriber);
+  installIfNeeded();
+  let unsubscribed = false;
+  return () => {
+    if (unsubscribed) {
+      return;
+    }
+    unsubscribed = true;
+    subscribers.delete(subscriber);
+    if (subscribers.size === 0 && installState === "installed") {
+      teardown();
+    }
+  };
+}
+
+function installIfNeeded(): void {
+  if (
+    installState === "pending" ||
+    installState === "installed" ||
+    installState === "failed"
+  ) {
+    return;
+  }
+  if (!isDragAndDropEventSupported()) {
+    installState = "failed";
+    return;
+  }
+  installState = "pending";
+  try {
+    Office.context.mailbox.addHandlerAsync(
+      Office.EventType.DragAndDropEvent,
+      handleOfficeEvent,
+      (result) => {
+        if (result.status !== Office.AsyncResultStatus.Succeeded) {
+          installState = "failed";
+          console.warn(
+            "[officeDragAndDropBroker] addHandlerAsync failed:",
+            result.error?.message,
+          );
+          return;
+        }
+        installState = "installed";
+        // If subscribers left while we were registering, tear down now.
+        if (subscribers.size === 0) {
+          teardown();
+        }
+      },
+    );
+  } catch (error) {
+    installState = "failed";
+    console.warn(
+      "[officeDragAndDropBroker] addHandlerAsync threw:",
+      error,
+    );
+  }
+}
+
+function teardown(): void {
+  if (installState !== "installed") {
+    return;
+  }
+  installState = "idle";
+  try {
+    Office.context.mailbox.removeHandlerAsync(
+      Office.EventType.DragAndDropEvent,
+      () => {},
+    );
+  } catch {
+    // Office host may be unloading; best-effort cleanup only.
+  }
+}
+
+function handleOfficeEvent(event: Office.DragAndDropEventArgs): void {
+  const data = event.dragAndDropEventData;
+  if (data.type === "dragover") {
+    for (const subscriber of subscribers) {
+      try {
+        subscriber.onDragover();
+      } catch (error) {
+        console.warn(
+          "[officeDragAndDropBroker] onDragover listener threw:",
+          error,
+        );
+      }
+    }
+    return;
+  }
+  if (data.type === "drop") {
+    const files = (data.dataTransfer?.files ?? []).map(toFile);
+    for (const subscriber of subscribers) {
+      try {
+        subscriber.onDrop(files);
+      } catch (error) {
+        console.warn(
+          "[officeDragAndDropBroker] onDrop listener threw:",
+          error,
+        );
+      }
+    }
+  }
+}
+
+function toFile(item: Office.DroppedItemDetails): File {
+  return new File([item.fileContent], item.name, { type: item.type });
+}
+
+function isDragAndDropEventSupported(): boolean {
+  try {
+    if (typeof Office === "undefined" || !Office.context?.requirements) {
+      return false;
+    }
+    return Office.context.requirements.isSetSupported("Mailbox", "1.5");
+  } catch {
+    return false;
+  }
+}
+
+/** Test-only hook to reset the module state between test cases. */
+export function __resetOfficeDragAndDropBrokerForTests(): void {
+  subscribers.clear();
+  installState = "idle";
+}

--- a/office-addin/src/hooks/officeDragAndDropBroker.ts
+++ b/office-addin/src/hooks/officeDragAndDropBroker.ts
@@ -83,10 +83,7 @@ function installIfNeeded(): void {
     );
   } catch (error) {
     installState = "failed";
-    console.warn(
-      "[officeDragAndDropBroker] addHandlerAsync threw:",
-      error,
-    );
+    console.warn("[officeDragAndDropBroker] addHandlerAsync threw:", error);
   }
 }
 
@@ -126,10 +123,7 @@ function handleOfficeEvent(event: Office.DragAndDropEventArgs): void {
       try {
         subscriber.onDrop(files);
       } catch (error) {
-        console.warn(
-          "[officeDragAndDropBroker] onDrop listener threw:",
-          error,
-        );
+        console.warn("[officeDragAndDropBroker] onDrop listener threw:", error);
       }
     }
   }

--- a/office-addin/src/hooks/useEmailDedupSet.ts
+++ b/office-addin/src/hooks/useEmailDedupSet.ts
@@ -1,0 +1,50 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface EmailDedupSet {
+  /**
+   * Render-visible mirror of the dedup set. Suitable for predicates that
+   * drive UI (e.g. suppressing the current-email preview when the email is
+   * already attached). Lags the ref by at most one render — never read it
+   * from inside an async event handler that may race with another handler.
+   */
+  ids: ReadonlySet<string>;
+  /** Synchronous read against the ref. Safe across `await` boundaries. */
+  has: (messageId: string) => boolean;
+  /**
+   * Atomic check-and-add. Returns `true` if the id was newly added, `false`
+   * if already present. Two synchronous calls with the same id are
+   * guaranteed to return `true` then `false` — this is what makes the hook
+   * safe under the cross-await race that a `useState<Set>` cannot solve.
+   */
+  tryAdd: (messageId: string) => boolean;
+  /** Rolls back a prior `tryAdd`. No-op if the id is not present. */
+  remove: (messageId: string) => void;
+}
+
+export function useEmailDedupSet(): EmailDedupSet {
+  const ref = useRef<Set<string>>(new Set());
+  const [ids, setIds] = useState<ReadonlySet<string>>(ref.current);
+
+  const has = useCallback((messageId: string): boolean => {
+    return ref.current.has(messageId);
+  }, []);
+
+  const tryAdd = useCallback((messageId: string): boolean => {
+    if (ref.current.has(messageId)) {
+      return false;
+    }
+    ref.current.add(messageId);
+    setIds(new Set(ref.current));
+    return true;
+  }, []);
+
+  const remove = useCallback((messageId: string): void => {
+    if (!ref.current.has(messageId)) {
+      return;
+    }
+    ref.current.delete(messageId);
+    setIds(new Set(ref.current));
+  }, []);
+
+  return { ids, has, tryAdd, remove };
+}

--- a/office-addin/src/hooks/useOfficeDragAndDrop.ts
+++ b/office-addin/src/hooks/useOfficeDragAndDrop.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from "react";
+
+import { subscribeToOfficeDragAndDrop } from "./officeDragAndDropBroker";
+
+interface UseOfficeDragAndDropOptions {
+  /**
+   * Called on drop with the resolved files (messages arrive as `.eml`,
+   * attachments keep their original type). Exceptions are logged and
+   * swallowed so one throwing caller doesn't poison the broker.
+   */
+  onDrop: (files: File[]) => void | Promise<void>;
+  /** When true, the component does not subscribe to the broker. */
+  disabled?: boolean;
+}
+
+interface UseOfficeDragAndDropResult {
+  isDragActive: boolean;
+}
+
+/**
+ * Subscribes to Office.js `DragAndDropEvent` via a module-level singleton
+ * broker. The broker registers the Office.js handler exactly once regardless
+ * of how many React consumers mount, which is essential under React 18/19
+ * StrictMode where effects double-invoke and naive per-component
+ * `addHandlerAsync` calls race and end up firing drops twice.
+ *
+ * Target surfaces: Outlook on the web, New Outlook on Windows. Classic
+ * Outlook on Windows and Outlook on Mac receive drops as native File DOM
+ * events and are handled by the shared `useConversationDropzone` path.
+ */
+export function useOfficeDragAndDrop({
+  onDrop,
+  disabled = false,
+}: UseOfficeDragAndDropOptions): UseOfficeDragAndDropResult {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+
+  useEffect(() => {
+    if (disabled) {
+      setIsDragActive(false);
+      return;
+    }
+    const unsubscribe = subscribeToOfficeDragAndDrop({
+      onDragover: () => setIsDragActive(true),
+      onDrop: (files) => {
+        setIsDragActive(false);
+        if (files.length === 0) {
+          return;
+        }
+        void Promise.resolve(onDropRef.current(files)).catch((error) => {
+          console.warn("[useOfficeDragAndDrop] onDrop threw:", error);
+        });
+      },
+    });
+    return unsubscribe;
+  }, [disabled]);
+
+  return { isDragActive };
+}

--- a/office-addin/src/hooks/useOutlookMailListDrag.ts
+++ b/office-addin/src/hooks/useOutlookMailListDrag.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  MAILLISTROW_TRANSFER_TYPE,
+  parseOutlookMailListPayload,
+  type OutlookMailListDragItem,
+} from "../utils/outlookMailListDragParse";
+
+interface UseOutlookMailListDragOptions {
+  /** Called on drop with the parsed mail-list items (one per dragged row). */
+  onDrop: (items: OutlookMailListDragItem[]) => void | Promise<void>;
+  /** When true, no listeners are registered and `isDragActive` stays false. */
+  disabled?: boolean;
+}
+
+interface UseOutlookMailListDragResult {
+  isDragActive: boolean;
+}
+
+/**
+ * Listens for the undocumented OWA/New Outlook "drag email from mail list"
+ * gesture. That drag is NOT a native file drag — it carries a custom
+ * `maillistrow` string payload and no `Files` entry — so react-dropzone's
+ * file-detection path cannot surface it. This hook runs in parallel to the
+ * shared conversation dropzone, detects `maillistrow` drags at the window
+ * level, and exposes its own `isDragActive` state so the caller can mirror
+ * the existing drop overlay.
+ *
+ * Resilience notes:
+ *   - The payload shape is an OWA-internal contract and may change without
+ *     notice. Parsing is delegated to `parseOutlookMailListPayload` which
+ *     returns null (not throws) when the shape drifts.
+ *   - Listeners are registered on `window` in capture phase so they see the
+ *     drag regardless of which element in the iframe is the direct target.
+ *   - dragleave with `relatedTarget === null` indicates the drag has left the
+ *     iframe entirely; only then do we clear `isDragActive`.
+ */
+export function useOutlookMailListDrag({
+  onDrop,
+  disabled = false,
+}: UseOutlookMailListDragOptions): UseOutlookMailListDragResult {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const onDropRef = useRef(onDrop);
+  onDropRef.current = onDrop;
+
+  const isMailListDrag = useCallback((event: DragEvent): boolean => {
+    if (!event.dataTransfer) {
+      return false;
+    }
+    return Array.from(event.dataTransfer.types).includes(
+      MAILLISTROW_TRANSFER_TYPE,
+    );
+  }, []);
+
+  useEffect(() => {
+    if (disabled) {
+      setIsDragActive(false);
+      return;
+    }
+
+    const handleDragEnter = (event: DragEvent) => {
+      if (isMailListDrag(event)) {
+        setIsDragActive(true);
+      }
+    };
+
+    const handleDragOver = (event: DragEvent) => {
+      if (isMailListDrag(event)) {
+        // Required so the browser will fire a subsequent `drop`.
+        event.preventDefault();
+        setIsDragActive(true);
+      }
+    };
+
+    const handleDragLeave = (event: DragEvent) => {
+      // relatedTarget === null means the drag left the whole document.
+      if (event.relatedTarget === null) {
+        setIsDragActive(false);
+      }
+    };
+
+    const handleDrop = (event: DragEvent) => {
+      if (!isMailListDrag(event)) {
+        return;
+      }
+      event.preventDefault();
+      setIsDragActive(false);
+      const raw = event.dataTransfer?.getData(MAILLISTROW_TRANSFER_TYPE) ?? "";
+      const items = parseOutlookMailListPayload(raw);
+      if (items && items.length > 0) {
+        void onDropRef.current(items);
+      }
+    };
+
+    window.addEventListener("dragenter", handleDragEnter, true);
+    window.addEventListener("dragover", handleDragOver, true);
+    window.addEventListener("dragleave", handleDragLeave, true);
+    window.addEventListener("drop", handleDrop, true);
+
+    return () => {
+      window.removeEventListener("dragenter", handleDragEnter, true);
+      window.removeEventListener("dragover", handleDragOver, true);
+      window.removeEventListener("dragleave", handleDragLeave, true);
+      window.removeEventListener("drop", handleDrop, true);
+    };
+  }, [disabled, isMailListDrag]);
+
+  return { isDragActive };
+}

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -53,6 +53,21 @@ msgstr "Anmeldung erforderlich"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.aria"
+msgstr "Chatverlauf"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.dropzone.ariaLabel"
+msgstr "Dateien zum Hochladen an einer beliebigen Stelle im Chat ablegen"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.fileDrop.overlay.label"
+msgstr "Zum Hochladen ablegen"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Neuer Chat"
 
@@ -73,8 +88,18 @@ msgstr "E-Mail"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
-msgid "officeAddin.chatInput.loadingAttachments"
-msgstr "Anhänge werden geladen..."
+msgid "officeAddin.chatInput.emailLabel"
+msgstr "E-Mail"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.expandingDroppedEmails"
+msgstr "Abgelegte E-Mails werden verarbeitet…"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+#~ msgid "officeAddin.chatInput.loadingAttachments"
+#~ msgstr "Anhänge werden geladen..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -115,6 +140,11 @@ msgstr "Auswahl ersetzen"
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.addFiles"
 msgstr "Dateien hinzufügen"
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.alreadyAdded"
+msgstr "Bereits hinzugefügt"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -53,6 +53,21 @@ msgstr "Sign-in required"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.aria"
+msgstr "Chat conversation"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.dropzone.ariaLabel"
+msgstr "Drop files anywhere in the conversation to upload"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.fileDrop.overlay.label"
+msgstr "Drop to upload"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "New Chat"
 
@@ -73,8 +88,18 @@ msgstr "Email"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
-msgid "officeAddin.chatInput.loadingAttachments"
-msgstr "Loading attachments..."
+msgid "officeAddin.chatInput.emailLabel"
+msgstr "Email"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.expandingDroppedEmails"
+msgstr "Processing dropped emails…"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+#~ msgid "officeAddin.chatInput.loadingAttachments"
+#~ msgstr "Loading attachments..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -115,6 +140,11 @@ msgstr "Replace Selection"
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.addFiles"
 msgstr "Add files"
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.alreadyAdded"
+msgstr "Already added"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -53,6 +53,21 @@ msgstr "Se requiere iniciar sesión"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.aria"
+msgstr "Conversación del chat"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.dropzone.ariaLabel"
+msgstr "Suelta archivos en cualquier parte de la conversación para subirlos"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.fileDrop.overlay.label"
+msgstr "Suelta para subir"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nuevo chat"
 
@@ -73,8 +88,18 @@ msgstr "Correo electrónico"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
-msgid "officeAddin.chatInput.loadingAttachments"
-msgstr "Cargando archivos adjuntos..."
+msgid "officeAddin.chatInput.emailLabel"
+msgstr "Correo electrónico"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.expandingDroppedEmails"
+msgstr "Procesando los correos electrónicos soltados…"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+#~ msgid "officeAddin.chatInput.loadingAttachments"
+#~ msgstr "Cargando archivos adjuntos..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -115,6 +140,11 @@ msgstr "Reemplazar selección"
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.addFiles"
 msgstr "Agregar archivos"
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.alreadyAdded"
+msgstr "Ya agregado"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -53,6 +53,21 @@ msgstr "Connexion requise"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.aria"
+msgstr "Conversation du chat"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.dropzone.ariaLabel"
+msgstr "Déposez des fichiers n’importe où dans la conversation pour les téléverser"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.fileDrop.overlay.label"
+msgstr "Déposez pour téléverser"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nouveau chat"
 
@@ -73,8 +88,18 @@ msgstr "E-mail"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
-msgid "officeAddin.chatInput.loadingAttachments"
-msgstr "Chargement des pièces jointes..."
+msgid "officeAddin.chatInput.emailLabel"
+msgstr "E-mail"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.expandingDroppedEmails"
+msgstr "Traitement des e-mails déposés…"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+#~ msgid "officeAddin.chatInput.loadingAttachments"
+#~ msgstr "Chargement des pièces jointes..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -115,6 +140,11 @@ msgstr "Remplacer la sélection"
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.addFiles"
 msgstr "Ajouter des fichiers"
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.alreadyAdded"
+msgstr "Déjà ajouté"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -53,6 +53,21 @@ msgstr "Wymagane logowanie"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.aria"
+msgstr "Rozmowa na czacie"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.conversation.dropzone.ariaLabel"
+msgstr "Upuść pliki w dowolnym miejscu rozmowy, aby je przesłać"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
+msgid "officeAddin.chat.fileDrop.overlay.label"
+msgstr "Upuść, aby przesłać"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChat.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nowy czat"
 
@@ -73,8 +88,18 @@ msgstr "E-mail"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
-msgid "officeAddin.chatInput.loadingAttachments"
-msgstr "Ładowanie załączników..."
+msgid "officeAddin.chatInput.emailLabel"
+msgstr "E-mail"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.expandingDroppedEmails"
+msgstr "Przetwarzanie upuszczonych e-maili…"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+#~ msgid "officeAddin.chatInput.loadingAttachments"
+#~ msgstr "Ładowanie załączników..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -115,6 +140,11 @@ msgstr "Zastąp zaznaczenie"
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.addFiles"
 msgstr "Dodaj pliki"
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.alreadyAdded"
+msgstr "Już dodano"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -10,7 +10,6 @@ import {
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { emailToHtmlFile } from "../utils/emailToFile";
 
-
 import type { LocalFilePreviewItem } from "@erato/frontend/library";
 import type { ReactNode } from "react";
 

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -1,13 +1,65 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
-import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
+import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { emailToHtmlFile } from "../utils/emailToFile";
 
+
 import type { LocalFilePreviewItem } from "@erato/frontend/library";
+import type { ReactNode } from "react";
 
 const OUTLOOK_CLOUD_ATTACHMENT_TYPE = "cloud";
 
-export function useOutlookEmailSource() {
+interface OutlookEmailSourceContextValue {
+  emailSubject: string;
+  isEmailBodyIncluded: boolean;
+  emailBodyFile: File | null;
+  selectedAttachmentItems: LocalFilePreviewItem[];
+  isLoadingAttachments: boolean;
+  removeEmailBody: () => void;
+  removeAttachment: (attachmentId: string) => void;
+  restoreEmailBody: () => void;
+  restoreAttachment: (attachmentId: string) => void;
+  isEmailBodyDismissed: boolean;
+  dismissedAttachmentIds: string[];
+  resolveSelectedFilesForSend: () => Promise<File[]>;
+  hasSelectedEmailSource: boolean;
+}
+
+const defaultValue: OutlookEmailSourceContextValue = {
+  emailSubject: "",
+  isEmailBodyIncluded: false,
+  emailBodyFile: null,
+  selectedAttachmentItems: [],
+  isLoadingAttachments: false,
+  removeEmailBody: () => {},
+  removeAttachment: () => {},
+  restoreEmailBody: () => {},
+  restoreAttachment: () => {},
+  isEmailBodyDismissed: false,
+  dismissedAttachmentIds: [],
+  resolveSelectedFilesForSend: async () => [],
+  hasSelectedEmailSource: false,
+};
+
+const OutlookEmailSourceContext =
+  createContext<OutlookEmailSourceContextValue>(defaultValue);
+
+export function useOutlookEmailSource(): OutlookEmailSourceContextValue {
+  return useContext(OutlookEmailSourceContext);
+}
+
+export function OutlookEmailSourceProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
   const {
     itemIdentity,
     mailItem,
@@ -43,10 +95,10 @@ export function useOutlookEmailSource() {
     }
   }, [dismissedBodyMailIdentity, itemIdentity]);
 
-  const isEmailBodyIncluded =
-    !!emailBodyFile &&
-    !!itemIdentity &&
-    dismissedBodyMailIdentity !== itemIdentity;
+  const isEmailBodyDismissed =
+    !!itemIdentity && dismissedBodyMailIdentity === itemIdentity;
+
+  const isEmailBodyIncluded = !!emailBodyFile && !isEmailBodyDismissed;
 
   const selectableAttachments = useMemo(() => {
     return attachments.filter((attachment) => !attachment.isInline);
@@ -73,6 +125,16 @@ export function useOutlookEmailSource() {
   const removeAttachment = useCallback((attachmentId: string) => {
     setDismissedAttachmentIds((previous) =>
       previous.includes(attachmentId) ? previous : [...previous, attachmentId],
+    );
+  }, []);
+
+  const restoreEmailBody = useCallback(() => {
+    setDismissedBodyMailIdentity(null);
+  }, []);
+
+  const restoreAttachment = useCallback((attachmentId: string) => {
+    setDismissedAttachmentIds((previous) =>
+      previous.filter((id) => id !== attachmentId),
     );
   }, []);
 
@@ -119,16 +181,42 @@ export function useOutlookEmailSource() {
     selectableAttachments,
   ]);
 
-  return {
-    emailSubject: mailItem?.subject ?? "",
-    isEmailBodyIncluded,
-    emailBodyFile,
-    selectedAttachmentItems,
-    isLoadingAttachments,
-    removeEmailBody,
-    removeAttachment,
-    resolveSelectedFilesForSend,
-    hasSelectedEmailSource:
-      isEmailBodyIncluded || selectedAttachmentItems.length > 0,
-  };
+  const value = useMemo<OutlookEmailSourceContextValue>(
+    () => ({
+      emailSubject: mailItem?.subject ?? "",
+      isEmailBodyIncluded,
+      emailBodyFile,
+      selectedAttachmentItems,
+      isLoadingAttachments,
+      removeEmailBody,
+      removeAttachment,
+      restoreEmailBody,
+      restoreAttachment,
+      isEmailBodyDismissed,
+      dismissedAttachmentIds,
+      resolveSelectedFilesForSend,
+      hasSelectedEmailSource:
+        isEmailBodyIncluded || selectedAttachmentItems.length > 0,
+    }),
+    [
+      dismissedAttachmentIds,
+      emailBodyFile,
+      isEmailBodyDismissed,
+      isEmailBodyIncluded,
+      isLoadingAttachments,
+      mailItem?.subject,
+      removeAttachment,
+      removeEmailBody,
+      resolveSelectedFilesForSend,
+      restoreAttachment,
+      restoreEmailBody,
+      selectedAttachmentItems,
+    ],
+  );
+
+  return (
+    <OutlookEmailSourceContext.Provider value={value}>
+      {children}
+    </OutlookEmailSourceContext.Provider>
+  );
 }

--- a/office-addin/src/styles.css
+++ b/office-addin/src/styles.css
@@ -46,6 +46,10 @@ body {
   min-width: 0;
 }
 
+.office-shell [data-ui="chat-header"] {
+  display: none;
+}
+
 .office-shell [data-ui="chat-input-controls"] {
   flex-wrap: wrap;
   gap: calc(var(--theme-spacing-control-gap) / 2);

--- a/office-addin/src/test/fixtures/msg.ts
+++ b/office-addin/src/test/fixtures/msg.ts
@@ -1,0 +1,52 @@
+import * as CFB from "cfb";
+
+/**
+ * Builds a minimal CFB (Compound File Binary) blob containing the given
+ * named streams. Shared across tests that exercise the `.msg` parsing chain
+ * — the extractor in isolation and the `parseMsgFile` glue that runs the
+ * real extractor against a stubbed Graph fetch.
+ */
+export function buildCfbWith(
+  entries: { name: string; content: Uint8Array }[],
+): Uint8Array {
+  const container = CFB.utils.cfb_new();
+  for (const entry of entries) {
+    CFB.utils.cfb_add(container, entry.name, entry.content);
+  }
+  const written = CFB.write(container, {
+    type: "array",
+  }) as unknown as ArrayLike<number>;
+  return new Uint8Array(written);
+}
+
+/** UTF-16LE encoding for MAPI PT_UNICODE string properties. */
+export function utf16le(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length * 2);
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    bytes[index * 2] = code & 0xff;
+    bytes[index * 2 + 1] = (code >> 8) & 0xff;
+  }
+  return bytes;
+}
+
+/** Stream name for PR_INTERNET_MESSAGE_ID_W (MAPI tag 0x1035, PT_UNICODE). */
+export const INTERNET_MESSAGE_ID_STREAM_NAME = "__substg1.0_1035001F";
+
+/**
+ * Builds a valid `.msg` CFB blob exposing only the given RFC 5322 Message-ID
+ * via PR_INTERNET_MESSAGE_ID_W. Omits all other MAPI properties — the parser
+ * we exercise reads exactly that one stream.
+ */
+export function buildMsgWithInternetMessageId(messageId: string): Uint8Array {
+  return buildCfbWith([
+    { name: INTERNET_MESSAGE_ID_STREAM_NAME, content: utf16le(messageId) },
+  ]);
+}
+
+/** Wraps raw bytes in a File with the Outlook `.msg` MIME type. */
+export function msgFileFromBytes(bytes: Uint8Array, name = "item.msg"): File {
+  const buffer = new ArrayBuffer(bytes.length);
+  new Uint8Array(buffer).set(bytes);
+  return new File([buffer], name, { type: "application/vnd.ms-outlook" });
+}

--- a/office-addin/src/utils/__tests__/buildEmailBodyHtml.test.ts
+++ b/office-addin/src/utils/__tests__/buildEmailBodyHtml.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEmailBodyFile } from "../buildEmailBodyHtml";
+
+describe("buildEmailBodyFile", () => {
+  it("renders From/To/CC/Date/Subject headers with HTML escaping", async () => {
+    const file = buildEmailBodyFile({
+      subject: "Hello & welcome",
+      from: { name: "Alice", address: "alice@x" },
+      to: [{ address: "bob@x" }],
+      cc: [{ name: "Carol", address: "carol@x" }],
+      date: new Date("2024-01-02T03:04:05Z"),
+      bodyText: "hi",
+    });
+
+    expect(file.type).toBe("text/html");
+    expect(file.name).toBe("Hello & welcome.html");
+
+    const text = await file.text();
+    expect(text).toContain("<strong>From:</strong> Alice &lt;alice@x&gt;");
+    expect(text).toContain("<strong>To:</strong> bob@x");
+    expect(text).toContain("<strong>CC:</strong> Carol &lt;carol@x&gt;");
+    expect(text).toContain("<strong>Subject:</strong> Hello &amp; welcome");
+    expect(text).toContain("<strong>Date:</strong>");
+  });
+
+  it("wraps plain text body in <pre> when no HTML is provided", async () => {
+    const file = buildEmailBodyFile({
+      subject: "Plain",
+      bodyText: "line one\nline <two>",
+    });
+
+    const text = await file.text();
+    expect(text).toContain("<pre>line one\nline &lt;two&gt;</pre>");
+  });
+
+  it("prefers bodyHtml verbatim when present", async () => {
+    const file = buildEmailBodyFile({
+      subject: "Rich",
+      bodyHtml: "<p>hi</p>",
+      bodyText: "ignored",
+    });
+
+    const text = await file.text();
+    expect(text).toContain("<p>hi</p>");
+    expect(text).not.toContain("<pre>");
+  });
+
+  it("falls back to empty body when neither text nor html is provided", async () => {
+    const file = buildEmailBodyFile({
+      subject: "Empty",
+    });
+
+    const text = await file.text();
+    expect(text).toContain("<strong>Subject:</strong> Empty");
+    expect(text).not.toContain("<pre>");
+  });
+
+  it("sanitizes illegal filename characters derived from the subject", () => {
+    const file = buildEmailBodyFile({
+      subject: 'a/b:c<d>e?f|g"h\\i*',
+    });
+    expect(file.name).toBe("a_b_c_d_e_f_g_h_i_.html");
+  });
+});

--- a/office-addin/src/utils/__tests__/buildEmailBodyHtml.test.ts
+++ b/office-addin/src/utils/__tests__/buildEmailBodyHtml.test.ts
@@ -62,4 +62,60 @@ describe("buildEmailBodyFile", () => {
     });
     expect(file.name).toBe("a_b_c_d_e_f_g_h_i_.html");
   });
+
+  it("strips <script> from bodyHtml while preserving surrounding markup", async () => {
+    const file = buildEmailBodyFile({
+      subject: "xss-script",
+      bodyHtml: "<p>before</p><script>alert(1)</script><p>after</p>",
+    });
+    const text = await file.text();
+    expect(text).toContain("<p>before</p>");
+    expect(text).toContain("<p>after</p>");
+    expect(text).not.toMatch(/<script\b/i);
+    expect(text).not.toContain("alert(1)");
+  });
+
+  it("removes inline event handlers from bodyHtml but keeps the element", async () => {
+    const file = buildEmailBodyFile({
+      subject: "xss-event-handler",
+      bodyHtml: '<img src="x" onerror="alert(1)">',
+    });
+    const text = await file.text();
+    expect(text).toMatch(/<img\b/i);
+    expect(text.toLowerCase()).not.toContain("onerror");
+    expect(text).not.toContain("alert(1)");
+  });
+
+  it("strips javascript: URLs from anchors but keeps the link text", async () => {
+    const file = buildEmailBodyFile({
+      subject: "xss-javascript-url",
+      bodyHtml: '<a href="javascript:alert(1)">click</a>',
+    });
+    const text = await file.text();
+    expect(text).toContain("click");
+    expect(text.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("strips <script> embedded inside <svg>", async () => {
+    const file = buildEmailBodyFile({
+      subject: "xss-svg",
+      bodyHtml: '<svg><script>alert(1)</script><circle r="5"/></svg>',
+    });
+    const text = await file.text();
+    expect(text).not.toMatch(/<script\b/i);
+    expect(text).not.toContain("alert(1)");
+  });
+
+  it("preserves email-fidelity markup: tables, inline styles, and cid: images", async () => {
+    const file = buildEmailBodyFile({
+      subject: "fidelity",
+      bodyHtml:
+        '<table><tr><td style="color:red">cell</td></tr></table>' +
+        '<img src="cid:logo123">',
+    });
+    const text = await file.text();
+    expect(text).toMatch(/<table\b/i);
+    expect(text).toMatch(/<td\b[^>]*style=/i);
+    expect(text).toContain("cid:logo123");
+  });
 });

--- a/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
+++ b/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { expandDroppedEmailFiles } from "../expandDroppedEmailFiles";
+import * as parseEmlFileModule from "../parseEmlFile";
+
+import type * as ParseEmlFileModule from "../parseEmlFile";
+
+vi.mock("../parseEmlFile", async () => {
+  const actual =
+    await vi.importActual<typeof ParseEmlFileModule>("../parseEmlFile");
+  return {
+    ...actual,
+    parseEmlFileToFiles: vi.fn(),
+  };
+});
+
+const mockedParse = vi.mocked(parseEmlFileModule.parseEmlFileToFiles);
+
+describe("expandDroppedEmailFiles", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockedParse.mockReset();
+  });
+
+  it("expands .eml files and preserves order of mixed input", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    const pdf = new File(["pdfbytes"], "doc.pdf", { type: "application/pdf" });
+    const body = new File(["<html></html>"], "msg.html", { type: "text/html" });
+    const attach = new File(["a"], "a.txt", { type: "text/plain" });
+
+    mockedParse.mockResolvedValueOnce([body, attach]);
+
+    const result = await expandDroppedEmailFiles([eml, pdf]);
+    expect(mockedParse).toHaveBeenCalledTimes(1);
+    expect(result.map((f) => f.name)).toEqual(["msg.html", "a.txt", "doc.pdf"]);
+  });
+
+  it("passes non-eml files through unchanged", async () => {
+    const pdf = new File(["pdfbytes"], "doc.pdf", { type: "application/pdf" });
+    const png = new File(["pngbytes"], "img.png", { type: "image/png" });
+
+    const result = await expandDroppedEmailFiles([pdf, png]);
+    expect(mockedParse).not.toHaveBeenCalled();
+    expect(result).toEqual([pdf, png]);
+  });
+
+  it("returns [] when the only .eml input fails to parse", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    mockedParse.mockResolvedValueOnce([]);
+
+    const result = await expandDroppedEmailFiles([eml]);
+    expect(result).toEqual([]);
+  });
+});

--- a/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
+++ b/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
@@ -119,6 +119,65 @@ describe("expandDroppedEmailFiles", () => {
     expect(result).toEqual([body]);
   });
 
+  it("invokes onAttachedEmail with the Message-ID of each successfully expanded .eml", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    const body = new File(["<html>"], "msg.html", { type: "text/html" });
+    mockedParse.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<m1@x>",
+    });
+    const onAttachedEmail = vi.fn();
+
+    await expandDroppedEmailFiles([eml], { onAttachedEmail });
+
+    expect(onAttachedEmail).toHaveBeenCalledTimes(1);
+    expect(onAttachedEmail).toHaveBeenCalledWith("<m1@x>");
+  });
+
+  it("does not call onAttachedEmail when the email was skipped", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    mockedParse.mockResolvedValueOnce({
+      files: [new File(["<html>"], "msg.html", { type: "text/html" })],
+      messageId: "<preview@host>",
+    });
+    const onAttachedEmail = vi.fn();
+    const shouldSkipEmail = () => true;
+
+    await expandDroppedEmailFiles([eml], { shouldSkipEmail, onAttachedEmail });
+
+    expect(onAttachedEmail).not.toHaveBeenCalled();
+  });
+
+  it("does not call onAttachedEmail when parsing produced no files", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    mockedParse.mockResolvedValueOnce({ files: [], messageId: "<m@x>" });
+    const onAttachedEmail = vi.fn();
+
+    await expandDroppedEmailFiles([eml], { onAttachedEmail });
+
+    expect(onAttachedEmail).not.toHaveBeenCalled();
+  });
+
+  it("invokes onAttachedEmail for a successfully expanded .msg", async () => {
+    const msg = new File([new Uint8Array([0])], "item.msg", {
+      type: "application/vnd.ms-outlook",
+    });
+    const body = new File(["<html>"], "body.html", { type: "text/html" });
+    const acquireGraphToken = vi.fn();
+    const onAttachedEmail = vi.fn();
+    mockedParseMsg.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<msg@x>",
+    });
+
+    await expandDroppedEmailFiles([msg], {
+      acquireGraphToken,
+      onAttachedEmail,
+    });
+
+    expect(onAttachedEmail).toHaveBeenCalledWith("<msg@x>");
+  });
+
   it("skips a dropped .msg whose Message-ID matches the shouldSkipEmail predicate", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const msg = new File([new Uint8Array([0])], "item.msg", {

--- a/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
+++ b/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
@@ -41,7 +41,10 @@ describe("expandDroppedEmailFiles", () => {
     const body = new File(["<html></html>"], "msg.html", { type: "text/html" });
     const attach = new File(["a"], "a.txt", { type: "text/plain" });
 
-    mockedParse.mockResolvedValueOnce([body, attach]);
+    mockedParse.mockResolvedValueOnce({
+      files: [body, attach],
+      messageId: "<m1@x>",
+    });
 
     const result = await expandDroppedEmailFiles([eml, pdf]);
     expect(mockedParse).toHaveBeenCalledTimes(1);
@@ -59,10 +62,86 @@ describe("expandDroppedEmailFiles", () => {
 
   it("returns [] when the only .eml input fails to parse", async () => {
     const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
-    mockedParse.mockResolvedValueOnce([]);
+    mockedParse.mockResolvedValueOnce({ files: [], messageId: null });
 
     const result = await expandDroppedEmailFiles([eml]);
     expect(result).toEqual([]);
+  });
+
+  it("skips a dropped .eml whose Message-ID matches the shouldSkipEmail predicate", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    const body = new File(["<html>"], "msg.html", { type: "text/html" });
+    mockedParse.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<preview@host>",
+    });
+
+    const shouldSkipEmail = vi.fn(
+      (messageId: string) => messageId === "<preview@host>",
+    );
+
+    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+
+    expect(shouldSkipEmail).toHaveBeenCalledWith("<preview@host>");
+    expect(result).toEqual([]);
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("keeps a dropped .eml whose Message-ID does not match the skip predicate", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    const body = new File(["<html>"], "msg.html", { type: "text/html" });
+    mockedParse.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<other@host>",
+    });
+
+    const shouldSkipEmail = vi.fn(
+      (messageId: string) => messageId === "<preview@host>",
+    );
+
+    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+
+    expect(shouldSkipEmail).toHaveBeenCalledWith("<other@host>");
+    expect(result).toEqual([body]);
+  });
+
+  it("does not consult shouldSkipEmail when the parsed email has no Message-ID", async () => {
+    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
+    const body = new File(["<html>"], "msg.html", { type: "text/html" });
+    mockedParse.mockResolvedValueOnce({ files: [body], messageId: null });
+
+    const shouldSkipEmail = vi.fn(() => true);
+
+    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+
+    expect(shouldSkipEmail).not.toHaveBeenCalled();
+    expect(result).toEqual([body]);
+  });
+
+  it("skips a dropped .msg whose Message-ID matches the shouldSkipEmail predicate", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const msg = new File([new Uint8Array([0])], "item.msg", {
+      type: "application/vnd.ms-outlook",
+    });
+    const body = new File(["<html>"], "body.html", { type: "text/html" });
+    mockedParseMsg.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<preview@host>",
+    });
+    const acquireGraphToken = vi.fn();
+    const shouldSkipEmail = vi.fn(
+      (messageId: string) => messageId === "<preview@host>",
+    );
+
+    const result = await expandDroppedEmailFiles([msg], {
+      acquireGraphToken,
+      shouldSkipEmail,
+    });
+
+    expect(shouldSkipEmail).toHaveBeenCalledWith("<preview@host>");
+    expect(result).toEqual([]);
+    expect(logSpy).toHaveBeenCalled();
   });
 
   it("routes .msg files through parseMsgFileToFiles when a Graph token is provided", async () => {
@@ -71,7 +150,10 @@ describe("expandDroppedEmailFiles", () => {
     });
     const body = new File(["<html>"], "body.html", { type: "text/html" });
     const acquireGraphToken = vi.fn();
-    mockedParseMsg.mockResolvedValueOnce([body]);
+    mockedParseMsg.mockResolvedValueOnce({
+      files: [body],
+      messageId: "<m@x>",
+    });
 
     const result = await expandDroppedEmailFiles([msg], { acquireGraphToken });
 
@@ -94,7 +176,7 @@ describe("expandDroppedEmailFiles", () => {
   it("matches .msg by filename extension even when MIME is empty", async () => {
     const msg = new File([new Uint8Array([0])], "NoType.MSG");
     const acquireGraphToken = vi.fn();
-    mockedParseMsg.mockResolvedValueOnce([]);
+    mockedParseMsg.mockResolvedValueOnce({ files: [], messageId: null });
 
     await expandDroppedEmailFiles([msg], { acquireGraphToken });
 

--- a/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
+++ b/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
@@ -68,7 +68,7 @@ describe("expandDroppedEmailFiles", () => {
     expect(result).toEqual([]);
   });
 
-  it("skips a dropped .eml whose Message-ID matches the shouldSkipEmail predicate", async () => {
+  it("drops a parsed .eml when tryAttachEmail returns false", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
     const body = new File(["<html>"], "msg.html", { type: "text/html" });
@@ -77,18 +77,18 @@ describe("expandDroppedEmailFiles", () => {
       messageId: "<preview@host>",
     });
 
-    const shouldSkipEmail = vi.fn(
-      (messageId: string) => messageId === "<preview@host>",
+    const tryAttachEmail = vi.fn(
+      (messageId: string) => messageId !== "<preview@host>",
     );
 
-    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+    const result = await expandDroppedEmailFiles([eml], { tryAttachEmail });
 
-    expect(shouldSkipEmail).toHaveBeenCalledWith("<preview@host>");
+    expect(tryAttachEmail).toHaveBeenCalledWith("<preview@host>");
     expect(result).toEqual([]);
     expect(logSpy).toHaveBeenCalled();
   });
 
-  it("keeps a dropped .eml whose Message-ID does not match the skip predicate", async () => {
+  it("keeps a parsed .eml when tryAttachEmail returns true", async () => {
     const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
     const body = new File(["<html>"], "msg.html", { type: "text/html" });
     mockedParse.mockResolvedValueOnce({
@@ -96,75 +96,44 @@ describe("expandDroppedEmailFiles", () => {
       messageId: "<other@host>",
     });
 
-    const shouldSkipEmail = vi.fn(
-      (messageId: string) => messageId === "<preview@host>",
-    );
+    const tryAttachEmail = vi.fn(() => true);
 
-    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+    const result = await expandDroppedEmailFiles([eml], { tryAttachEmail });
 
-    expect(shouldSkipEmail).toHaveBeenCalledWith("<other@host>");
+    expect(tryAttachEmail).toHaveBeenCalledWith("<other@host>");
     expect(result).toEqual([body]);
   });
 
-  it("does not consult shouldSkipEmail when the parsed email has no Message-ID", async () => {
+  it("does not consult tryAttachEmail when the parsed email has no Message-ID", async () => {
     const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
     const body = new File(["<html>"], "msg.html", { type: "text/html" });
     mockedParse.mockResolvedValueOnce({ files: [body], messageId: null });
 
-    const shouldSkipEmail = vi.fn(() => true);
+    const tryAttachEmail = vi.fn(() => false);
 
-    const result = await expandDroppedEmailFiles([eml], { shouldSkipEmail });
+    const result = await expandDroppedEmailFiles([eml], { tryAttachEmail });
 
-    expect(shouldSkipEmail).not.toHaveBeenCalled();
+    expect(tryAttachEmail).not.toHaveBeenCalled();
     expect(result).toEqual([body]);
   });
 
-  it("invokes onAttachedEmail with the Message-ID of each successfully expanded .eml", async () => {
-    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
-    const body = new File(["<html>"], "msg.html", { type: "text/html" });
-    mockedParse.mockResolvedValueOnce({
-      files: [body],
-      messageId: "<m1@x>",
-    });
-    const onAttachedEmail = vi.fn();
-
-    await expandDroppedEmailFiles([eml], { onAttachedEmail });
-
-    expect(onAttachedEmail).toHaveBeenCalledTimes(1);
-    expect(onAttachedEmail).toHaveBeenCalledWith("<m1@x>");
-  });
-
-  it("does not call onAttachedEmail when the email was skipped", async () => {
-    const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
-    mockedParse.mockResolvedValueOnce({
-      files: [new File(["<html>"], "msg.html", { type: "text/html" })],
-      messageId: "<preview@host>",
-    });
-    const onAttachedEmail = vi.fn();
-    const shouldSkipEmail = () => true;
-
-    await expandDroppedEmailFiles([eml], { shouldSkipEmail, onAttachedEmail });
-
-    expect(onAttachedEmail).not.toHaveBeenCalled();
-  });
-
-  it("does not call onAttachedEmail when parsing produced no files", async () => {
+  it("does not consult tryAttachEmail when parsing produced no files", async () => {
     const eml = new File(["email"], "msg.eml", { type: "message/rfc822" });
     mockedParse.mockResolvedValueOnce({ files: [], messageId: "<m@x>" });
-    const onAttachedEmail = vi.fn();
+    const tryAttachEmail = vi.fn();
 
-    await expandDroppedEmailFiles([eml], { onAttachedEmail });
+    await expandDroppedEmailFiles([eml], { tryAttachEmail });
 
-    expect(onAttachedEmail).not.toHaveBeenCalled();
+    expect(tryAttachEmail).not.toHaveBeenCalled();
   });
 
-  it("invokes onAttachedEmail for a successfully expanded .msg", async () => {
+  it("invokes tryAttachEmail for a successfully expanded .msg", async () => {
     const msg = new File([new Uint8Array([0])], "item.msg", {
       type: "application/vnd.ms-outlook",
     });
     const body = new File(["<html>"], "body.html", { type: "text/html" });
     const acquireGraphToken = vi.fn();
-    const onAttachedEmail = vi.fn();
+    const tryAttachEmail = vi.fn(() => true);
     mockedParseMsg.mockResolvedValueOnce({
       files: [body],
       messageId: "<msg@x>",
@@ -172,13 +141,13 @@ describe("expandDroppedEmailFiles", () => {
 
     await expandDroppedEmailFiles([msg], {
       acquireGraphToken,
-      onAttachedEmail,
+      tryAttachEmail,
     });
 
-    expect(onAttachedEmail).toHaveBeenCalledWith("<msg@x>");
+    expect(tryAttachEmail).toHaveBeenCalledWith("<msg@x>");
   });
 
-  it("skips a dropped .msg whose Message-ID matches the shouldSkipEmail predicate", async () => {
+  it("drops a .msg when tryAttachEmail returns false", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const msg = new File([new Uint8Array([0])], "item.msg", {
       type: "application/vnd.ms-outlook",
@@ -189,16 +158,16 @@ describe("expandDroppedEmailFiles", () => {
       messageId: "<preview@host>",
     });
     const acquireGraphToken = vi.fn();
-    const shouldSkipEmail = vi.fn(
-      (messageId: string) => messageId === "<preview@host>",
+    const tryAttachEmail = vi.fn(
+      (messageId: string) => messageId !== "<preview@host>",
     );
 
     const result = await expandDroppedEmailFiles([msg], {
       acquireGraphToken,
-      shouldSkipEmail,
+      tryAttachEmail,
     });
 
-    expect(shouldSkipEmail).toHaveBeenCalledWith("<preview@host>");
+    expect(tryAttachEmail).toHaveBeenCalledWith("<preview@host>");
     expect(result).toEqual([]);
     expect(logSpy).toHaveBeenCalled();
   });

--- a/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
+++ b/office-addin/src/utils/__tests__/expandDroppedEmailFiles.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { expandDroppedEmailFiles } from "../expandDroppedEmailFiles";
 import * as parseEmlFileModule from "../parseEmlFile";
+import * as parseMsgFileModule from "../parseMsgFile";
 
 import type * as ParseEmlFileModule from "../parseEmlFile";
+import type * as ParseMsgFileModule from "../parseMsgFile";
 
 vi.mock("../parseEmlFile", async () => {
   const actual =
@@ -14,12 +16,23 @@ vi.mock("../parseEmlFile", async () => {
   };
 });
 
+vi.mock("../parseMsgFile", async () => {
+  const actual =
+    await vi.importActual<typeof ParseMsgFileModule>("../parseMsgFile");
+  return {
+    ...actual,
+    parseMsgFileToFiles: vi.fn(),
+  };
+});
+
 const mockedParse = vi.mocked(parseEmlFileModule.parseEmlFileToFiles);
+const mockedParseMsg = vi.mocked(parseMsgFileModule.parseMsgFileToFiles);
 
 describe("expandDroppedEmailFiles", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     mockedParse.mockReset();
+    mockedParseMsg.mockReset();
   });
 
   it("expands .eml files and preserves order of mixed input", async () => {
@@ -50,5 +63,41 @@ describe("expandDroppedEmailFiles", () => {
 
     const result = await expandDroppedEmailFiles([eml]);
     expect(result).toEqual([]);
+  });
+
+  it("routes .msg files through parseMsgFileToFiles when a Graph token is provided", async () => {
+    const msg = new File([new Uint8Array([0])], "item.msg", {
+      type: "application/vnd.ms-outlook",
+    });
+    const body = new File(["<html>"], "body.html", { type: "text/html" });
+    const acquireGraphToken = vi.fn();
+    mockedParseMsg.mockResolvedValueOnce([body]);
+
+    const result = await expandDroppedEmailFiles([msg], { acquireGraphToken });
+
+    expect(mockedParseMsg).toHaveBeenCalledTimes(1);
+    expect(mockedParseMsg).toHaveBeenCalledWith(msg, acquireGraphToken);
+    expect(result).toEqual([body]);
+  });
+
+  it("skips .msg files when no Graph token is available and logs a warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const msg = new File([new Uint8Array([0])], "item.msg");
+
+    const result = await expandDroppedEmailFiles([msg]);
+
+    expect(result).toEqual([]);
+    expect(mockedParseMsg).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("matches .msg by filename extension even when MIME is empty", async () => {
+    const msg = new File([new Uint8Array([0])], "NoType.MSG");
+    const acquireGraphToken = vi.fn();
+    mockedParseMsg.mockResolvedValueOnce([]);
+
+    await expandDroppedEmailFiles([msg], { acquireGraphToken });
+
+    expect(mockedParseMsg).toHaveBeenCalledWith(msg, acquireGraphToken);
   });
 });

--- a/office-addin/src/utils/__tests__/extractMsgInternetMessageId.test.ts
+++ b/office-addin/src/utils/__tests__/extractMsgInternetMessageId.test.ts
@@ -1,0 +1,95 @@
+import * as CFB from "cfb";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractMsgInternetMessageId,
+  extractMsgInternetMessageIdFromBytes,
+} from "../extractMsgInternetMessageId";
+
+function buildCfbWith(
+  entries: { name: string; content: Uint8Array }[],
+): Uint8Array {
+  const container = CFB.utils.cfb_new();
+  for (const entry of entries) {
+    CFB.utils.cfb_add(container, entry.name, entry.content);
+  }
+  const written = CFB.write(container, {
+    type: "array",
+  }) as unknown as ArrayLike<number>;
+  return new Uint8Array(written);
+}
+
+function utf16le(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length * 2);
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    bytes[index * 2] = code & 0xff;
+    bytes[index * 2 + 1] = (code >> 8) & 0xff;
+  }
+  return bytes;
+}
+
+describe("extractMsgInternetMessageIdFromBytes", () => {
+  it("returns the Message-ID string when the stream is present", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001F",
+        content: utf16le("<abc123@example.com>"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe(
+      "<abc123@example.com>",
+    );
+  });
+
+  it("strips trailing UTF-16 null padding and whitespace", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001F",
+        content: utf16le("<abc@host>  \u0000\u0000"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe("<abc@host>");
+  });
+
+  it("returns null when the stream is missing", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_0037001F",
+        content: utf16le("Some subject"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBeNull();
+  });
+
+  it("returns null for an empty stream", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001F",
+        content: new Uint8Array(0),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBeNull();
+  });
+
+  it("returns null for non-CFB input", () => {
+    expect(
+      extractMsgInternetMessageIdFromBytes(new Uint8Array([1, 2, 3, 4])),
+    ).toBeNull();
+  });
+
+  it("accepts a File via the async wrapper", async () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001F",
+        content: utf16le("<xyz@host>"),
+      },
+    ]);
+    const buffer = new ArrayBuffer(cfbBytes.length);
+    new Uint8Array(buffer).set(cfbBytes);
+    const file = new File([buffer], "sample.msg", {
+      type: "application/vnd.ms-outlook",
+    });
+    expect(await extractMsgInternetMessageId(file)).toBe("<xyz@host>");
+  });
+});

--- a/office-addin/src/utils/__tests__/extractMsgInternetMessageId.test.ts
+++ b/office-addin/src/utils/__tests__/extractMsgInternetMessageId.test.ts
@@ -1,33 +1,10 @@
-import * as CFB from "cfb";
 import { describe, expect, it } from "vitest";
 
+import { buildCfbWith, utf16le } from "../../test/fixtures/msg";
 import {
   extractMsgInternetMessageId,
   extractMsgInternetMessageIdFromBytes,
 } from "../extractMsgInternetMessageId";
-
-function buildCfbWith(
-  entries: { name: string; content: Uint8Array }[],
-): Uint8Array {
-  const container = CFB.utils.cfb_new();
-  for (const entry of entries) {
-    CFB.utils.cfb_add(container, entry.name, entry.content);
-  }
-  const written = CFB.write(container, {
-    type: "array",
-  }) as unknown as ArrayLike<number>;
-  return new Uint8Array(written);
-}
-
-function utf16le(value: string): Uint8Array {
-  const bytes = new Uint8Array(value.length * 2);
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index);
-    bytes[index * 2] = code & 0xff;
-    bytes[index * 2 + 1] = (code >> 8) & 0xff;
-  }
-  return bytes;
-}
 
 describe("extractMsgInternetMessageIdFromBytes", () => {
   it("returns the Message-ID string when the stream is present", () => {

--- a/office-addin/src/utils/__tests__/fetchOutlookMessage.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessage.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockAsyncResult } from "../../test/helpers/asyncResult";
+import {
+  installMockMailbox,
+  uninstallMockMailbox,
+} from "../../test/mocks/outlook/mailbox";
+import { fetchOutlookMessageFiles } from "../fetchOutlookMessage";
+
+type MailboxMock = ReturnType<typeof installMockMailbox> & {
+  convertToRestId: ReturnType<typeof vi.fn>;
+  getCallbackTokenAsync: ReturnType<typeof vi.fn>;
+  restUrl?: string;
+};
+
+const EWS_ID = "AAkALgAAA-ews-id";
+const REST_ID = "rest-id-converted";
+
+function installFetchMock(response: {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  jsonValue?: unknown;
+}) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status ?? 200,
+    statusText: response.statusText ?? "OK",
+    json: () => Promise.resolve(response.jsonValue ?? {}),
+  } as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function installOutlookMailboxMock(): MailboxMock {
+  const mailbox = installMockMailbox() as MailboxMock;
+  (Office.MailboxEnums as unknown as Record<string, unknown>).RestVersion = {
+    v2_0: "v2.0",
+  };
+  mailbox.convertToRestId = vi.fn().mockReturnValue(REST_ID);
+  mailbox.getCallbackTokenAsync = vi.fn((_options, callback) => {
+    callback(createMockAsyncResult("bearer-token-abc"));
+  });
+  mailbox.restUrl = "https://outlook.office.com";
+  return mailbox;
+}
+
+describe("fetchOutlookMessageFiles", () => {
+  beforeEach(() => {
+    installOutlookMailboxMock();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    vi.unstubAllGlobals();
+  });
+
+  it("assembles the REST URL with converted id and bearer token", async () => {
+    const fetchMock = installFetchMock({
+      ok: true,
+      jsonValue: {
+        Subject: "Test",
+        Body: { ContentType: "Text", Content: "hello" },
+        Attachments: [],
+      },
+    });
+
+    await fetchOutlookMessageFiles(EWS_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      `https://outlook.office.com/api/v2.0/me/messages/${encodeURIComponent(REST_ID)}?$expand=Attachments`,
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer bearer-token-abc");
+    expect(headers.Accept).toBe("application/json");
+  });
+
+  it("builds an HTML body file with rendered headers from a text-body message", async () => {
+    installFetchMock({
+      ok: true,
+      jsonValue: {
+        Subject: "Hey how are you?",
+        Body: { ContentType: "Text", Content: "plain text body" },
+        From: { EmailAddress: { Name: "Alice", Address: "alice@x" } },
+        ToRecipients: [{ EmailAddress: { Address: "bob@x" } }],
+        Attachments: [],
+      },
+    });
+
+    const { subject, files } = await fetchOutlookMessageFiles(EWS_ID);
+    expect(subject).toBe("Hey how are you?");
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("Hey how are you_.html");
+    expect(files[0].type).toBe("text/html");
+
+    const html = await files[0].text();
+    expect(html).toContain("<strong>From:</strong> Alice &lt;alice@x&gt;");
+    expect(html).toContain("<strong>To:</strong> bob@x");
+    expect(html).toContain(
+      "<strong>Subject:</strong> Hey how are you?",
+    );
+    expect(html).toContain("<pre>plain text body</pre>");
+  });
+
+  it("keeps HTML-body content verbatim rather than wrapping in <pre>", async () => {
+    installFetchMock({
+      ok: true,
+      jsonValue: {
+        Subject: "Formatted",
+        Body: { ContentType: "HTML", Content: "<p>rich</p>" },
+        Attachments: [],
+      },
+    });
+
+    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    const html = await files[0].text();
+    expect(html).toContain("<p>rich</p>");
+    expect(html).not.toContain("<pre>");
+  });
+
+  it("decodes FileAttachment entries into File objects", async () => {
+    const base64 = btoa("hello-pdf-bytes");
+    installFetchMock({
+      ok: true,
+      jsonValue: {
+        Subject: "With attachment",
+        Body: { ContentType: "Text", Content: "see attached" },
+        Attachments: [
+          {
+            "@odata.type": "#Microsoft.OutlookServices.FileAttachment",
+            Name: "doc.pdf",
+            ContentType: "application/pdf",
+            Size: 14,
+            IsInline: false,
+            ContentBytes: base64,
+          },
+        ],
+      },
+    });
+
+    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    expect(files).toHaveLength(2);
+    const attachment = files[1];
+    expect(attachment.name).toBe("doc.pdf");
+    expect(attachment.type).toBe("application/pdf");
+    expect(await attachment.text()).toBe("hello-pdf-bytes");
+  });
+
+  it("skips inline attachments and non-file attachment types", async () => {
+    installFetchMock({
+      ok: true,
+      jsonValue: {
+        Subject: "Mixed",
+        Body: { ContentType: "Text", Content: "x" },
+        Attachments: [
+          {
+            "@odata.type": "#Microsoft.OutlookServices.FileAttachment",
+            Name: "inline.png",
+            ContentType: "image/png",
+            IsInline: true,
+            ContentBytes: btoa("inline"),
+          },
+          {
+            "@odata.type": "#Microsoft.OutlookServices.ItemAttachment",
+            Name: "nested.msg",
+          },
+          {
+            "@odata.type": "#Microsoft.OutlookServices.ReferenceAttachment",
+            Name: "cloud-link",
+          },
+        ],
+      },
+    });
+
+    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("Mixed.html");
+  });
+
+  it("throws when the REST endpoint returns a non-OK status", async () => {
+    installFetchMock({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+    });
+
+    await expect(fetchOutlookMessageFiles(EWS_ID)).rejects.toThrow(
+      /Outlook REST fetch failed: 403 Forbidden/,
+    );
+  });
+
+  it("throws when mailbox.restUrl is not available", async () => {
+    const mailbox = Office.context.mailbox as unknown as {
+      restUrl?: string;
+    };
+    mailbox.restUrl = undefined;
+    installFetchMock({ ok: true });
+
+    await expect(fetchOutlookMessageFiles(EWS_ID)).rejects.toThrow(
+      /restUrl is not available/,
+    );
+  });
+});

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installMockMailbox,
+  uninstallMockMailbox,
+} from "../../test/mocks/outlook/mailbox";
+import {
+  fetchOutlookMessageFilesByInternetMessageIdViaGraph,
+  fetchOutlookMessageFilesViaGraph,
+} from "../fetchOutlookMessageGraph";
+
+const EWS_ID = "AAkALgAAA-ews-id";
+const GRAPH_ID = "graph-id-converted";
+
+type MailboxMock = ReturnType<typeof installMockMailbox> & {
+  convertToRestId: ReturnType<typeof vi.fn>;
+};
+
+function installOutlookMailboxMock(): MailboxMock {
+  const mailbox = installMockMailbox() as MailboxMock;
+  (Office.MailboxEnums as unknown as Record<string, unknown>).RestVersion = {
+    v2_0: "v2.0",
+  };
+  mailbox.convertToRestId = vi.fn().mockReturnValue(GRAPH_ID);
+  return mailbox;
+}
+
+function installFetchMock(
+  responder: (url: string, init?: RequestInit) => {
+    ok: boolean;
+    status?: number;
+    statusText?: string;
+    jsonValue?: unknown;
+  },
+) {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const response = responder(url, init);
+    return {
+      ok: response.ok,
+      status: response.status ?? 200,
+      statusText: response.statusText ?? "OK",
+      json: () => Promise.resolve(response.jsonValue ?? {}),
+    } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("fetchOutlookMessageFilesViaGraph", () => {
+  beforeEach(() => {
+    installOutlookMailboxMock();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    vi.unstubAllGlobals();
+  });
+
+  it("hits the Graph v1.0 /me/messages endpoint with the converted id and the MSAL bearer token", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("graph-token-xyz");
+    const fetchMock = installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        subject: "Test",
+        body: { contentType: "text", content: "plain" },
+        attachments: [],
+      },
+    }));
+
+    await fetchOutlookMessageFilesViaGraph(EWS_ID, acquireToken);
+
+    expect(acquireToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(GRAPH_ID)}?$expand=attachments`,
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer graph-token-xyz");
+  });
+
+  it("builds an HTML body file with rendered headers for a camelCase Graph message", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        subject: "Hey how are you?",
+        body: { contentType: "text", content: "plain text body" },
+        from: { emailAddress: { name: "Alice", address: "alice@x" } },
+        toRecipients: [{ emailAddress: { address: "bob@x" } }],
+        attachments: [],
+      },
+    }));
+
+    const { subject, files } = await fetchOutlookMessageFilesViaGraph(
+      EWS_ID,
+      acquireToken,
+    );
+    expect(subject).toBe("Hey how are you?");
+    expect(files).toHaveLength(1);
+    expect(files[0].type).toBe("text/html");
+    const html = await files[0].text();
+    expect(html).toContain("<strong>From:</strong> Alice &lt;alice@x&gt;");
+    expect(html).toContain("<strong>To:</strong> bob@x");
+    expect(html).toContain("<pre>plain text body</pre>");
+  });
+
+  it("decodes Graph fileAttachment entries into File objects", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const base64 = btoa("pdf-bytes");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        subject: "With attachment",
+        body: { contentType: "text", content: "see attached" },
+        attachments: [
+          {
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            name: "doc.pdf",
+            contentType: "application/pdf",
+            size: 9,
+            isInline: false,
+            contentBytes: base64,
+          },
+        ],
+      },
+    }));
+
+    const { files } = await fetchOutlookMessageFilesViaGraph(
+      EWS_ID,
+      acquireToken,
+    );
+    expect(files).toHaveLength(2);
+    expect(files[1].name).toBe("doc.pdf");
+    expect(files[1].type).toBe("application/pdf");
+    expect(await files[1].text()).toBe("pdf-bytes");
+  });
+
+  it("throws when Graph returns a non-OK status", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+    }));
+
+    await expect(
+      fetchOutlookMessageFilesViaGraph(EWS_ID, acquireToken),
+    ).rejects.toThrow(/Graph fetch failed: 403 Forbidden/);
+  });
+});
+
+describe("fetchOutlookMessageFilesByInternetMessageIdViaGraph", () => {
+  beforeEach(() => {
+    installOutlookMailboxMock();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    vi.unstubAllGlobals();
+  });
+
+  it("filters /me/messages by internetMessageId and then fetches the matched message", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const fetchMock = installFetchMock((url) => {
+      if (url.includes("$filter=")) {
+        return {
+          ok: true,
+          jsonValue: {
+            value: [{ id: "matched-graph-id", subject: "Matched" }],
+          },
+        };
+      }
+      return {
+        ok: true,
+        jsonValue: {
+          id: "matched-graph-id",
+          subject: "Matched",
+          body: { contentType: "text", content: "body" },
+          attachments: [],
+        },
+      };
+    });
+
+    const result =
+      await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+        "<abc@host>",
+        acquireToken,
+      );
+
+    expect(result).not.toBeNull();
+    expect(result?.subject).toBe("Matched");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [filterUrl] = fetchMock.mock.calls[0];
+    expect(filterUrl).toContain(
+      encodeURIComponent("internetMessageId eq '<abc@host>'"),
+    );
+    const [fetchUrl] = fetchMock.mock.calls[1];
+    expect(fetchUrl).toContain(
+      `/me/messages/${encodeURIComponent("matched-graph-id")}`,
+    );
+  });
+
+  it("returns null when Graph's filter yields no matches", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({ ok: true, jsonValue: { value: [] } }));
+
+    const result =
+      await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+        "<missing@host>",
+        acquireToken,
+      );
+
+    expect(result).toBeNull();
+  });
+
+  it("escapes single quotes inside the internet message id for the OData filter", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const fetchMock = installFetchMock((url) => {
+      if (url.includes("$filter=")) {
+        return { ok: true, jsonValue: { value: [] } };
+      }
+      return { ok: true, jsonValue: {} };
+    });
+
+    await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+      "<a'b@host>",
+      acquireToken,
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain(
+      encodeURIComponent("internetMessageId eq '<a''b@host>'"),
+    );
+  });
+});

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -72,9 +72,10 @@ describe("fetchOutlookMessageFilesViaGraph", () => {
     expect(acquireToken).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe(
+    expect(url).toContain(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(GRAPH_ID)}?$expand=attachments`,
     );
+    expect(url).toContain("internetMessageId");
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer graph-token-xyz");
   });
@@ -134,6 +135,22 @@ describe("fetchOutlookMessageFilesViaGraph", () => {
     expect(files[1].name).toBe("doc.pdf");
     expect(files[1].type).toBe("application/pdf");
     expect(await files[1].text()).toBe("pdf-bytes");
+  });
+
+  it("surfaces internetMessageId from the Graph response in the return value", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        subject: "With id",
+        body: { contentType: "text", content: "x" },
+        internetMessageId: "<abc@host>",
+        attachments: [],
+      },
+    }));
+
+    const result = await fetchOutlookMessageFilesViaGraph(EWS_ID, acquireToken);
+    expect(result.internetMessageId).toBe("<abc@host>");
   });
 
   it("throws when Graph returns a non-OK status", async () => {

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -26,7 +26,10 @@ function installOutlookMailboxMock(): MailboxMock {
 }
 
 function installFetchMock(
-  responder: (url: string, init?: RequestInit) => {
+  responder: (
+    url: string,
+    init?: RequestInit,
+  ) => {
     ok: boolean;
     status?: number;
     statusText?: string;
@@ -199,11 +202,10 @@ describe("fetchOutlookMessageFilesByInternetMessageIdViaGraph", () => {
       };
     });
 
-    const result =
-      await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
-        "<abc@host>",
-        acquireToken,
-      );
+    const result = await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+      "<abc@host>",
+      acquireToken,
+    );
 
     expect(result).not.toBeNull();
     expect(result?.subject).toBe("Matched");
@@ -222,11 +224,10 @@ describe("fetchOutlookMessageFilesByInternetMessageIdViaGraph", () => {
     const acquireToken = vi.fn().mockResolvedValue("tok");
     installFetchMock(() => ({ ok: true, jsonValue: { value: [] } }));
 
-    const result =
-      await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
-        "<missing@host>",
-        acquireToken,
-      );
+    const result = await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+      "<missing@host>",
+      acquireToken,
+    );
 
     expect(result).toBeNull();
   });

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
@@ -5,7 +5,7 @@ import {
   installMockMailbox,
   uninstallMockMailbox,
 } from "../../test/mocks/outlook/mailbox";
-import { fetchOutlookMessageFiles } from "../fetchOutlookMessage";
+import { fetchOutlookMessageFilesViaRestV2 } from "../fetchOutlookMessageRestV2";
 
 type MailboxMock = ReturnType<typeof installMockMailbox> & {
   convertToRestId: ReturnType<typeof vi.fn>;
@@ -45,7 +45,7 @@ function installOutlookMailboxMock(): MailboxMock {
   return mailbox;
 }
 
-describe("fetchOutlookMessageFiles", () => {
+describe("fetchOutlookMessageFilesViaRestV2", () => {
   beforeEach(() => {
     installOutlookMailboxMock();
   });
@@ -65,7 +65,7 @@ describe("fetchOutlookMessageFiles", () => {
       },
     });
 
-    await fetchOutlookMessageFiles(EWS_ID);
+    await fetchOutlookMessageFilesViaRestV2(EWS_ID);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
@@ -89,7 +89,7 @@ describe("fetchOutlookMessageFiles", () => {
       },
     });
 
-    const { subject, files } = await fetchOutlookMessageFiles(EWS_ID);
+    const { subject, files } = await fetchOutlookMessageFilesViaRestV2(EWS_ID);
     expect(subject).toBe("Hey how are you?");
     expect(files).toHaveLength(1);
     expect(files[0].name).toBe("Hey how are you_.html");
@@ -114,7 +114,7 @@ describe("fetchOutlookMessageFiles", () => {
       },
     });
 
-    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    const { files } = await fetchOutlookMessageFilesViaRestV2(EWS_ID);
     const html = await files[0].text();
     expect(html).toContain("<p>rich</p>");
     expect(html).not.toContain("<pre>");
@@ -140,7 +140,7 @@ describe("fetchOutlookMessageFiles", () => {
       },
     });
 
-    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    const { files } = await fetchOutlookMessageFilesViaRestV2(EWS_ID);
     expect(files).toHaveLength(2);
     const attachment = files[1];
     expect(attachment.name).toBe("doc.pdf");
@@ -174,7 +174,7 @@ describe("fetchOutlookMessageFiles", () => {
       },
     });
 
-    const { files } = await fetchOutlookMessageFiles(EWS_ID);
+    const { files } = await fetchOutlookMessageFilesViaRestV2(EWS_ID);
     expect(files).toHaveLength(1);
     expect(files[0].name).toBe("Mixed.html");
   });
@@ -186,7 +186,7 @@ describe("fetchOutlookMessageFiles", () => {
       statusText: "Forbidden",
     });
 
-    await expect(fetchOutlookMessageFiles(EWS_ID)).rejects.toThrow(
+    await expect(fetchOutlookMessageFilesViaRestV2(EWS_ID)).rejects.toThrow(
       /Outlook REST fetch failed: 403 Forbidden/,
     );
   });
@@ -198,7 +198,7 @@ describe("fetchOutlookMessageFiles", () => {
     mailbox.restUrl = undefined;
     installFetchMock({ ok: true });
 
-    await expect(fetchOutlookMessageFiles(EWS_ID)).rejects.toThrow(
+    await expect(fetchOutlookMessageFilesViaRestV2(EWS_ID)).rejects.toThrow(
       /restUrl is not available/,
     );
   });

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
@@ -27,7 +27,7 @@ function installFetchMock(response: {
     status: response.status ?? 200,
     statusText: response.statusText ?? "OK",
     json: () => Promise.resolve(response.jsonValue ?? {}),
-  } as Response);
+  });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageRestV2.test.ts
@@ -98,9 +98,7 @@ describe("fetchOutlookMessageFilesViaRestV2", () => {
     const html = await files[0].text();
     expect(html).toContain("<strong>From:</strong> Alice &lt;alice@x&gt;");
     expect(html).toContain("<strong>To:</strong> bob@x");
-    expect(html).toContain(
-      "<strong>Subject:</strong> Hey how are you?",
-    );
+    expect(html).toContain("<strong>Subject:</strong> Hey how are you?");
     expect(html).toContain("<pre>plain text body</pre>");
   });
 

--- a/office-addin/src/utils/__tests__/outlookMailListDragParse.test.ts
+++ b/office-addin/src/utils/__tests__/outlookMailListDragParse.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAILLISTROW_TRANSFER_TYPE,
+  parseOutlookMailListPayload,
+} from "../outlookMailListDragParse";
+
+// Real payload captured from OWA drag-from-mail-list on 2026-04-19
+const REAL_OWA_PAYLOAD = JSON.stringify({
+  itemType: MAILLISTROW_TRANSFER_TYPE,
+  rowKeys: ["AQAAAQ5of+4BAAABDmiB6AAAAAA="],
+  tableViewId: "folderId:AQMk...",
+  tableListViewType: 1,
+  subjects: ["Hey how are you?"],
+  haveIRM: [false],
+  sizes: [61783],
+  mailboxInfos: [
+    {
+      sourceId: "DEFDEFDE-FDEF-DEFD-EFDE-FDEFDEFDEFDE",
+      type: "UserMailbox",
+      mailboxSmtpAddress: "testuser@maxgoisser.onmicrosoft.com",
+      userIdentity: "testuser@maxgoisser.onmicrosoft.com",
+      mailboxRank: "Coprincipal",
+      mailboxProvider: "Office365",
+    },
+  ],
+  latestItemIds: [
+    "AAkALgAAAAAAHYQDEapmEc2byACqAC/EWg0AWgnVLFiQIkWwcVdZvFpnJQABBI9sNAAA",
+  ],
+  itemIds: [
+    "AAkALgAAAAAAHYQDEapmEc2byACqAC/EWg0AWgnVLFiQIkWwcVdZvFpnJQABBI9sNAAA",
+  ],
+  nodeIds: [],
+});
+
+describe("parseOutlookMailListPayload", () => {
+  it("extracts itemIds, subjects, sizes, and mailbox addresses from the real OWA payload", () => {
+    const items = parseOutlookMailListPayload(REAL_OWA_PAYLOAD);
+    expect(items).toEqual([
+      {
+        itemId:
+          "AAkALgAAAAAAHYQDEapmEc2byACqAC/EWg0AWgnVLFiQIkWwcVdZvFpnJQABBI9sNAAA",
+        subject: "Hey how are you?",
+        size: 61783,
+        mailboxSmtpAddress: "testuser@maxgoisser.onmicrosoft.com",
+      },
+    ]);
+  });
+
+  it("parses multi-select payloads by index-aligning the parallel arrays", () => {
+    const payload = JSON.stringify({
+      itemType: MAILLISTROW_TRANSFER_TYPE,
+      itemIds: ["id-a", "id-b", "id-c"],
+      subjects: ["A", "B", "C"],
+      sizes: [100, 200, 300],
+      mailboxInfos: [
+        { mailboxSmtpAddress: "a@x" },
+        { mailboxSmtpAddress: "b@x" },
+        { mailboxSmtpAddress: "c@x" },
+      ],
+    });
+    const items = parseOutlookMailListPayload(payload);
+    expect(items).toEqual([
+      { itemId: "id-a", subject: "A", size: 100, mailboxSmtpAddress: "a@x" },
+      { itemId: "id-b", subject: "B", size: 200, mailboxSmtpAddress: "b@x" },
+      { itemId: "id-c", subject: "C", size: 300, mailboxSmtpAddress: "c@x" },
+    ]);
+  });
+
+  it("returns null for non-JSON strings", () => {
+    expect(parseOutlookMailListPayload("")).toBeNull();
+    expect(parseOutlookMailListPayload("not-json")).toBeNull();
+    expect(parseOutlookMailListPayload("{")).toBeNull();
+  });
+
+  it("returns null when itemType is not maillistrow", () => {
+    const payload = JSON.stringify({
+      itemType: "somethingelse",
+      itemIds: ["id-a"],
+    });
+    expect(parseOutlookMailListPayload(payload)).toBeNull();
+  });
+
+  it("returns null when itemIds is missing or empty", () => {
+    expect(
+      parseOutlookMailListPayload(
+        JSON.stringify({ itemType: MAILLISTROW_TRANSFER_TYPE }),
+      ),
+    ).toBeNull();
+    expect(
+      parseOutlookMailListPayload(
+        JSON.stringify({ itemType: MAILLISTROW_TRANSFER_TYPE, itemIds: [] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to empty strings / zero sizes when parallel arrays are missing or shorter", () => {
+    const payload = JSON.stringify({
+      itemType: MAILLISTROW_TRANSFER_TYPE,
+      itemIds: ["id-a", "id-b"],
+      subjects: ["only-first"],
+    });
+    const items = parseOutlookMailListPayload(payload);
+    expect(items).toEqual([
+      {
+        itemId: "id-a",
+        subject: "only-first",
+        size: 0,
+        mailboxSmtpAddress: "",
+      },
+      { itemId: "id-b", subject: "", size: 0, mailboxSmtpAddress: "" },
+    ]);
+  });
+
+  it("returns null when itemIds array contains non-string entries", () => {
+    const payload = JSON.stringify({
+      itemType: MAILLISTROW_TRANSFER_TYPE,
+      itemIds: ["id-a", 42, "id-c"],
+    });
+    expect(parseOutlookMailListPayload(payload)).toBeNull();
+  });
+});

--- a/office-addin/src/utils/__tests__/parseEmlFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseEmlFile.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isEmlFile, parseEmlFileToFiles } from "../parseEmlFile";
+
+function makeEmlFile(content: string, name = "message.eml"): File {
+  return new File([content], name, { type: "message/rfc822" });
+}
+
+const CRLF = "\r\n";
+
+describe("isEmlFile", () => {
+  it("returns true for MIME message/rfc822", () => {
+    const file = new File(["x"], "something.bin", { type: "message/rfc822" });
+    expect(isEmlFile(file)).toBe(true);
+  });
+
+  it("returns true for .eml filenames regardless of case", () => {
+    expect(isEmlFile(new File(["x"], "lower.eml", { type: "" }))).toBe(true);
+    expect(isEmlFile(new File(["x"], "UPPER.EML", { type: "" }))).toBe(true);
+  });
+
+  it("returns false for unrelated files", () => {
+    expect(isEmlFile(new File(["x"], "doc.pdf", { type: "application/pdf" }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("parseEmlFileToFiles", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses a plain-text .eml into a single HTML body file with rendered headers", async () => {
+    const eml =
+      `From: Alice <alice@example.com>${CRLF}` +
+      `To: Bob <bob@example.com>${CRLF}` +
+      `Subject: Hello there${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: text/plain; charset=utf-8${CRLF}` +
+      `${CRLF}` +
+      `plain body content`;
+
+    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(result).toHaveLength(1);
+    const body = result[0];
+    expect(body.type).toBe("text/html");
+    const text = await body.text();
+    expect(text).toContain("<strong>From:</strong> Alice &lt;alice@example.com&gt;");
+    expect(text).toContain("<strong>To:</strong> Bob &lt;bob@example.com&gt;");
+    expect(text).toContain("<strong>Subject:</strong> Hello there");
+    expect(text).toMatch(/<pre>plain body content\s*<\/pre>/);
+  });
+
+  it("keeps HTML body content verbatim, without <pre> wrapping", async () => {
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: Rich${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: text/html; charset=utf-8${CRLF}` +
+      `${CRLF}` +
+      `<p>hi there</p>`;
+
+    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(result).toHaveLength(1);
+    const text = await result[0].text();
+    expect(text).toContain("<p>hi there</p>");
+    expect(text).not.toContain("<pre>");
+  });
+
+  it("produces a body file plus one File per non-inline attachment", async () => {
+    const boundary = "----BOUNDARY1";
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: With attachment${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}` +
+      `${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: text/plain; charset=utf-8${CRLF}` +
+      `${CRLF}` +
+      `see attached${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: text/plain; name="notes.txt"${CRLF}` +
+      `Content-Disposition: attachment; filename="notes.txt"${CRLF}` +
+      `${CRLF}` +
+      `attachment body${CRLF}` +
+      `--${boundary}--${CRLF}`;
+
+    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(result).toHaveLength(2);
+    const attachment = result[1];
+    expect(attachment.name).toBe("notes.txt");
+    expect(attachment.type).toContain("text/plain");
+    expect((await attachment.text()).trim()).toBe("attachment body");
+  });
+
+  it("skips inline attachments (Content-Disposition: inline)", async () => {
+    const boundary = "----BOUNDARY2";
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: With inline${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: multipart/mixed; boundary="${boundary}"${CRLF}` +
+      `${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: text/plain; charset=utf-8${CRLF}` +
+      `${CRLF}` +
+      `body${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: image/png; name="inline.png"${CRLF}` +
+      `Content-Disposition: inline; filename="inline.png"${CRLF}` +
+      `Content-Transfer-Encoding: base64${CRLF}` +
+      `${CRLF}` +
+      `${btoa("pngbytes")}${CRLF}` +
+      `--${boundary}--${CRLF}`;
+
+    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(result).toHaveLength(1);
+  });
+
+  it("skips related (CID-referenced) attachments in multipart/related", async () => {
+    const boundary = "----BOUNDARY3";
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: With related${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: multipart/related; boundary="${boundary}"${CRLF}` +
+      `${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: text/html; charset=utf-8${CRLF}` +
+      `${CRLF}` +
+      `<p><img src="cid:logo"></p>${CRLF}` +
+      `--${boundary}${CRLF}` +
+      `Content-Type: image/png; name="logo.png"${CRLF}` +
+      `Content-ID: <logo>${CRLF}` +
+      `Content-Transfer-Encoding: base64${CRLF}` +
+      `${CRLF}` +
+      `${btoa("pngbytes")}${CRLF}` +
+      `--${boundary}--${CRLF}`;
+
+    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns [] on malformed input", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const bogus = new File([new Uint8Array([0xff, 0xfe, 0xfd])], "broken.eml", {
+      type: "message/rfc822",
+    });
+    // Force postal-mime to throw by providing a file.arrayBuffer that rejects.
+    const failing = new File(["anything"], "broken.eml", {
+      type: "message/rfc822",
+    });
+    vi.spyOn(failing, "arrayBuffer").mockRejectedValue(new Error("boom"));
+
+    const result = await parseEmlFileToFiles(failing);
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    // Also confirm behaviour with the bogus bytes path.
+    void bogus;
+  });
+});

--- a/office-addin/src/utils/__tests__/parseEmlFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseEmlFile.test.ts
@@ -20,9 +20,9 @@ describe("isEmlFile", () => {
   });
 
   it("returns false for unrelated files", () => {
-    expect(isEmlFile(new File(["x"], "doc.pdf", { type: "application/pdf" }))).toBe(
-      false,
-    );
+    expect(
+      isEmlFile(new File(["x"], "doc.pdf", { type: "application/pdf" })),
+    ).toBe(false);
   });
 });
 
@@ -46,7 +46,9 @@ describe("parseEmlFileToFiles", () => {
     const body = result[0];
     expect(body.type).toBe("text/html");
     const text = await body.text();
-    expect(text).toContain("<strong>From:</strong> Alice &lt;alice@example.com&gt;");
+    expect(text).toContain(
+      "<strong>From:</strong> Alice &lt;alice@example.com&gt;",
+    );
     expect(text).toContain("<strong>To:</strong> Bob &lt;bob@example.com&gt;");
     expect(text).toContain("<strong>Subject:</strong> Hello there");
     expect(text).toMatch(/<pre>plain body content\s*<\/pre>/);

--- a/office-addin/src/utils/__tests__/parseEmlFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseEmlFile.test.ts
@@ -41,7 +41,7 @@ describe("parseEmlFileToFiles", () => {
       `${CRLF}` +
       `plain body content`;
 
-    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    const { files: result } = await parseEmlFileToFiles(makeEmlFile(eml));
     expect(result).toHaveLength(1);
     const body = result[0];
     expect(body.type).toBe("text/html");
@@ -62,7 +62,7 @@ describe("parseEmlFileToFiles", () => {
       `${CRLF}` +
       `<p>hi there</p>`;
 
-    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    const { files: result } = await parseEmlFileToFiles(makeEmlFile(eml));
     expect(result).toHaveLength(1);
     const text = await result[0].text();
     expect(text).toContain("<p>hi there</p>");
@@ -89,7 +89,7 @@ describe("parseEmlFileToFiles", () => {
       `attachment body${CRLF}` +
       `--${boundary}--${CRLF}`;
 
-    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    const { files: result } = await parseEmlFileToFiles(makeEmlFile(eml));
     expect(result).toHaveLength(2);
     const attachment = result[1];
     expect(attachment.name).toBe("notes.txt");
@@ -118,7 +118,7 @@ describe("parseEmlFileToFiles", () => {
       `${btoa("pngbytes")}${CRLF}` +
       `--${boundary}--${CRLF}`;
 
-    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    const { files: result } = await parseEmlFileToFiles(makeEmlFile(eml));
     expect(result).toHaveLength(1);
   });
 
@@ -143,7 +143,7 @@ describe("parseEmlFileToFiles", () => {
       `${btoa("pngbytes")}${CRLF}` +
       `--${boundary}--${CRLF}`;
 
-    const result = await parseEmlFileToFiles(makeEmlFile(eml));
+    const { files: result } = await parseEmlFileToFiles(makeEmlFile(eml));
     expect(result).toHaveLength(1);
   });
 
@@ -159,9 +159,38 @@ describe("parseEmlFileToFiles", () => {
     vi.spyOn(failing, "arrayBuffer").mockRejectedValue(new Error("boom"));
 
     const result = await parseEmlFileToFiles(failing);
-    expect(result).toEqual([]);
+    expect(result).toEqual({ files: [], messageId: null });
     expect(warnSpy).toHaveBeenCalled();
     // Also confirm behaviour with the bogus bytes path.
     void bogus;
+  });
+
+  it("surfaces the RFC 5322 Message-ID header when present", async () => {
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: With id${CRLF}` +
+      `Message-ID: <abc-123@example.com>${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: text/plain${CRLF}` +
+      `${CRLF}` +
+      `body`;
+
+    const { messageId } = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(messageId).toBe("<abc-123@example.com>");
+  });
+
+  it("returns messageId null when the header is absent", async () => {
+    const eml =
+      `From: a@x${CRLF}` +
+      `To: b@x${CRLF}` +
+      `Subject: No id${CRLF}` +
+      `MIME-Version: 1.0${CRLF}` +
+      `Content-Type: text/plain${CRLF}` +
+      `${CRLF}` +
+      `body`;
+
+    const { messageId } = await parseEmlFileToFiles(makeEmlFile(eml));
+    expect(messageId).toBeNull();
   });
 });

--- a/office-addin/src/utils/__tests__/parseMsgFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseMsgFile.test.ts
@@ -1,103 +1,144 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { extractMsgInternetMessageId } from "../extractMsgInternetMessageId";
-import { fetchOutlookMessageFilesByInternetMessageIdViaGraph } from "../fetchOutlookMessageGraph";
+import {
+  buildCfbWith,
+  buildMsgWithInternetMessageId,
+  msgFileFromBytes,
+  utf16le,
+} from "../../test/fixtures/msg";
 import { parseMsgFileToFiles } from "../parseMsgFile";
 
-vi.mock("../extractMsgInternetMessageId", () => ({
-  extractMsgInternetMessageId: vi.fn(),
-}));
+// Both collaborators (`extractMsgInternetMessageId` and the Graph client) run
+// for real. Only the network boundary is stubbed, via `vi.stubGlobal("fetch")`
+// mirroring `fetchOutlookMessageGraph.test.ts`. This pins the load-bearing
+// contract — "preserve the Message-ID on Graph failure so the dedup path
+// still works" — against real CFB decoding and real Graph-request shaping;
+// drift in either module now fails a test in this file.
 
-vi.mock("../fetchOutlookMessageGraph", () => ({
-  fetchOutlookMessageFilesByInternetMessageIdViaGraph: vi.fn(),
-}));
+interface MockResponse {
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  jsonValue?: unknown;
+}
 
-const mockExtract = extractMsgInternetMessageId as unknown as ReturnType<
-  typeof vi.fn
->;
-const mockGraph =
-  fetchOutlookMessageFilesByInternetMessageIdViaGraph as unknown as ReturnType<
-    typeof vi.fn
-  >;
+function installFetchMock(
+  responder: (url: string, init?: RequestInit) => MockResponse,
+) {
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const response = responder(url, init);
+    return {
+      ok: response.ok,
+      status: response.status ?? 200,
+      statusText: response.statusText ?? "OK",
+      json: () => Promise.resolve(response.jsonValue ?? {}),
+    } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
 
 describe("parseMsgFileToFiles", () => {
   beforeEach(() => {
-    mockExtract.mockReset();
-    mockGraph.mockReset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
-  it("returns the Graph-fetched files when the lookup succeeds", async () => {
-    const bodyFile = new File(["<html>"], "body.html", { type: "text/html" });
-    const attachmentFile = new File(["x"], "attach.pdf", {
-      type: "application/pdf",
-    });
-    mockExtract.mockResolvedValue("<abc@host>");
-    mockGraph.mockResolvedValue({
-      subject: "Hi",
-      files: [bodyFile, attachmentFile],
-      internetMessageId: "<abc@host>",
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("decodes real CFB, resolves via Graph filter + fetch, and returns files with the id", async () => {
+    const file = msgFileFromBytes(buildMsgWithInternetMessageId("<abc@host>"));
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const fetchMock = installFetchMock((url) => {
+      if (url.includes("$filter=")) {
+        return {
+          ok: true,
+          jsonValue: { value: [{ id: "matched-id", subject: "Hi" }] },
+        };
+      }
+      return {
+        ok: true,
+        jsonValue: {
+          id: "matched-id",
+          subject: "Hi",
+          body: { contentType: "text", content: "plain body" },
+          internetMessageId: "<abc@host>",
+          attachments: [],
+        },
+      };
     });
 
-    const acquireToken = vi.fn().mockResolvedValue("tok");
-    const file = new File([new Uint8Array([0])], "sample.msg");
     const result = await parseMsgFileToFiles(file, acquireToken);
 
-    expect(mockExtract).toHaveBeenCalledWith(file);
-    expect(mockGraph).toHaveBeenCalledWith("<abc@host>", acquireToken);
-    expect(result).toEqual({
-      files: [bodyFile, attachmentFile],
-      messageId: "<abc@host>",
-    });
+    expect(result.messageId).toBe("<abc@host>");
+    expect(result.files.length).toBeGreaterThan(0);
+    expect(acquireToken).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [filterUrl] = fetchMock.mock.calls[0];
+    expect(filterUrl).toContain(
+      encodeURIComponent("internetMessageId eq '<abc@host>'"),
+    );
   });
 
-  it("returns empty files with null messageId when the Internet Message-ID cannot be read", async () => {
-    mockExtract.mockResolvedValue(null);
-    const acquireToken = vi.fn();
-
-    const result = await parseMsgFileToFiles(
-      new File([new Uint8Array(0)], "no-id.msg"),
-      acquireToken,
+  it("returns empty files with null id and does not hit Graph when the CFB has no Internet-Message-ID stream", async () => {
+    // Valid CFB carrying a different MAPI property (subject) but no
+    // PR_INTERNET_MESSAGE_ID_W — mirrors drafts that haven't been assigned
+    // an Internet Message-ID yet, which is the documented skip path.
+    const file = msgFileFromBytes(
+      buildCfbWith([
+        { name: "__substg1.0_0037001F", content: utf16le("Some subject") },
+      ]),
+      "no-id.msg",
     );
+    const acquireToken = vi.fn();
+    const fetchMock = installFetchMock(() => ({ ok: true }));
+
+    const result = await parseMsgFileToFiles(file, acquireToken);
 
     expect(result).toEqual({ files: [], messageId: null });
-    expect(mockGraph).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(acquireToken).not.toHaveBeenCalled();
   });
 
-  it("returns empty files with null messageId when the CFB read throws", async () => {
-    mockExtract.mockRejectedValue(new Error("bad bytes"));
+  it("returns empty files with null id and does not hit Graph for non-CFB bytes", async () => {
+    const file = msgFileFromBytes(new Uint8Array([1, 2, 3, 4]), "broken.msg");
     const acquireToken = vi.fn();
+    const fetchMock = installFetchMock(() => ({ ok: true }));
 
-    const result = await parseMsgFileToFiles(
-      new File([new Uint8Array(0)], "broken.msg"),
-      acquireToken,
-    );
+    const result = await parseMsgFileToFiles(file, acquireToken);
 
     expect(result).toEqual({ files: [], messageId: null });
-    expect(mockGraph).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(acquireToken).not.toHaveBeenCalled();
   });
 
-  it("returns empty files but preserves messageId when Graph has no match", async () => {
-    mockExtract.mockResolvedValue("<missing@host>");
-    mockGraph.mockResolvedValue(null);
+  // Both flavors of Graph failure must preserve the extracted Message-ID so
+  // that `expandDroppedEmailFiles`' dedup path can still suppress re-drops
+  // of the same email. Parameterized because the outcome is identical.
+  it.each([
+    {
+      label: "Graph filter yields no match",
+      responder: (): MockResponse => ({
+        ok: true,
+        jsonValue: { value: [] },
+      }),
+    },
+    {
+      label: "Graph filter returns a non-OK status",
+      responder: (): MockResponse => ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    },
+  ])("preserves the Message-ID when $label", async ({ responder }) => {
+    const file = msgFileFromBytes(buildMsgWithInternetMessageId("<abc@host>"));
     const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(responder);
 
-    const result = await parseMsgFileToFiles(
-      new File([new Uint8Array(0)], "missing.msg"),
-      acquireToken,
-    );
-
-    expect(result).toEqual({ files: [], messageId: "<missing@host>" });
-  });
-
-  it("returns empty files but preserves messageId when Graph fetch throws", async () => {
-    mockExtract.mockResolvedValue("<abc@host>");
-    mockGraph.mockRejectedValue(new Error("graph down"));
-    const acquireToken = vi.fn().mockResolvedValue("tok");
-
-    const result = await parseMsgFileToFiles(
-      new File([new Uint8Array(0)], "err.msg"),
-      acquireToken,
-    );
+    const result = await parseMsgFileToFiles(file, acquireToken);
 
     expect(result).toEqual({ files: [], messageId: "<abc@host>" });
   });

--- a/office-addin/src/utils/__tests__/parseMsgFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseMsgFile.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { extractMsgInternetMessageId } from "../extractMsgInternetMessageId";
+import { fetchOutlookMessageFilesByInternetMessageIdViaGraph } from "../fetchOutlookMessageGraph";
+import { parseMsgFileToFiles } from "../parseMsgFile";
+
+vi.mock("../extractMsgInternetMessageId", () => ({
+  extractMsgInternetMessageId: vi.fn(),
+}));
+
+vi.mock("../fetchOutlookMessageGraph", () => ({
+  fetchOutlookMessageFilesByInternetMessageIdViaGraph: vi.fn(),
+}));
+
+const mockExtract = extractMsgInternetMessageId as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockGraph =
+  fetchOutlookMessageFilesByInternetMessageIdViaGraph as unknown as ReturnType<
+    typeof vi.fn
+  >;
+
+describe("parseMsgFileToFiles", () => {
+  beforeEach(() => {
+    mockExtract.mockReset();
+    mockGraph.mockReset();
+  });
+
+  it("returns the Graph-fetched files when the lookup succeeds", async () => {
+    const bodyFile = new File(["<html>"], "body.html", { type: "text/html" });
+    const attachmentFile = new File(["x"], "attach.pdf", {
+      type: "application/pdf",
+    });
+    mockExtract.mockResolvedValue("<abc@host>");
+    mockGraph.mockResolvedValue({
+      subject: "Hi",
+      files: [bodyFile, attachmentFile],
+    });
+
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const file = new File([new Uint8Array([0])], "sample.msg");
+    const result = await parseMsgFileToFiles(file, acquireToken);
+
+    expect(mockExtract).toHaveBeenCalledWith(file);
+    expect(mockGraph).toHaveBeenCalledWith("<abc@host>", acquireToken);
+    expect(result).toEqual([bodyFile, attachmentFile]);
+  });
+
+  it("returns [] when the Internet Message-ID cannot be read from the .msg", async () => {
+    mockExtract.mockResolvedValue(null);
+    const acquireToken = vi.fn();
+
+    const result = await parseMsgFileToFiles(
+      new File([new Uint8Array(0)], "no-id.msg"),
+      acquireToken,
+    );
+
+    expect(result).toEqual([]);
+    expect(mockGraph).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when the CFB read throws", async () => {
+    mockExtract.mockRejectedValue(new Error("bad bytes"));
+    const acquireToken = vi.fn();
+
+    const result = await parseMsgFileToFiles(
+      new File([new Uint8Array(0)], "broken.msg"),
+      acquireToken,
+    );
+
+    expect(result).toEqual([]);
+    expect(mockGraph).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when Graph has no match for the Message-ID", async () => {
+    mockExtract.mockResolvedValue("<missing@host>");
+    mockGraph.mockResolvedValue(null);
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+
+    const result = await parseMsgFileToFiles(
+      new File([new Uint8Array(0)], "missing.msg"),
+      acquireToken,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when Graph fetch itself throws", async () => {
+    mockExtract.mockResolvedValue("<abc@host>");
+    mockGraph.mockRejectedValue(new Error("graph down"));
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+
+    const result = await parseMsgFileToFiles(
+      new File([new Uint8Array(0)], "err.msg"),
+      acquireToken,
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/office-addin/src/utils/__tests__/parseMsgFile.test.ts
+++ b/office-addin/src/utils/__tests__/parseMsgFile.test.ts
@@ -35,6 +35,7 @@ describe("parseMsgFileToFiles", () => {
     mockGraph.mockResolvedValue({
       subject: "Hi",
       files: [bodyFile, attachmentFile],
+      internetMessageId: "<abc@host>",
     });
 
     const acquireToken = vi.fn().mockResolvedValue("tok");
@@ -43,10 +44,13 @@ describe("parseMsgFileToFiles", () => {
 
     expect(mockExtract).toHaveBeenCalledWith(file);
     expect(mockGraph).toHaveBeenCalledWith("<abc@host>", acquireToken);
-    expect(result).toEqual([bodyFile, attachmentFile]);
+    expect(result).toEqual({
+      files: [bodyFile, attachmentFile],
+      messageId: "<abc@host>",
+    });
   });
 
-  it("returns [] when the Internet Message-ID cannot be read from the .msg", async () => {
+  it("returns empty files with null messageId when the Internet Message-ID cannot be read", async () => {
     mockExtract.mockResolvedValue(null);
     const acquireToken = vi.fn();
 
@@ -55,11 +59,11 @@ describe("parseMsgFileToFiles", () => {
       acquireToken,
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ files: [], messageId: null });
     expect(mockGraph).not.toHaveBeenCalled();
   });
 
-  it("returns [] when the CFB read throws", async () => {
+  it("returns empty files with null messageId when the CFB read throws", async () => {
     mockExtract.mockRejectedValue(new Error("bad bytes"));
     const acquireToken = vi.fn();
 
@@ -68,11 +72,11 @@ describe("parseMsgFileToFiles", () => {
       acquireToken,
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ files: [], messageId: null });
     expect(mockGraph).not.toHaveBeenCalled();
   });
 
-  it("returns [] when Graph has no match for the Message-ID", async () => {
+  it("returns empty files but preserves messageId when Graph has no match", async () => {
     mockExtract.mockResolvedValue("<missing@host>");
     mockGraph.mockResolvedValue(null);
     const acquireToken = vi.fn().mockResolvedValue("tok");
@@ -82,10 +86,10 @@ describe("parseMsgFileToFiles", () => {
       acquireToken,
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ files: [], messageId: "<missing@host>" });
   });
 
-  it("returns [] when Graph fetch itself throws", async () => {
+  it("returns empty files but preserves messageId when Graph fetch throws", async () => {
     mockExtract.mockResolvedValue("<abc@host>");
     mockGraph.mockRejectedValue(new Error("graph down"));
     const acquireToken = vi.fn().mockResolvedValue("tok");
@@ -95,6 +99,6 @@ describe("parseMsgFileToFiles", () => {
       acquireToken,
     );
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ files: [], messageId: "<abc@host>" });
   });
 });

--- a/office-addin/src/utils/buildEmailBodyHtml.ts
+++ b/office-addin/src/utils/buildEmailBodyHtml.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from "./htmlConvert";
+import { EMAIL_BODY_CSP, sanitizeEmailHtml } from "./sanitizeEmailHtml";
 
 export interface EmailAddressInput {
   name?: string;
@@ -40,13 +41,13 @@ export function buildEmailBodyFile(input: EmailBodyInput): File {
   headerRows.push(`<strong>Subject:</strong> ${escapeHtml(subject)}`);
 
   const body = input.bodyHtml
-    ? input.bodyHtml
+    ? sanitizeEmailHtml(input.bodyHtml)
     : input.bodyText
       ? `<pre>${escapeHtml(input.bodyText)}</pre>`
       : "";
 
   const html = `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${EMAIL_BODY_CSP}"><base target="_blank"><title>${escapeHtml(subject)}</title></head>
 <body>
 <div style="font-family:sans-serif;font-size:13px;color:#333;border-bottom:1px solid #ccc;padding-bottom:8px;margin-bottom:16px">
   ${headerRows.join("<br>")}

--- a/office-addin/src/utils/buildEmailBodyHtml.ts
+++ b/office-addin/src/utils/buildEmailBodyHtml.ts
@@ -1,0 +1,92 @@
+import { escapeHtml } from "./htmlConvert";
+
+export interface EmailAddressInput {
+  name?: string;
+  address?: string;
+}
+
+export interface EmailBodyInput {
+  subject: string;
+  from?: EmailAddressInput | null;
+  to?: EmailAddressInput[] | null;
+  cc?: EmailAddressInput[] | null;
+  date?: Date | null;
+  bodyHtml?: string | null;
+  bodyText?: string | null;
+}
+
+export function buildEmailBodyFile(input: EmailBodyInput): File {
+  const subject = input.subject?.trim() ? input.subject : "(no subject)";
+  const filename = `${sanitizeFilename(subject)}.html`;
+
+  const headerRows: string[] = [];
+  const fromAddress = formatAddress(input.from);
+  if (fromAddress) {
+    headerRows.push(`<strong>From:</strong> ${escapeHtml(fromAddress)}`);
+  }
+  const toAddresses = formatAddressList(input.to);
+  if (toAddresses) {
+    headerRows.push(`<strong>To:</strong> ${escapeHtml(toAddresses)}`);
+  }
+  const ccAddresses = formatAddressList(input.cc);
+  if (ccAddresses) {
+    headerRows.push(`<strong>CC:</strong> ${escapeHtml(ccAddresses)}`);
+  }
+  if (input.date && !isNaN(input.date.getTime())) {
+    headerRows.push(
+      `<strong>Date:</strong> ${escapeHtml(input.date.toLocaleString())}`,
+    );
+  }
+  headerRows.push(`<strong>Subject:</strong> ${escapeHtml(subject)}`);
+
+  const body = input.bodyHtml
+    ? input.bodyHtml
+    : input.bodyText
+      ? `<pre>${escapeHtml(input.bodyText)}</pre>`
+      : "";
+
+  const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body>
+<div style="font-family:sans-serif;font-size:13px;color:#333;border-bottom:1px solid #ccc;padding-bottom:8px;margin-bottom:16px">
+  ${headerRows.join("<br>")}
+</div>
+${body}
+</body></html>`;
+
+  return new File([html], filename, { type: "text/html" });
+}
+
+function formatAddress(address: EmailAddressInput | null | undefined): string {
+  if (!address?.address) {
+    return "";
+  }
+  const { name, address: addr } = address;
+  return name && name !== addr ? `${name} <${addr}>` : addr;
+}
+
+function formatAddressList(
+  addresses: EmailAddressInput[] | null | undefined,
+): string {
+  if (!addresses || addresses.length === 0) {
+    return "";
+  }
+  return addresses
+    .map(formatAddress)
+    .filter((entry) => entry.length > 0)
+    .join(", ");
+}
+
+function sanitizeFilename(name: string): string {
+  const base = name.trim() || "email";
+  return Array.from(base)
+    .map((character) => {
+      if ('<>:"/\\|?*'.includes(character)) {
+        return "_";
+      }
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint < 32 ? "_" : character;
+    })
+    .join("")
+    .slice(0, 100);
+}

--- a/office-addin/src/utils/expandDroppedEmailFiles.ts
+++ b/office-addin/src/utils/expandDroppedEmailFiles.ts
@@ -17,6 +17,13 @@ interface ExpandDroppedEmailFilesOptions {
    * preview path.
    */
   shouldSkipEmail?: (messageId: string) => boolean;
+  /**
+   * Called once per successfully expanded email (after the skip check).
+   * Receives the RFC 5322 `Message-ID`. The caller typically records this
+   * so the current-email preview can be suppressed for emails that are
+   * already represented in the attachment list.
+   */
+  onAttachedEmail?: (messageId: string) => void;
 }
 
 /**
@@ -40,6 +47,9 @@ export async function expandDroppedEmailFiles(
       if (shouldSkip(messageId, options.shouldSkipEmail)) {
         logSkip(file.name, messageId);
         continue;
+      }
+      if (messageId && parsed.length > 0) {
+        options.onAttachedEmail?.(messageId);
       }
       expanded.push(...parsed);
       continue;
@@ -82,6 +92,9 @@ async function parseMsgFileIfPossible(
   if (shouldSkip(messageId, options.shouldSkipEmail)) {
     logSkip(file.name, messageId);
     return [];
+  }
+  if (messageId && files.length > 0) {
+    options.onAttachedEmail?.(messageId);
   }
   return files;
 }

--- a/office-addin/src/utils/expandDroppedEmailFiles.ts
+++ b/office-addin/src/utils/expandDroppedEmailFiles.ts
@@ -9,6 +9,14 @@ interface ExpandDroppedEmailFilesOptions {
    * the caller only ever drops `.eml` / regular files.
    */
   acquireGraphToken?: AcquireGraphToken;
+  /**
+   * Optional predicate consulted with the RFC 5322 `Message-ID` of each
+   * parsed email. When the predicate returns `true`, the entire email is
+   * dropped from the output (body + attachments). Used to avoid duplicating
+   * the currently-open Outlook email which is already included via the
+   * preview path.
+   */
+  shouldSkipEmail?: (messageId: string) => boolean;
 }
 
 /**
@@ -28,7 +36,11 @@ export async function expandDroppedEmailFiles(
   const expanded: File[] = [];
   for (const file of files) {
     if (isEmlFile(file)) {
-      const parsed = await parseEmlFileToFiles(file);
+      const { files: parsed, messageId } = await parseEmlFileToFiles(file);
+      if (shouldSkip(messageId, options.shouldSkipEmail)) {
+        logSkip(file.name, messageId);
+        continue;
+      }
       expanded.push(...parsed);
       continue;
     }
@@ -63,5 +75,31 @@ async function parseMsgFileIfPossible(
     return [];
   }
   const { parseMsgFileToFiles } = await import("./parseMsgFile");
-  return parseMsgFileToFiles(file, options.acquireGraphToken);
+  const { files, messageId } = await parseMsgFileToFiles(
+    file,
+    options.acquireGraphToken,
+  );
+  if (shouldSkip(messageId, options.shouldSkipEmail)) {
+    logSkip(file.name, messageId);
+    return [];
+  }
+  return files;
+}
+
+function shouldSkip(
+  messageId: string | null,
+  predicate: ((messageId: string) => boolean) | undefined,
+): boolean {
+  if (!messageId || !predicate) {
+    return false;
+  }
+  return predicate(messageId);
+}
+
+function logSkip(fileName: string, messageId: string | null): void {
+  console.log(
+    "[expandDroppedEmailFiles] skipping dropped email already represented by the current-email preview:",
+    fileName,
+    messageId,
+  );
 }

--- a/office-addin/src/utils/expandDroppedEmailFiles.ts
+++ b/office-addin/src/utils/expandDroppedEmailFiles.ts
@@ -1,0 +1,23 @@
+import { isEmlFile, parseEmlFileToFiles } from "./parseEmlFile";
+
+/**
+ * Expands dropped `.eml` files into their constituent body + attachment
+ * files before they are handed to the upload pipeline. Non-`.eml` files are
+ * passed through unchanged so this wrapper is safe to apply to arbitrary
+ * dropzone input. `.msg` files are intentionally untouched — their parsing
+ * strategy is handled separately.
+ */
+export async function expandDroppedEmailFiles(
+  files: File[],
+): Promise<File[]> {
+  const expanded: File[] = [];
+  for (const file of files) {
+    if (isEmlFile(file)) {
+      const parsed = await parseEmlFileToFiles(file);
+      expanded.push(...parsed);
+      continue;
+    }
+    expanded.push(file);
+  }
+  return expanded;
+}

--- a/office-addin/src/utils/expandDroppedEmailFiles.ts
+++ b/office-addin/src/utils/expandDroppedEmailFiles.ts
@@ -1,14 +1,29 @@
 import { isEmlFile, parseEmlFileToFiles } from "./parseEmlFile";
 
+import type { AcquireGraphToken } from "./fetchOutlookMessageGraph";
+
+interface ExpandDroppedEmailFilesOptions {
+  /**
+   * Required for `.msg` expansion — `.msg` lookup goes through Microsoft
+   * Graph and therefore needs a MSAL NAA `Mail.Read` token. Safe to omit if
+   * the caller only ever drops `.eml` / regular files.
+   */
+  acquireGraphToken?: AcquireGraphToken;
+}
+
 /**
- * Expands dropped `.eml` files into their constituent body + attachment
- * files before they are handed to the upload pipeline. Non-`.eml` files are
- * passed through unchanged so this wrapper is safe to apply to arbitrary
- * dropzone input. `.msg` files are intentionally untouched — their parsing
- * strategy is handled separately.
+ * Expands dropped email files into their constituent body + attachment files
+ * before they are handed to the upload pipeline. Non-email files are passed
+ * through unchanged, so this wrapper is safe to apply to arbitrary dropzone
+ * input.
+ *
+ * `.eml` is parsed locally via postal-mime. `.msg` resolution is deferred to
+ * `./parseMsgFile.ts` (Graph lookup by RFC 5322 Message-ID), which requires
+ * the `acquireGraphToken` option.
  */
 export async function expandDroppedEmailFiles(
   files: File[],
+  options: ExpandDroppedEmailFilesOptions = {},
 ): Promise<File[]> {
   const expanded: File[] = [];
   for (const file of files) {
@@ -17,7 +32,36 @@ export async function expandDroppedEmailFiles(
       expanded.push(...parsed);
       continue;
     }
+
+    if (isMsgFile(file)) {
+      const parsed = await parseMsgFileIfPossible(file, options);
+      expanded.push(...parsed);
+      continue;
+    }
+
     expanded.push(file);
   }
   return expanded;
+}
+
+function isMsgFile(file: File): boolean {
+  if (file.type === "application/vnd.ms-outlook") {
+    return true;
+  }
+  return file.name.toLowerCase().endsWith(".msg");
+}
+
+async function parseMsgFileIfPossible(
+  file: File,
+  options: ExpandDroppedEmailFilesOptions,
+): Promise<File[]> {
+  if (!options.acquireGraphToken) {
+    console.warn(
+      "[expandDroppedEmailFiles] .msg drop received without a Graph token — skipping",
+      file.name,
+    );
+    return [];
+  }
+  const { parseMsgFileToFiles } = await import("./parseMsgFile");
+  return parseMsgFileToFiles(file, options.acquireGraphToken);
 }

--- a/office-addin/src/utils/expandDroppedEmailFiles.ts
+++ b/office-addin/src/utils/expandDroppedEmailFiles.ts
@@ -10,20 +10,16 @@ interface ExpandDroppedEmailFilesOptions {
    */
   acquireGraphToken?: AcquireGraphToken;
   /**
-   * Optional predicate consulted with the RFC 5322 `Message-ID` of each
-   * parsed email. When the predicate returns `true`, the entire email is
-   * dropped from the output (body + attachments). Used to avoid duplicating
-   * the currently-open Outlook email which is already included via the
-   * preview path.
+   * Atomic claim consulted with the RFC 5322 `Message-ID` of each
+   * successfully parsed email. Returning `true` claims the email and
+   * includes it in the output; returning `false` drops it (already
+   * attached). Implementations must be atomic — two concurrent calls with
+   * the same id must produce one `true` and one `false` (see
+   * `useEmailDedupSet#tryAdd`). The check-and-claim are unified into a
+   * single callback specifically to close the cross-await race that arose
+   * from a separate `shouldSkip` + `onAttached` pair.
    */
-  shouldSkipEmail?: (messageId: string) => boolean;
-  /**
-   * Called once per successfully expanded email (after the skip check).
-   * Receives the RFC 5322 `Message-ID`. The caller typically records this
-   * so the current-email preview can be suppressed for emails that are
-   * already represented in the attachment list.
-   */
-  onAttachedEmail?: (messageId: string) => void;
+  tryAttachEmail?: (messageId: string) => boolean;
 }
 
 /**
@@ -44,12 +40,14 @@ export async function expandDroppedEmailFiles(
   for (const file of files) {
     if (isEmlFile(file)) {
       const { files: parsed, messageId } = await parseEmlFileToFiles(file);
-      if (shouldSkip(messageId, options.shouldSkipEmail)) {
+      if (
+        messageId &&
+        parsed.length > 0 &&
+        options.tryAttachEmail &&
+        !options.tryAttachEmail(messageId)
+      ) {
         logSkip(file.name, messageId);
         continue;
-      }
-      if (messageId && parsed.length > 0) {
-        options.onAttachedEmail?.(messageId);
       }
       expanded.push(...parsed);
       continue;
@@ -89,24 +87,16 @@ async function parseMsgFileIfPossible(
     file,
     options.acquireGraphToken,
   );
-  if (shouldSkip(messageId, options.shouldSkipEmail)) {
+  if (
+    messageId &&
+    files.length > 0 &&
+    options.tryAttachEmail &&
+    !options.tryAttachEmail(messageId)
+  ) {
     logSkip(file.name, messageId);
     return [];
   }
-  if (messageId && files.length > 0) {
-    options.onAttachedEmail?.(messageId);
-  }
   return files;
-}
-
-function shouldSkip(
-  messageId: string | null,
-  predicate: ((messageId: string) => boolean) | undefined,
-): boolean {
-  if (!messageId || !predicate) {
-    return false;
-  }
-  return predicate(messageId);
 }
 
 function logSkip(fileName: string, messageId: string | null): void {

--- a/office-addin/src/utils/extractMsgInternetMessageId.ts
+++ b/office-addin/src/utils/extractMsgInternetMessageId.ts
@@ -1,0 +1,48 @@
+import * as CFB from "cfb";
+
+/**
+ * Reads ONLY the PR_INTERNET_MESSAGE_ID stream (MAPI tag 0x1035, type PT_UNICODE)
+ * from a `.msg` Compound File Binary Format blob. Deliberately avoids full
+ * MSG semantics — all we need is the RFC 5322 `Message-ID` so we can look
+ * the message up via Microsoft Graph.
+ *
+ * MAPI stream naming convention: each string property is stored in a stream
+ * named `__substg1.0_<TAG>`, where `<TAG>` is the 4-byte property tag in
+ * uppercase hex. PR_INTERNET_MESSAGE_ID_W = 0x1035001F.
+ */
+
+const INTERNET_MESSAGE_ID_STREAM_NAME = "__substg1.0_1035001F";
+
+export async function extractMsgInternetMessageId(
+  file: File,
+): Promise<string | null> {
+  const buffer = new Uint8Array(await file.arrayBuffer());
+  return extractMsgInternetMessageIdFromBytes(buffer);
+}
+
+export function extractMsgInternetMessageIdFromBytes(
+  bytes: Uint8Array,
+): string | null {
+  let container;
+  try {
+    container = CFB.read(bytes, { type: "array" });
+  } catch {
+    return null;
+  }
+
+  const entry = CFB.find(container, INTERNET_MESSAGE_ID_STREAM_NAME);
+  if (!entry) {
+    return null;
+  }
+
+  const content = entry.content;
+  const streamBytes =
+    content instanceof Uint8Array ? content : new Uint8Array(content);
+  if (streamBytes.length === 0) {
+    return null;
+  }
+
+  const decoded = new TextDecoder("utf-16le").decode(streamBytes);
+  const trimmed = decoded.replace(/\0+$/u, "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/office-addin/src/utils/fetchOutlookMessage.ts
+++ b/office-addin/src/utils/fetchOutlookMessage.ts
@@ -1,0 +1,195 @@
+import { buildEmailBodyFile } from "./buildEmailBodyHtml";
+import { callOfficeAsync } from "./officeAsync";
+
+/**
+ * Fetches a single Outlook message by its EWS item id and returns its body
+ * and attachments as an array of File objects suitable for the existing
+ * upload pipeline.
+ *
+ * Uses the Outlook REST API v2.0 via the token returned by
+ * `Office.context.mailbox.getCallbackTokenAsync({ isRest: true })`. No extra
+ * MSAL / Graph scopes are required. The REST v2.0 surface has been flagged
+ * for eventual retirement by Microsoft; if that happens we can swap to
+ * Microsoft Graph without changing callers of this module.
+ */
+
+interface OutlookRestEmailAddress {
+  Name?: string;
+  Address?: string;
+}
+
+interface OutlookRestRecipient {
+  EmailAddress?: OutlookRestEmailAddress;
+}
+
+interface OutlookRestBody {
+  ContentType?: "HTML" | "Text";
+  Content?: string;
+}
+
+interface OutlookRestAttachment {
+  "@odata.type"?: string;
+  Id?: string;
+  Name?: string;
+  ContentType?: string;
+  Size?: number;
+  IsInline?: boolean;
+  ContentBytes?: string;
+}
+
+interface OutlookRestMessage {
+  Id?: string;
+  Subject?: string;
+  Body?: OutlookRestBody;
+  From?: OutlookRestRecipient;
+  ToRecipients?: OutlookRestRecipient[];
+  CcRecipients?: OutlookRestRecipient[];
+  ReceivedDateTime?: string;
+  Attachments?: OutlookRestAttachment[];
+}
+
+export interface FetchOutlookMessageResult {
+  subject: string;
+  files: File[];
+}
+
+const FILE_ATTACHMENT_ODATA_TYPE = "#Microsoft.OutlookServices.FileAttachment";
+
+export async function fetchOutlookMessageFiles(
+  ewsItemId: string,
+): Promise<FetchOutlookMessageResult> {
+  const restId = convertToRestId(ewsItemId);
+  const token = await getRestCallbackToken();
+  const restUrl = getRestUrl();
+  const message = await fetchMessage(restUrl, restId, token);
+
+  const files: File[] = [];
+  const bodyFile = buildBodyFile(message);
+  if (bodyFile) {
+    files.push(bodyFile);
+  }
+
+  for (const attachment of message.Attachments ?? []) {
+    const file = buildAttachmentFile(attachment);
+    if (file) {
+      files.push(file);
+    }
+  }
+
+  return { subject: message.Subject ?? "", files };
+}
+
+function convertToRestId(ewsItemId: string): string {
+  const mailbox = Office.context.mailbox;
+  return mailbox.convertToRestId(
+    ewsItemId,
+    Office.MailboxEnums.RestVersion.v2_0,
+  );
+}
+
+async function getRestCallbackToken(): Promise<string> {
+  return callOfficeAsync<string>((callback) =>
+    Office.context.mailbox.getCallbackTokenAsync({ isRest: true }, callback),
+  );
+}
+
+function getRestUrl(): string {
+  const mailbox = Office.context.mailbox as Office.Mailbox & {
+    restUrl?: string;
+  };
+  const restUrl = mailbox.restUrl;
+  if (!restUrl) {
+    throw new Error(
+      "Office.context.mailbox.restUrl is not available — REST API not accessible",
+    );
+  }
+  return restUrl.replace(/\/$/, "");
+}
+
+async function fetchMessage(
+  restUrl: string,
+  restId: string,
+  token: string,
+): Promise<OutlookRestMessage> {
+  const url = `${restUrl}/api/v2.0/me/messages/${encodeURIComponent(restId)}?$expand=Attachments`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Outlook REST fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as OutlookRestMessage;
+}
+
+function buildBodyFile(message: OutlookRestMessage): File | null {
+  const body = message.Body;
+  if (!body || !body.Content) {
+    return null;
+  }
+
+  const contentIsHtml = body.ContentType === "HTML";
+  const date = message.ReceivedDateTime
+    ? new Date(message.ReceivedDateTime)
+    : null;
+
+  return buildEmailBodyFile({
+    subject: message.Subject ?? "(no subject)",
+    from: toAddress(message.From),
+    to: (message.ToRecipients ?? []).map(toAddress),
+    cc: (message.CcRecipients ?? []).map(toAddress),
+    date,
+    bodyHtml: contentIsHtml ? body.Content : null,
+    bodyText: contentIsHtml ? null : body.Content,
+  });
+}
+
+function toAddress(
+  recipient: OutlookRestRecipient | undefined,
+): { name?: string; address?: string } {
+  const emailAddress = recipient?.EmailAddress;
+  return {
+    name: emailAddress?.Name,
+    address: emailAddress?.Address,
+  };
+}
+
+function buildAttachmentFile(attachment: OutlookRestAttachment): File | null {
+  if (attachment["@odata.type"] !== FILE_ATTACHMENT_ODATA_TYPE) {
+    // itemAttachments (nested messages) and referenceAttachments (cloud
+    // links) are skipped — they have no ContentBytes payload.
+    return null;
+  }
+  if (!attachment.ContentBytes || !attachment.Name) {
+    return null;
+  }
+  if (attachment.IsInline) {
+    return null;
+  }
+
+  const buffer = decodeBase64ToBuffer(attachment.ContentBytes);
+  if (!buffer) {
+    return null;
+  }
+  return new File([buffer], attachment.Name, {
+    type: attachment.ContentType ?? "application/octet-stream",
+  });
+}
+
+function decodeBase64ToBuffer(base64: string): ArrayBuffer | null {
+  try {
+    const binary = atob(base64);
+    const buffer = new ArrayBuffer(binary.length);
+    const view = new Uint8Array(buffer);
+    for (let index = 0; index < binary.length; index += 1) {
+      view[index] = binary.charCodeAt(index);
+    }
+    return buffer;
+  } catch {
+    return null;
+  }
+}

--- a/office-addin/src/utils/fetchOutlookMessage.ts
+++ b/office-addin/src/utils/fetchOutlookMessage.ts
@@ -1,195 +1,27 @@
-import { buildEmailBodyFile } from "./buildEmailBodyHtml";
-import { callOfficeAsync } from "./officeAsync";
+import { fetchOutlookMessageFilesViaGraph } from "./fetchOutlookMessageGraph";
+
+import type {
+  AcquireGraphToken,
+  FetchOutlookMessageResult,
+} from "./fetchOutlookMessageGraph";
 
 /**
- * Fetches a single Outlook message by its EWS item id and returns its body
- * and attachments as an array of File objects suitable for the existing
- * upload pipeline.
+ * Public entry point for fetching an Outlook message's body and attachments
+ * by EWS item id. Dispatches to the right backend implementation for the
+ * current environment.
  *
- * Uses the Outlook REST API v2.0 via the token returned by
- * `Office.context.mailbox.getCallbackTokenAsync({ isRest: true })`. No extra
- * MSAL / Graph scopes are required. The REST v2.0 surface has been flagged
- * for eventual retirement by Microsoft; if that happens we can swap to
- * Microsoft Graph without changing callers of this module.
+ * Today the dispatcher always routes to Microsoft Graph — see
+ * `./fetchOutlookMessageGraph.ts`. The Exchange on-premises path, which uses
+ * the legacy callback-token + Outlook REST v2.0 surface, is preserved in
+ * `./fetchOutlookMessageRestV2.ts` and will be re-wired here when on-prem
+ * mailbox support is brought back.
  */
 
-interface OutlookRestEmailAddress {
-  Name?: string;
-  Address?: string;
-}
-
-interface OutlookRestRecipient {
-  EmailAddress?: OutlookRestEmailAddress;
-}
-
-interface OutlookRestBody {
-  ContentType?: "HTML" | "Text";
-  Content?: string;
-}
-
-interface OutlookRestAttachment {
-  "@odata.type"?: string;
-  Id?: string;
-  Name?: string;
-  ContentType?: string;
-  Size?: number;
-  IsInline?: boolean;
-  ContentBytes?: string;
-}
-
-interface OutlookRestMessage {
-  Id?: string;
-  Subject?: string;
-  Body?: OutlookRestBody;
-  From?: OutlookRestRecipient;
-  ToRecipients?: OutlookRestRecipient[];
-  CcRecipients?: OutlookRestRecipient[];
-  ReceivedDateTime?: string;
-  Attachments?: OutlookRestAttachment[];
-}
-
-export interface FetchOutlookMessageResult {
-  subject: string;
-  files: File[];
-}
-
-const FILE_ATTACHMENT_ODATA_TYPE = "#Microsoft.OutlookServices.FileAttachment";
+export type { AcquireGraphToken, FetchOutlookMessageResult };
 
 export async function fetchOutlookMessageFiles(
   ewsItemId: string,
+  acquireGraphToken: AcquireGraphToken,
 ): Promise<FetchOutlookMessageResult> {
-  const restId = convertToRestId(ewsItemId);
-  const token = await getRestCallbackToken();
-  const restUrl = getRestUrl();
-  const message = await fetchMessage(restUrl, restId, token);
-
-  const files: File[] = [];
-  const bodyFile = buildBodyFile(message);
-  if (bodyFile) {
-    files.push(bodyFile);
-  }
-
-  for (const attachment of message.Attachments ?? []) {
-    const file = buildAttachmentFile(attachment);
-    if (file) {
-      files.push(file);
-    }
-  }
-
-  return { subject: message.Subject ?? "", files };
-}
-
-function convertToRestId(ewsItemId: string): string {
-  const mailbox = Office.context.mailbox;
-  return mailbox.convertToRestId(
-    ewsItemId,
-    Office.MailboxEnums.RestVersion.v2_0,
-  );
-}
-
-async function getRestCallbackToken(): Promise<string> {
-  return callOfficeAsync<string>((callback) =>
-    Office.context.mailbox.getCallbackTokenAsync({ isRest: true }, callback),
-  );
-}
-
-function getRestUrl(): string {
-  const mailbox = Office.context.mailbox as Office.Mailbox & {
-    restUrl?: string;
-  };
-  const restUrl = mailbox.restUrl;
-  if (!restUrl) {
-    throw new Error(
-      "Office.context.mailbox.restUrl is not available — REST API not accessible",
-    );
-  }
-  return restUrl.replace(/\/$/, "");
-}
-
-async function fetchMessage(
-  restUrl: string,
-  restId: string,
-  token: string,
-): Promise<OutlookRestMessage> {
-  const url = `${restUrl}/api/v2.0/me/messages/${encodeURIComponent(restId)}?$expand=Attachments`;
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Outlook REST fetch failed: ${response.status} ${response.statusText}`,
-    );
-  }
-  return (await response.json()) as OutlookRestMessage;
-}
-
-function buildBodyFile(message: OutlookRestMessage): File | null {
-  const body = message.Body;
-  if (!body || !body.Content) {
-    return null;
-  }
-
-  const contentIsHtml = body.ContentType === "HTML";
-  const date = message.ReceivedDateTime
-    ? new Date(message.ReceivedDateTime)
-    : null;
-
-  return buildEmailBodyFile({
-    subject: message.Subject ?? "(no subject)",
-    from: toAddress(message.From),
-    to: (message.ToRecipients ?? []).map(toAddress),
-    cc: (message.CcRecipients ?? []).map(toAddress),
-    date,
-    bodyHtml: contentIsHtml ? body.Content : null,
-    bodyText: contentIsHtml ? null : body.Content,
-  });
-}
-
-function toAddress(
-  recipient: OutlookRestRecipient | undefined,
-): { name?: string; address?: string } {
-  const emailAddress = recipient?.EmailAddress;
-  return {
-    name: emailAddress?.Name,
-    address: emailAddress?.Address,
-  };
-}
-
-function buildAttachmentFile(attachment: OutlookRestAttachment): File | null {
-  if (attachment["@odata.type"] !== FILE_ATTACHMENT_ODATA_TYPE) {
-    // itemAttachments (nested messages) and referenceAttachments (cloud
-    // links) are skipped — they have no ContentBytes payload.
-    return null;
-  }
-  if (!attachment.ContentBytes || !attachment.Name) {
-    return null;
-  }
-  if (attachment.IsInline) {
-    return null;
-  }
-
-  const buffer = decodeBase64ToBuffer(attachment.ContentBytes);
-  if (!buffer) {
-    return null;
-  }
-  return new File([buffer], attachment.Name, {
-    type: attachment.ContentType ?? "application/octet-stream",
-  });
-}
-
-function decodeBase64ToBuffer(base64: string): ArrayBuffer | null {
-  try {
-    const binary = atob(base64);
-    const buffer = new ArrayBuffer(binary.length);
-    const view = new Uint8Array(buffer);
-    for (let index = 0; index < binary.length; index += 1) {
-      view[index] = binary.charCodeAt(index);
-    }
-    return buffer;
-  } catch {
-    return null;
-  }
+  return fetchOutlookMessageFilesViaGraph(ewsItemId, acquireGraphToken);
 }

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -1,0 +1,230 @@
+import { buildEmailBodyFile } from "./buildEmailBodyHtml";
+
+/**
+ * Fetches a single Outlook message via Microsoft Graph and returns its body
+ * and attachments as an array of File objects suitable for the existing
+ * upload pipeline.
+ *
+ * This is the Microsoft-365 / Exchange-Online path. It is the blessed
+ * replacement for the legacy callback-token + Outlook REST v2.0 route
+ * (preserved for on-prem in `./fetchOutlookMessageRestV2.ts`). Callers
+ * provide an `acquireGraphToken` function bound to the `Mail.Read` scope via
+ * MSAL NAA; see `AddinChat.tsx` for the wiring.
+ */
+
+const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
+const FILE_ATTACHMENT_ODATA_TYPE = "#microsoft.graph.fileAttachment";
+
+interface GraphEmailAddress {
+  name?: string;
+  address?: string;
+}
+
+interface GraphRecipient {
+  emailAddress?: GraphEmailAddress;
+}
+
+interface GraphBody {
+  contentType?: "html" | "text";
+  content?: string;
+}
+
+interface GraphAttachment {
+  "@odata.type"?: string;
+  id?: string;
+  name?: string;
+  contentType?: string;
+  size?: number;
+  isInline?: boolean;
+  contentBytes?: string;
+}
+
+interface GraphMessage {
+  id?: string;
+  subject?: string;
+  body?: GraphBody;
+  from?: GraphRecipient;
+  toRecipients?: GraphRecipient[];
+  ccRecipients?: GraphRecipient[];
+  receivedDateTime?: string;
+  attachments?: GraphAttachment[];
+  internetMessageId?: string;
+}
+
+export interface FetchOutlookMessageResult {
+  subject: string;
+  files: File[];
+}
+
+export type AcquireGraphToken = () => Promise<string>;
+
+/**
+ * Fetches a message by its EWS item id. The id is converted to the Graph-
+ * compatible REST id via `Office.context.mailbox.convertToRestId` before the
+ * HTTP call.
+ */
+export async function fetchOutlookMessageFilesViaGraph(
+  ewsItemId: string,
+  acquireToken: AcquireGraphToken,
+): Promise<FetchOutlookMessageResult> {
+  const restId = convertEwsIdToGraphId(ewsItemId);
+  const token = await acquireToken();
+  const message = await fetchMessageById(restId, token);
+  return { subject: message.subject ?? "", files: toFiles(message) };
+}
+
+/**
+ * Looks up a message by its RFC 5322 `Message-ID` header, returning the body
+ * and attachments if exactly one match is found. Returns `null` when Graph's
+ * filter returns an empty result (e.g. for drafts that don't yet have an
+ * indexed internet message id).
+ */
+export async function fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+  internetMessageId: string,
+  acquireToken: AcquireGraphToken,
+): Promise<FetchOutlookMessageResult | null> {
+  const token = await acquireToken();
+  const match = await findMessageByInternetMessageId(internetMessageId, token);
+  if (!match) {
+    return null;
+  }
+  if (!match.id) {
+    return null;
+  }
+  const message = await fetchMessageById(match.id, token);
+  return { subject: message.subject ?? "", files: toFiles(message) };
+}
+
+function convertEwsIdToGraphId(ewsItemId: string): string {
+  const mailbox = Office.context.mailbox;
+  return mailbox.convertToRestId(
+    ewsItemId,
+    Office.MailboxEnums.RestVersion.v2_0,
+  );
+}
+
+async function fetchMessageById(
+  messageId: string,
+  token: string,
+): Promise<GraphMessage> {
+  const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}?$expand=attachments`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Graph fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as GraphMessage;
+}
+
+async function findMessageByInternetMessageId(
+  internetMessageId: string,
+  token: string,
+): Promise<GraphMessage | null> {
+  const filter = `internetMessageId eq '${escapeODataString(internetMessageId)}'`;
+  const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=1&$select=id,subject,internetMessageId`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Graph lookup failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  const payload = (await response.json()) as { value?: GraphMessage[] };
+  const first = payload.value?.[0];
+  return first ?? null;
+}
+
+function toFiles(message: GraphMessage): File[] {
+  const files: File[] = [];
+  const body = buildBodyFile(message);
+  if (body) {
+    files.push(body);
+  }
+  for (const attachment of message.attachments ?? []) {
+    const file = buildAttachmentFile(attachment);
+    if (file) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+function buildBodyFile(message: GraphMessage): File | null {
+  const body = message.body;
+  if (!body?.content) {
+    return null;
+  }
+  const contentIsHtml = body.contentType === "html";
+  const date = message.receivedDateTime
+    ? new Date(message.receivedDateTime)
+    : null;
+  return buildEmailBodyFile({
+    subject: message.subject ?? "(no subject)",
+    from: toAddress(message.from),
+    to: (message.toRecipients ?? []).map(toAddress),
+    cc: (message.ccRecipients ?? []).map(toAddress),
+    date,
+    bodyHtml: contentIsHtml ? body.content : null,
+    bodyText: contentIsHtml ? null : body.content,
+  });
+}
+
+function toAddress(recipient: GraphRecipient | undefined): {
+  name?: string;
+  address?: string;
+} {
+  const emailAddress = recipient?.emailAddress;
+  return {
+    name: emailAddress?.name,
+    address: emailAddress?.address,
+  };
+}
+
+function buildAttachmentFile(attachment: GraphAttachment): File | null {
+  if (attachment["@odata.type"] !== FILE_ATTACHMENT_ODATA_TYPE) {
+    // itemAttachment (nested messages) and referenceAttachment (cloud links)
+    // have no contentBytes payload — skip them.
+    return null;
+  }
+  if (!attachment.contentBytes || !attachment.name) {
+    return null;
+  }
+  if (attachment.isInline) {
+    return null;
+  }
+  const buffer = decodeBase64ToBuffer(attachment.contentBytes);
+  if (!buffer) {
+    return null;
+  }
+  return new File([buffer], attachment.name, {
+    type: attachment.contentType ?? "application/octet-stream",
+  });
+}
+
+function decodeBase64ToBuffer(base64: string): ArrayBuffer | null {
+  try {
+    const binary = atob(base64);
+    const buffer = new ArrayBuffer(binary.length);
+    const view = new Uint8Array(buffer);
+    for (let index = 0; index < binary.length; index += 1) {
+      view[index] = binary.charCodeAt(index);
+    }
+    return buffer;
+  } catch {
+    return null;
+  }
+}
+
+function escapeODataString(value: string): string {
+  return value.replace(/'/g, "''");
+}

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -54,6 +54,7 @@ interface GraphMessage {
 export interface FetchOutlookMessageResult {
   subject: string;
   files: File[];
+  internetMessageId: string | null;
 }
 
 export type AcquireGraphToken = () => Promise<string>;
@@ -70,7 +71,11 @@ export async function fetchOutlookMessageFilesViaGraph(
   const restId = convertEwsIdToGraphId(ewsItemId);
   const token = await acquireToken();
   const message = await fetchMessageById(restId, token);
-  return { subject: message.subject ?? "", files: toFiles(message) };
+  return {
+    subject: message.subject ?? "",
+    files: toFiles(message),
+    internetMessageId: message.internetMessageId ?? null,
+  };
 }
 
 /**
@@ -92,7 +97,11 @@ export async function fetchOutlookMessageFilesByInternetMessageIdViaGraph(
     return null;
   }
   const message = await fetchMessageById(match.id, token);
-  return { subject: message.subject ?? "", files: toFiles(message) };
+  return {
+    subject: message.subject ?? "",
+    files: toFiles(message),
+    internetMessageId: message.internetMessageId ?? internetMessageId,
+  };
 }
 
 function convertEwsIdToGraphId(ewsItemId: string): string {
@@ -107,7 +116,7 @@ async function fetchMessageById(
   messageId: string,
   token: string,
 ): Promise<GraphMessage> {
-  const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}?$expand=attachments`;
+  const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}?$expand=attachments&$select=subject,body,from,toRecipients,ccRecipients,receivedDateTime,internetMessageId`;
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/office-addin/src/utils/fetchOutlookMessageRestV2.ts
+++ b/office-addin/src/utils/fetchOutlookMessageRestV2.ts
@@ -155,9 +155,10 @@ function buildBodyFile(message: OutlookRestMessage): File | null {
   });
 }
 
-function toAddress(
-  recipient: OutlookRestRecipient | undefined,
-): { name?: string; address?: string } {
+function toAddress(recipient: OutlookRestRecipient | undefined): {
+  name?: string;
+  address?: string;
+} {
   const emailAddress = recipient?.EmailAddress;
   return {
     name: emailAddress?.Name,

--- a/office-addin/src/utils/fetchOutlookMessageRestV2.ts
+++ b/office-addin/src/utils/fetchOutlookMessageRestV2.ts
@@ -1,0 +1,202 @@
+import { buildEmailBodyFile } from "./buildEmailBodyHtml";
+import { callOfficeAsync } from "./officeAsync";
+
+/**
+ * PRESERVED FOR FUTURE ON-PREM SUPPORT — NOT WIRED INTO THE DISPATCHER TODAY.
+ *
+ * Fetches a single Outlook message by its EWS item id and returns its body
+ * and attachments as an array of File objects suitable for the existing
+ * upload pipeline.
+ *
+ * Uses the Outlook REST API v2.0 via the token returned by
+ * `Office.context.mailbox.getCallbackTokenAsync({ isRest: true })`. Legacy
+ * Exchange Online callback tokens were shut off across all Microsoft 365
+ * tenants in October 2025 (see MS NAA FAQ on legacy tokens), so this path no
+ * longer resolves for cloud mailboxes. It is retained here for the future
+ * Exchange on-premises target, where callback tokens + REST v2.0 still work
+ * and Microsoft Graph is not available.
+ *
+ * For the Microsoft 365 path see `./fetchOutlookMessageGraph.ts`. The
+ * environment dispatcher lives in `./fetchOutlookMessage.ts`.
+ */
+
+interface OutlookRestEmailAddress {
+  Name?: string;
+  Address?: string;
+}
+
+interface OutlookRestRecipient {
+  EmailAddress?: OutlookRestEmailAddress;
+}
+
+interface OutlookRestBody {
+  ContentType?: "HTML" | "Text";
+  Content?: string;
+}
+
+interface OutlookRestAttachment {
+  "@odata.type"?: string;
+  Id?: string;
+  Name?: string;
+  ContentType?: string;
+  Size?: number;
+  IsInline?: boolean;
+  ContentBytes?: string;
+}
+
+interface OutlookRestMessage {
+  Id?: string;
+  Subject?: string;
+  Body?: OutlookRestBody;
+  From?: OutlookRestRecipient;
+  ToRecipients?: OutlookRestRecipient[];
+  CcRecipients?: OutlookRestRecipient[];
+  ReceivedDateTime?: string;
+  Attachments?: OutlookRestAttachment[];
+}
+
+export interface FetchOutlookMessageResult {
+  subject: string;
+  files: File[];
+}
+
+const FILE_ATTACHMENT_ODATA_TYPE = "#Microsoft.OutlookServices.FileAttachment";
+
+export async function fetchOutlookMessageFilesViaRestV2(
+  ewsItemId: string,
+): Promise<FetchOutlookMessageResult> {
+  const restId = convertToRestId(ewsItemId);
+  const token = await getRestCallbackToken();
+  const restUrl = getRestUrl();
+  const message = await fetchMessage(restUrl, restId, token);
+
+  const files: File[] = [];
+  const bodyFile = buildBodyFile(message);
+  if (bodyFile) {
+    files.push(bodyFile);
+  }
+
+  for (const attachment of message.Attachments ?? []) {
+    const file = buildAttachmentFile(attachment);
+    if (file) {
+      files.push(file);
+    }
+  }
+
+  return { subject: message.Subject ?? "", files };
+}
+
+function convertToRestId(ewsItemId: string): string {
+  const mailbox = Office.context.mailbox;
+  return mailbox.convertToRestId(
+    ewsItemId,
+    Office.MailboxEnums.RestVersion.v2_0,
+  );
+}
+
+async function getRestCallbackToken(): Promise<string> {
+  return callOfficeAsync<string>((callback) =>
+    Office.context.mailbox.getCallbackTokenAsync({ isRest: true }, callback),
+  );
+}
+
+function getRestUrl(): string {
+  const mailbox = Office.context.mailbox as Office.Mailbox & {
+    restUrl?: string;
+  };
+  const restUrl = mailbox.restUrl;
+  if (!restUrl) {
+    throw new Error(
+      "Office.context.mailbox.restUrl is not available — REST API not accessible",
+    );
+  }
+  return restUrl.replace(/\/$/, "");
+}
+
+async function fetchMessage(
+  restUrl: string,
+  restId: string,
+  token: string,
+): Promise<OutlookRestMessage> {
+  const url = `${restUrl}/api/v2.0/me/messages/${encodeURIComponent(restId)}?$expand=Attachments`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Outlook REST fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as OutlookRestMessage;
+}
+
+function buildBodyFile(message: OutlookRestMessage): File | null {
+  const body = message.Body;
+  if (!body || !body.Content) {
+    return null;
+  }
+
+  const contentIsHtml = body.ContentType === "HTML";
+  const date = message.ReceivedDateTime
+    ? new Date(message.ReceivedDateTime)
+    : null;
+
+  return buildEmailBodyFile({
+    subject: message.Subject ?? "(no subject)",
+    from: toAddress(message.From),
+    to: (message.ToRecipients ?? []).map(toAddress),
+    cc: (message.CcRecipients ?? []).map(toAddress),
+    date,
+    bodyHtml: contentIsHtml ? body.Content : null,
+    bodyText: contentIsHtml ? null : body.Content,
+  });
+}
+
+function toAddress(
+  recipient: OutlookRestRecipient | undefined,
+): { name?: string; address?: string } {
+  const emailAddress = recipient?.EmailAddress;
+  return {
+    name: emailAddress?.Name,
+    address: emailAddress?.Address,
+  };
+}
+
+function buildAttachmentFile(attachment: OutlookRestAttachment): File | null {
+  if (attachment["@odata.type"] !== FILE_ATTACHMENT_ODATA_TYPE) {
+    // itemAttachments (nested messages) and referenceAttachments (cloud
+    // links) are skipped — they have no ContentBytes payload.
+    return null;
+  }
+  if (!attachment.ContentBytes || !attachment.Name) {
+    return null;
+  }
+  if (attachment.IsInline) {
+    return null;
+  }
+
+  const buffer = decodeBase64ToBuffer(attachment.ContentBytes);
+  if (!buffer) {
+    return null;
+  }
+  return new File([buffer], attachment.Name, {
+    type: attachment.ContentType ?? "application/octet-stream",
+  });
+}
+
+function decodeBase64ToBuffer(base64: string): ArrayBuffer | null {
+  try {
+    const binary = atob(base64);
+    const buffer = new ArrayBuffer(binary.length);
+    const view = new Uint8Array(buffer);
+    for (let index = 0; index < binary.length; index += 1) {
+      view[index] = binary.charCodeAt(index);
+    }
+    return buffer;
+  } catch {
+    return null;
+  }
+}

--- a/office-addin/src/utils/outlookMailListDragParse.ts
+++ b/office-addin/src/utils/outlookMailListDragParse.ts
@@ -1,0 +1,96 @@
+/**
+ * Parses the undocumented OWA/New Outlook `maillistrow` DataTransfer payload
+ * emitted when a user drags one or more emails from the Outlook mail list
+ * into an add-in task pane.
+ *
+ * Observed shape (OWA, 2026-04):
+ *   {
+ *     itemType: "maillistrow",
+ *     itemIds: ["AAkAL..."],        // EWS ids, parallel to subjects/sizes
+ *     subjects: ["Hey how are you?"],
+ *     sizes: [61783],
+ *     mailboxInfos: [{ mailboxSmtpAddress, userIdentity, ... }],
+ *     ... (additional internal fields)
+ *   }
+ *
+ * Contract note: this is an OWA-internal format and may change without
+ * notice. Parser is defensive — returns null for any shape it does not
+ * recognise rather than throwing.
+ */
+export const MAILLISTROW_TRANSFER_TYPE = "maillistrow";
+
+export interface OutlookMailListDragItem {
+  itemId: string;
+  subject: string;
+  size: number;
+  mailboxSmtpAddress: string;
+}
+
+export function parseOutlookMailListPayload(
+  raw: string,
+): OutlookMailListDragItem[] | null {
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || parsed.itemType !== MAILLISTROW_TRANSFER_TYPE) {
+    return null;
+  }
+
+  const itemIds = asStringArray(parsed.itemIds);
+  if (!itemIds || itemIds.length === 0) {
+    return null;
+  }
+
+  const subjects = asStringArray(parsed.subjects) ?? [];
+  const sizes = asNumberArray(parsed.sizes) ?? [];
+  const mailboxInfos = Array.isArray(parsed.mailboxInfos)
+    ? parsed.mailboxInfos
+    : [];
+
+  return itemIds.map((itemId, index) => ({
+    itemId,
+    subject: subjects[index] ?? "",
+    size: sizes[index] ?? 0,
+    mailboxSmtpAddress: extractMailboxSmtpAddress(mailboxInfos[index]),
+  }));
+}
+
+function extractMailboxSmtpAddress(info: unknown): string {
+  if (!isRecord(info)) {
+    return "";
+  }
+  const value = info.mailboxSmtpAddress;
+  return typeof value === "string" ? value : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  if (!value.every((entry): entry is string => typeof entry === "string")) {
+    return null;
+  }
+  return value;
+}
+
+function asNumberArray(value: unknown): number[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  if (!value.every((entry): entry is number => typeof entry === "number")) {
+    return null;
+  }
+  return value;
+}

--- a/office-addin/src/utils/parseEmlFile.ts
+++ b/office-addin/src/utils/parseEmlFile.ts
@@ -28,9 +28,7 @@ export function isEmlFile(file: File): boolean {
   return /\.eml$/i.test(file.name);
 }
 
-export async function parseEmlFileToFiles(
-  file: File,
-): Promise<EmlParseResult> {
+export async function parseEmlFileToFiles(file: File): Promise<EmlParseResult> {
   let parsed;
   try {
     const buffer = await file.arrayBuffer();

--- a/office-addin/src/utils/parseEmlFile.ts
+++ b/office-addin/src/utils/parseEmlFile.ts
@@ -10,7 +10,16 @@ import type { Address, Mailbox } from "postal-mime";
  * `fetchOutlookMessage.ts` for the OWA `maillistrow` drag path. The backend
  * rejects raw `.eml` uploads because `message/rfc822` is not a declared file
  * capability, so we parse them client-side before forwarding to upload.
+ *
+ * The RFC 5322 `Message-ID` header is returned alongside the files so the
+ * caller can correlate this drop against other representations of the same
+ * email (e.g. the currently-open email preview) and avoid duplicates.
  */
+
+export interface EmlParseResult {
+  files: File[];
+  messageId: string | null;
+}
 
 export function isEmlFile(file: File): boolean {
   if (file.type === "message/rfc822") {
@@ -19,14 +28,16 @@ export function isEmlFile(file: File): boolean {
   return /\.eml$/i.test(file.name);
 }
 
-export async function parseEmlFileToFiles(file: File): Promise<File[]> {
+export async function parseEmlFileToFiles(
+  file: File,
+): Promise<EmlParseResult> {
   let parsed;
   try {
     const buffer = await file.arrayBuffer();
     parsed = await PostalMime.parse(buffer);
   } catch (error) {
     console.warn("[parseEmlFile] failed to parse .eml file, skipping:", error);
-    return [];
+    return { files: [], messageId: null };
   }
 
   const date = parsed.date ? new Date(parsed.date) : null;
@@ -54,7 +65,10 @@ export async function parseEmlFileToFiles(file: File): Promise<File[]> {
     attachmentFiles.push(new File([blobPart], filename, { type: mimeType }));
   }
 
-  return [bodyFile, ...attachmentFiles];
+  return {
+    files: [bodyFile, ...attachmentFiles],
+    messageId: parsed.messageId ?? null,
+  };
 }
 
 function toMailbox(

--- a/office-addin/src/utils/parseEmlFile.ts
+++ b/office-addin/src/utils/parseEmlFile.ts
@@ -1,0 +1,113 @@
+import PostalMime from "postal-mime";
+
+import { buildEmailBodyFile } from "./buildEmailBodyHtml";
+
+import type { Address, Mailbox } from "postal-mime";
+
+/**
+ * Expands `.eml` files (MIME `message/rfc822`) into an HTML body file and
+ * separate attachment files, mirroring the shape produced by
+ * `fetchOutlookMessage.ts` for the OWA `maillistrow` drag path. The backend
+ * rejects raw `.eml` uploads because `message/rfc822` is not a declared file
+ * capability, so we parse them client-side before forwarding to upload.
+ */
+
+export function isEmlFile(file: File): boolean {
+  if (file.type === "message/rfc822") {
+    return true;
+  }
+  return /\.eml$/i.test(file.name);
+}
+
+export async function parseEmlFileToFiles(file: File): Promise<File[]> {
+  let parsed;
+  try {
+    const buffer = await file.arrayBuffer();
+    parsed = await PostalMime.parse(buffer);
+  } catch (error) {
+    console.warn("[parseEmlFile] failed to parse .eml file, skipping:", error);
+    return [];
+  }
+
+  const date = parsed.date ? new Date(parsed.date) : null;
+  const bodyFile = buildEmailBodyFile({
+    subject: parsed.subject ?? "(no subject)",
+    from: toMailbox(parsed.from),
+    to: flattenAddresses(parsed.to),
+    cc: flattenAddresses(parsed.cc),
+    date: date && !isNaN(date.getTime()) ? date : null,
+    bodyHtml: parsed.html ?? null,
+    bodyText: parsed.text ?? null,
+  });
+
+  const attachmentFiles: File[] = [];
+  for (const attachment of parsed.attachments ?? []) {
+    if (attachment.disposition === "inline" || attachment.related === true) {
+      continue;
+    }
+    const blobPart = toBlobPart(attachment.content);
+    if (blobPart === null) {
+      continue;
+    }
+    const filename = attachment.filename?.trim() || "attachment";
+    const mimeType = attachment.mimeType || "application/octet-stream";
+    attachmentFiles.push(new File([blobPart], filename, { type: mimeType }));
+  }
+
+  return [bodyFile, ...attachmentFiles];
+}
+
+function toMailbox(
+  address: Address | undefined,
+): { name?: string; address?: string } | null {
+  if (!address) {
+    return null;
+  }
+  if ("address" in address && address.address) {
+    return { name: address.name, address: address.address };
+  }
+  return null;
+}
+
+function flattenAddresses(
+  addresses: Address[] | undefined,
+): { name?: string; address?: string }[] | null {
+  if (!addresses || addresses.length === 0) {
+    return null;
+  }
+  const result: Mailbox[] = [];
+  for (const entry of addresses) {
+    if ("address" in entry && entry.address) {
+      result.push({ name: entry.name, address: entry.address });
+      continue;
+    }
+    if ("group" in entry && Array.isArray(entry.group)) {
+      for (const member of entry.group) {
+        if (member.address) {
+          result.push({ name: member.name, address: member.address });
+        }
+      }
+    }
+  }
+  return result.length > 0 ? result : null;
+}
+
+function toBlobPart(
+  content: ArrayBuffer | Uint8Array | string,
+): BlobPart | null {
+  if (typeof content === "string") {
+    const encoded = new TextEncoder().encode(content);
+    const copy = new Uint8Array(encoded.byteLength);
+    copy.set(encoded);
+    return copy.buffer;
+  }
+  if (content instanceof Uint8Array) {
+    const copy = new Uint8Array(content.byteLength);
+    copy.set(content);
+    return copy.buffer;
+  }
+  if (content instanceof ArrayBuffer) {
+    return content;
+  }
+  return null;
+}

--- a/office-addin/src/utils/parseMsgFile.ts
+++ b/office-addin/src/utils/parseMsgFile.ts
@@ -1,0 +1,65 @@
+import { extractMsgInternetMessageId } from "./extractMsgInternetMessageId";
+import { fetchOutlookMessageFilesByInternetMessageIdViaGraph } from "./fetchOutlookMessageGraph";
+
+import type { AcquireGraphToken } from "./fetchOutlookMessageGraph";
+
+/**
+ * Resolves a dropped `.msg` file into the same body + attachment File[] shape
+ * our other paths produce. Strategy: extract only the RFC 5322 `Message-ID`
+ * from the CFB, then look the message up via Microsoft Graph with a
+ * `Mail.Read` token. We never parse the binary body / attachments locally —
+ * Graph owns the fidelity-sensitive work (RTF-encapsulated HTML, embedded
+ * content types, etc.).
+ *
+ * Returns an empty array on any recoverable failure (unreadable CFB, missing
+ * Message-ID, Graph filter yields no match, network/auth failure). Failures
+ * are logged via `console.warn` so the caller gets an observable signal.
+ * The deliberate choice to swallow rather than throw matches how `.eml`
+ * parsing handles its own failures upstream.
+ */
+export async function parseMsgFileToFiles(
+  file: File,
+  acquireGraphToken: AcquireGraphToken,
+): Promise<File[]> {
+  let internetMessageId: string | null;
+  try {
+    internetMessageId = await extractMsgInternetMessageId(file);
+  } catch (error) {
+    console.warn(
+      "[parseMsgFile] Failed to read CFB from dropped .msg:",
+      file.name,
+      error,
+    );
+    return [];
+  }
+
+  if (!internetMessageId) {
+    console.warn(
+      "[parseMsgFile] Dropped .msg has no Internet Message-ID — cannot resolve via Graph:",
+      file.name,
+    );
+    return [];
+  }
+
+  try {
+    const result = await fetchOutlookMessageFilesByInternetMessageIdViaGraph(
+      internetMessageId,
+      acquireGraphToken,
+    );
+    if (!result) {
+      console.warn(
+        "[parseMsgFile] Graph lookup returned no match for Message-ID:",
+        internetMessageId,
+      );
+      return [];
+    }
+    return result.files;
+  } catch (error) {
+    console.warn(
+      "[parseMsgFile] Graph fetch failed for dropped .msg:",
+      file.name,
+      error,
+    );
+    return [];
+  }
+}

--- a/office-addin/src/utils/parseMsgFile.ts
+++ b/office-addin/src/utils/parseMsgFile.ts
@@ -11,16 +11,20 @@ import type { AcquireGraphToken } from "./fetchOutlookMessageGraph";
  * Graph owns the fidelity-sensitive work (RTF-encapsulated HTML, embedded
  * content types, etc.).
  *
- * Returns an empty array on any recoverable failure (unreadable CFB, missing
- * Message-ID, Graph filter yields no match, network/auth failure). Failures
- * are logged via `console.warn` so the caller gets an observable signal.
- * The deliberate choice to swallow rather than throw matches how `.eml`
- * parsing handles its own failures upstream.
+ * Returns an empty file list on any recoverable failure (unreadable CFB,
+ * missing Message-ID, Graph filter yields no match, network/auth failure).
+ * The extracted `messageId` (if any) is still surfaced so callers can apply
+ * de-duplication against other representations of the same email.
  */
+export interface MsgParseResult {
+  files: File[];
+  messageId: string | null;
+}
+
 export async function parseMsgFileToFiles(
   file: File,
   acquireGraphToken: AcquireGraphToken,
-): Promise<File[]> {
+): Promise<MsgParseResult> {
   let internetMessageId: string | null;
   try {
     internetMessageId = await extractMsgInternetMessageId(file);
@@ -30,7 +34,7 @@ export async function parseMsgFileToFiles(
       file.name,
       error,
     );
-    return [];
+    return { files: [], messageId: null };
   }
 
   if (!internetMessageId) {
@@ -38,7 +42,7 @@ export async function parseMsgFileToFiles(
       "[parseMsgFile] Dropped .msg has no Internet Message-ID — cannot resolve via Graph:",
       file.name,
     );
-    return [];
+    return { files: [], messageId: null };
   }
 
   try {
@@ -51,15 +55,15 @@ export async function parseMsgFileToFiles(
         "[parseMsgFile] Graph lookup returned no match for Message-ID:",
         internetMessageId,
       );
-      return [];
+      return { files: [], messageId: internetMessageId };
     }
-    return result.files;
+    return { files: result.files, messageId: internetMessageId };
   } catch (error) {
     console.warn(
       "[parseMsgFile] Graph fetch failed for dropped .msg:",
       file.name,
       error,
     );
-    return [];
+    return { files: [], messageId: internetMessageId };
   }
 }

--- a/office-addin/src/utils/sanitizeEmailHtml.ts
+++ b/office-addin/src/utils/sanitizeEmailHtml.ts
@@ -1,0 +1,42 @@
+import DOMPurify from "dompurify";
+
+// Email HTML carries inline <style> blocks, table-based layouts, and inline
+// images via cid: / data: URIs. We must preserve all of those for fidelity, so
+// this config is intentionally more permissive than sanitizeHtmlPreview in the
+// frontend (which strips <style> because it sanitizes model-produced fragments,
+// not full email bodies).
+const ALLOWED_URI_REGEXP =
+  /^(?:(?:https?|mailto|tel|cid|data):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i;
+
+const FORBID_TAGS = [
+  "script",
+  "iframe",
+  "object",
+  "embed",
+  "base",
+  "meta",
+  "link",
+  "form",
+];
+
+const FORBID_ATTR = ["srcset", "ping", "formaction"];
+
+export function sanitizeEmailHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    ADD_TAGS: ["style"],
+    ADD_ATTR: ["target"],
+    ALLOW_DATA_ATTR: false,
+    ALLOWED_URI_REGEXP,
+    FORBID_TAGS,
+    FORBID_ATTR,
+  });
+}
+
+// Embedded in the generated <head> as defense-in-depth: if a user opens the
+// downloaded .html attachment standalone in a browser, this blocks script
+// execution and external resource loads even if sanitization missed something.
+// `sandbox` and `frame-ancestors` are ignored in <meta> per spec, so they're
+// omitted here.
+export const EMAIL_BODY_CSP =
+  "default-src 'none'; img-src data: cid:; style-src 'unsafe-inline'; font-src data:; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";


### PR DESCRIPTION
This pull request introduces several important improvements to the chat UI and file upload handling, with a focus on modularity, extensibility, and code reuse. The main changes include extracting and standardizing chat message action handling, refactoring file dropzone logic for better reuse, and enabling component overrides for grouped file attachments. These updates improve maintainability and facilitate integration with specialized environments like the Office add-in.

**Chat Message Action Handling:**

- Extracted standard chat message action logic (edit, regenerate, like/dislike) into a new `useStandardMessageActions` hook, now used in the main `Chat` component and exported for reuse. This simplifies the `Chat` component and enables consistent behavior across different chat UIs. [[1]](diffhunk://#diff-06a7050bb28376cfe3ec336e608784556606e66b7df9926c0ef70af3a941570eR1-R102) [[2]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55R561-R570) [[3]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55L836-R832) [[4]](diffhunk://#diff-1d83fd3b11d67487855d42476a8ac31fcabbf302b401996c694e45f1d3ff8114R11) [[5]](diffhunk://#diff-f8fdb79a8f0e05aeeb3042be3a5cce6ee0db9f5851ddebc49ab36ef22801ae73R55-R68) [[6]](diffhunk://#diff-6f7c303c4179df38f5b9303b90759a1f27eee7053dff8a857939f83e5bee95dfR128)

**File Dropzone Refactoring:**

- Refactored file drop upload logic into a new `useConversationDropzone` hook, replacing direct usage of `react-dropzone` in the `Chat` component. This enables shared file drop handling for both the main chat and the Office add-in, and allows for customization of accepted file types. [[1]](diffhunk://#diff-850c81d14abd2728c427f3fc060c3dc2a3cdcb5a576cf36c67ab2415086445f1R1-R82) [[2]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55L13-R25) [[3]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55L575-R600) [[4]](diffhunk://#diff-1d41a2e49173afc4f9ca06510dca3928678a2f298b68cfaf7178d39b30b21088R1-R4) [[5]](diffhunk://#diff-f8fdb79a8f0e05aeeb3042be3a5cce6ee0db9f5851ddebc49ab36ef22801ae73R55-R68)

**Component Extensibility:**

- Added support for overriding the grouped file attachments preview via the `componentRegistry` (`ChatGroupedAttachmentsPreview`). This allows environments like the Office add-in to provide a custom visual presentation for grouped attachments, ensuring visual consistency. [[1]](diffhunk://#diff-5e86ef1836bb505dd85a0dade9bb51b43316367c61357ac64058f5b8561e22b4L55-R65) [[2]](diffhunk://#diff-5e86ef1836bb505dd85a0dade9bb51b43316367c61357ac64058f5b8561e22b4R201-R210) [[3]](diffhunk://#diff-c0da773e431427dfbdfca924dd5abc185c84a6619cb25f9d9523409f7863b6f1R32) [[4]](diffhunk://#diff-c0da773e431427dfbdfca924dd5abc185c84a6619cb25f9d9523409f7863b6f1R73-R83) [[5]](diffhunk://#diff-c0da773e431427dfbdfca924dd5abc185c84a6619cb25f9d9523409f7863b6f1R171)

**File Attachment Metadata:**

- Enhanced the `FileAttachmentGroupItem` type to support an optional `labelOverride` property, enabling custom display labels for file attachments (e.g., labeling an email body as "Email" instead of by file extension).

**Dependency and Config Updates:**

- Added new dependencies (`cfb`, `dompurify`, `postal-mime`) to the Office add-in for improved file and email handling, and updated ESLint globals to better support browser and Office add-in environments. [[1]](diffhunk://#diff-1580556e56688498f79ff22c32f27e9bbb635dbf63f5385a09b767f5c041afccR39-R41) [[2]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132R44-R52) [[3]](diffhunk://#diff-974df8e5e4102ba8337ecb252b81ba6c14d4e42c2cd1729a4d3440638905144cR39-R40)

These changes collectively improve code reuse, extensibility, and maintainability, especially for environments that require custom UI or file handling logic.