### PR TITLE
Persist action facets as markers; render in user turn with sentinel

### DIFF
--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -49,6 +49,8 @@ FOR THIS MESSAGE ONLY: The user is composing an email in {{body_format}} format 
 
 Rewrite ONLY the selected text above - do not include surrounding email content such as greetings, sign-offs, or other paragraphs.
 
+The current {{body_format}} is the only authoritative format for this response. Ignore any output formats used in previous turns of this conversation; if a prior turn used a different code-block language tag (for example, `erato-email` vs `erato-email-html`), do not carry it over.
+
 If {{body_format}} is "text", output the rewrite inside exactly one fenced code block with language tag erato-email. The block must contain only plain text replacement content - no HTML tags, no explanations, no labels, and no markdown inside the block.
 
 If {{body_format}} is "html", output the rewrite inside exactly one fenced code block with language tag erato-email-html. The block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no markdown, no explanations, no labels, and no full document wrappers such as <html> or <body>.
@@ -62,6 +64,8 @@ FOR THIS MESSAGE ONLY: The user is composing an email (format: {{body_format}}).
 {{full_body}}
 
 For this reply only:
+
+The current {{body_format}} is the only authoritative format for this response. Ignore any output formats used in previous turns of this conversation; if a prior turn used a different code-block language tag (for example, `erato-email` vs `erato-email-html`), do not carry it over.
 
 - If {{body_format}} is "text", output specific rewrite suggestions inside fenced code blocks with language tag erato-email. Each such block must contain only plain text suggestion content - no HTML tags, no labels, and no markdown inside the block.
 - If {{body_format}} is "html", output specific rewrite suggestions inside fenced code blocks with language tag erato-email-html. Each such block must contain only a simple HTML fragment suitable for inserting into an existing Outlook email body - no labels, no markdown inside the block, and no full document wrappers such as <html> or <body>.

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -186,6 +186,14 @@ pub enum ContentPart {
     TextFilePointer(ContentPartTextFilePointer),
     ImageFilePointer(ContentPartImageFilePointer),
     Image(ContentPartImage),
+    /// Reference to an action-facet directive that will be rendered fresh
+    /// at request-build time. Persisted in `generation_input_messages` as a
+    /// metadata-only marker (facet id + invocation args) instead of the
+    /// rendered template text — mirrors the `TextFilePointer` pattern.
+    /// Action facets are request-scoped: when this marker is loaded as part
+    /// of *prior-turn* history, the resolver drops it; for the *current
+    /// turn* it renders the template against the current config + args.
+    ActionFacetMarker(ContentPartActionFacetMarker),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -220,6 +228,16 @@ pub struct ContentPartImageFilePointer {
 pub struct ContentPartImage {
     pub content_type: String,
     pub base64_data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct ContentPartActionFacetMarker {
+    /// Identifier of the action facet whose template should be rendered.
+    pub facet_id: String,
+    /// Arguments captured at the time of the user's request (e.g. the
+    /// selected text for `outlook_rewrite_selection`, the compose body for
+    /// `outlook_review_draft`).
+    pub args: HashMap<String, String>,
 }
 
 /// Statistics for a list of messages
@@ -281,6 +299,9 @@ impl MessageSchema {
                 ContentPart::TextFilePointer(_) => None,
                 ContentPart::ImageFilePointer(_) => None,
                 ContentPart::Image(_) => None,
+                // Markers are placeholders for the action-facet resolver and
+                // do not contribute to a message's full text representation.
+                ContentPart::ActionFacetMarker(_) => None,
             })
             .collect::<Vec<&str>>()
             .join(" ")
@@ -699,6 +720,8 @@ impl InputMessage {
             ContentPart::TextFilePointer(_) => String::new(),
             ContentPart::ImageFilePointer(_) => String::new(),
             ContentPart::Image(_) => String::new(),
+            // Marker is metadata-only; rendering happens in the resolver.
+            ContentPart::ActionFacetMarker(_) => String::new(),
         }
     }
 }

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -715,6 +715,24 @@ impl GenerationInputMessages {
     }
 }
 
