### PR TITLE
Make settings dialog tabs scroll horizontally on small viewports

### DIFF
--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
@@ -352,7 +352,9 @@ export function UserPreferencesDialog({
   const mcpServers = mcpServersResponse?.servers ?? [];
 
   const focusTab = (tab: PreferencesTab) => {
-    document.getElementById(tabIds[tab])?.focus();
+    const element = document.getElementById(tabIds[tab]);
+    element?.focus({ preventScroll: true });
+    element?.scrollIntoView({ block: "nearest", inline: "nearest" });
   };
 
   const handleTabKeyDown = (
@@ -507,8 +509,8 @@ export function UserPreferencesDialog({
       title={t({ id: "preferences.dialog.title", message: "Preferences" })}
       contentClassName="h-[80vh] max-h-[700px] max-w-4xl"
     >
-      <div className="flex h-full gap-5">
-        <aside className="w-48 shrink-0 border-r border-theme-border pr-4">
+      <div className="flex h-full flex-col gap-4 md:flex-row md:gap-5">
+        <aside className="shrink-0 border-b border-theme-border pb-3 md:w-48 md:border-b-0 md:border-r md:pb-0 md:pr-4">
           <div
             role="tablist"
             aria-label={t({
@@ -516,7 +518,7 @@ export function UserPreferencesDialog({
               message: "Preferences",
             })}
             aria-orientation="vertical"
-            className="space-y-1"
+            className="flex gap-1 overflow-x-auto md:flex-col md:overflow-x-visible"
           >
             {visibleTabs.map((tab) => {
               const isActive = activeTab === tab;
@@ -531,7 +533,7 @@ export function UserPreferencesDialog({
                   aria-controls={panelIds[tab]}
                   tabIndex={isActive ? 0 : -1}
                   className={clsx(
-                    "flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-left text-sm",
+                    "flex shrink-0 cursor-pointer items-center gap-2 whitespace-nowrap rounded-md px-3 py-2 text-left text-sm md:w-full",
                     "theme-transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus",
                     isActive
                       ? "bg-theme-bg-hover font-medium text-theme-fg-primary"

--- a/frontend/src/lib/setupTests.ts
+++ b/frontend/src/lib/setupTests.ts
@@ -61,6 +61,9 @@ Object.defineProperty(window, "scrollTo", {
   value: () => {},
 });
 
+// jsdom does not implement Element.prototype.scrollIntoView
+Element.prototype.scrollIntoView = () => {};
+
 // Provide a default API root for tests that load theme config.
 window.API_ROOT_URL = "http://localhost";
 


### PR DESCRIPTION
## Summary
- On viewports below `md`, the preferences dialog now stacks: tabs become a horizontally-scrollable strip on top, content fills the rest. At `md`+ the existing 192px vertical sidebar is unchanged.
- Keyboard navigation now scrolls the focused tab into view (`scrollIntoView({ block: "nearest", inline: "nearest" })` after `focus({ preventScroll: true })`) so off-screen tabs are reachable on mobile. No-op on desktop.
- Layout flip is pure CSS via Tailwind viewport breakpoints. `aria-orientation="vertical"` is intentionally left static — the keyboard handler already accepts both axes, so the only cost is screen readers announcing the wrong orientation hint on mobile, which is acceptable.
- Added a global `Element.prototype.scrollIntoView` stub in `setupTests.ts` since jsdom does not implement it.

## Test plan
- [ ] Open the preferences dialog on a desktop viewport — vertical sidebar still renders, no visual change.
- [ ] Resize below `md` (≤ 767px) — tabs become a horizontal strip with `overflow-x-auto`; tab labels do not wrap.
- [ ] Keyboard nav (Arrow keys, Home, End) cycles tabs and scrolls off-screen tabs into view on mobile.
- [ ] All 13 `UserPreferencesDialog` tests pass; existing `aria-orientation="vertical"` assertion still holds.

Foundation for a future container-query swap when the same dialog is reused inside the office add-in's narrow task pane (the breakpoint there will need to fire on container width, not viewport).