### PR TITLE
Fix user message soft line breaks

### DIFF
--- a/frontend/src/components/ui/Chat/ChatMessage.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.test.tsx
@@ -1,6 +1,6 @@
 import { I18nProvider } from "@lingui/react";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { messages as enMessages } from "@/locales/en/messages.json";
 
@@ -8,6 +8,8 @@ import { ChatMessage } from "./ChatMessage";
 
 import type { UiChatMessage } from "@/utils/adapters/messageAdapter";
 import type { Messages } from "@lingui/core";
+
+const messageContentMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/hooks/chat/store/messagingStore", () => ({
   useMessagingStore: () => ({
@@ -36,7 +38,10 @@ vi.mock("@/providers/FeatureConfigProvider", () => ({
 }));
 
 vi.mock("../Message/MessageContent", () => ({
-  MessageContent: () => <div data-testid="message-content-stub" />,
+  MessageContent: (props: unknown) => {
+    messageContentMock(props);
+    return <div data-testid="message-content-stub" />;
+  },
 }));
 
 vi.mock("../Message/ImageLightbox", () => ({
@@ -44,6 +49,10 @@ vi.mock("../Message/ImageLightbox", () => ({
 }));
 
 describe("ChatMessage", () => {
+  beforeEach(() => {
+    messageContentMock.mockClear();
+  });
+
   it("exposes stable message hooks for theme.css selectors", async () => {
     const message: UiChatMessage = {
       id: "msg_1",
@@ -93,6 +102,46 @@ describe("ChatMessage", () => {
     expect(messageShell.firstElementChild).toHaveStyle({
       gap: "var(--theme-spacing-message-gap)",
     });
+    expect(messageContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveSoftLineBreaks: false }),
+    );
     expect(screen.getByTestId("message-controls-probe")).toBeInTheDocument();
+  });
+
+  it("preserves soft line breaks for user message rendering", async () => {
+    const message: UiChatMessage = {
+      id: "msg_user_1",
+      content: [{ content_type: "text", text: "First\nSecond" }],
+      role: "user",
+      sender: "user",
+      authorId: "user_1",
+      createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+      status: "complete",
+    };
+
+    const Controls = () => <div data-testid="message-controls-probe" />;
+
+    const { i18n } = await import("@lingui/core");
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ChatMessage
+          message={message}
+          controls={Controls}
+          controlsContext={{
+            currentUserId: "user_1",
+            dialogOwnerId: "user_1",
+            isSharedDialog: false,
+          }}
+          onMessageAction={async () => true}
+        />
+      </I18nProvider>,
+    );
+
+    expect(messageContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ preserveSoftLineBreaks: true }),
+    );
   });
 });

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -204,6 +204,7 @@ export const ChatMessage = memo(function ChatMessage({
             showRaw={showRawMarkdown}
             onImageClick={lightbox.openLightbox}
             onFileLinkPreview={onFilePreview}
+            preserveSoftLineBreaks={isUser}
           />
 
           {/* Display attached files if any */}

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
   THEME_MODE_LOCAL_STORAGE_KEY,
@@ -42,6 +42,33 @@ const makeFile = (overrides: Partial<FileUploadItem> = {}): FileUploadItem => ({
     "sample-report-compressed.pdf",
   ),
   ...overrides,
+});
+
+beforeAll(() => {
+  const store = new Map<string, string>();
+  const stub: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+  };
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: stub,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: stub,
+  });
 });
 
 describe("MessageContent", () => {
@@ -199,6 +226,23 @@ describe("MessageContent", () => {
     expect(paragraphs).toHaveLength(2);
     expect(paragraphs[0].tagName).toBe("P");
     expect(paragraphs[1].tagName).toBe("P");
+  });
+
+  it("can preserve soft line breaks while keeping markdown lists", () => {
+    const { container } = renderWithTheme(
+      <MessageContent
+        content={textContent("First line\nSecond line\n\n- One\n- Two")}
+        preserveSoftLineBreaks
+      />,
+    );
+
+    expect(container.querySelector("article")).toHaveClass(
+      "whitespace-pre-wrap",
+    );
+    expect(screen.getByText(/First line\s+Second line/).tagName).toBe("P");
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("One").tagName).toBe("LI");
+    expect(screen.getByText("Two").tagName).toBe("LI");
   });
 
   it("renders persisted reasoning in a collapsed section", () => {

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -33,6 +33,8 @@ interface MessageContentProps {
   /** Map of file IDs to their metadata for erato-file:// link resolution */
   filesById?: Record<string, FileUploadItem>;
   onFileLinkPreview?: (file: FileUploadItem) => void;
+  /** Preserve soft markdown line breaks as visual line breaks. */
+  preserveSoftLineBreaks?: boolean;
 }
 
 const INLINE_CODE_CLASS_NAME =
@@ -295,6 +297,7 @@ export const MessageContent = memo(function MessageContent({
   onImageClick,
   filesById = {},
   onFileLinkPreview,
+  preserveSoftLineBreaks = false,
 }: MessageContentProps) {
   const imageAdvisory = useOptionalTranslation("chat.message.image_advisory");
 
@@ -650,7 +653,12 @@ export const MessageContent = memo(function MessageContent({
   }
 
   return (
-    <article className="max-w-none font-sans text-base">
+    <article
+      className={clsx(
+        "max-w-none font-sans text-base",
+        preserveSoftLineBreaks && "whitespace-pre-wrap",
+      )}
+    >
       {content.map((part, index) => {
         const isLastRenderablePart = index === lastRenderableIndex;
 


### PR DESCRIPTION
This pull request introduces the ability to preserve soft line breaks (single newlines) in user messages, ensuring that user-entered line breaks are displayed as intended without disrupting markdown formatting. The changes include updates to both the `ChatMessage` and `MessageContent` components, as well as comprehensive tests to verify the new behavior.

**Feature: Preserve Soft Line Breaks in User Messages**

* `ChatMessage.tsx`, `MessageContent.tsx`: Added a new `preserveSoftLineBreaks` prop to `MessageContent`, which is set to `true` for user messages. This ensures that single newlines in user messages are rendered as visual line breaks. [[1]](diffhunk://#diff-9c2de7f8b5558506ffbc24e5fcace70e28d4317fb713d67be1d0fdfdacf16910R207) [[2]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R36-R37) [[3]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R300) [[4]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3L653-R661)

**Testing Enhancements**

* [`ChatMessage.test.tsx`](diffhunk://#diff-b4fc3a24872164c40e40d23066848edded216ce2f5fac0641ef63a1e319a6283L3-R3): Added tests to verify that `preserveSoftLineBreaks` is correctly passed to `MessageContent` for user messages, and that the prop is set to `false` for other message types. Improved mocking to track prop usage. [[1]](diffhunk://#diff-b4fc3a24872164c40e40d23066848edded216ce2f5fac0641ef63a1e319a6283L3-R3) [[2]](diffhunk://#diff-b4fc3a24872164c40e40d23066848edded216ce2f5fac0641ef63a1e319a6283R12-R13) [[3]](diffhunk://#diff-b4fc3a24872164c40e40d23066848edded216ce2f5fac0641ef63a1e319a6283L39-R55) [[4]](diffhunk://#diff-b4fc3a24872164c40e40d23066848edded216ce2f5fac0641ef63a1e319a6283R105-R146)
* [`MessageContent.test.tsx`](diffhunk://#diff-824e708b28ba8f347fbb14ba2adb08ef3625a19ad61f96dd5a39a364111d1568L2-R2): Added a test to confirm that soft line breaks are preserved in user messages while markdown lists are still rendered correctly. Also, added a `beforeAll` hook to stub `localStorage` for test isolation. [[1]](diffhunk://#diff-824e708b28ba8f347fbb14ba2adb08ef3625a19ad61f96dd5a39a364111d1568L2-R2) [[2]](diffhunk://#diff-824e708b28ba8f347fbb14ba2adb08ef3625a19ad61f96dd5a39a364111d1568R47-R73) [[3]](diffhunk://#diff-824e708b28ba8f347fbb14ba2adb08ef3625a19ad61f96dd5a39a364111d1568R231-R247)