+/// Action-facet templates (e.g. `outlook_review_draft`,
+/// `outlook_rewrite_selection`) prefix every rendered prompt with the
+/// literal string `"FOR THIS MESSAGE ONLY:"`. They are request-scoped and
+/// must never replay into later turns — when they do, the model sees
+/// multiple competing format directives in the same chat request and
+/// drifts. We filter on the prefix rather than a sentinel marker so this
+/// also cleans up history rows already saved before the filter existed,
+/// without requiring a DB migration.
+fn is_action_facet_system_message(message: &InputMessage) -> bool {
+    if !matches!(message.role, MessageRole::System) {
+        return false;
+    }
+    if let ContentPart::Text(ContentPartText { text }) = &message.content {
+        return text.trim_start().starts_with("FOR THIS MESSAGE ONLY:");
+    }
+    false
+}
+
 /// Helper function to determine if a file is an image based on its extension
 fn is_image_file(filename: &str) -> bool {
     if let Some(extension) = filename.rsplit('.').next() {
@@ -756,7 +774,21 @@ pub async fn get_generation_input_messages_by_previous_message_id(
         current_message_id_opt = message.previous_message_id;
 
         if let Some(gen_input_json) = &message.generation_input_messages {
-            base_history = Some(GenerationInputMessages::validate(gen_input_json)?);
+            let validated = GenerationInputMessages::validate(gen_input_json)?;
+            // Strip per-turn action-facet System messages that pollute prior
+            // turns' snapshots. Each action-facet directive is request-scoped
+            // ("FOR THIS MESSAGE ONLY") and must not leak into later turns —
+            // when it does, the model sees competing format directives from
+            // past turns and the current turn, and drifts toward whichever
+            // pattern its history-bias prefers (typically the older one).
+            let filtered = GenerationInputMessages {
+                messages: validated
+                    .messages
+                    .into_iter()
+                    .filter(|msg| !is_action_facet_system_message(msg))
+                    .collect(),
+            };
+            base_history = Some(filtered);
             messages_to_process.push(message);
             break; // Found anchor
         } else {
@@ -918,4 +950,64 @@ pub async fn regenerate_image_urls_in_content(
     }
 
     Ok(updated_content)
+}
+
+#[cfg(test)]
+mod action_facet_filter_tests {
+    use super::is_action_facet_system_message;
+    use super::{ContentPart, ContentPartText, InputMessage, MessageRole};
+
+    fn system_text(text: &str) -> InputMessage {
+        InputMessage {
+            role: MessageRole::System,
+            content: ContentPart::Text(ContentPartText {
+                text: text.to_string(),
+            }),
+        }
+    }
+
+    fn user_text(text: &str) -> InputMessage {
+        InputMessage {
+            role: MessageRole::User,
+            content: ContentPart::Text(ContentPartText {
+                text: text.to_string(),
+            }),
+        }
+    }
+
+    #[test]
+    fn flags_action_facet_directives_for_both_outlook_templates() {
+        assert!(is_action_facet_system_message(&system_text(
+            "FOR THIS MESSAGE ONLY: The user is composing an email (format: text). The full draft body is:\n\nHi"
+        )));
+        assert!(is_action_facet_system_message(&system_text(
+            "FOR THIS MESSAGE ONLY: The user is composing an email in html format and has selected the following text from the email body:\n\nHi"
+        )));
+    }
+
+    #[test]
+    fn tolerates_leading_whitespace_in_rendered_template() {
+        // The rendered template is wrapped in r#"..."# string literals that
+        // begin with a newline; the trim before prefix-match handles that.
+        assert!(is_action_facet_system_message(&system_text(
+            "\nFOR THIS MESSAGE ONLY: The user is composing an email"
+        )));
+    }
+
+    #[test]
+    fn ignores_user_messages_even_with_matching_text() {
+        assert!(!is_action_facet_system_message(&user_text(
+            "FOR THIS MESSAGE ONLY: not really, just user prose"
+        )));
+    }
+
+    #[test]
+    fn ignores_unrelated_system_messages() {
+        assert!(!is_action_facet_system_message(&system_text(
+            "You are a helpful assistant."
+        )));
+        assert!(!is_action_facet_system_message(&system_text(
+            "Respond in plain text."
+        )));
+    }
 }

--- a/backend/erato/src/server/api/v1beta/file_resolution.rs
+++ b/backend/erato/src/server/api/v1beta/file_resolution.rs
@@ -107,6 +107,15 @@ pub(crate) async fn resolve_file_pointers_in_generation_input(
     })
 }
 
+/// Sentinel tag wrapping a rendered action-facet directive in the user
+/// turn. Mirrors Claude Code's own `<system-reminder>` convention — the
+/// model has been trained to treat XML-tagged user content as authoritative
+/// guidance rather than ordinary user prose, while keeping the directive
+/// in the user turn (which Anthropic explicitly recommends for per-turn
+/// instructions and which preserves the system prompt cache).
+const ACTION_FACET_SENTINEL_OPEN: &str = "<system-reminder>";
+const ACTION_FACET_SENTINEL_CLOSE: &str = "</system-reminder>";
+
 /// Resolve `ContentPart::ActionFacetMarker` entries by rendering the
 /// referenced facet template against the current `AppConfig` using the
 /// args captured at request time.
@@ -120,6 +129,10 @@ pub(crate) async fn resolve_file_pointers_in_generation_input(
 /// reaches this resolver belongs to the current turn and gets rendered.
 /// If the referenced facet config is missing (renamed/deleted), the
 /// marker is dropped with a warning rather than rendering empty text.
+///
+/// Output is wrapped in a `<system-reminder>` sentinel in the user turn
+/// (the marker carries `MessageRole::User`); see that comment for
+/// reasoning.
 pub(crate) fn resolve_action_facet_markers_in_generation_input(
     app_state: &AppState,
     generation_input_messages: GenerationInputMessages,
@@ -141,9 +154,13 @@ pub(crate) fn resolve_action_facet_markers_in_generation_input(
                 if rendered.is_empty() {
                     return None;
                 }
+                let wrapped = format!(
+                    "{}\n{}\n{}",
+                    ACTION_FACET_SENTINEL_OPEN, rendered, ACTION_FACET_SENTINEL_CLOSE,
+                );
                 Some(InputMessage {
                     role: input_message.role,
-                    content: ContentPart::Text(ContentPartText { text: rendered }),
+                    content: ContentPart::Text(ContentPartText { text: wrapped }),
                 })
             }
             _ => Some(input_message),

--- a/backend/erato/src/server/api/v1beta/file_resolution.rs
+++ b/backend/erato/src/server/api/v1beta/file_resolution.rs
@@ -1,8 +1,9 @@
 use crate::db::entity::prelude::FileUploads;
-use crate::models::message::{ContentPart, ContentPartText, GenerationInputMessages};
+use crate::models::message::{ContentPart, ContentPartText, GenerationInputMessages, InputMessage};
 use crate::server::api::v1beta::message_streaming::FileContent;
 use crate::services::file_processing_cached::get_file_cached;
 use crate::services::file_storage::{SharepointContext, is_missing_permissions_error};
+use crate::services::prompt_composition::transforms::render_action_facet_template;
 use crate::state::AppState;
 use eyre::Report;
 use sea_orm::EntityTrait;
@@ -104,6 +105,53 @@ pub(crate) async fn resolve_file_pointers_in_generation_input(
     Ok(GenerationInputMessages {
         messages: resolved_messages,
     })
+}
+
+/// Resolve `ContentPart::ActionFacetMarker` entries by rendering the
+/// referenced facet template against the current `AppConfig` using the
+/// args captured at request time.
+///
+/// Mirrors `resolve_file_pointers_in_generation_input` — the saved
+/// `generation_input_messages` carries metadata-only markers; rendering
+/// happens lazily here, immediately before the chat-request hits the LLM.
+///
+/// Prior-turn markers are stripped earlier in
+/// `compose_prompt_messages`'s historical-replay step, so any marker that
+/// reaches this resolver belongs to the current turn and gets rendered.
+/// If the referenced facet config is missing (renamed/deleted), the
+/// marker is dropped with a warning rather than rendering empty text.
+pub(crate) fn resolve_action_facet_markers_in_generation_input(
+    app_state: &AppState,
+    generation_input_messages: GenerationInputMessages,
+) -> GenerationInputMessages {
+    let action_facet_configs = &app_state.config.action_facets.facets;
+    let resolved_messages = generation_input_messages
+        .messages
+        .into_iter()
+        .filter_map(|input_message| match input_message.content {
+            ContentPart::ActionFacetMarker(marker) => {
+                let Some(config) = action_facet_configs.get(&marker.facet_id) else {
+                    tracing::warn!(
+                        facet_id = %marker.facet_id,
+                        "Action-facet config not found while resolving marker — dropping",
+                    );
+                    return None;
+                };
+                let rendered = render_action_facet_template(&config.template, &marker.args);
+                if rendered.is_empty() {
+                    return None;
+                }
+                Some(InputMessage {
+                    role: input_message.role,
+                    content: ContentPart::Text(ContentPartText { text: rendered }),
+                })
+            }
+            _ => Some(input_message),
+        })
+        .collect();
+    GenerationInputMessages {
+        messages: resolved_messages,
+    }
 }
 
 fn format_image_file_pointer_message(file_upload_id: Uuid) -> ContentPart {

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -19,7 +19,9 @@ use crate::models::message::{
 use crate::policy::engine::PolicyEngine;
 use crate::policy::types::Subject;
 use crate::server::api::v1beta::ChatMessage;
-use crate::server::api::v1beta::file_resolution::resolve_file_pointers_in_generation_input;
+use crate::server::api::v1beta::file_resolution::{
+    resolve_action_facet_markers_in_generation_input, resolve_file_pointers_in_generation_input,
+};
 use crate::server::api::v1beta::me_profile_middleware::MeProfile;
 use crate::server::api::v1beta::message_streaming_file_extraction::{
     parse_content_filter_error_from_mcp_tool_result, post_process_mcp_tool_result,
@@ -1569,6 +1571,16 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         me_profile_input.access_token,
     )
     .await?;
+
+    // Render any ActionFacetMarker entries against the current config.
+    // Saved snapshot keeps the markers; only the about-to-be-sent
+    // chat_request gets rendered text. Past-turn markers were already
+    // stripped during historical replay in `compose_prompt_messages`, so
+    // anything that reaches here is the current turn's directive.
+    let resolved_generation_input_messages = resolve_action_facet_markers_in_generation_input(
+        app_state,
+        resolved_generation_input_messages,
+    );
 
     // Build genai ChatRequest (messages + tools) + ChatOptions
     let mut chat_request = resolved_generation_input_messages

--- a/backend/erato/src/services/genai.rs
+++ b/backend/erato/src/services/genai.rs
@@ -46,6 +46,14 @@ impl From<ContentPart> for GenAiMessageContent {
                 );
                 GenAiMessageContent::from_parts(vec![binary_part])
             }
+            ContentPart::ActionFacetMarker(_) => {
+                // Should never reach here after resolve_action_facet_markers_in_generation_input.
+                // Log error and return empty text rather than panicking.
+                tracing::error!(
+                    "ActionFacetMarker found during LLM conversion - should have been resolved"
+                );
+                GenAiMessageContent::from_text(String::new())
+            }
         }
     }
 }

--- a/backend/erato/src/services/genai_langfuse.rs
+++ b/backend/erato/src/services/genai_langfuse.rs
@@ -156,6 +156,16 @@ pub fn convert_content_parts_to_json(content_parts: &[ContentPart]) -> Result<Js
                     "base64_data_length": image.base64_data.len()
                 }));
             }
