### PR TITLE
Show reply-context chip when composing a reply in Outlook

### DIFF
--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -37,6 +37,7 @@ describe("GroupedFileAttachmentsPreview", () => {
             label: "Current email",
             items: [
               {
+                kind: "attachment",
                 id: "body",
                 file: {
                   id: "body",
@@ -45,6 +46,7 @@ describe("GroupedFileAttachmentsPreview", () => {
                 },
               },
               {
+                kind: "attachment",
                 id: "file-1",
                 file: {
                   id: "file-1",
@@ -53,6 +55,7 @@ describe("GroupedFileAttachmentsPreview", () => {
                 },
               },
               {
+                kind: "attachment",
                 id: "file-2",
                 file: {
                   id: "file-2",
@@ -93,12 +96,8 @@ describe("GroupedFileAttachmentsPreview", () => {
             label: "Current email",
             items: [
               {
+                kind: "loading",
                 id: "loading-1",
-                file: {
-                  id: "loading-1",
-                  filename: "loading-placeholder",
-                },
-                isLoading: true,
               },
             ],
           },
@@ -122,6 +121,7 @@ describe("GroupedFileAttachmentsPreview", () => {
             label: "Current email",
             items: [
               {
+                kind: "attachment",
                 id: "file-1",
                 file: {
                   id: "file-1",

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -25,6 +25,14 @@ export interface FileAttachmentGroupItem {
    * `.html` but meant to be labelled "Email").
    */
   labelOverride?: string;
+  /**
+   * Marks the item as informational / non-interactive. When true the
+   * renderer should suppress the remove affordance entirely (no greyed-out
+   * button the user might try to click). Used by clients that surface
+   * derived context — e.g. the Outlook add-in's "Reply context" chip —
+   * which is read-only and not a managed attachment.
+   */
+  isContextOnly?: boolean;
 }
 
 export interface FileAttachmentGroup {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -13,27 +13,35 @@ import { Button } from "../Controls/Button";
 
 import type React from "react";
 
-export interface FileAttachmentGroupItem {
-  id: string;
-  file: FileResource;
-  isLoading?: boolean;
-  /**
-   * Optional display label for the item's metadata row. When set, renderers
-   * should show this verbatim instead of deriving a label from the file's
-   * capability / extension. Useful for items synthesised client-side whose
-   * backend capability id would not read well (e.g. email body rendered as
-   * `.html` but meant to be labelled "Email").
-   */
-  labelOverride?: string;
-  /**
-   * Marks the item as informational / non-interactive. When true the
-   * renderer should suppress the remove affordance entirely (no greyed-out
-   * button the user might try to click). Used by clients that surface
-   * derived context — e.g. the Outlook add-in's "Reply context" chip —
-   * which is read-only and not a managed attachment.
-   */
-  isContextOnly?: boolean;
-}
+/**
+ * Discriminated union by `kind`:
+ * - `attachment`: a normal managed attachment; renders as a removable chip.
+ * - `context`: a read-only context chip (e.g. the Outlook add-in's "Reply
+ *   context"); renderers must suppress the remove affordance.
+ * - `loading`: an in-flight placeholder; rendered as a spinner. Has no
+ *   `file` because no file has materialised yet.
+ *
+ * `labelOverride` lets callers force the metadata row text (e.g. label an
+ * `.html` synthetic file as "Email") instead of deriving it from the file's
+ * capability / extension.
+ */
+export type FileAttachmentGroupItem =
+  | {
+      kind: "attachment";
+      id: string;
+      file: FileResource;
+      labelOverride?: string;
+    }
+  | {
+      kind: "context";
+      id: string;
+      file: FileResource;
+      labelOverride?: string;
+    }
+  | {
+      kind: "loading";
+      id: string;
+    };
 
 export interface FileAttachmentGroup {
   id: string;
@@ -54,7 +62,9 @@ export interface GroupedFileAttachmentsPreviewProps {
   defaultVisibleItems?: number;
 }
 
-function getFileKey(item: FileAttachmentGroupItem): string {
+function getFileKey(
+  item: Extract<FileAttachmentGroupItem, { kind: "attachment" | "context" }>,
+): string {
   if ("id" in item.file) {
     return item.file.id;
   }
@@ -62,7 +72,9 @@ function getFileKey(item: FileAttachmentGroupItem): string {
   return `${item.id}:${item.file.name}`;
 }
 
-function getFileId(item: FileAttachmentGroupItem): string {
+function getFileId(
+  item: Extract<FileAttachmentGroupItem, { kind: "attachment" | "context" }>,
+): string {
   if ("id" in item.file) {
     return item.file.id;
   }
@@ -146,7 +158,7 @@ const DefaultGroupedFileAttachmentsPreview: React.FC<
 
             <div className="flex flex-col gap-2">
               {visibleItems.map((item) => {
-                if (item.isLoading) {
+                if (item.kind === "loading") {
                   return (
                     <FilePreviewLoading
                       key={item.id}

--- a/frontend/src/stories/ui/GroupedFileAttachmentsPreview.stories.tsx
+++ b/frontend/src/stories/ui/GroupedFileAttachmentsPreview.stories.tsx
@@ -31,6 +31,7 @@ export const Collapsed: Story = {
         label: "Current email",
         items: [
           {
+            kind: "attachment",
             id: "body",
             file: {
               id: "body",
@@ -39,6 +40,7 @@ export const Collapsed: Story = {
             },
           },
           {
+            kind: "attachment",
             id: "pdf",
             file: {
               id: "pdf",
@@ -47,6 +49,7 @@ export const Collapsed: Story = {
             },
           },
           {
+            kind: "attachment",
             id: "xlsx",
             file: {
               id: "xlsx",
@@ -55,6 +58,7 @@ export const Collapsed: Story = {
             },
           },
           {
+            kind: "attachment",
             id: "docx",
             file: {
               id: "docx",
@@ -79,6 +83,7 @@ export const WithLoading: Story = {
         label: "Current email",
         items: [
           {
+            kind: "attachment",
             id: "body",
             file: {
               id: "body",
@@ -87,12 +92,8 @@ export const WithLoading: Story = {
             },
           },
           {
+            kind: "loading",
             id: "loading-attachment",
-            file: {
-              id: "loading-attachment",
-              filename: "placeholder",
-            },
-            isLoading: true,
           },
         ],
       },

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -317,7 +317,7 @@ packages:
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-GioFM8flbDLwXfzvPp4hBxIW4RXKNUYhq2cHqx+Rc2Ud9VFEgBEoYbzvxMyzvah8k77hG4j3n23f7QWAYM27Ow==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-GP3MaYULO7sqtUaqPWcQs0Grw1PNUuLWCfsQUSsk+semtDDBYWnB7XaNYXBthde98mr1FEOKe7/kqSY6RryZZA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -317,7 +317,7 @@ packages:
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-GP3MaYULO7sqtUaqPWcQs0Grw1PNUuLWCfsQUSsk+semtDDBYWnB7XaNYXBthde98mr1FEOKe7/kqSY6RryZZA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-bxr68hcK4LCGdrihevjED5cpvDye76UXHYm0aqRQH2LzdjAKi1lIwB7VZlZsW+MrC1pBzoVy3Et0zO+os4N22w==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -123,14 +123,15 @@ export const AddinChatInput = forwardRef<
   } = useOutlookEmailSource();
   const shouldUseSuggestedEmailSource =
     showSuggestedEmailSource && hasSelectedEmailSource;
-  const emailSourceItems = useMemo(() => {
+  const emailSourceItems = useMemo<FileAttachmentGroupItem[]>(() => {
+    const items: FileAttachmentGroupItem[] = [];
+
     // "Reply context" chip: shown only in compose-reply mode where Graph
-    // resolved a parent message. Display-only — `isContextOnly: true`
-    // suppresses the remove affordance, and the chip is *not* threaded
-    // into `resolveSelectedFilesForSend`. The parent's body content
-    // already reaches the LLM via the auto-quote inside the draft body
-    // (carried by the `outlook_review_draft.full_body` action facet).
-    const replyContextItems: FileAttachmentGroupItem[] = [];
+    // resolved a parent message. Marked `kind: "context"` so renderers
+    // suppress the remove affordance, and the chip is *not* threaded into
+    // `resolveSelectedFilesForSend`. The parent's body content already
+    // reaches the LLM via the auto-quote inside the draft body (carried by
+    // the `outlook_review_draft.full_body` action facet).
     if (parentReplyContext) {
       const senderLabel =
         parentReplyContext.fromName?.trim() ||
@@ -142,7 +143,8 @@ export const AddinChatInput = forwardRef<
           id: "officeAddin.chatInput.replyContext.untitled",
           message: "(no subject)",
         });
-      replyContextItems.push({
+      items.push({
+        kind: "context",
         id: "reply-context",
         file: {
           id: "reply-context",
@@ -150,64 +152,46 @@ export const AddinChatInput = forwardRef<
           displayName: senderLabel
             ? `${subjectLabel} — ${senderLabel}`
             : subjectLabel,
-        } as unknown as FileAttachmentGroupItem["file"],
-        isLoading: false,
+        },
         labelOverride: t({
           id: "officeAddin.chatInput.replyContext.label",
           message: "Reply context",
         }),
-        isContextOnly: true,
       });
     } else if (isLoadingParentReplyContext) {
-      replyContextItems.push({
-        id: "reply-context-loading",
+      items.push({ kind: "loading", id: "reply-context-loading" });
+    }
+
+    if (isEmailBodyIncluded && emailBodyFile) {
+      items.push({
+        kind: "attachment",
+        id: "email-body",
         file: {
-          id: "reply-context-loading",
-          filename: "reply-context-loading",
-        } as unknown as FileAttachmentGroupItem["file"],
-        isLoading: true,
-        isContextOnly: true,
+          id: "email-body",
+          filename: emailBodyFile.name,
+          displayName: "Email thread",
+          size: emailBodyFile.size,
+        },
+        labelOverride: t({
+          id: "officeAddin.chatInput.emailLabel",
+          message: "Email",
+        }),
       });
     }
 
-    return [
-      ...replyContextItems,
-      ...(isEmailBodyIncluded && emailBodyFile
-        ? [
-            {
-              id: "email-body",
-              file: {
-                id: "email-body",
-                filename: emailBodyFile.name,
-                displayName: "Email thread",
-                size: emailBodyFile.size,
-              },
-              isLoading: false,
-              labelOverride: t({
-                id: "officeAddin.chatInput.emailLabel",
-                message: "Email",
-              }),
-            },
-          ]
-        : []),
-      ...selectedAttachmentItems.map((attachmentItem) => ({
+    for (const attachmentItem of selectedAttachmentItems) {
+      items.push({
+        kind: "attachment",
         id: attachmentItem.id,
         file: attachmentItem,
-        isLoading: false,
-      })),
-      ...(isLoadingAttachments
-        ? [
-            {
-              id: "attachments-loading",
-              file: {
-                id: "attachments-loading",
-                filename: "attachments-loading",
-              },
-              isLoading: true,
-            },
-          ]
-        : []),
-    ];
+      });
+    }
+
+    if (isLoadingAttachments) {
+      items.push({ kind: "loading", id: "attachments-loading" });
+    }
+
+    return items;
   }, [
     emailBodyFile,
     isEmailBodyIncluded,
@@ -215,18 +199,10 @@ export const AddinChatInput = forwardRef<
     isLoadingParentReplyContext,
     parentReplyContext,
     selectedAttachmentItems,
-  ]) as FileAttachmentGroupItem[];
+  ]);
 
   const handleRemoveEmailSourceFile = useCallback(
     (fileId: string) => {
-      // Reply-context chip is display-only (`isContextOnly: true` suppresses
-      // the remove button). Belt-and-suspenders: if the chip ever does fire
-      // a remove, drop it on the floor rather than poisoning
-      // `dismissedAttachmentIds` with a synthetic id.
-      if (fileId === "reply-context" || fileId === "reply-context-loading") {
-        return;
-      }
-
       if (fileId === "email-body") {
         removeEmailBody();
         return;

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -123,6 +123,18 @@ export const AddinChatInput = forwardRef<
   } = useOutlookEmailSource();
   const shouldUseSuggestedEmailSource =
     showSuggestedEmailSource && hasSelectedEmailSource;
+  // Render the email-source preview whenever there is *something* to show:
+  // a real attachment, an in-flight attachment fetch, or the reply-context
+  // chip (resolved or still loading). Without this gate the preview region
+  // would render an empty card whenever the host is Outlook in compose
+  // mode but Graph hasn't yet returned a parent message.
+  const shouldShowEmailSourcePreview =
+    host === "Outlook" &&
+    showSuggestedEmailSource &&
+    (hasSelectedEmailSource ||
+      isLoadingAttachments ||
+      parentReplyContext !== null ||
+      isLoadingParentReplyContext);
   const emailSourceItems = useMemo<FileAttachmentGroupItem[]>(() => {
     const items: FileAttachmentGroupItem[] = [];
 
@@ -339,13 +351,8 @@ export const AddinChatInput = forwardRef<
           : "flex min-w-0 flex-col"
       }
     >
-      {host === "Outlook" &&
-        showSuggestedEmailSource &&
-        (hasSelectedEmailSource ||
-          isLoadingAttachments ||
-          parentReplyContext !== null ||
-          isLoadingParentReplyContext) && (
-          <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
+      {shouldShowEmailSourcePreview && (
+        <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
             <GroupedFileAttachmentsPreview
               groups={[
                 {

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -353,28 +353,28 @@ export const AddinChatInput = forwardRef<
     >
       {shouldShowEmailSourcePreview && (
         <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
-            <GroupedFileAttachmentsPreview
-              groups={[
-                {
-                  id: "current-email",
-                  label:
-                    emailSubject ||
-                    t({
-                      id: "officeAddin.chatInput.emailFallback",
-                      message: "Email",
-                    }),
-                  metaLabel: "",
-                  items: emailSourceItems,
-                },
-              ]}
-              onRemoveFile={handleRemoveEmailSourceFile}
-              disabled={isUploadingEmail}
-              showFileTypes={true}
-              showFileSizes={true}
-              defaultVisibleItems={3}
-            />
-          </div>
-        )}
+          <GroupedFileAttachmentsPreview
+            groups={[
+              {
+                id: "current-email",
+                label:
+                  emailSubject ||
+                  t({
+                    id: "officeAddin.chatInput.emailFallback",
+                    message: "Email",
+                  }),
+                metaLabel: "",
+                items: emailSourceItems,
+              },
+            ]}
+            onRemoveFile={handleRemoveEmailSourceFile}
+            disabled={isUploadingEmail}
+            showFileTypes={true}
+            showFileSizes={true}
+            defaultVisibleItems={3}
+          />
+        </div>
+      )}
 
       {isExpandingDroppedEmails && (
         <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -118,11 +118,60 @@ export const AddinChatInput = forwardRef<
     removeEmailBody,
     removeAttachment,
     resolveSelectedFilesForSend,
+    parentReplyContext,
+    isLoadingParentReplyContext,
   } = useOutlookEmailSource();
   const shouldUseSuggestedEmailSource =
     showSuggestedEmailSource && hasSelectedEmailSource;
   const emailSourceItems = useMemo(() => {
+    // "Reply context" chip: shown only in compose-reply mode where Graph
+    // resolved a parent message. Display-only — `isContextOnly: true`
+    // suppresses the remove affordance, and the chip is *not* threaded
+    // into `resolveSelectedFilesForSend`. The parent's body content
+    // already reaches the LLM via the auto-quote inside the draft body
+    // (carried by the `outlook_review_draft.full_body` action facet).
+    const replyContextItems: FileAttachmentGroupItem[] = [];
+    if (parentReplyContext) {
+      const senderLabel =
+        parentReplyContext.fromName?.trim() ||
+        parentReplyContext.fromAddress?.trim() ||
+        "";
+      const subjectLabel =
+        parentReplyContext.subject.trim() ||
+        t({
+          id: "officeAddin.chatInput.replyContext.untitled",
+          message: "(no subject)",
+        });
+      replyContextItems.push({
+        id: "reply-context",
+        file: {
+          id: "reply-context",
+          filename: subjectLabel,
+          displayName: senderLabel
+            ? `${subjectLabel} — ${senderLabel}`
+            : subjectLabel,
+        } as unknown as FileAttachmentGroupItem["file"],
+        isLoading: false,
+        labelOverride: t({
+          id: "officeAddin.chatInput.replyContext.label",
+          message: "Reply context",
+        }),
+        isContextOnly: true,
+      });
+    } else if (isLoadingParentReplyContext) {
+      replyContextItems.push({
+        id: "reply-context-loading",
+        file: {
+          id: "reply-context-loading",
+          filename: "reply-context-loading",
+        } as unknown as FileAttachmentGroupItem["file"],
+        isLoading: true,
+        isContextOnly: true,
+      });
+    }
+
     return [
+      ...replyContextItems,
       ...(isEmailBodyIncluded && emailBodyFile
         ? [
             {
@@ -163,11 +212,21 @@ export const AddinChatInput = forwardRef<
     emailBodyFile,
     isEmailBodyIncluded,
     isLoadingAttachments,
+    isLoadingParentReplyContext,
+    parentReplyContext,
     selectedAttachmentItems,
   ]) as FileAttachmentGroupItem[];
 
   const handleRemoveEmailSourceFile = useCallback(
     (fileId: string) => {
+      // Reply-context chip is display-only (`isContextOnly: true` suppresses
+      // the remove button). Belt-and-suspenders: if the chip ever does fire
+      // a remove, drop it on the floor rather than poisoning
+      // `dismissedAttachmentIds` with a synthetic id.
+      if (fileId === "reply-context" || fileId === "reply-context-loading") {
+        return;
+      }
+
       if (fileId === "email-body") {
         removeEmailBody();
         return;
@@ -306,7 +365,10 @@ export const AddinChatInput = forwardRef<
     >
       {host === "Outlook" &&
         showSuggestedEmailSource &&
-        (hasSelectedEmailSource || isLoadingAttachments) && (
+        (hasSelectedEmailSource ||
+          isLoadingAttachments ||
+          parentReplyContext !== null ||
+          isLoadingParentReplyContext) && (
           <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
             <GroupedFileAttachmentsPreview
               groups={[

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -102,6 +102,16 @@ msgstr "Abgelegte E-Mails werden verarbeitet…"
 #~ msgstr "Anhänge werden geladen..."
 
 #. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Kopiert!"

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -104,12 +104,12 @@ msgstr "Abgelegte E-Mails werden verarbeitet…"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.label"
-msgstr ""
+msgstr "Antwortkontext"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.untitled"
-msgstr ""
+msgstr "(kein Betreff)"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -102,6 +102,16 @@ msgstr "Processing dropped emails…"
 #~ msgstr "Loading attachments..."
 
 #. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.label"
+msgstr "Reply context"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.untitled"
+msgstr "(no subject)"
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copied!"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -104,12 +104,12 @@ msgstr "Procesando los correos electrónicos soltados…"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.label"
-msgstr ""
+msgstr "Contexto de respuesta"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.untitled"
-msgstr ""
+msgstr "(sin asunto)"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -102,6 +102,16 @@ msgstr "Procesando los correos electrónicos soltados…"
 #~ msgstr "Cargando archivos adjuntos..."
 
 #. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copiado"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -102,6 +102,16 @@ msgstr "Traitement des e-mails déposés…"
 #~ msgstr "Chargement des pièces jointes..."
 
 #. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copié"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -104,12 +104,12 @@ msgstr "Traitement des e-mails déposés…"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.label"
-msgstr ""
+msgstr "Contexte de réponse"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.untitled"
-msgstr ""
+msgstr "(sans objet)"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -104,12 +104,12 @@ msgstr "Przetwarzanie upuszczonych e-maili…"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.label"
-msgstr ""
+msgstr "Kontekst odpowiedzi"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.replyContext.untitled"
-msgstr ""
+msgstr "(brak tematu)"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -102,6 +102,16 @@ msgstr "Przetwarzanie upuszczonych e-maili…"
 #~ msgstr "Ładowanie załączników..."
 
 #. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.replyContext.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Skopiowano"

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -10,7 +10,9 @@ import {
 import { useMsalNaa } from "./MsalNaaProvider";
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { fetchCurrentEmailEml } from "../utils/fetchCurrentEmailEml";
+import { fetchParentMessageInConversationViaGraph } from "../utils/fetchOutlookMessageGraph";
 
+import type { ParentMessageMetadata } from "../utils/fetchOutlookMessageGraph";
 import type { LocalFilePreviewItem } from "@erato/frontend/library";
 import type { ReactNode } from "react";
 
@@ -32,6 +34,17 @@ interface OutlookEmailSourceContextValue {
   dismissedAttachmentIds: string[];
   resolveSelectedFilesForSend: () => Promise<File[]>;
   hasSelectedEmailSource: boolean;
+  /**
+   * Metadata of the most recent non-draft message in the same conversation
+   * thread, when the user is in Outlook compose mode replying / forwarding.
+   * Display-only — surfaces a "Reply context" chip in the chat input UI.
+   * Not part of `resolveSelectedFilesForSend`: the body is already in the
+   * draft via Outlook's auto-quote and reaches the LLM through the
+   * `outlook_review_draft.full_body` action facet, so re-sending it here
+   * would double the token cost.
+   */
+  parentReplyContext: ParentMessageMetadata | null;
+  isLoadingParentReplyContext: boolean;
 }
 
 const defaultValue: OutlookEmailSourceContextValue = {
@@ -49,6 +62,8 @@ const defaultValue: OutlookEmailSourceContextValue = {
   dismissedAttachmentIds: [],
   resolveSelectedFilesForSend: async () => [],
   hasSelectedEmailSource: false,
+  parentReplyContext: null,
+  isLoadingParentReplyContext: false,
 };
 
 const OutlookEmailSourceContext =
@@ -79,6 +94,10 @@ export function OutlookEmailSourceProvider({
   >([]);
   const [emailBodyFile, setEmailBodyFile] = useState<File | null>(null);
   const [isLoadingEmailBody, setIsLoadingEmailBody] = useState(false);
+  const [parentReplyContext, setParentReplyContext] =
+    useState<ParentMessageMetadata | null>(null);
+  const [isLoadingParentReplyContext, setIsLoadingParentReplyContext] =
+    useState(false);
 
   const acquireGraphToken = useCallback(
     () => acquireToken(GRAPH_MAIL_SCOPES),
@@ -86,6 +105,8 @@ export function OutlookEmailSourceProvider({
   );
 
   const itemId = mailItem?.itemId ?? null;
+  const conversationId = mailItem?.conversationId ?? null;
+  const isComposeMode = mailItem?.isComposeMode ?? false;
 
   // Fetch the raw `.eml` via Graph whenever the open email changes. Drafts
   // and compose items have no itemId, so no accessory is produced — matches
@@ -119,6 +140,45 @@ export function OutlookEmailSourceProvider({
       cancelled = true;
     };
   }, [acquireGraphToken, itemId]);
+
+  // Fetch the parent-thread metadata when the user is composing a reply or
+  // forward. Graph's `/me/messages/{itemId}` 404s on drafts (the very issue
+  // that gates the read-mode preview above), but the *parent* message is
+  // indexed and addressable by `conversationId`. We surface a display-only
+  // "Reply context" chip; the body itself reaches the LLM via the auto-quote
+  // already embedded in the draft, so re-fetching it here is unnecessary.
+  useEffect(() => {
+    if (!isComposeMode || !conversationId || itemId) {
+      setParentReplyContext(null);
+      setIsLoadingParentReplyContext(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingParentReplyContext(true);
+    setParentReplyContext(null);
+
+    void fetchParentMessageInConversationViaGraph(
+      conversationId,
+      acquireGraphToken,
+    )
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setParentReplyContext(result);
+      })
+      .finally(() => {
+        if (cancelled) {
+          return;
+        }
+        setIsLoadingParentReplyContext(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [acquireGraphToken, conversationId, isComposeMode, itemId]);
 
   useEffect(() => {
     if (!itemIdentity) {
@@ -239,6 +299,8 @@ export function OutlookEmailSourceProvider({
       resolveSelectedFilesForSend,
       hasSelectedEmailSource:
         isEmailBodyIncluded || selectedAttachmentItems.length > 0,
+      parentReplyContext,
+      isLoadingParentReplyContext,
     }),
     [
       dismissedAttachmentIds,
@@ -247,7 +309,9 @@ export function OutlookEmailSourceProvider({
       isEmailBodyIncluded,
       isLoadingAttachments,
       isLoadingEmailBody,
+      isLoadingParentReplyContext,
       mailItem?.subject,
+      parentReplyContext,
       removeAttachment,
       removeEmailBody,
       resolveSelectedFilesForSend,

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   fetchOutlookMessageFilesByInternetMessageIdViaGraph,
   fetchOutlookMessageFilesViaGraph,
+  fetchParentMessageInConversationViaGraph,
 } from "../fetchOutlookMessageGraph";
 
 const EWS_ID = "AAkALgAAA-ews-id";
@@ -284,5 +285,129 @@ describe("fetchOutlookMessageFilesByInternetMessageIdViaGraph", () => {
     expect(url).toContain(
       encodeURIComponent("internetMessageId eq '<a''b@host>'"),
     );
+  });
+});
+
+describe("fetchParentMessageInConversationViaGraph", () => {
+  beforeEach(() => {
+    installOutlookMailboxMock();
+  });
+
+  afterEach(() => {
+    uninstallMockMailbox();
+    vi.unstubAllGlobals();
+  });
+
+  it("filters /me/messages by conversationId and isDraft, ordered by receivedDateTime desc, top 1", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const fetchMock = installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        value: [
+          {
+            subject: "Re: Quarterly review",
+            from: {
+              emailAddress: {
+                name: "Alice Sender",
+                address: "alice@example.com",
+              },
+            },
+          },
+        ],
+      },
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "AAQkAGE5...convId",
+      acquireToken,
+    );
+
+    expect(result).toEqual({
+      subject: "Re: Quarterly review",
+      fromName: "Alice Sender",
+      fromAddress: "alice@example.com",
+    });
+    expect(acquireToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain(
+      encodeURIComponent(
+        "conversationId eq 'AAQkAGE5...convId' and isDraft eq false",
+      ),
+    );
+    expect(url).toContain(encodeURIComponent("receivedDateTime desc"));
+    expect(url).toContain("$top=1");
+    expect(url).toContain("$select=subject,from");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("returns null when the conversation has no indexed messages", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({ ok: true, jsonValue: { value: [] } }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "fresh-conv",
+      acquireToken,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null on Graph error rather than throwing", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "any-conv",
+      acquireToken,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("escapes single quotes in conversationId for the OData filter", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    const fetchMock = installFetchMock(() => ({
+      ok: true,
+      jsonValue: { value: [] },
+    }));
+
+    await fetchParentMessageInConversationViaGraph(
+      "conv'with'quotes",
+      acquireToken,
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain(
+      encodeURIComponent(
+        "conversationId eq 'conv''with''quotes' and isDraft eq false",
+      ),
+    );
+  });
+
+  it("falls back to null name/address when Graph response is missing fields", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        value: [{ subject: "Subject only" }],
+      },
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "conv",
+      acquireToken,
+    );
+
+    expect(result).toEqual({
+      subject: "Subject only",
+      fromName: null,
+      fromAddress: null,
+    });
   });
 });

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -298,7 +298,7 @@ describe("fetchParentMessageInConversationViaGraph", () => {
     vi.unstubAllGlobals();
   });
 
-  it("filters /me/messages by conversationId and isDraft, ordered by receivedDateTime desc, top 1", async () => {
+  it("filters /me/messages by conversationId only ($top 20, no $orderby) and returns the latest non-draft", async () => {
     const acquireToken = vi.fn().mockResolvedValue("tok");
     const fetchMock = installFetchMock(() => ({
       ok: true,
@@ -306,6 +306,8 @@ describe("fetchParentMessageInConversationViaGraph", () => {
         value: [
           {
             subject: "Re: Quarterly review",
+            receivedDateTime: "2026-04-29T10:00:00Z",
+            isDraft: false,
             from: {
               emailAddress: {
                 name: "Alice Sender",
@@ -331,15 +333,81 @@ describe("fetchParentMessageInConversationViaGraph", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain(
-      encodeURIComponent(
-        "conversationId eq 'AAQkAGE5...convId' and isDraft eq false",
-      ),
+      encodeURIComponent("conversationId eq 'AAQkAGE5...convId'"),
     );
-    expect(url).toContain(encodeURIComponent("receivedDateTime desc"));
-    expect(url).toContain("$top=1");
-    expect(url).toContain("$select=subject,from");
+    expect(url).toContain("$top=20");
+    expect(url).toContain("$select=id,subject,from,receivedDateTime,isDraft");
+    // The Graph "InefficientFilter" rule forbids combining `$orderby` with
+    // a `$filter` that doesn't reference the orderby property. We sort
+    // client-side instead, so the URL must NOT include `$orderby`.
+    expect(url).not.toContain("$orderby");
+    expect(url).not.toContain(encodeURIComponent("isDraft eq false"));
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("picks the most recent non-draft when Graph returns multiple thread messages", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        value: [
+          {
+            subject: "Earlier reply",
+            receivedDateTime: "2026-04-27T08:00:00Z",
+            isDraft: false,
+            from: { emailAddress: { name: "Bob", address: "bob@x" } },
+          },
+          {
+            subject: "My in-progress draft",
+            receivedDateTime: "2026-04-29T11:00:00Z",
+            isDraft: true,
+            from: { emailAddress: { name: "Me", address: "me@x" } },
+          },
+          {
+            subject: "Latest non-draft",
+            receivedDateTime: "2026-04-29T09:00:00Z",
+            isDraft: false,
+            from: { emailAddress: { name: "Carol", address: "carol@x" } },
+          },
+        ],
+      },
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "thread",
+      acquireToken,
+    );
+
+    expect(result).toEqual({
+      subject: "Latest non-draft",
+      fromName: "Carol",
+      fromAddress: "carol@x",
+    });
+  });
+
+  it("returns null when the conversation contains only drafts", async () => {
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        value: [
+          {
+            subject: "Drafted reply",
+            receivedDateTime: "2026-04-29T11:00:00Z",
+            isDraft: true,
+            from: { emailAddress: { name: "Me", address: "me@x" } },
+          },
+        ],
+      },
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "draft-only",
+      acquireToken,
+    );
+
+    expect(result).toBeNull();
   });
 
   it("returns null when the conversation has no indexed messages", async () => {
@@ -384,9 +452,7 @@ describe("fetchParentMessageInConversationViaGraph", () => {
 
     const [url] = fetchMock.mock.calls[0];
     expect(url).toContain(
-      encodeURIComponent(
-        "conversationId eq 'conv''with''quotes' and isDraft eq false",
-      ),
+      encodeURIComponent("conversationId eq 'conv''with''quotes'"),
     );
   });
 

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -456,6 +456,42 @@ describe("fetchParentMessageInConversationViaGraph", () => {
     );
   });
 
+  it("tolerates non-draft rows with a missing receivedDateTime and still picks the latest dated one", async () => {
+    // Defends the `receivedDateTime ?? ""` coalesce in the client-side sort:
+    // if Graph ever omits the field on a non-draft row, the sort must still
+    // produce a deterministic ordering rather than throwing.
+    const acquireToken = vi.fn().mockResolvedValue("tok");
+    installFetchMock(() => ({
+      ok: true,
+      jsonValue: {
+        value: [
+          {
+            subject: "Undated row",
+            isDraft: false,
+            from: { emailAddress: { name: "Mallory", address: "m@x" } },
+          },
+          {
+            subject: "Dated row",
+            receivedDateTime: "2026-04-29T10:00:00Z",
+            isDraft: false,
+            from: { emailAddress: { name: "Alice", address: "a@x" } },
+          },
+        ],
+      },
+    }));
+
+    const result = await fetchParentMessageInConversationViaGraph(
+      "mixed",
+      acquireToken,
+    );
+
+    expect(result).toEqual({
+      subject: "Dated row",
+      fromName: "Alice",
+      fromAddress: "a@x",
+    });
+  });
+
   it("falls back to null name/address when Graph response is missing fields", async () => {
     const acquireToken = vi.fn().mockResolvedValue("tok");
     installFetchMock(() => ({

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -51,6 +51,72 @@ export async function fetchOutlookMessageFilesViaGraph(
 }
 
 /**
+ * Looks up the most recent non-draft message in a conversation thread —
+ * i.e. the message a user is replying to / forwarding when their compose
+ * window has a `conversationId` but no `itemId` (drafts aren't indexed by
+ * Graph). Used by the add-in's "reply context" preview chip.
+ *
+ * Returns just the metadata needed to render the chip (subject + sender);
+ * deliberately does *not* fetch the body. The body is already present in
+ * the user's draft via Outlook's auto-quote and reaches the LLM via
+ * `outlook_review_draft.full_body` — fetching it again here would double
+ * the token cost.
+ *
+ * Returns `null` when the conversation has no indexed messages (a brand-
+ * new outbound thread, for example) or when Graph errors out.
+ */
+export interface ParentMessageMetadata {
+  subject: string;
+  fromName: string | null;
+  fromAddress: string | null;
+}
+
+export async function fetchParentMessageInConversationViaGraph(
+  conversationId: string,
+  acquireToken: AcquireGraphToken,
+): Promise<ParentMessageMetadata | null> {
+  try {
+    const token = await acquireToken();
+    const filter = `conversationId eq '${escapeODataString(conversationId)}' and isDraft eq false`;
+    const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$orderby=${encodeURIComponent("receivedDateTime desc")}&$top=1&$select=subject,from`;
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      console.warn(
+        "[fetchParentMessageInConversationViaGraph] non-OK status:",
+        response.status,
+        response.statusText,
+      );
+      return null;
+    }
+    const payload = (await response.json()) as {
+      value?: Array<{
+        subject?: string;
+        from?: {
+          emailAddress?: { name?: string; address?: string };
+        };
+      }>;
+    };
+    const first = payload.value?.[0];
+    if (!first) {
+      return null;
+    }
+    return {
+      subject: first.subject ?? "",
+      fromName: first.from?.emailAddress?.name ?? null,
+      fromAddress: first.from?.emailAddress?.address ?? null,
+    };
+  } catch (error) {
+    console.warn("[fetchParentMessageInConversationViaGraph] failed:", error);
+    return null;
+  }
+}
+
+/**
  * Looks up a message by its RFC 5322 `Message-ID` header, returning a single
  * `.eml` File if exactly one match is found. Returns `null` when Graph's
  * filter returns an empty result (e.g. for drafts that don't yet have an

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -77,8 +77,16 @@ export async function fetchParentMessageInConversationViaGraph(
 ): Promise<ParentMessageMetadata | null> {
   try {
     const token = await acquireToken();
-    const filter = `conversationId eq '${escapeODataString(conversationId)}' and isDraft eq false`;
-    const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$orderby=${encodeURIComponent("receivedDateTime desc")}&$top=1&$select=subject,from`;
+    // Single-clause filter on an indexed property + no `$orderby`. Adding
+    // `and isDraft eq false` plus `$orderby=receivedDateTime desc` trips
+    // Graph's `InefficientFilter` constraint: properties in `$orderby` must
+    // also appear in `$filter`, in the same order, before non-orderby
+    // properties — see the rule at
+    // https://learn.microsoft.com/en-us/graph/api/user-list-messages.
+    // We instead pull the most recent ~thread-worth of messages and pick
+    // the latest non-draft client-side.
+    const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
+    const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=20&$select=id,subject,from,receivedDateTime,isDraft`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -96,19 +104,29 @@ export async function fetchParentMessageInConversationViaGraph(
     const payload = (await response.json()) as {
       value?: Array<{
         subject?: string;
+        receivedDateTime?: string;
+        isDraft?: boolean;
         from?: {
           emailAddress?: { name?: string; address?: string };
         };
       }>;
     };
-    const first = payload.value?.[0];
-    if (!first) {
+    const candidates = payload.value ?? [];
+    // Drop drafts; sort by receivedDateTime desc; take the latest. We
+    // don't need to be defensive about missing receivedDateTime — Exchange
+    // populates it for any indexed message.
+    const latest = candidates
+      .filter((message) => message.isDraft !== true)
+      .sort((a, b) =>
+        (b.receivedDateTime ?? "").localeCompare(a.receivedDateTime ?? ""),
+      )[0];
+    if (!latest) {
       return null;
     }
     return {
-      subject: first.subject ?? "",
-      fromName: first.from?.emailAddress?.name ?? null,
-      fromAddress: first.from?.emailAddress?.address ?? null,
+      subject: latest.subject ?? "",
+      fromName: latest.from?.emailAddress?.name ?? null,
+      fromAddress: latest.from?.emailAddress?.address ?? null,
     };
   } catch (error) {
     console.warn("[fetchParentMessageInConversationViaGraph] failed:", error);


### PR DESCRIPTION
This pull request enhances the Outlook add-in's chat input by surfacing "Reply context" information when composing replies or forwards. It introduces a new display-only chip that shows the subject and sender of the parent message in the conversation thread, improving user awareness of the context being replied to. The implementation includes backend logic to fetch the parent message metadata via Microsoft Graph, ensures the chip is non-interactive, and adds comprehensive tests for the new fetch logic.

**Outlook Add-in: Reply Context Chip and Metadata Fetching**

*UI and User Experience:*
- Adds a "Reply context" chip to the chat input, displaying the subject and sender of the parent message when composing a reply/forward. This chip is informational only and cannot be removed by the user. [[1]](diffhunk://#diff-4f956ffba26f86fc66923be47550fc6f812707699930f7ecc722bbe26bdc9e9fR121-R174) [[2]](diffhunk://#diff-4f956ffba26f86fc66923be47550fc6f812707699930f7ecc722bbe26bdc9e9fL309-R371) [[3]](diffhunk://#diff-5e86ef1836bb505dd85a0dade9bb51b43316367c61357ac64058f5b8561e22b4R28-R35)
- Ensures the chip is excluded from file send operations and suppresses remove affordances both visually and in logic.

*Provider and State Management:*
- Updates `OutlookEmailSourceProvider` to fetch parent message metadata using the conversation ID in compose mode, exposing `parentReplyContext` and `isLoadingParentReplyContext` in the context. [[1]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR37-R47) [[2]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR65-R66) [[3]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR97-R109) [[4]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR144-R182) [[5]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR302-R303) [[6]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR312-R314)

*Graph API Integration:*
- Implements `fetchParentMessageInConversationViaGraph`, which retrieves the latest non-draft message in a conversation thread via the Microsoft Graph API. It returns only the metadata needed for the chip (subject and sender), avoiding unnecessary token usage by not fetching the body.

*Testing:*
- Adds thorough tests for the new Graph fetch function, covering various edge cases (multiple messages, drafts only, missing fields, error handling, and OData filter escaping). [[1]](diffhunk://#diff-6d1845b8f27738e6a6afd91ae71c97218a68ff1850d3262fbba503af3da2a3b9R10) [[2]](diffhunk://#diff-6d1845b8f27738e6a6afd91ae71c97218a68ff1850d3262fbba503af3da2a3b9R290-R479)

*Other:*
- Updates the frontend package lock to reflect the new build.