### PR TITLE
Add secrecy for preventing leakage in log messages

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "rmcp",
  "rmcp-sse",
  "sea-orm",
+ "secrecy",
  "sentry",
  "sentry-tower",
  "serde",
@@ -7667,6 +7668,15 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/backend/erato/Cargo.toml
+++ b/backend/erato/Cargo.toml
@@ -22,6 +22,7 @@ sea-orm = { version = "1.1.10",  features = ["runtime-tokio", "sqlx-postgres", "
 sqlx = { version = "0.8.5", features=["postgres", "runtime-tokio", "runtime-tokio-native-tls"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
+secrecy = "0.10.3"
 tokio = { version = "1.43.0", features = ["rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 tracing = "0.1.41"

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -5,8 +5,11 @@ use config::builder::DefaultState;
 use config::{Config, ConfigBuilder, ConfigError, Environment};
 use eyre::{OptionExt, Report, eyre};
 use facet::Facet;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize, de};
 use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
 use utoipa::ToSchema;
 
 use crate::config_facet_attrs as erato_config;
@@ -65,6 +68,77 @@ For this reply only:
 
 For general feedback (tone, completeness, structure), use plain text. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new draft, respond normally in plain text.
 "#;
+
+#[derive(Clone, Default, Facet)]
+#[facet(opaque)]
+pub struct SecretConfigString(SecretString);
+
+impl SecretConfigString {
+    pub fn expose_secret(&self) -> &str {
+        self.0.expose_secret()
+    }
+}
+
+impl From<String> for SecretConfigString {
+    fn from(value: String) -> Self {
+        Self(SecretString::from(value))
+    }
+}
+
+impl From<&str> for SecretConfigString {
+    fn from(value: &str) -> Self {
+        Self(SecretString::from(value.to_string()))
+    }
+}
+
+impl fmt::Debug for SecretConfigString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl PartialEq for SecretConfigString {
+    fn eq(&self, other: &Self) -> bool {
+        self.expose_secret() == other.expose_secret()
+    }
+}
+
+impl PartialEq<String> for SecretConfigString {
+    fn eq(&self, other: &String) -> bool {
+        self.expose_secret() == other
+    }
+}
+
+impl PartialEq<SecretConfigString> for String {
+    fn eq(&self, other: &SecretConfigString) -> bool {
+        self == other.expose_secret()
+    }
+}
+
+impl PartialEq<&str> for SecretConfigString {
+    fn eq(&self, other: &&str) -> bool {
+        self.expose_secret() == *other
+    }
+}
+
+impl Eq for SecretConfigString {}
+
+impl Deref for SecretConfigString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.expose_secret()
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretConfigString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::from)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Facet)]
 #[facet(untagged)]
@@ -233,7 +307,8 @@ pub struct AppConfig {
     // The HTTP port to listen on.
     // Defaults to `3130`.
     pub http_port: i32,
-    pub database_url: String,
+    #[facet(sensitive)]
+    pub database_url: SecretConfigString,
     pub chat_providers: Option<ChatProvidersConfig>,
     // A list of file storage providers to use.
     //
@@ -336,7 +411,8 @@ pub struct AppConfig {
         replacement_key = "integrations.sentry.sentry_dsn",
         planned_removal_version = "0.6.0"
     ))]
-    pub sentry_dsn: Option<String>,
+    #[facet(sensitive)]
+    pub sentry_dsn: Option<SecretConfigString>,
     // **Deprecated**: Please use `frontend.additional_environment` instead.
     //
     // This is a dictionary where each value can be a string or a map (string key, string value).
@@ -968,7 +1044,7 @@ impl AppConfig {
     /// Returns the Sentry DSN from either the new location (integrations.sentry.sentry_dsn)
     /// or the old deprecated location (sentry_dsn) for backward compatibility.
     #[allow(deprecated)]
-    pub fn get_sentry_dsn(&self) -> Option<&String> {
+    pub fn get_sentry_dsn(&self) -> Option<&SecretConfigString> {
         self.integrations
             .sentry
             .sentry_dsn
@@ -984,7 +1060,8 @@ pub struct ServerConfig {
     // The value must be base64-encoded and decode to exactly 32 bytes.
     // Example generation command:
     // `openssl rand -base64 32`
-    pub encryption_key: Option<String>,
+    #[facet(sensitive)]
+    pub encryption_key: Option<SecretConfigString>,
 }
 
 impl ServerConfig {
@@ -993,7 +1070,7 @@ impl ServerConfig {
             return Ok(());
         };
 
-        let decoded = STANDARD.decode(encryption_key).map_err(|error| {
+        let decoded = STANDARD.decode(encryption_key.expose_secret()).map_err(|error| {
             eyre!(
                 "server.encryption_key must be valid base64 for a 32-byte AES-256-GCM-SIV key: {}",
                 error
@@ -1101,7 +1178,8 @@ pub struct ChatProviderConfig {
     // If provider_kind is `vertex_ai` and base_url is not provided, this will be used
     // to construct a regional Vertex AI endpoint.
     pub region: Option<String>,
-    pub api_key: Option<String>,
+    #[facet(sensitive)]
+    pub api_key: Option<SecretConfigString>,
     // For Azure OpenAI, the API version to use (e.g. "2024-10-21").
     // This will be automatically converted to additional_request_parameters during config loading.
     pub api_version: Option<String>,
@@ -1110,7 +1188,8 @@ pub struct ChatProviderConfig {
     pub additional_request_parameters: Option<Vec<String>>,
     // Additional request headers to be added to API requests.
     // E.g. 'api-key=XYZ'
-    pub additional_request_headers: Option<Vec<String>>,
+    #[facet(sensitive)]
+    pub additional_request_headers: Option<Vec<SecretConfigString>>,
     // Optional system prompt to use with the chat provider.
     pub system_prompt: Option<PromptSourceSpecification>,
     // Optional Langfuse system prompt configuration.
@@ -1147,7 +1226,7 @@ impl ChatProviderConfig {
         let mut headers = HashMap::new();
         if let Some(header_vec) = &self.additional_request_headers {
             for header in header_vec {
-                if let Some((key, value)) = header.split_once('=') {
+                if let Some((key, value)) = header.expose_secret().split_once('=') {
                     headers.insert(key.trim().to_string(), value.trim().to_string());
                 }
             }
@@ -1193,7 +1272,7 @@ impl ChatProviderConfig {
         // Prepare additional_request_headers
         let mut additional_headers = self.additional_request_headers.unwrap_or_default();
         if let Some(api_key) = &self.api_key {
-            additional_headers.push(format!("api-key={}", api_key));
+            additional_headers.push(format!("api-key={}", api_key.expose_secret()).into());
         }
 
         Ok(ChatProviderConfig {
@@ -1343,7 +1422,8 @@ pub struct StorageProviderAzBlobConfig {
     pub container: String,
     pub endpoint: String,
     pub account_name: Option<String>,
-    pub account_key: Option<String>,
+    #[facet(sensitive)]
+    pub account_key: Option<SecretConfigString>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq, Clone, Facet)]
@@ -1352,22 +1432,27 @@ pub struct StorageProviderS3Config {
     pub root: Option<String>,
     pub bucket: String,
     pub region: Option<String>,
-    pub access_key_id: Option<String>,
-    pub secret_access_key: Option<String>,
+    #[facet(sensitive)]
+    pub access_key_id: Option<SecretConfigString>,
+    #[facet(sensitive)]
+    pub secret_access_key: Option<SecretConfigString>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Default, Facet)]
 /// Merged config for storage provider specific configs.
 pub struct StorageProviderSpecificConfigMerged {
-    pub access_key_id: Option<String>,
-    pub account_key: Option<String>,
+    #[facet(sensitive)]
+    pub access_key_id: Option<SecretConfigString>,
+    #[facet(sensitive)]
+    pub account_key: Option<SecretConfigString>,
     pub account_name: Option<String>,
     pub bucket: Option<String>,
     pub container: Option<String>,
     pub endpoint: Option<String>,
     pub region: Option<String>,
     pub root: Option<String>,
-    pub secret_access_key: Option<String>,
+    #[facet(sensitive)]
+    pub secret_access_key: Option<SecretConfigString>,
 }
 
 impl StorageProviderSpecificConfigMerged {
@@ -1482,7 +1567,8 @@ pub enum McpServerForwardedCredential {
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Facet)]
 pub struct McpServerFixedAuthenticationConfig {
-    pub api_key: String,
+    #[facet(sensitive)]
+    pub api_key: SecretConfigString,
     #[serde(default = "default_mcp_fixed_auth_header_name")]
     pub header_name: String,
     #[serde(default = "default_mcp_fixed_auth_prefix")]
@@ -1492,7 +1578,8 @@ pub struct McpServerFixedAuthenticationConfig {
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Facet)]
 pub struct McpServerOauth2AuthenticationConfig {
     pub client_id: Option<String>,
-    pub client_secret: Option<String>,
+    #[facet(sensitive)]
+    pub client_secret: Option<SecretConfigString>,
     #[serde(default)]
     pub scopes: Vec<String>,
     pub client_name: Option<String>,
@@ -2249,7 +2336,8 @@ pub struct LangfuseConfig {
     pub public_key: Option<String>,
 
     // The secret key for Langfuse API authentication.
-    pub secret_key: Option<String>,
+    #[facet(sensitive)]
+    pub secret_key: Option<SecretConfigString>,
 
     // Whether tracing is enabled for Langfuse.
     // Defaults to `false`.
@@ -2347,7 +2435,8 @@ pub struct ModelSettings {
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Default, Facet)]
 pub struct SentryConfig {
     // If present, will enable Sentry for error reporting.
-    pub sentry_dsn: Option<String>,
+    #[facet(sensitive)]
+    pub sentry_dsn: Option<SecretConfigString>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone, Default, Facet)]

--- a/backend/erato/src/services/file_storage.rs
+++ b/backend/erato/src/services/file_storage.rs
@@ -338,10 +338,10 @@ impl OpenDalStorage {
             builder = builder.region(val);
         }
         if let Some(val) = &config.access_key_id {
-            builder = builder.access_key_id(val);
+            builder = builder.access_key_id(val.expose_secret());
         }
         if let Some(val) = &config.secret_access_key {
-            builder = builder.secret_access_key(val);
+            builder = builder.secret_access_key(val.expose_secret());
         }
 
         let op: Operator = Operator::new(builder)?.finish();
@@ -361,7 +361,7 @@ impl OpenDalStorage {
             builder = builder.account_name(val);
         }
         if let Some(val) = &config.account_key {
-            builder = builder.account_key(val);
+            builder = builder.account_key(val.expose_secret());
         }
 
         let op: Operator = Operator::new(builder)?.finish();
@@ -483,13 +483,13 @@ impl OpenDalStorage {
             .ok_or_eyre("Missing azblob account_name for preview URL generation")?;
         let account_key = config
             .account_key
-            .as_deref()
+            .as_ref()
             .ok_or_eyre("Missing azblob account_key for preview URL generation")?;
 
         build_azblob_service_sas_preview_url(
             config,
             account_name,
-            account_key,
+            account_key.expose_secret(),
             path,
             content_type,
             duration,

--- a/backend/erato/src/services/langfuse.rs
+++ b/backend/erato/src/services/langfuse.rs
@@ -63,7 +63,8 @@ impl LangfuseClient {
             .secret_key
             .as_ref()
             .ok_or_else(|| eyre!("secret_key is required when Langfuse is enabled"))?
-            .clone();
+            .expose_secret()
+            .to_string();
 
         tracing::debug!(
             base_url = %base_url,
@@ -1179,7 +1180,7 @@ mod tests {
             enabled: true,
             base_url: Some("https://cloud.langfuse.com".to_string()),
             public_key: Some("pk-lf-test".to_string()),
-            secret_key: Some("sk-lf-test".to_string()),
+            secret_key: Some("sk-lf-test".into()),
             ..Default::default()
         };
 

--- a/backend/erato/src/services/mcp_oauth.rs
+++ b/backend/erato/src/services/mcp_oauth.rs
@@ -384,7 +384,7 @@ async fn load_or_build_client_config(
         let mut config = OAuthClientConfig::new(client_id.clone(), redirect_uri.to_string())
             .with_scopes(oauth2.scopes.clone());
         if let Some(client_secret) = &oauth2.client_secret {
-            config = config.with_client_secret(client_secret.clone());
+            config = config.with_client_secret(client_secret.expose_secret().to_string());
         }
         return Ok(Some(config));
     }

--- a/backend/erato/src/services/mcp_transports.rs
+++ b/backend/erato/src/services/mcp_transports.rs
@@ -73,7 +73,7 @@ async fn apply_auth_headers(
         McpServerAuthenticationConfig::Fixed { fixed } => apply_auth_header(
             default_headers,
             &fixed.header_name,
-            &format!("{}{}", fixed.prefix, fixed.api_key),
+            &format!("{}{}", fixed.prefix, fixed.api_key.expose_secret()),
         ),
         McpServerAuthenticationConfig::Oauth2 { oauth2 } => {
             let app_state = auth_context

--- a/backend/erato/src/services/sentry.rs
+++ b/backend/erato/src/services/sentry.rs
@@ -1,3 +1,4 @@
+use crate::config::SecretConfigString;
 use crate::state::AppState;
 use axum::Router;
 use axum::body::Body;
@@ -7,13 +8,13 @@ use sentry::{Hub, event_from_error};
 use std::error::Error;
 
 pub fn setup_sentry(
-    sentry_dsn: Option<&String>,
+    sentry_dsn: Option<&SecretConfigString>,
     environment: String,
     _sentry_guard: &mut Option<sentry::ClientInitGuard>,
 ) {
     if let Some(sentry_dsn) = sentry_dsn {
         *_sentry_guard = Some(sentry::init((
-            sentry_dsn.as_str(),
+            sentry_dsn.expose_secret(),
             sentry::ClientOptions {
                 release: sentry::release_name!(),
                 debug: std::env::var("SENTRY_DEBUG").is_ok(),

--- a/backend/erato/src/services/sentry_stub.rs
+++ b/backend/erato/src/services/sentry_stub.rs
@@ -1,10 +1,11 @@
+use crate::config::SecretConfigString;
 use crate::state::AppState;
 use axum::Router;
 use axum::http::StatusCode;
 use eyre::Report;
 
 pub fn setup_sentry(
-    _sentry_dsn: Option<&String>,
+    _sentry_dsn: Option<&SecretConfigString>,
     _environment: String,
     _sentry_guard: &mut Option<()>,
 ) {

--- a/backend/erato/src/state.rs
+++ b/backend/erato/src/state.rs
@@ -170,7 +170,7 @@ impl std::fmt::Debug for AppState {
 
 impl AppState {
     pub async fn new(config: AppConfig) -> Result<Self, Report> {
-        let db_connect_options = ConnectOptions::new(&config.database_url);
+        let db_connect_options = ConnectOptions::new(config.database_url.expose_secret());
         // TODO: Change level to Debug, but that also seems to deactivate some other logging (e.g. Errors during request?)
         // db_connect_options.sqlx_logging_level(LevelFilter::Debug);
         let mut db = Database::connect(db_connect_options).await?;
@@ -322,10 +322,10 @@ impl AppState {
             .config
             .server
             .encryption_key
-            .as_deref()
+            .as_ref()
             .ok_or_eyre("server.encryption_key is not configured")?;
         let key_bytes = STANDARD
-            .decode(encryption_key)
+            .decode(encryption_key.expose_secret())
             .map_err(|error| eyre::eyre!("Failed to decode server.encryption_key: {}", error))?;
 
         Aes256GcmSiv::new_from_slice(&key_bytes)
@@ -643,7 +643,7 @@ impl AppState {
                 // TODO: Allow specifying auth in config
                 let mut auth = AuthData::from_single("PLACEHOLDER");
                 if let Some(api_key) = config.api_key.clone() {
-                    auth = AuthData::from_single(api_key);
+                    auth = AuthData::from_single(api_key.expose_secret().to_string());
                 }
 
                 let model = ModelIden::new(adapter_kind, config.model_name.clone());

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -69,7 +69,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
         .expect("chat_provider should be configured");
     assert_eq!(chat_provider.provider_kind, "openai");
     assert_eq!(chat_provider.model_name, "o4-mini");
-    assert_eq!(chat_provider.api_key, Some("sk-XXX".to_string()));
+    assert_eq!(chat_provider.api_key.as_deref(), Some("sk-XXX"));
     assert_eq!(chat_provider.base_url, None);
     assert_eq!(chat_provider.system_prompt, None);
 
@@ -254,7 +254,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
         .expect("chat_provider should be configured");
     assert_eq!(chat_provider.provider_kind, "openai");
     assert_eq!(chat_provider.model_name, "gpt-4");
-    assert_eq!(chat_provider.api_key, Some("sk-test-key".to_string()));
+    assert_eq!(chat_provider.api_key.as_deref(), Some("sk-test-key"));
     assert_eq!(
         chat_provider.base_url,
         Some("https://api.custom-openai.com/v1/".to_string())
@@ -413,14 +413,14 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
     assert_eq!(primary.provider_kind, "openai");
     assert_eq!(primary.model_name, "gpt-4");
     assert_eq!(primary.model_display_name(), "GPT-4 (Primary)");
-    assert_eq!(primary.api_key, Some("sk-primary-key".to_string()));
+    assert_eq!(primary.api_key.as_deref(), Some("sk-primary-key"));
 
     // Test secondary provider
     let secondary = chat_providers.providers.get("secondary").unwrap();
     assert_eq!(secondary.provider_kind, "openai");
     assert_eq!(secondary.model_name, "gpt-3.5-turbo");
     assert_eq!(secondary.model_display_name(), "GPT-3.5 Turbo (Backup)");
-    assert_eq!(secondary.api_key, Some("sk-secondary-key".to_string()));
+    assert_eq!(secondary.api_key.as_deref(), Some("sk-secondary-key"));
     assert_eq!(
         secondary.base_url,
         Some("https://api.backup-openai.com/v1/".to_string())
@@ -512,7 +512,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
     assert_eq!(default_provider.provider_kind, "openai");
     assert_eq!(default_provider.model_name, "gpt-4");
     assert_eq!(default_provider.model_display_name(), "My GPT-4");
-    assert_eq!(default_provider.api_key, Some("sk-test-key".to_string()));
+    assert_eq!(default_provider.api_key.as_deref(), Some("sk-test-key"));
 
     // Test that the methods work correctly with migrated config
     assert_eq!(
@@ -630,7 +630,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
             .additional_request_headers
             .as_ref()
             .unwrap()
-            .contains(&"api-key=primary-azure-key".to_string())
+            .contains(&"api-key=primary-azure-key".into())
     );
 
     let azure_backup = chat_providers.providers.get("azure_backup").unwrap();
@@ -657,7 +657,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
             .additional_request_headers
             .as_ref()
             .unwrap()
-            .contains(&"api-key=backup-azure-key".to_string())
+            .contains(&"api-key=backup-azure-key".into())
     );
 
     // Test that regular OpenAI provider was not affected
@@ -665,7 +665,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
     assert_eq!(openai_provider.provider_kind, "openai");
     assert_eq!(openai_provider.model_name, "gpt-4o");
     assert_eq!(openai_provider.model_display_name(), "OpenAI GPT-4o");
-    assert_eq!(openai_provider.api_key, Some("openai-key".to_string()));
+    assert_eq!(openai_provider.api_key.as_deref(), Some("openai-key"));
     assert!(openai_provider.additional_request_parameters.is_none());
     assert!(openai_provider.additional_request_headers.is_none());
 
@@ -840,13 +840,13 @@ sentry_dsn = "https://test-key@sentry.io/12345"
 
     // Verify the new sentry configuration is parsed correctly
     assert_eq!(
-        config.integrations.sentry.sentry_dsn,
-        Some("https://test-key@sentry.io/12345".to_string())
+        config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://test-key@sentry.io/12345")
     );
     // The get_sentry_dsn() method should return the new config value
     assert_eq!(
-        config.get_sentry_dsn(),
-        Some(&"https://test-key@sentry.io/12345".to_string())
+        config.get_sentry_dsn().map(|dsn| dsn.expose_secret()),
+        Some("https://test-key@sentry.io/12345")
     );
     // The old deprecated field should be None
     assert_eq!(config.sentry_dsn, None);
@@ -987,21 +987,23 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
 
     // Before migration - verify the old field is loaded from TOML
     assert_eq!(
-        config.sentry_dsn,
-        Some("https://old-key@sentry.io/67890".to_string())
+        config.sentry_dsn.as_deref(),
+        Some("https://old-key@sentry.io/67890")
     );
 
     // After migration - the value should be moved to the new location and old cleared
     let migrated_config = config.migrate();
     assert_eq!(migrated_config.sentry_dsn, None);
     assert_eq!(
-        migrated_config.integrations.sentry.sentry_dsn,
-        Some("https://old-key@sentry.io/67890".to_string())
+        migrated_config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://old-key@sentry.io/67890")
     );
     // The get_sentry_dsn() method should return the migrated value
     assert_eq!(
-        migrated_config.get_sentry_dsn(),
-        Some(&"https://old-key@sentry.io/67890".to_string())
+        migrated_config
+            .get_sentry_dsn()
+            .map(|dsn| dsn.expose_secret()),
+        Some("https://old-key@sentry.io/67890")
     );
 }
 
@@ -1061,26 +1063,28 @@ sentry_dsn = "https://new-key@sentry.io/12345"
 
     // Before migration - verify both values are loaded from TOML
     assert_eq!(
-        config.sentry_dsn,
-        Some("https://old-key@sentry.io/67890".to_string())
+        config.sentry_dsn.as_deref(),
+        Some("https://old-key@sentry.io/67890")
     );
     assert_eq!(
-        config.integrations.sentry.sentry_dsn,
-        Some("https://new-key@sentry.io/12345".to_string())
+        config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://new-key@sentry.io/12345")
     );
 
     // After migration - the new config should be preserved, old should be cleared
     let migrated_config = config.migrate();
     assert_eq!(migrated_config.sentry_dsn, None);
     assert_eq!(
-        migrated_config.integrations.sentry.sentry_dsn,
-        Some("https://new-key@sentry.io/12345".to_string())
+        migrated_config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://new-key@sentry.io/12345")
     );
 
     // The get_sentry_dsn() method should return the new value (taking precedence)
     assert_eq!(
-        migrated_config.get_sentry_dsn(),
-        Some(&"https://new-key@sentry.io/12345".to_string())
+        migrated_config
+            .get_sentry_dsn()
+            .map(|dsn| dsn.expose_secret()),
+        Some("https://new-key@sentry.io/12345")
     );
 }
 
@@ -1137,8 +1141,8 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
 
     // Before migration - the old field should have the value, the new should be None
     assert_eq!(
-        config.sentry_dsn,
-        Some("https://old-key@sentry.io/67890".to_string())
+        config.sentry_dsn.as_deref(),
+        Some("https://old-key@sentry.io/67890")
     );
     assert_eq!(config.integrations.sentry.sentry_dsn, None);
 
@@ -1146,14 +1150,16 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
     let migrated_config = config.migrate();
     assert_eq!(migrated_config.sentry_dsn, None);
     assert_eq!(
-        migrated_config.integrations.sentry.sentry_dsn,
-        Some("https://old-key@sentry.io/67890".to_string())
+        migrated_config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://old-key@sentry.io/67890")
     );
 
     // The get_sentry_dsn() method should return the migrated value
     assert_eq!(
-        migrated_config.get_sentry_dsn(),
-        Some(&"https://old-key@sentry.io/67890".to_string())
+        migrated_config
+            .get_sentry_dsn()
+            .map(|dsn| dsn.expose_secret()),
+        Some("https://old-key@sentry.io/67890")
     );
 }
 
@@ -1215,14 +1221,16 @@ sentry_dsn = "https://new-key@sentry.io/12345"
     let migrated_config = config.migrate();
     assert_eq!(migrated_config.sentry_dsn, None);
     assert_eq!(
-        migrated_config.integrations.sentry.sentry_dsn,
-        Some("https://new-key@sentry.io/12345".to_string())
+        migrated_config.integrations.sentry.sentry_dsn.as_deref(),
+        Some("https://new-key@sentry.io/12345")
     );
 
     // The get_sentry_dsn() method should return the new value (not the old one)
     assert_eq!(
-        migrated_config.get_sentry_dsn(),
-        Some(&"https://new-key@sentry.io/12345".to_string())
+        migrated_config
+            .get_sentry_dsn()
+            .map(|dsn| dsn.expose_secret()),
+        Some("https://new-key@sentry.io/12345")
     );
 }
 
@@ -2534,8 +2542,7 @@ config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", ac
 #[sqlx::test(migrator = "MIGRATOR")]
 async fn test_app_state_encrypt_decrypt_round_trip(pool: Pool<Postgres>) {
     let mut app_config = hermetic_app_config(None, None);
-    app_config.server.encryption_key =
-        Some("MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=".to_string());
+    app_config.server.encryption_key = Some("MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=".into());
 
     let app_state = test_app_state(app_config, pool).await;
 

--- a/backend/erato/tests/integration_tests/llm/mcp_auth.rs
+++ b/backend/erato/tests/integration_tests/llm/mcp_auth.rs
@@ -53,7 +53,7 @@ async fn test_mcp_auth_variants_execute_expected_tools(pool: Pool<Postgres>) {
             "/mcp/auth-fixed",
             McpServerAuthenticationConfig::Fixed {
                 fixed: McpServerFixedAuthenticationConfig {
-                    api_key: "fixed-api-key-secret".to_string(),
+                    api_key: "fixed-api-key-secret".into(),
                     header_name: "Authorization".to_string(),
                     prefix: "Bearer ".to_string(),
                 },
@@ -67,7 +67,7 @@ async fn test_mcp_auth_variants_execute_expected_tools(pool: Pool<Postgres>) {
             "/mcp/auth-fixed-custom",
             McpServerAuthenticationConfig::Fixed {
                 fixed: McpServerFixedAuthenticationConfig {
-                    api_key: "fixed-api-key-secret".to_string(),
+                    api_key: "fixed-api-key-secret".into(),
                     header_name: "X-API-Key".to_string(),
                     prefix: "Token ".to_string(),
                 },


### PR DESCRIPTION
Related Linear issue: ERMAIN-245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core configuration types for DB/auth/keys and updates multiple service integrations to unwrap secrets explicitly; mistakes could break startup or cause auth failures. Risk is mitigated by mostly mechanical type changes plus updated tests.
> 
> **Overview**
> Introduces `secrecy` and a new `SecretConfigString` wrapper (debug-prints as `[REDACTED]`) to reduce accidental leakage of secrets via logs/diagnostics.
> 
> Updates `AppConfig` and related configs to store sensitive values (e.g. `database_url`, Sentry/Langfuse keys, encryption key, MCP credentials, S3/AzBlob keys, and provider headers) as `SecretConfigString` and marks them `#[facet(sensitive)]`, then adjusts call sites (`AppState` DB connect, encryption decode, OpenDAL builders, Langfuse auth, MCP auth headers, Sentry setup) to explicitly `expose_secret()` when needed.
> 
> Refreshes integration tests to compare against exposed values and uses `.into()` where new secret types are constructed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56329fd49234839f76396c904c2f1ca42522b510. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->