+            ContentPart::ActionFacetMarker(marker) => {
+                // Langfuse trace shows the marker metadata (canonical form)
+                // — the rendered text is reconstructable from facet_id + args
+                // and the current template if needed.
+                output_parts.push(json!({
+                    "type": "action_facet_marker",
+                    "facet_id": marker.facet_id,
+                    "args": marker.args,
+                }));
+            }
         }
     }
 

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2132,8 +2132,12 @@ mod test_cases {
 
         // Verify ActionFacetPrompt is in the abstract sequence
         let has_action_facet_part = abstract_seq.parts.iter().any(|p| {
-            matches!(p, AbstractChatSequencePart::ActionFacetPrompt { content }
-                if content.contains("meeting notes"))
+            matches!(
+                p,
+                AbstractChatSequencePart::ActionFacetPrompt { facet_id, args }
+                    if facet_id == "email_compose"
+                        && args.get("context") == Some(&"meeting notes".to_string())
+            )
         });
         assert!(
             has_action_facet_part,
@@ -2155,17 +2159,19 @@ mod test_cases {
         assert!(matches!(resolved.messages[1].role, MessageRole::System));
         assert!(matches!(resolved.messages[2].role, MessageRole::User));
 
-        // The action facet prompt should contain the rendered template
+        // The action facet prompt is now an ActionFacetMarker — rendering
+        // happens later in `resolve_action_facet_markers_in_generation_input`.
+        // Here we verify the marker is structurally present with the right
+        // facet_id and args, which is what gets persisted to the DB.
         match &resolved.messages[1].content {
-            ContentPart::Text(text) => {
-                assert!(
-                    text.text
-                        .contains("You are composing an email. Context: meeting notes"),
-                    "Action facet prompt not rendered correctly: {}",
-                    text.text
+            ContentPart::ActionFacetMarker(marker) => {
+                assert_eq!(marker.facet_id, "email_compose");
+                assert_eq!(
+                    marker.args.get("context"),
+                    Some(&"meeting notes".to_string())
                 );
             }
-            other => panic!("Expected text content for action facet, got: {:?}", other),
+            other => panic!("Expected ActionFacetMarker, got: {:?}", other),
         }
     }
 
@@ -2288,12 +2294,15 @@ mod test_cases {
             "Base system prompt should be present from history"
         );
 
-        // Verify action facet prompt is present
+        // Verify action facet marker is present (rendering happens later
+        // in `resolve_action_facet_markers_in_generation_input`).
         let has_action_facet = system_messages.iter().any(|m| match &m.content {
-            ContentPart::Text(text) => text.text.contains("Compose a reply with tone: formal"),
+            ContentPart::ActionFacetMarker(marker) => {
+                marker.args.get("tone") == Some(&"formal".to_string())
+            }
             _ => false,
         });
-        assert!(has_action_facet, "Action facet prompt should be present");
+        assert!(has_action_facet, "Action facet marker should be present");
 
         // Full sequence: base_system + action_facet + user1 + assistant + user2
         assert_eq!(

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2148,7 +2148,7 @@ mod test_cases {
             .await
             .expect("Failed to resolve sequence");
 
-        // Should have: base system prompt + action facet system prompt + user message
+        // Should have: base system prompt + action facet user-turn marker + user message
         assert_eq!(
             resolved.messages.len(),
             3,
@@ -2156,7 +2156,9 @@ mod test_cases {
             resolved.messages.len()
         );
         assert!(matches!(resolved.messages[0].role, MessageRole::System));
-        assert!(matches!(resolved.messages[1].role, MessageRole::System));
+        // Action-facet marker now lands in the User turn (per Anthropic
+        // guidance for per-turn directives + sentinel-tagged user prose).
+        assert!(matches!(resolved.messages[1].role, MessageRole::User));
         assert!(matches!(resolved.messages[2].role, MessageRole::User));
 
         // The action facet prompt is now an ActionFacetMarker — rendering
@@ -2263,46 +2265,38 @@ mod test_cases {
             .await
             .expect("Failed to resolve second sequence");
 
-        // Count system messages
-        let system_messages: Vec<_> = resolved2
-            .messages
-            .iter()
-            .filter(|m| matches!(m.role, MessageRole::System))
-            .collect();
-
-        // Both the base system prompt (from history) and the action facet prompt
-        // should be present — action facets are additive, not replacing.
-        assert_eq!(
-            system_messages.len(),
-            2,
-            "Expected 2 system messages (base + action facet), found {}. Messages: {:#?}",
-            system_messages.len(),
-            resolved2
-                .messages
-                .iter()
-                .map(|m| format!("{:?}: {:?}", m.role, m.content))
-                .collect::<Vec<_>>()
-        );
-
-        // Verify base system prompt is replayed from history
-        let has_base_prompt = system_messages.iter().any(|m| match &m.content {
-            ContentPart::Text(text) => text.text.contains("You are helpful"),
-            _ => false,
+        // The base system prompt should still be replayed from history
+        // (action facets are additive — they must not suppress the base
+        // prompt). With Phase 2, the action-facet marker lands on a User-
+        // role message instead of System, so we look for it across all
+        // messages, not just the System ones.
+        let has_base_prompt = resolved2.messages.iter().any(|m| {
+            matches!(m.role, MessageRole::System)
+                && matches!(
+                    &m.content,
+                    ContentPart::Text(text) if text.text.contains("You are helpful")
+                )
         });
         assert!(
             has_base_prompt,
             "Base system prompt should be present from history"
         );
 
-        // Verify action facet marker is present (rendering happens later
-        // in `resolve_action_facet_markers_in_generation_input`).
-        let has_action_facet = system_messages.iter().any(|m| match &m.content {
-            ContentPart::ActionFacetMarker(marker) => {
-                marker.args.get("tone") == Some(&"formal".to_string())
-            }
-            _ => false,
+        // Verify action facet marker is present in a User-role message
+        // (rendering happens later in
+        // `resolve_action_facet_markers_in_generation_input`).
+        let has_action_facet = resolved2.messages.iter().any(|m| {
+            matches!(m.role, MessageRole::User)
+                && matches!(
+                    &m.content,
+                    ContentPart::ActionFacetMarker(marker)
+                        if marker.args.get("tone") == Some(&"formal".to_string())
+                )
         });
-        assert!(has_action_facet, "Action facet marker should be present");
+        assert!(
+            has_action_facet,
+            "Action facet marker should be present in a user message"
+        );
 
         // Full sequence: base_system + action_facet + user1 + assistant + user2
         assert_eq!(

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -456,8 +456,16 @@ pub async fn resolve_sequence(
                 // Emit a marker (not rendered text). The resolver in
                 // `file_resolution.rs` renders it for the current turn and
                 // drops it for past turns when this snapshot is replayed.
+                //
+                // Role is `User` to match Anthropic's guidance for per-turn
+                // directives ("inject what were previously prefilled-
+                // assistant reminders into the user turn") and OpenAI's
+                // observed instruction-recency bias. The resolver wraps the
+                // rendered template in a `<system-reminder>` sentinel so
+                // the model still recognises it as a directive, not casual
+                // user prose.
                 input_messages.push(InputMessage {
-                    role: MessageRole::System,
+                    role: MessageRole::User,
                     content: ContentPart::ActionFacetMarker(ContentPartActionFacetMarker {
                         facet_id,
                         args,

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -14,8 +14,9 @@ use crate::config::ExperimentalFacetsConfig;
 use crate::db::entity::chats;
 use crate::db::entity::messages;
 use crate::models::message::{
-    ContentPart, ContentPartImageFilePointer, ContentPartText, ContentPartTextFilePointer,
-    GenerationInputMessages, GenerationParameters, InputMessage, MessageRole, MessageSchema,
+    ContentPart, ContentPartActionFacetMarker, ContentPartImageFilePointer, ContentPartText,
+    ContentPartTextFilePointer, GenerationInputMessages, GenerationParameters, InputMessage,
+    MessageRole, MessageSchema,
 };
 use eyre::Report;
 use sea_orm::prelude::Uuid;
@@ -222,14 +223,16 @@ pub async fn build_abstract_sequence_with_facet_tool_expansions(
         }
     }
 
-    // 9.6 Inject action facet prompt (request-scoped, no toggle detection)
+    // 9.6 Inject action facet directive (request-scoped, no toggle detection).
+    // The marker carries facet_id + args; rendering moves to the resolver
+    // step so the persisted snapshot stores metadata, not derived text.
     if let Some(af) = action_facet
-        && let Some(af_config) = action_facet_configs.get(&af.id)
+        && action_facet_configs.contains_key(&af.id)
     {
-        let rendered = render_action_facet_template(&af_config.template, &af.args);
-        if !rendered.is_empty() {
-            sequence.push(AbstractChatSequencePart::ActionFacetPrompt { content: rendered });
-        }
+        sequence.push(AbstractChatSequencePart::ActionFacetPrompt {
+            facet_id: af.id.clone(),
+            args: af.args.clone(),
+        });
     }
 
     // 10. Add previous messages to the sequence
@@ -445,13 +448,20 @@ pub async fn resolve_sequence(
                 has_system_message = true;
             }
 
-            AbstractChatSequencePart::ActionFacetPrompt { content } => {
+            AbstractChatSequencePart::ActionFacetPrompt { facet_id, args } => {
                 // Do NOT set has_system_message — action facet prompts are
                 // per-request additive instructions that must not suppress
                 // the base system prompt replayed from history.
+                //
+                // Emit a marker (not rendered text). The resolver in
+                // `file_resolution.rs` renders it for the current turn and
+                // drops it for past turns when this snapshot is replayed.
                 input_messages.push(InputMessage {
                     role: MessageRole::System,
-                    content: ContentPart::Text(ContentPartText { text: content }),
+                    content: ContentPart::ActionFacetMarker(ContentPartActionFacetMarker {
+                        facet_id,
+                        args,
+                    }),
                 });
             }
 
@@ -466,6 +476,16 @@ pub async fn resolve_sequence(
                         Ok(gen_input) => {
                             let include_system = !has_system_message;
                             for input_msg in gen_input.messages {
+                                // Strip prior-turn action-facet directives so
+                                // they don't replay alongside the current
+                                // turn's directive. Two filters:
+                                //   • new format → ContentPart::ActionFacetMarker
+                                //   • legacy rendered text (pre-marker rows
+                                //     in the DB) → System message whose text
+                                //     starts with "FOR THIS MESSAGE ONLY:"
+                                if is_prior_turn_action_facet_message(&input_msg) {
+                                    continue;
+                                }
                                 let input_msg = normalize_historical_input_message(input_msg);
                                 if include_system || !matches!(input_msg.role, MessageRole::System)
                                 {
@@ -561,6 +581,29 @@ pub async fn resolve_sequence(
 
 fn normalize_historical_input_message(input_msg: InputMessage) -> InputMessage {
     input_msg
+}
+
+/// True when an `InputMessage` represents an action-facet directive emitted
+/// by a prior turn. Action facets are request-scoped ("FOR THIS MESSAGE
+/// ONLY") — replaying them turns conflicting format directives into a noisy
+/// chat history and the model drifts.
+///
+/// Two shapes need stripping:
+///   * New format: `ContentPart::ActionFacetMarker` (any role).
+///   * Legacy format: `System` messages whose text starts with the literal
+///     `"FOR THIS MESSAGE ONLY:"` prefix from the rendered template — for
+///     `generation_input_messages` rows persisted before the marker
+///     migration. The prefix is stable across all current action-facet
+///     templates (`config.rs`).
+fn is_prior_turn_action_facet_message(input_msg: &InputMessage) -> bool {
+    match &input_msg.content {
+        ContentPart::ActionFacetMarker(_) => true,
+        ContentPart::Text(ContentPartText { text }) => {
+            matches!(input_msg.role, MessageRole::System)
+                && text.trim_start().starts_with("FOR THIS MESSAGE ONLY:")
+        }
+        _ => false,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/backend/erato/src/services/prompt_composition/types.rs
+++ b/backend/erato/src/services/prompt_composition/types.rs
@@ -71,8 +71,14 @@ pub enum AbstractChatSequencePart {
     /// Facet-specific additional system prompt
     FacetAdditionalSystemPrompt { spec: PromptSpec, facet_id: String },
 
-    /// Action-facet rendered prompt (request-scoped, parameterized)
-    ActionFacetPrompt { content: String },
+    /// Action-facet directive (request-scoped, parameterized). Carries the
+    /// facet identity + invocation args; rendering happens later in the
+    /// resolver step so persisted history stores a metadata-only marker
+    /// instead of the rendered template text.
+    ActionFacetPrompt {
+        facet_id: String,
+        args: HashMap<String, String>,
+    },
 
     /// File attached to the current user input
     UserFile { file_id: Uuid },

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2686,19 +2686,22 @@ async fn test_action_facet_rendered_prompt_in_generation_input(pool: Pool<Postgr
         .clone()
         .expect("Missing generation_input_messages");
 
-    // Persisted shape: an `ActionFacetMarker` with the facet id + args.
-    // Rendering is deferred until request-build time, so the saved row
-    // stores source-of-truth metadata, not derived text. The `tone` and
-    // `content` args round-trip through the JSON unchanged.
+    // Persisted shape: an `ActionFacetMarker` on a User-role message with
+    // the facet id + args. Rendering is deferred until request-build time
+    // (the resolver wraps it in a `<system-reminder>` sentinel), so the
+    // saved row stores source-of-truth metadata, not derived text. The
+    // `tone` and `content` args round-trip through the JSON unchanged.
     let marker = gen_input_value["messages"]
         .as_array()
         .expect("Expected messages array")
         .iter()
         .find(|msg| {
-            msg["role"].as_str() == Some("system")
+            msg["role"].as_str() == Some("user")
                 && msg["content"]["content_type"].as_str() == Some("action_facet_marker")
         })
-        .expect("Expected ActionFacetMarker as system message in saved generation_input_messages");
+        .expect(
+            "Expected ActionFacetMarker as user-role message in saved generation_input_messages",
+        );
 
     assert_eq!(
         marker["content"]["facet_id"].as_str(),
@@ -2770,7 +2773,7 @@ async fn test_action_facet_template_literal_values_no_rerendering(pool: Pool<Pos
         .expect("Expected messages array")
         .iter()
         .find(|msg| {
-            msg["role"].as_str() == Some("system")
+            msg["role"].as_str() == Some("user")
                 && msg["content"]["content_type"].as_str() == Some("action_facet_marker")
         })
         .expect("Expected ActionFacetMarker in saved generation_input_messages");

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2686,27 +2686,34 @@ async fn test_action_facet_rendered_prompt_in_generation_input(pool: Pool<Postgr
         .clone()
         .expect("Missing generation_input_messages");
 
-    let system_texts: Vec<String> = gen_input_value["messages"]
+    // Persisted shape: an `ActionFacetMarker` with the facet id + args.
+    // Rendering is deferred until request-build time, so the saved row
+    // stores source-of-truth metadata, not derived text. The `tone` and
+    // `content` args round-trip through the JSON unchanged.
+    let marker = gen_input_value["messages"]
         .as_array()
         .expect("Expected messages array")
         .iter()
-        .filter(|msg| msg["role"].as_str() == Some("system"))
-        .filter_map(|msg| {
-            if msg["content"]["content_type"].as_str() == Some("text") {
-                msg["content"]["text"].as_str().map(str::to_string)
-            } else {
-                None
-            }
+        .find(|msg| {
+            msg["role"].as_str() == Some("system")
+                && msg["content"]["content_type"].as_str() == Some("action_facet_marker")
         })
-        .collect();
+        .expect("Expected ActionFacetMarker as system message in saved generation_input_messages");
 
-    let found = system_texts.iter().any(|text| {
-        text.contains("Rewrite the following in a professional tone")
-            && text.contains("yo whats up")
-    });
-    assert!(
-        found,
-        "Expected rendered action facet prompt as system message. System texts: {system_texts:?}"
+    assert_eq!(
+        marker["content"]["facet_id"].as_str(),
+        Some("rewrite"),
+        "Expected marker.facet_id to round-trip into saved JSON"
+    );
+    assert_eq!(
+        marker["content"]["args"]["tone"].as_str(),
+        Some("professional"),
+        "Expected marker.args.tone to round-trip into saved JSON"
+    );
+    assert_eq!(
+        marker["content"]["args"]["content"].as_str(),
+        Some("yo whats up"),
+        "Expected marker.args.content to round-trip into saved JSON"
     );
 }
 
@@ -2753,27 +2760,28 @@ async fn test_action_facet_template_literal_values_no_rerendering(pool: Pool<Pos
         .clone()
         .expect("Missing generation_input_messages");
 
-    let system_texts: Vec<String> = gen_input_value["messages"]
+    // The marker preserves args verbatim — `{{content}}` in the tone arg
+    // round-trips into the saved JSON unchanged. Re-rendering protection
+    // (one-pass template substitution; arg values are NOT re-expanded) now
+    // lives in the resolver step at request-build time and is covered by
+    // the unit tests for `render_action_facet_template`.
+    let marker = gen_input_value["messages"]
         .as_array()
         .expect("Expected messages array")
         .iter()
-        .filter(|msg| msg["role"].as_str() == Some("system"))
-        .filter_map(|msg| {
-            if msg["content"]["content_type"].as_str() == Some("text") {
-                msg["content"]["text"].as_str().map(str::to_string)
-            } else {
-                None
-            }
+        .find(|msg| {
+            msg["role"].as_str() == Some("system")
+                && msg["content"]["content_type"].as_str() == Some("action_facet_marker")
         })
-        .collect();
+        .expect("Expected ActionFacetMarker in saved generation_input_messages");
 
-    // The rendered template should contain the literal "{{content}}" from the tone arg,
-    // not "actual content" substituted again
-    let found = system_texts
-        .iter()
-        .any(|text| text.contains("{{content}}") && text.contains("actual content"));
-    assert!(
-        found,
-        "Expected literal '{{{{content}}}}' in rendered prompt (no re-rendering). System texts: {system_texts:?}"
+    assert_eq!(
+        marker["content"]["args"]["tone"].as_str(),
+        Some("{{content}}"),
+        "Marker must preserve `{{content}}` literally in args, no re-rendering"
+    );
+    assert_eq!(
+        marker["content"]["args"]["content"].as_str(),
+        Some("actual content")
     );
 }

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2950,8 +2950,54 @@
                 }
               }
             ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContentPartActionFacetMarker",
+                "description": "Reference to an action-facet directive that will be rendered fresh\nat request-build time. Persisted in `generation_input_messages` as a\nmetadata-only marker (facet id + invocation args) instead of the\nrendered template text — mirrors the `TextFilePointer` pattern.\nAction facets are request-scoped: when this marker is loaded as part\nof *prior-turn* history, the resolver drops it; for the *current\nturn* it renders the template against the current config + args."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "content_type"
+                ],
+                "properties": {
+                  "content_type": {
+                    "type": "string",
+                    "enum": [
+                      "action_facet_marker"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Reference to an action-facet directive that will be rendered fresh\nat request-build time. Persisted in `generation_input_messages` as a\nmetadata-only marker (facet id + invocation args) instead of the\nrendered template text — mirrors the `TextFilePointer` pattern.\nAction facets are request-scoped: when this marker is loaded as part\nof *prior-turn* history, the resolver drops it; for the *current\nturn* it renders the template against the current config + args."
           }
         ]
+      },
+      "ContentPartActionFacetMarker": {
+        "type": "object",
+        "required": [
+          "facet_id",
+          "args"
+        ],
+        "properties": {
+          "args": {
+            "type": "object",
+            "description": "Arguments captured at the time of the user's request (e.g. the\nselected text for `outlook_rewrite_selection`, the compose body for\n`outlook_review_draft`).",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "facet_id": {
+            "type": "string",
+            "description": "Identifier of the action facet whose template should be rendered."
+          }
+        }
       },
       "ContentPartImage": {
         "type": "object",

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -415,7 +415,25 @@ export type ContentPart =
   | {
       base64_data: string;
       content_type: "image";
-    };
+    }
+  | (ContentPartActionFacetMarker & {
+      content_type: "action_facet_marker";
+    });
+
+export type ContentPartActionFacetMarker = {
+  /**
+   * Arguments captured at the time of the user's request (e.g. the
+   * selected text for `outlook_rewrite_selection`, the compose body for
+   * `outlook_review_draft`).
+   */
+  args: {
+    [key: string]: string;
+  };
+  /**
+   * Identifier of the action facet whose template should be rendered.
+   */
+  facet_id: string;
+};
 
 export type ContentPartImage = {
   base64_data: string;


### PR DESCRIPTION
## Summary

Migrates the persistence shape for Outlook action-facet directives (`outlook_review_draft`, `outlook_rewrite_selection`) from "rendered system-prompt text saved verbatim" to "metadata-only marker, rendered fresh at request-build time." Eliminates a real model-drift bug and aligns the runtime placement with 2026 industry guidance for per-turn directives.

The bug it fixes: when the user composed in text mode in turn 1 and then switched to HTML mode in turn 2, the model received **both** turn 1's "format: text" and turn 2's "format: html" system messages in the same chat request and stuck with text. Recovery through prompt language alone was unreliable because the templates appeared as competing current instructions, not "previous vs. current."

## What changes

- **New `ContentPart::ActionFacetMarker { facet_id, args }` variant** — what gets persisted in `generation_input_messages`. Mirrors the existing `TextFilePointer` "store metadata, resolve later" pattern.
- **Compose step (`transforms.rs`)** stops calling `render_action_facet_template` inline; emits the marker on a `User`-role `InputMessage`. Action-facet templates are inherently request-scoped, so persisting the marker (not derived text) means template evolution is safe and old chats aren't frozen at outdated prompt language.
- **Historical-replay step (`transforms.rs::HistoricMessagesFromGenerationInputMessages`)** strips both new-format markers and legacy `"FOR THIS MESSAGE ONLY:"` rendered text from prior turns. No DB migration needed; old rows are filtered transparently on every load.
- **New resolver (`file_resolution.rs::resolve_action_facet_markers_in_generation_input`)** renders each surviving marker against the current `AppConfig`, wraps the result in `<system-reminder>...</system-reminder>` per Anthropic's published guidance + Claude Code's own convention, and emits as a User-role `Text` part. Wired into `message_streaming.rs` immediately after file-pointer resolution.
- **Role choice**: User turn (not System). Two reasons: (1) Anthropic explicitly recommends per-turn directives in the user turn, with persistent identity in `system`; (2) recency bias on the user turn helps the model attend to the directive when it conflicts with anything in history. The `<system-reminder>` sentinel preserves directive authority.

The earlier two commits on this branch (`d38609c1`, `b7326ea3`) attempted to fix the bug at the prompt-language and load-filter levels respectively. They land alongside the structural fix as belt-and-suspenders. `b7326ea3` turned out to live in a function that the live request path doesn't call (`models/message.rs::get_generation_input_messages_by_previous_message_id`); harmless but worth knowing — the production filter is now in `transforms.rs::is_prior_turn_action_facet_message`.

## Follow-up

Filed [ERMAIN-284](https://linear.app/erato-labs/issue/ERMAIN-284/investigate-marker-pattern-for-regular-facets-facetprompttemplate) to investigate whether regular facets (`FacetPromptTemplate`, `FacetAdditionalSystemPrompt`) should follow the same marker pattern. They have the same persistence shape but no observable drift bug today; the trade-offs warrant a deliberate decision.

## Test plan

- [x] Restart backend, open Outlook compose with the body in plain-text mode, send a chat. Verify `body_format: "text"` reaches the LLM and the model outputs `erato-email`.
- [x] Switch the same compose to HTML mode (or open a new HTML reply), send another chat in the same conversation. Verify the model now outputs `erato-email-html` — no drift toward the prior turn's text format.
- [x] Inspect the wire payload of turn 2 in the DB / Langfuse: the `User`-role action-facet directive is present and wrapped in `<system-reminder>`; turn 1's marker is **not** in turn 2's chat_request (filtered during historical replay).
- [x] Inspect the saved `generation_input_messages` JSON for any new turn — confirm `content.content_type === "action_facet_marker"` with `facet_id` and `args`, not the rendered template text.
- [x] Backend tests: `cargo nextest run test_action_facet` (6/6 pass).
- [x] Backend tests: `cargo nextest run` full suite — pre-existing MCP-auth and unrelated flakes aside, no new failures.
- [x] Frontend codegen + typecheck still clean (`just check` in `frontend/`).
