### PR TITLE
Collapse trace timeline behind a 'Thought for X' summary on cold load

### DIFF
--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -199,6 +199,9 @@ export const ChatMessage = memo(function ChatMessage({
             onImageClick={lightbox.openLightbox}
             onFileLinkPreview={onFilePreview}
             preserveSoftLineBreaks={isUser}
+            createdAt={message.createdAt}
+            updatedAt={message.updatedAt}
+            hasError={!!message.error}
           />
 
           {/* Display attached files if any */}

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -245,9 +245,11 @@ describe("MessageContent", () => {
     expect(screen.getByText("Two").tagName).toBe("LI");
   });
 
-  it("renders persisted reasoning collapsed, expandable on click", () => {
+  it("renders cold-load reasoning behind a 'Thought for' pill that toggles the timeline", () => {
     renderWithTheme(
       <MessageContent
+        createdAt="2026-05-07T12:00:00Z"
+        updatedAt="2026-05-07T12:00:23Z"
         content={[
           reasoningContent("I checked the input and compared options."),
           { content_type: "text", text: "Final answer." },
@@ -255,15 +257,37 @@ describe("MessageContent", () => {
       />,
     );
 
-    const toggle = screen.getByRole("button", {
-      name: "I checked the input and compared options.",
-    });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    const pill = screen.getByRole("button", { name: /Thought for 23s/ });
+    expect(pill).toHaveAttribute("aria-expanded", "false");
     expect(screen.getByText("Final answer.")).toBeInTheDocument();
 
-    fireEvent.click(toggle);
+    fireEvent.click(pill);
+    expect(pill).toHaveAttribute("aria-expanded", "true");
+  });
 
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  it("labels the cold-load pill 'Stopped after X' when the message has an error", () => {
+    renderWithTheme(
+      <MessageContent
+        createdAt="2026-05-07T12:00:00Z"
+        updatedAt="2026-05-07T12:00:05Z"
+        hasError
+        content={[reasoningContent("Tried to think about it.")]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Stopped after 5s/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the cold-load pill without a duration when timestamps are missing", () => {
+    renderWithTheme(
+      <MessageContent content={[reasoningContent("I checked the input.")]} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^Thought$/ }),
+    ).toBeInTheDocument();
   });
 
   it("streams reasoning expanded and collapses it once answer text arrives", () => {

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -6,7 +6,11 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import remarkGfm from "remark-gfm";
 
 import { useTheme } from "@/components/providers/ThemeProvider";
-import { Trace, groupIntoTraceClusters } from "@/components/ui/Trace";
+import {
+  Trace,
+  durationBetween,
+  groupIntoTraceClusters,
+} from "@/components/ui/Trace";
 import {
   DEFAULT_DARK_CODE_HIGHLIGHT_PRESET,
   DEFAULT_LIGHT_CODE_HIGHLIGHT_PRESET,
@@ -35,6 +39,14 @@ interface MessageContentProps {
   onFileLinkPreview?: (file: FileUploadItem) => void;
   /** Preserve soft markdown line breaks as visual line breaks. */
   preserveSoftLineBreaks?: boolean;
+  /**
+   * Message-level timestamps used to compute the trace cluster's "Thought
+   * for X" cold-load summary. Both should be ISO-8601; either may be missing.
+   */
+  createdAt?: string;
+  updatedAt?: string;
+  /** When true, the cold-load trace pill flips to "Stopped after X". */
+  hasError?: boolean;
 }
 
 const INLINE_CODE_CLASS_NAME =
@@ -248,6 +260,9 @@ export const MessageContent = memo(function MessageContent({
   filesById = {},
   onFileLinkPreview,
   preserveSoftLineBreaks = false,
+  createdAt,
+  updatedAt,
+  hasError = false,
 }: MessageContentProps) {
   const imageAdvisory = useOptionalTranslation("chat.message.image_advisory");
 
@@ -588,6 +603,11 @@ export const MessageContent = memo(function MessageContent({
     [content],
   );
 
+  const traceDurationMs = React.useMemo(
+    () => durationBetween(createdAt, updatedAt),
+    [createdAt, updatedAt],
+  );
+
   // If showing raw, just show text-like content without rendering markdown.
   if (showRaw) {
     const rawText = content
@@ -631,6 +651,8 @@ export const MessageContent = memo(function MessageContent({
               isStreaming={!!isStreaming}
               hasLaterContent={hasLaterContent}
               renderMarkdown={renderMarkdown}
+              durationMs={traceDurationMs}
+              hasError={hasError}
             />
           );
         }

--- a/frontend/src/components/ui/Trace/Trace.tsx
+++ b/frontend/src/components/ui/Trace/Trace.tsx
@@ -4,7 +4,9 @@ import { TraceClusterHeader } from "./TraceClusterHeader";
 import { TraceCollapse } from "./TraceCollapse";
 import { TraceConnector } from "./TraceConnector";
 import { TraceDoneMarker } from "./TraceDoneMarker";
+import { TraceThinkingPlaceholder } from "./TraceThinkingPlaceholder";
 import { parseReasoningSegments } from "./hooks/useReasoningSegments";
+import { useThinkingGap } from "./hooks/useThinkingGap";
 import { stepStatus } from "./hooks/useTraceState";
 import { ReasoningStep } from "./steps/ReasoningStep";
 import { ToolUseStep } from "./steps/ToolUseStep";
@@ -60,6 +62,14 @@ export const Trace = ({
   hasError = false,
 }: TraceProps) => {
   const logicalSteps = flattenToLogicalSteps(parts);
+  // Hooks must run on every render path. The gap detector is internally
+  // gated on streaming/hasLaterContent, so it returns false when irrelevant.
+  const showThinkingPlaceholder = useThinkingGap(
+    parts,
+    isStreaming,
+    hasLaterContent,
+  );
+
   if (logicalSteps.length === 0) return null;
 
   // Mid-stream the timeline is rendered directly. Once text starts (the
@@ -75,6 +85,7 @@ export const Trace = ({
         hasLaterContent={hasLaterContent}
         renderMarkdown={renderMarkdown}
         showDoneMarker={!isTraceActive}
+        showThinkingPlaceholder={showThinkingPlaceholder}
       />
     );
   }
@@ -121,7 +132,8 @@ const ColdLoadTrace = ({
           isTraceActive={false}
           hasLaterContent={hasLaterContent}
           renderMarkdown={renderMarkdown}
-          showDoneMarker={false}
+          showDoneMarker
+          showThinkingPlaceholder={false}
         />
       </TraceCollapse>
     </div>
@@ -133,8 +145,13 @@ interface TraceTimelineProps {
   isTraceActive: boolean;
   hasLaterContent: boolean;
   renderMarkdown: (text: string) => ReactNode;
-  /** Whether to render the Done marker at the bottom (streaming only today). */
+  /** Whether to render the Done marker at the bottom. */
   showDoneMarker: boolean;
+  /**
+   * Whether to render the transient "Thinking…" placeholder between the last
+   * step and the Done marker. Driven by `useThinkingGap` upstream.
+   */
+  showThinkingPlaceholder: boolean;
 }
 
 const TraceTimeline = ({
@@ -143,39 +160,53 @@ const TraceTimeline = ({
   hasLaterContent,
   renderMarkdown,
   showDoneMarker,
-}: TraceTimelineProps) => (
-  <div className="min-w-0 py-1.5">
-    <TraceConnector hasLine={false} />
-    {logicalSteps.map((step, index) => {
-      const isLastStep = index === logicalSteps.length - 1;
-      const isLastNodeInTimeline = isLastStep && !showDoneMarker;
-      const status = stepStatus(step, isLastStep, isTraceActive);
-      const isCollapsed = !isLastStep || hasLaterContent;
+  showThinkingPlaceholder,
+}: TraceTimelineProps) => {
+  const placeholderIsLastNode = !showDoneMarker;
 
-      const stepNode = renderStep({
-        step,
-        status,
-        isStreaming: isTraceActive,
-        isCollapsed,
-        isLastStep: isLastNodeInTimeline,
-        renderMarkdown,
-      });
+  return (
+    <div className="min-w-0 py-1.5">
+      <TraceConnector hasLine={false} />
+      {logicalSteps.map((step, index) => {
+        const isLastStep = index === logicalSteps.length - 1;
+        // The rail line continues through whatever follows: the placeholder,
+        // the Done marker, or both.
+        const isLastNodeInTimeline =
+          isLastStep && !showDoneMarker && !showThinkingPlaceholder;
+        const status = stepStatus(step, isLastStep, isTraceActive);
+        const isCollapsed = !isLastStep || hasLaterContent;
 
-      return (
-        <div key={step.key}>
-          {stepNode}
-          <TraceConnector hasLine={!isLastNodeInTimeline} />
-        </div>
-      );
-    })}
-    {showDoneMarker && (
-      <>
-        <TraceDoneMarker />
-        <TraceConnector hasLine={false} />
-      </>
-    )}
-  </div>
-);
+        const stepNode = renderStep({
+          step,
+          status,
+          isStreaming: isTraceActive,
+          isCollapsed,
+          isLastStep: isLastNodeInTimeline,
+          renderMarkdown,
+        });
+
+        return (
+          <div key={step.key}>
+            {stepNode}
+            <TraceConnector hasLine={!isLastNodeInTimeline} />
+          </div>
+        );
+      })}
+      {showThinkingPlaceholder && (
+        <>
+          <TraceThinkingPlaceholder isLastNode={placeholderIsLastNode} />
+          <TraceConnector hasLine={!placeholderIsLastNode} />
+        </>
+      )}
+      {showDoneMarker && (
+        <>
+          <TraceDoneMarker />
+          <TraceConnector hasLine={false} />
+        </>
+      )}
+    </div>
+  );
+};
 
 /**
  * Expand a contiguous run of trace-eligible parts into a flat list of logical

--- a/frontend/src/components/ui/Trace/Trace.tsx
+++ b/frontend/src/components/ui/Trace/Trace.tsx
@@ -1,3 +1,7 @@
+import { useState } from "react";
+
+import { TraceClusterHeader } from "./TraceClusterHeader";
+import { TraceCollapse } from "./TraceCollapse";
 import { TraceConnector } from "./TraceConnector";
 import { TraceDoneMarker } from "./TraceDoneMarker";
 import { parseReasoningSegments } from "./hooks/useReasoningSegments";
@@ -24,6 +28,14 @@ interface TraceProps {
   hasLaterContent: boolean;
   /** Markdown renderer reused from the parent (handles erato-file: links etc). */
   renderMarkdown: (text: string) => ReactNode;
+  /**
+   * Total assistant-turn duration in ms (parent message `updated_at -
+   * created_at`). Used to label the cold-load summary pill. `null` when
+   * unknown (e.g. mid-stream or missing `updated_at`).
+   */
+  durationMs?: number | null;
+  /** When true, the cold-load pill flips to a "Stopped after Xs" label. */
+  hasError?: boolean;
 }
 
 /**
@@ -31,61 +43,139 @@ interface TraceProps {
  * pattern from the "Steps" UI: a fixed 20px icon rail plus a fluid body, with
  * an unbroken connector line between adjacent steps.
  *
- * Reasoning parts may expand into multiple `**Header**`-bounded segments —
- * each rendered as its own step. Tool calls are always 1:1.
+ * Two modes:
+ *
+ * - **Streaming**: render the timeline directly with the running step as the
+ *   active writer at the bottom. No header pill.
+ * - **Cold load** (parent message complete): render a "Thought for X" header
+ *   pill above a collapsible body. The body contains the same timeline. The
+ *   trailing Done marker is dropped — the pill is the closing summary.
  */
 export const Trace = ({
   parts,
   isStreaming,
   hasLaterContent,
   renderMarkdown,
+  durationMs = null,
+  hasError = false,
 }: TraceProps) => {
   const logicalSteps = flattenToLogicalSteps(parts);
   if (logicalSteps.length === 0) return null;
 
-  // The trace cluster is the "active writer" only while the parent is still
-  // streaming AND no later content (text/images) has begun. Once text starts,
-  // the trace is done — even if the parent stream itself is still going.
-  const isTraceActive = isStreaming && !hasLaterContent;
-  const showDoneMarker = !isTraceActive;
+  // Mid-stream the timeline is rendered directly. Once text starts (the
+  // trace is no longer the active writer), the Done marker drops in to mark
+  // the trace's logical end. The cold-load pill only appears after the
+  // entire message stream is complete.
+  if (isStreaming) {
+    const isTraceActive = !hasLaterContent;
+    return (
+      <TraceTimeline
+        logicalSteps={logicalSteps}
+        isTraceActive={isTraceActive}
+        hasLaterContent={hasLaterContent}
+        renderMarkdown={renderMarkdown}
+        showDoneMarker={!isTraceActive}
+      />
+    );
+  }
 
   return (
-    <div className="min-w-0 py-1.5">
-      <TraceConnector hasLine={false} />
-      {logicalSteps.map((step, index) => {
-        const isLastStep = index === logicalSteps.length - 1;
-        // The rail line continues to the Done marker when one is rendered.
-        const isLastNodeInTimeline = isLastStep && !showDoneMarker;
-        const status = stepStatus(step, isLastStep, isTraceActive);
-        // Earlier steps collapse once a later step (or non-trace content)
-        // begins. The active writer stays open.
-        const isCollapsed = !isLastStep || hasLaterContent;
+    <ColdLoadTrace
+      logicalSteps={logicalSteps}
+      hasLaterContent={hasLaterContent}
+      renderMarkdown={renderMarkdown}
+      durationMs={durationMs}
+      hasError={hasError}
+    />
+  );
+};
 
-        const stepNode = renderStep({
-          step,
-          status,
-          isStreaming: isTraceActive,
-          isCollapsed,
-          isLastStep: isLastNodeInTimeline,
-          renderMarkdown,
-        });
+interface ColdLoadTraceProps {
+  logicalSteps: LogicalStep[];
+  hasLaterContent: boolean;
+  renderMarkdown: (text: string) => ReactNode;
+  durationMs: number | null;
+  hasError: boolean;
+}
 
-        return (
-          <div key={step.key}>
-            {stepNode}
-            <TraceConnector hasLine={!isLastNodeInTimeline} />
-          </div>
-        );
-      })}
-      {showDoneMarker && (
-        <>
-          <TraceDoneMarker />
-          <TraceConnector hasLine={false} />
-        </>
-      )}
+const ColdLoadTrace = ({
+  logicalSteps,
+  hasLaterContent,
+  renderMarkdown,
+  durationMs,
+  hasError,
+}: ColdLoadTraceProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="my-2 min-w-0">
+      <TraceClusterHeader
+        durationMs={durationMs}
+        hasError={hasError}
+        isOpen={isOpen}
+        onToggle={() => setIsOpen((prev) => !prev)}
+      />
+      <TraceCollapse isOpen={isOpen}>
+        <TraceTimeline
+          logicalSteps={logicalSteps}
+          isTraceActive={false}
+          hasLaterContent={hasLaterContent}
+          renderMarkdown={renderMarkdown}
+          showDoneMarker={false}
+        />
+      </TraceCollapse>
     </div>
   );
 };
+
+interface TraceTimelineProps {
+  logicalSteps: LogicalStep[];
+  isTraceActive: boolean;
+  hasLaterContent: boolean;
+  renderMarkdown: (text: string) => ReactNode;
+  /** Whether to render the Done marker at the bottom (streaming only today). */
+  showDoneMarker: boolean;
+}
+
+const TraceTimeline = ({
+  logicalSteps,
+  isTraceActive,
+  hasLaterContent,
+  renderMarkdown,
+  showDoneMarker,
+}: TraceTimelineProps) => (
+  <div className="min-w-0 py-1.5">
+    <TraceConnector hasLine={false} />
+    {logicalSteps.map((step, index) => {
+      const isLastStep = index === logicalSteps.length - 1;
+      const isLastNodeInTimeline = isLastStep && !showDoneMarker;
+      const status = stepStatus(step, isLastStep, isTraceActive);
+      const isCollapsed = !isLastStep || hasLaterContent;
+
+      const stepNode = renderStep({
+        step,
+        status,
+        isStreaming: isTraceActive,
+        isCollapsed,
+        isLastStep: isLastNodeInTimeline,
+        renderMarkdown,
+      });
+
+      return (
+        <div key={step.key}>
+          {stepNode}
+          <TraceConnector hasLine={!isLastNodeInTimeline} />
+        </div>
+      );
+    })}
+    {showDoneMarker && (
+      <>
+        <TraceDoneMarker />
+        <TraceConnector hasLine={false} />
+      </>
+    )}
+  </div>
+);
 
 /**
  * Expand a contiguous run of trace-eligible parts into a flat list of logical

--- a/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
+++ b/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
@@ -1,0 +1,64 @@
+import { t } from "@lingui/core/macro";
+import clsx from "clsx";
+
+import { ChevronRightIcon } from "@/components/ui/icons";
+
+import { formatThinkingDuration } from "./hooks/useThinkingDuration";
+
+interface TraceClusterHeaderProps {
+  /** Total trace duration in ms (or null if unknown). */
+  durationMs: number | null;
+  /** When true, label shifts to "Stopped after Xs" / "Stopped". */
+  hasError?: boolean;
+  /** Whether the timeline below is currently expanded. */
+  isOpen: boolean;
+  /** Toggle handler. */
+  onToggle: () => void;
+}
+
+const buildLabel = (durationMs: number | null, hasError: boolean): string => {
+  const formatted = formatThinkingDuration(durationMs);
+
+  if (hasError) {
+    return formatted ? t`Stopped after ${formatted}` : t`Stopped`;
+  }
+  return formatted ? t`Thought for ${formatted}` : t`Thought`;
+};
+
+/**
+ * The cold-load summary "pill" rendered above the timeline. Toggles the
+ * full reasoning + tool-call timeline visible/hidden when clicked.
+ *
+ * Only rendered for completed (non-streaming) traces — during streaming,
+ * the parent omits it and the live timeline is shown directly.
+ */
+export const TraceClusterHeader = ({
+  durationMs,
+  hasError = false,
+  isOpen,
+  onToggle,
+}: TraceClusterHeaderProps) => {
+  const label = buildLabel(durationMs, hasError);
+
+  return (
+    <button
+      type="button"
+      aria-expanded={isOpen}
+      onClick={onToggle}
+      className={clsx(
+        "flex items-center gap-2 rounded-full px-3 py-1 text-sm",
+        "text-theme-fg-secondary transition-colors hover:text-theme-fg-primary",
+        "cursor-pointer",
+      )}
+    >
+      <span className="font-medium">{label}</span>
+      <ChevronRightIcon
+        aria-hidden="true"
+        className={clsx(
+          "size-3 shrink-0 text-theme-fg-muted transition-transform",
+          isOpen ? "rotate-90" : "rotate-0",
+        )}
+      />
+    </button>
+  );
+};

--- a/frontend/src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+++ b/frontend/src/components/ui/Trace/TraceThinkingPlaceholder.tsx
@@ -1,0 +1,33 @@
+import { t } from "@lingui/core/macro";
+
+import { HourglassIcon } from "@/components/ui/icons";
+
+import { TraceRailIcon } from "./TraceRailIcon";
+
+interface TraceThinkingPlaceholderProps {
+  /** Whether this is the bottom of the timeline (no rail line below). */
+  isLastNode: boolean;
+}
+
+/**
+ * A transient "Thinking…" row that appears in the middle of an active stream
+ * when no new event has arrived for a short period. Indicates that the model
+ * is mid-thought between two visible blocks (e.g. between a tool result and
+ * the next reasoning step).
+ *
+ * Stateless — visibility is decided by the parent based on `useThinkingGap`.
+ */
+export const TraceThinkingPlaceholder = ({
+  isLastNode,
+}: TraceThinkingPlaceholderProps) => (
+  <div className="flex flex-row">
+    <TraceRailIcon
+      icon={<HourglassIcon className="size-4" />}
+      hasTrailingLine={!isLastNode}
+      isActive
+    />
+    <div className="min-w-0 flex-1 pl-2.5 pt-0.5 text-sm italic text-theme-fg-muted">
+      <span className="animate-pulse">{t`Thinking…`}</span>
+    </div>
+  </div>
+);

--- a/frontend/src/components/ui/Trace/hooks/useThinkingDuration.test.ts
+++ b/frontend/src/components/ui/Trace/hooks/useThinkingDuration.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { durationBetween, formatThinkingDuration } from "./useThinkingDuration";
+
+describe("formatThinkingDuration", () => {
+  it("returns null for invalid or non-positive durations", () => {
+    expect(formatThinkingDuration(null)).toBeNull();
+    expect(formatThinkingDuration(0)).toBeNull();
+    expect(formatThinkingDuration(-1)).toBeNull();
+    expect(formatThinkingDuration(Number.NaN)).toBeNull();
+    expect(formatThinkingDuration(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("labels sub-second durations as 'less than a second'", () => {
+    expect(formatThinkingDuration(1)).toBe("less than a second");
+    expect(formatThinkingDuration(999)).toBe("less than a second");
+  });
+
+  it("renders sub-minute durations in seconds", () => {
+    expect(formatThinkingDuration(1_000)).toBe("1s");
+    expect(formatThinkingDuration(45_000)).toBe("45s");
+    expect(formatThinkingDuration(59_499)).toBe("59s");
+  });
+
+  it("renders minutes-and-seconds for durations between 1 and 10 minutes", () => {
+    expect(formatThinkingDuration(60_000)).toBe("1m");
+    expect(formatThinkingDuration(60_999)).toBe("1m 1s");
+    expect(formatThinkingDuration(3 * 60_000 + 23_000)).toBe("3m 23s");
+    expect(formatThinkingDuration(9 * 60_000 + 59_000)).toBe("9m 59s");
+  });
+
+  it("drops the seconds component beyond 10 minutes", () => {
+    expect(formatThinkingDuration(10 * 60_000)).toBe("10m");
+    expect(formatThinkingDuration(15 * 60_000 + 30_000)).toBe("15m");
+  });
+
+  it("renders hours for very long durations", () => {
+    expect(formatThinkingDuration(60 * 60_000)).toBe("1h");
+    expect(formatThinkingDuration(60 * 60_000 + 5 * 60_000)).toBe("1h 5m");
+    expect(formatThinkingDuration(2 * 60 * 60_000 + 30 * 60_000)).toBe(
+      "2h 30m",
+    );
+  });
+});
+
+describe("durationBetween", () => {
+  it("returns null when either timestamp is missing", () => {
+    expect(durationBetween(undefined, "2026-05-07T12:00:00Z")).toBeNull();
+    expect(durationBetween("2026-05-07T12:00:00Z", undefined)).toBeNull();
+    expect(durationBetween(undefined, undefined)).toBeNull();
+  });
+
+  it("returns null when timestamps are unparseable", () => {
+    expect(durationBetween("not-a-date", "2026-05-07T12:00:00Z")).toBeNull();
+    expect(durationBetween("2026-05-07T12:00:00Z", "not-a-date")).toBeNull();
+  });
+
+  it("returns null when end is before or equal to start", () => {
+    expect(
+      durationBetween("2026-05-07T12:00:01Z", "2026-05-07T12:00:00Z"),
+    ).toBeNull();
+    expect(
+      durationBetween("2026-05-07T12:00:00Z", "2026-05-07T12:00:00Z"),
+    ).toBeNull();
+  });
+
+  it("returns the difference in ms for valid timestamps", () => {
+    expect(
+      durationBetween("2026-05-07T12:00:00Z", "2026-05-07T12:00:03Z"),
+    ).toBe(3_000);
+    expect(
+      durationBetween("2026-05-07T12:00:00Z", "2026-05-07T12:03:23Z"),
+    ).toBe(3 * 60_000 + 23_000);
+  });
+});

--- a/frontend/src/components/ui/Trace/hooks/useThinkingDuration.ts
+++ b/frontend/src/components/ui/Trace/hooks/useThinkingDuration.ts
@@ -1,0 +1,62 @@
+import { t } from "@lingui/core/macro";
+import { useMemo } from "react";
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+// Drop seconds from the label once we cross this threshold — beyond ~10
+// minutes, the seconds component is noise.
+const SECONDS_THRESHOLD_MS = 10 * MS_PER_MINUTE;
+
+/**
+ * Format a duration in milliseconds as a compact human-readable label
+ * (e.g. "23s", "3m 7s", "12m", "1h 5m"). Returns `null` when the duration is
+ * non-positive or invalid, signalling "no usable duration to display".
+ */
+export const formatThinkingDuration = (ms: number | null): string | null => {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
+
+  if (ms < MS_PER_SECOND) return t`less than a second`;
+
+  const totalSeconds = Math.round(ms / MS_PER_SECOND);
+
+  if (ms >= MS_PER_HOUR) {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.round((totalSeconds % 3600) / 60);
+    return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+  }
+
+  if (ms >= MS_PER_MINUTE) {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    if (ms >= SECONDS_THRESHOLD_MS) return `${minutes}m`;
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+  }
+
+  return `${totalSeconds}s`;
+};
+
+/**
+ * Compute the duration in milliseconds between two ISO-8601 timestamps, or
+ * `null` if either is missing or unparseable.
+ */
+export const durationBetween = (
+  startIso: string | undefined,
+  endIso: string | undefined,
+): number | null => {
+  if (!startIso || !endIso) return null;
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  const ms = end - start;
+  return ms > 0 ? ms : null;
+};
+
+/**
+ * Hook variant returning a memoized duration in ms between the two timestamps.
+ */
+export const useDurationBetween = (
+  startIso: string | undefined,
+  endIso: string | undefined,
+): number | null =>
+  useMemo(() => durationBetween(startIso, endIso), [startIso, endIso]);

--- a/frontend/src/components/ui/Trace/hooks/useThinkingGap.ts
+++ b/frontend/src/components/ui/Trace/hooks/useThinkingGap.ts
@@ -1,0 +1,53 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type { TraceablePart } from "../types";
+
+const DEFAULT_THINKING_GAP_MS = 1500;
+
+/**
+ * Build a fingerprint of the parts that changes whenever ANY meaningful
+ * activity happens — a new part appears, a reasoning text grows by even one
+ * character, or a tool call's status flips. Reference equality on the parts
+ * array isn't enough: parents may produce a fresh array each render even when
+ * the content hasn't changed.
+ */
+const buildActivityFingerprint = (parts: TraceablePart[]): string =>
+  parts
+    .map((part) =>
+      part.content_type === "reasoning"
+        ? `r:${part.text.length}`
+        : `t:${part.tool_call_id}:${part.status}`,
+    )
+    .join("|");
+
+/**
+ * Returns `true` once a quiet period (no streaming activity) has lasted long
+ * enough to warrant showing a "Thinking…" placeholder step at the tail of the
+ * timeline. The timer resets every time the parts fingerprint changes — so
+ * during a busy stream of deltas it never fires, but after a tool call
+ * completes (or any other lull) the placeholder appears.
+ *
+ * Only active during streaming AND while the trace is the live writer; for
+ * cold-load and once text has begun, this always returns `false`.
+ */
+export const useThinkingGap = (
+  parts: TraceablePart[],
+  isStreaming: boolean,
+  hasLaterContent: boolean,
+  thresholdMs: number = DEFAULT_THINKING_GAP_MS,
+): boolean => {
+  const fingerprint = useMemo(() => buildActivityFingerprint(parts), [parts]);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!isStreaming || hasLaterContent) {
+      setShow(false);
+      return;
+    }
+    setShow(false);
+    const id = window.setTimeout(() => setShow(true), thresholdMs);
+    return () => window.clearTimeout(id);
+  }, [fingerprint, isStreaming, hasLaterContent, thresholdMs]);
+
+  return show;
+};

--- a/frontend/src/components/ui/Trace/index.ts
+++ b/frontend/src/components/ui/Trace/index.ts
@@ -12,3 +12,8 @@ export {
   useReasoningSegments,
 } from "./hooks/useReasoningSegments";
 export type { ReasoningSegment } from "./hooks/useReasoningSegments";
+export {
+  durationBetween,
+  formatThinkingDuration,
+  useDurationBetween,
+} from "./hooks/useThinkingDuration";

--- a/frontend/src/customer/examples/ChatMessageBubble.example.tsx
+++ b/frontend/src/customer/examples/ChatMessageBubble.example.tsx
@@ -147,6 +147,9 @@ export const ChatMessageBubble = memo(function ChatMessageBubble({
               showRaw={showRawMarkdown}
               onImageClick={lightbox.openLightbox}
               onFileLinkPreview={onFilePreview}
+              createdAt={message.createdAt}
+              updatedAt={message.updatedAt}
+              hasError={!!message.error}
             />
 
             {message.input_files_ids && message.input_files_ids.length > 0 && (
@@ -245,6 +248,9 @@ export const ChatMessageBubble = memo(function ChatMessageBubble({
           showRaw={showRawMarkdown}
           onImageClick={lightbox.openLightbox}
           onFileLinkPreview={onFilePreview}
+          createdAt={message.createdAt}
+          updatedAt={message.updatedAt}
+          hasError={!!message.error}
         />
 
         {message.input_files_ids && message.input_files_ids.length > 0 && (

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -504,12 +504,19 @@ describe("useChatMessaging", () => {
       content: [{ content_type: "text", text: "Hello" }],
       role: "user",
       createdAt: "2023-01-01T12:00:00.000Z",
+      updatedAt: "2023-01-01T12:00:00.000Z",
       status: "complete",
       input_files_ids: undefined,
       previous_message_id: undefined,
       sender: "user",
       authorId: "user_id",
       is_message_in_active_thread: true,
+      files: undefined,
+      feedback: undefined,
+      error: undefined,
+      mcp_servers_unavailable: undefined,
+      action_facet_id: undefined,
+      action_facet_args: undefined,
     });
 
     expect(result.current.messages[secondMessageId]).toEqual({
@@ -517,12 +524,19 @@ describe("useChatMessaging", () => {
       content: [{ content_type: "text", text: "Hi there" }],
       role: "assistant",
       createdAt: "2023-01-01T12:01:00.000Z",
+      updatedAt: "2023-01-01T12:01:00.000Z",
       status: "complete",
       input_files_ids: undefined,
       previous_message_id: undefined,
       sender: "assistant",
       authorId: "assistant_id",
       is_message_in_active_thread: true,
+      files: undefined,
+      feedback: undefined,
+      error: undefined,
+      mcp_servers_unavailable: undefined,
+      action_facet_id: undefined,
+      action_facet_args: undefined,
     });
   });
 

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2129,7 +2129,7 @@ msgstr "Größte Kontextbeiträge von Dateien:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
 msgid "less than a second"
-msgstr ""
+msgstr "weniger als eine Sekunde"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
@@ -2506,11 +2506,11 @@ msgstr "Audiodiktat stoppen"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped"
-msgstr ""
+msgstr "Abgebrochen"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped after {formatted}"
-msgstr ""
+msgstr "Abgebrochen nach {formatted}"
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
@@ -2552,7 +2552,7 @@ msgstr "Denkt nach"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 msgid "Thinking…"
-msgstr ""
+msgstr "Denkt nach…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -2564,11 +2564,11 @@ msgstr "Diese Nachricht verwendet {percentUsed}% des verfügbaren Token-Limits (
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought"
-msgstr ""
+msgstr "Nachgedacht"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought for {formatted}"
-msgstr ""
+msgstr "Nachgedacht für {formatted}"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2550,6 +2550,10 @@ msgstr "Die folgenden Dateien können nicht verarbeitet werden und wurden nicht 
 msgid "Thinking"
 msgstr "Denkt nach"
 
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "Thinking…"
+msgstr ""
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
 msgstr "Diese Nachricht überschreitet das Token-Limit von {maxTokensFormatted}. Bitte kürzen Sie die Nachricht oder entfernen Sie angehängte Dateien."

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2127,6 +2127,10 @@ msgstr "Ungültiges Datum für MessageTimestamp bereitgestellt, aktuelles Datum 
 msgid "Largest file context contributors:"
 msgstr "Größte Kontextbeiträge von Dateien:"
 
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "less than a second"
+msgstr ""
+
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Heller Modus"
@@ -2500,6 +2504,14 @@ msgstr "Audiodiktat stoppen"
 #~ msgid "Stop recording"
 #~ msgstr "Aufnahme stoppen"
 
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped after {formatted}"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
 msgstr "Erfolgreich"
@@ -2545,6 +2557,14 @@ msgstr "Diese Nachricht überschreitet das Token-Limit von {maxTokensFormatted}.
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 msgstr "Diese Nachricht verwendet {percentUsed}% des verfügbaren Token-Limits ({totalTokensFormatted} von {maxTokensFormatted})."
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought for {formatted}"
+msgstr ""
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2127,6 +2127,10 @@ msgstr "Invalid date provided to MessageTimestamp, using current date"
 msgid "Largest file context contributors:"
 msgstr "Largest file context contributors:"
 
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "less than a second"
+msgstr "less than a second"
+
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Light mode"
@@ -2500,6 +2504,14 @@ msgstr "Stop dictation"
 #~ msgid "Stop recording"
 #~ msgstr "Stop recording"
 
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped"
+msgstr "Stopped"
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped after {formatted}"
+msgstr "Stopped after {formatted}"
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
 msgstr "Success"
@@ -2545,6 +2557,14 @@ msgstr "This message exceeds the token limit of {maxTokensFormatted}. Please red
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 msgstr "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought"
+msgstr "Thought"
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought for {formatted}"
+msgstr "Thought for {formatted}"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2550,6 +2550,10 @@ msgstr "The following files cannot be processed and were not uploaded: {filename
 msgid "Thinking"
 msgstr "Thinking"
 
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "Thinking…"
+msgstr "Thinking…"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
 msgstr "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2127,6 +2127,10 @@ msgstr "Fecha inválida proporcionada a MessageTimestamp, usando fecha actual"
 msgid "Largest file context contributors:"
 msgstr "Mayores contribuciones de contexto de archivos:"
 
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "less than a second"
+msgstr ""
+
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Modo claro"
@@ -2500,6 +2504,14 @@ msgstr "Detener dictado"
 #~ msgid "Stop recording"
 #~ msgstr "Detener grabación"
 
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped after {formatted}"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
 msgstr "Éxito"
@@ -2545,6 +2557,14 @@ msgstr "Este mensaje excede el límite de tokens de {maxTokensFormatted}. Por fa
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 msgstr "Este mensaje está usando {percentUsed}% del límite de tokens disponible ({totalTokensFormatted} de {maxTokensFormatted})."
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought for {formatted}"
+msgstr ""
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2550,6 +2550,10 @@ msgstr "Los siguientes archivos no pueden ser procesados y no se subieron: {file
 msgid "Thinking"
 msgstr "Pensando"
 
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "Thinking…"
+msgstr ""
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
 msgstr "Este mensaje excede el límite de tokens de {maxTokensFormatted}. Por favor, reduzca la longitud del mensaje o elimine archivos adjuntos."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2129,7 +2129,7 @@ msgstr "Mayores contribuciones de contexto de archivos:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
 msgid "less than a second"
-msgstr ""
+msgstr "menos de un segundo"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
@@ -2506,11 +2506,11 @@ msgstr "Detener dictado"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped"
-msgstr ""
+msgstr "Detenido"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped after {formatted}"
-msgstr ""
+msgstr "Detenido tras {formatted}"
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
@@ -2552,7 +2552,7 @@ msgstr "Pensando"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 msgid "Thinking…"
-msgstr ""
+msgstr "Pensando…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -2564,11 +2564,11 @@ msgstr "Este mensaje está usando {percentUsed}% del límite de tokens disponibl
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought"
-msgstr ""
+msgstr "Pensado"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought for {formatted}"
-msgstr ""
+msgstr "Pensado durante {formatted}"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2129,7 +2129,7 @@ msgstr "Principales contributions des fichiers au contexte :"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
 msgid "less than a second"
-msgstr ""
+msgstr "moins d'une seconde"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
@@ -2506,11 +2506,11 @@ msgstr "Arrêter la dictée"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped"
-msgstr ""
+msgstr "Arrêté"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped after {formatted}"
-msgstr ""
+msgstr "Arrêté après {formatted}"
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
@@ -2552,7 +2552,7 @@ msgstr "Réflexion"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 msgid "Thinking…"
-msgstr ""
+msgstr "Réflexion…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -2564,11 +2564,11 @@ msgstr "Ce message utilise {percentUsed}% de la limite de tokens disponible ({to
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought"
-msgstr ""
+msgstr "Réfléchi"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought for {formatted}"
-msgstr ""
+msgstr "Réfléchi pendant {formatted}"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2550,6 +2550,10 @@ msgstr "Les fichiers suivants ne peuvent pas être traités et n'ont pas été t
 msgid "Thinking"
 msgstr "Réflexion"
 
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "Thinking…"
+msgstr ""
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
 msgstr "Ce message dépasse la limite de tokens de {maxTokensFormatted}. Veuillez réduire la longueur du message ou supprimer les fichiers joints."

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2127,6 +2127,10 @@ msgstr "Date invalide fournie à MessageTimestamp, utilisation de la date actuel
 msgid "Largest file context contributors:"
 msgstr "Principales contributions des fichiers au contexte :"
 
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "less than a second"
+msgstr ""
+
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Mode clair"
@@ -2500,6 +2504,14 @@ msgstr "Arrêter la dictée"
 #~ msgid "Stop recording"
 #~ msgstr "Arrêter l'enregistrement"
 
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped after {formatted}"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
 msgstr "Succès"
@@ -2545,6 +2557,14 @@ msgstr "Ce message dépasse la limite de tokens de {maxTokensFormatted}. Veuille
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 msgstr "Ce message utilise {percentUsed}% de la limite de tokens disponible ({totalTokensFormatted} sur {maxTokensFormatted})."
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought for {formatted}"
+msgstr ""
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2129,7 +2129,7 @@ msgstr "Największy udział plików w kontekście:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
 msgid "less than a second"
-msgstr ""
+msgstr "mniej niż sekundę"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
@@ -2506,11 +2506,11 @@ msgstr "Zatrzymaj dyktowanie"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped"
-msgstr ""
+msgstr "Zatrzymano"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Stopped after {formatted}"
-msgstr ""
+msgstr "Zatrzymano po {formatted}"
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
@@ -2552,7 +2552,7 @@ msgstr "Myślę"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 msgid "Thinking…"
-msgstr ""
+msgstr "Myślę…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -2564,11 +2564,11 @@ msgstr "Ta wiadomość używa {percentUsed}% dostępnego limitu tokenów ({total
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought"
-msgstr ""
+msgstr "Myślano"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
 msgid "Thought for {formatted}"
-msgstr ""
+msgstr "Myślano przez {formatted}"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2550,6 +2550,10 @@ msgstr "Następujące pliki nie mogą być przetworzone i nie zostały przesłan
 msgid "Thinking"
 msgstr "Myślę"
 
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "Thinking…"
+msgstr ""
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
 msgstr "Ta wiadomość przekracza limit tokenów {maxTokensFormatted}. Proszę skrócić wiadomość lub usunąć załączone pliki."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2127,6 +2127,10 @@ msgstr "Podano nieprawidłową datę do MessageTimestamp, używam bieżącej dat
 msgid "Largest file context contributors:"
 msgstr "Największy udział plików w kontekście:"
 
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "less than a second"
+msgstr ""
+
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Tryb jasny"
@@ -2500,6 +2504,14 @@ msgstr "Zatrzymaj dyktowanie"
 #~ msgid "Stop recording"
 #~ msgstr "Zatrzymaj nagrywanie"
 
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Stopped after {formatted}"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Success"
 msgstr "Sukces"
@@ -2545,6 +2557,14 @@ msgstr "Ta wiadomość przekracza limit tokenów {maxTokensFormatted}. Proszę s
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 msgstr "Ta wiadomość używa {percentUsed}% dostępnego limitu tokenów ({totalTokensFormatted} z {maxTokensFormatted})."
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought"
+msgstr ""
+
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "Thought for {formatted}"
+msgstr ""
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -32,6 +32,11 @@ export interface Message {
   content: ContentPart[];
   role: "user" | "assistant" | "system";
   createdAt: string;
+  /**
+   * Last-modified timestamp from the backend (ISO-8601). Set on persisted
+   * messages; missing on optimistic placeholders pre-stream.
+   */
+  updatedAt?: string;
   input_files_ids?: string[];
   status?: "sending" | "complete" | "error";
   error?: MessageError;

--- a/frontend/src/utils/adapters/messageAdapter.ts
+++ b/frontend/src/utils/adapters/messageAdapter.ts
@@ -49,6 +49,7 @@ export function mapApiMessageToUiMessage(
     sender: apiMessage.role,
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     createdAt: apiMessage.created_at ?? new Date().toISOString(),
+    updatedAt: apiMessage.updated_at,
     authorId: apiMessage.role === "user" ? "user_id" : "assistant_id",
     // map active thread flag
     is_message_in_active_thread: apiMessage.is_message_in_active_thread,


### PR DESCRIPTION
This pull request introduces a new "cold-load" summary pill for completed assistant reasoning traces, improving the clarity and usability of the chat timeline. When a message is fully loaded, a pill labeled with the total "thinking" duration (or "Stopped after X" if there was an error) is shown above a collapsible reasoning timeline. The pull request also adds a transient "Thinking…" placeholder during streaming lulls, and includes robust duration formatting and testing. 

The most important changes are:

**Cold-load summary pill and timeline improvements:**

* Added a `TraceClusterHeader` pill above completed assistant traces, showing "Thought for X" (duration) or "Stopped after X" (on error), with the ability to expand/collapse the timeline. This uses message-level timestamps to compute and display the duration. (`frontend/src/components/ui/Trace/Trace.tsx`, `frontend/src/components/ui/Trace/TraceClusterHeader.tsx`, `frontend/src/components/ui/Message/MessageContent.tsx`, `frontend/src/components/ui/Chat/ChatMessage.tsx`) [[1]](diffhunk://#diff-e1ee60d67dc585fe1c07e7b8fa13dc3e7014bad3657e93fe55a06fc3728a59e3R1-R9) [[2]](diffhunk://#diff-e1ee60d67dc585fe1c07e7b8fa13dc3e7014bad3657e93fe55a06fc3728a59e3R33-L61) [[3]](diffhunk://#diff-e1ee60d67dc585fe1c07e7b8fa13dc3e7014bad3657e93fe55a06fc3728a59e3R195-R200) [[4]](diffhunk://#diff-85dc80542c0df899a88da5026e06f7aa7b03a83ddd75c53bdb79cf89e4d16721R1-R64) [[5]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R42-R49) [[6]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R263-R265) [[7]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R606-R610) [[8]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R654-R655) [[9]](diffhunk://#diff-9c2de7f8b5558506ffbc24e5fcace70e28d4317fb713d67be1d0fdfdacf16910R202-R204)

* Updated the message content and trace components to accept `createdAt`, `updatedAt`, and `hasError` props, passing these through to enable duration calculation and error labeling for the summary pill. (`frontend/src/components/ui/Message/MessageContent.tsx`, `frontend/src/components/ui/Chat/ChatMessage.tsx`) [[1]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R42-R49) [[2]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R263-R265) [[3]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R606-R610) [[4]](diffhunk://#diff-d763762df1be4c52d288b293c560a4fb3128d585e0a0cdf909e5e3338095a7a3R654-R655) [[5]](diffhunk://#diff-9c2de7f8b5558506ffbc24e5fcace70e28d4317fb713d67be1d0fdfdacf16910R202-R204)

**Streaming UX improvements:**

* Added a `TraceThinkingPlaceholder` component and `useThinkingGap` hook to display a transient "Thinking…" row in the timeline during streaming gaps, making model thinking states more visible to users. (`frontend/src/components/ui/Trace/TraceThinkingPlaceholder.tsx`, `frontend/src/components/ui/Trace/Trace.tsx`, `frontend/src/components/ui/Trace/hooks/useThinkingGap.ts`) [[1]](diffhunk://#diff-cce76d3fe76923cc70f8e03f4094f925037571247f42d2f7a458672f32fcac56R1-R33) [[2]](diffhunk://#diff-e1ee60d67dc585fe1c07e7b8fa13dc3e7014bad3657e93fe55a06fc3728a59e3R1-R9) [[3]](diffhunk://#diff-e1ee60d67dc585fe1c07e7b8fa13dc3e7014bad3657e93fe55a06fc3728a59e3R195-R200) [[4]](diffhunk://#diff-c847b6e36cf22ba9176439ac5a173b8bc40df279b63455b6ca0b98a5746ebdf7R1-R53)

**Duration calculation and formatting:**

* Implemented utility functions and a hook for robustly computing and formatting durations between timestamps, including edge case handling and internationalization. (`frontend/src/components/ui/Trace/hooks/useThinkingDuration.ts`)

* Added thorough unit tests for duration formatting and calculation logic, ensuring correct labels for a wide range of durations and input scenarios. (`frontend/src/components/ui/Trace/hooks/useThinkingDuration.test.ts`)

**Test coverage and UI tests:**

* Expanded and updated UI tests for the `MessageContent` component to cover the new cold-load pill, error state labeling, and behavior when timestamps are missing. (`frontend/src/components/ui/Message/MessageContent.test.tsx`)

These changes collectively enhance the user experience by making assistant reasoning steps more understandable and interactive, both during and after streaming.