### PR TITLE
Add audio-mode button with shared Waveform primitives

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -32,6 +32,7 @@ const mockUseCreateChat = vi.fn();
 const mockFetchGetFile = vi.fn();
 const mockModelSelector = vi.fn();
 const mockUseAudioDictationRecorder = vi.fn();
+const mockUseAudioTranscriptionRecorder = vi.fn();
 
 vi.mock("@/providers/ChatProvider", () => ({
   useChatContext: () => mockUseChatContext(),
@@ -61,6 +62,11 @@ vi.mock("@/hooks/ui", () => ({
 vi.mock("@/hooks/audio/useAudioDictationRecorder", () => ({
   useAudioDictationRecorder: (...args: unknown[]) =>
     mockUseAudioDictationRecorder(...args),
+}));
+
+vi.mock("@/hooks/audio/useAudioTranscriptionRecorder", () => ({
+  useAudioTranscriptionRecorder: (...args: unknown[]) =>
+    mockUseAudioTranscriptionRecorder(...args),
 }));
 
 vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
@@ -232,6 +238,19 @@ describe("ChatInput", () => {
       setDictationError: vi.fn(),
       dictationBars: [2, 2, 2, 2, 2],
       toggleDictation: vi.fn(),
+    });
+    mockUseAudioTranscriptionRecorder.mockReturnValue({
+      isRecording: false,
+      isRecordingUpload: false,
+      recordingError: null,
+      setRecordingError: vi.fn(),
+      recordingBars: [2, 2, 2, 2, 2],
+      retryingAudioFileId: null,
+      retryAudioTranscription: vi.fn(),
+      removeRecordedAudioFile: vi.fn(),
+      clearRecordedAudioFiles: vi.fn(),
+      hasRecordedAudioFile: () => false,
+      toggleAudioRecording: vi.fn(),
     });
   });
 
@@ -1227,5 +1246,382 @@ describe("ChatInput", () => {
     fireEvent.click(screen.getByTestId("remove-file-audio-file-4"));
     expect(removeFile).toHaveBeenCalledWith("audio-file-4");
     confirmSpy.mockRestore();
+  });
+
+  describe("audio mode button (transcription)", () => {
+    it("shows the audio-mode button instead of send when input is empty", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.getByTestId("chat-input-audio-mode-start"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-send-message"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("flips to the send button when the user types and back when cleared", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "hi" } });
+
+      expect(
+        screen.getByTestId("chat-input-send-message"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.change(textarea, { target: { value: "" } });
+
+      expect(
+        screen.getByTestId("chat-input-audio-mode-start"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-send-message"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show the audio-mode button when transcription is disabled", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-send-message"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the audio-mode button in edit mode", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              onSendMessage={vi.fn()}
+              mode="edit"
+              editMessageId="m-1"
+              onCancelEdit={vi.fn()}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-save-edit")).toBeInTheDocument();
+    });
+
+    it("invokes toggleAudioRecording when the audio-mode button is clicked", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const toggleAudioRecording = vi.fn();
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-start"));
+      expect(toggleAudioRecording).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the audio-mode button (in stop state) while recording", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: true,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [3, 6, 9, 6, 3],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording: vi.fn(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      const stopButton = screen.getByTestId("chat-input-audio-mode-stop");
+      expect(stopButton).toBeInTheDocument();
+      expect(stopButton).toHaveAccessibleName("Stop audio recording");
+      expect(
+        screen.getByTestId("chat-input-audio-mode-recording-waveform"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-audio-mode-stop-icon"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the cancel-generation button (not audio-mode) while a response is pending", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseChatContext.mockReturnValue({
+        isPendingResponse: true,
+        isMessagingLoading: false,
+        isUploading: false,
+        cancelMessage: vi.fn(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.getByTestId("chat-input-stop-generation"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the audio-mode button when only an attachment is present", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [
+          {
+            id: "f-1",
+            filename: "notes.pdf",
+            download_url: "/files/f-1",
+          },
+        ] as unknown as FileUploadItem[],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-send-message"),
+      ).toBeInTheDocument();
+    });
+
+    it("disables the audio-mode button while dictation is active", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioDictationFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioDictationRecorder.mockReturnValue({
+        isDictating: true,
+        isDictationStarting: false,
+        isDictationCompleting: false,
+        dictationError: null,
+        setDictationError: vi.fn(),
+        dictationBars: [2, 5, 8, 5, 2],
+        toggleDictation: vi.fn(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(screen.getByTestId("chat-input-audio-mode-start")).toBeDisabled();
+    });
+
+    it("disables the audio-mode button while an attachment is still transcribing", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [
+          {
+            id: "audio-in-progress",
+            filename: "voice-memo.wav",
+            download_url: "/files/audio-in-progress",
+            audio_transcription: { status: "transcribing" },
+          },
+        ] as unknown as FileUploadItem[],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      // An in-progress transcription counts as an attachment, so the slot
+      // shows the send button (also disabled). The audio-mode button is not
+      // available while another transcription is still running.
+      expect(
+        screen.queryByTestId("chat-input-audio-mode-start"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-send-message")).toBeDisabled();
+    });
   });
 });

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1307,9 +1307,7 @@ describe("ChatInput", () => {
       const textarea = screen.getByPlaceholderText("Type a message...");
       fireEvent.change(textarea, { target: { value: "hi" } });
 
-      expect(
-        screen.getByTestId("chat-input-send-message"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-send-message")).toBeInTheDocument();
       expect(
         screen.queryByTestId("chat-input-audio-mode-start"),
       ).not.toBeInTheDocument();
@@ -1344,9 +1342,7 @@ describe("ChatInput", () => {
       expect(
         screen.queryByTestId("chat-input-audio-mode-start"),
       ).not.toBeInTheDocument();
-      expect(
-        screen.getByTestId("chat-input-send-message"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-send-message")).toBeInTheDocument();
     });
 
     it("does not show the audio-mode button in edit mode", async () => {
@@ -1540,9 +1536,7 @@ describe("ChatInput", () => {
       expect(
         screen.queryByTestId("chat-input-audio-mode-start"),
       ).not.toBeInTheDocument();
-      expect(
-        screen.getByTestId("chat-input-send-message"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-send-message")).toBeInTheDocument();
     });
 
     it("disables the audio-mode button while dictation is active", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1023,8 +1023,8 @@ describe("ChatInput", () => {
       "group-focus-visible:opacity-0",
     );
     expect(waveform.children[2]).toHaveClass(
-      "transition-[height]",
-      "duration-75",
+      "motion-safe:transition-[height]",
+      "motion-safe:duration-75",
     );
     expect(waveform.children[2]).not.toHaveClass("dictation-wave-bar");
     expect(waveform.children[2]).toHaveStyle({ height: "14px" });
@@ -1033,6 +1033,11 @@ describe("ChatInput", () => {
       "group-focus-visible:opacity-100",
     );
     expect(stopIcon).toHaveTextContent("stop");
+
+    const statusNodes = screen
+      .getAllByRole("status", { hidden: true })
+      .map((node) => node.textContent);
+    expect(statusNodes).toContain("Dictating audio");
   });
 
   it("shows a loading indicator while dictation is finishing", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -37,9 +37,11 @@ import { resolveChatSendErrorMessage } from "@/utils/chatSendErrorMessage";
 import { createLogger } from "@/utils/debugLogger";
 
 import { ArrowUpIcon, LoadingIcon, StopIcon, VoiceIcon } from "../icons";
+import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
 import { ChatInputTokenUsage } from "./ChatInputTokenUsage";
 import { FacetSelector } from "./FacetSelector";
 import { ModelSelector } from "./ModelSelector";
+import { WaveformButton } from "./WaveformButton";
 import { Button } from "../Controls/Button";
 import { Alert } from "../Feedback/Alert";
 import { BudgetWarning } from "../Feedback/ChatWarnings/BudgetWarning";
@@ -56,7 +58,6 @@ import type { ClipboardEvent as ReactClipboardEvent, Ref } from "react";
 
 const logger = createLogger("UI", "ChatInput");
 const AUDIO_TRANSCRIPTION_STATUS_POLL_INTERVAL_MS = 1000;
-const DICTATION_WAVEFORM_MAX_BAR_HEIGHT_PX = 14;
 
 type AudioTranscriptionAttachment = {
   fileId: string;
@@ -419,11 +420,13 @@ export const ChatInput = ({
     isRecordingUpload,
     recordingError,
     setRecordingError,
+    recordingBars,
     retryingAudioFileId,
     retryAudioTranscription,
     removeRecordedAudioFile,
     clearRecordedAudioFiles,
     hasRecordedAudioFile,
+    toggleAudioRecording,
   } = useAudioTranscriptionRecorder({
     audioTranscriptionEnabled,
     uploadEnabled,
@@ -1160,6 +1163,28 @@ export const ChatInput = ({
     !hasIncompleteAudioTranscription &&
     !isDictationCompleting;
 
+  // The send button slot becomes a dedicated audio-mode button when the
+  // input is empty in compose mode and audio transcription is enabled.
+  // While recording, the same slot keeps the audio-mode button (now in its
+  // stop-on-hover state) so the toggle stays in one place.
+  const hasComposeContent =
+    message.trim().length > 0 || attachedFiles.length > 0;
+  const showAudioModeButton =
+    audioTranscriptionEnabled &&
+    mode === "compose" &&
+    (isRecording || (!hasComposeContent && !isRecordingUpload));
+  const isAudioModeButtonDisabled =
+    !isRecording &&
+    (disabled ||
+      isLoading ||
+      isUploading ||
+      isFileButtonProcessing ||
+      isAnyTokenLimitExceeded ||
+      hasIncompleteAudioTranscription ||
+      isDictating ||
+      isDictationStarting ||
+      isDictationCompleting);
+
   // Log just before rendering the component and its preview section
   logger.log(
     "Rendering component. Preview should render if attachedFiles > 0. attachedFiles:",
@@ -1489,78 +1514,60 @@ export const ChatInput = ({
                   disabled={!isSelectionReady}
                 />
               )}
-              {audioDictationEnabled && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  className={clsx(
-                    isDictating && "group relative overflow-hidden",
-                  )}
-                  icon={
-                    isDictating ? undefined : isDictationStarting ||
-                      isDictationCompleting ? (
-                      <LoadingIcon
-                        className="size-4 animate-spin text-[var(--theme-fg-primary)]"
-                        data-testid="chat-input-dictation-loading-icon"
-                      />
-                    ) : (
-                      <VoiceIcon className="text-[var(--theme-fg-primary)]" />
-                    )
-                  }
-                  onClick={toggleDictationForCurrentTarget}
-                  disabled={
-                    disabled ||
-                    isLoading ||
-                    isPendingResponse ||
-                    isUploading ||
-                    isFileButtonProcessing ||
-                    isDictationStarting ||
-                    isDictationCompleting ||
-                    isAnyTokenLimitExceeded
-                  }
-                  data-testid="chat-input-record-audio"
-                  aria-label={
-                    isDictating
-                      ? t`Stop dictation`
-                      : isDictationStarting
+              {audioDictationEnabled &&
+                (isDictating ? (
+                  <WaveformButton
+                    onClick={toggleDictationForCurrentTarget}
+                    bars={dictationBars}
+                    disabled={
+                      disabled ||
+                      isLoading ||
+                      isPendingResponse ||
+                      isUploading ||
+                      isFileButtonProcessing ||
+                      isAnyTokenLimitExceeded
+                    }
+                    ariaLabel={t`Stop dictation`}
+                    testId="chat-input-record-audio"
+                    waveformTestId="chat-input-dictation-waveform"
+                    stopIconTestId="chat-input-dictation-stop-icon"
+                  />
+                ) : (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    icon={
+                      isDictationStarting || isDictationCompleting ? (
+                        <LoadingIcon
+                          className="size-4 animate-spin text-[var(--theme-fg-primary)]"
+                          data-testid="chat-input-dictation-loading-icon"
+                        />
+                      ) : (
+                        <VoiceIcon className="text-[var(--theme-fg-primary)]" />
+                      )
+                    }
+                    onClick={toggleDictationForCurrentTarget}
+                    disabled={
+                      disabled ||
+                      isLoading ||
+                      isPendingResponse ||
+                      isUploading ||
+                      isFileButtonProcessing ||
+                      isDictationStarting ||
+                      isDictationCompleting ||
+                      isAnyTokenLimitExceeded
+                    }
+                    data-testid="chat-input-record-audio"
+                    aria-label={
+                      isDictationStarting
                         ? t`Starting dictation`
                         : isDictationCompleting
                           ? t`Finishing dictation`
                           : t`Start dictation`
-                  }
-                >
-                  {isDictating ? (
-                    <>
-                      <span
-                        aria-label={t`Dictating audio`}
-                        className="flex h-4 items-center gap-0.5 transition-opacity duration-150 group-hover:opacity-0 group-focus-visible:opacity-0"
-                        data-testid="chat-input-dictation-waveform"
-                      >
-                        {dictationBars.map((height, barIndex) => (
-                          <span
-                            key={barIndex}
-                            className="w-1 rounded-full bg-current transition-[height] duration-75"
-                            style={{
-                              height: `${Math.min(
-                                Math.max(height, 2) * 2,
-                                DICTATION_WAVEFORM_MAX_BAR_HEIGHT_PX,
-                              )}px`,
-                            }}
-                          />
-                        ))}
-                      </span>
-                      <span
-                        aria-hidden="true"
-                        className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
-                        data-testid="chat-input-dictation-stop-icon"
-                      >
-                        <StopIcon className="size-4" />
-                      </span>
-                    </>
-                  ) : null}
-                </Button>
-              )}
+                    }
+                  />
+                ))}
               {isPendingResponse ? (
                 <Button
                   type="button"
@@ -1570,6 +1577,13 @@ export const ChatInput = ({
                   onClick={cancelMessage}
                   data-testid="chat-input-stop-generation"
                   aria-label={t`Stop`}
+                />
+              ) : showAudioModeButton ? (
+                <ChatInputAudioModeButton
+                  onClick={toggleAudioRecording}
+                  isRecording={isRecording}
+                  recordingBars={recordingBars}
+                  disabled={isAudioModeButtonDisabled}
                 />
               ) : (
                 <Button

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1586,13 +1586,13 @@ export const ChatInput = ({
                   <ChatInputAudioModeButton
                     isRecording
                     recordingBars={recordingBars}
-                    onClick={toggleAudioRecording}
+                    onToggle={toggleAudioRecording}
                     disabled={isAudioModeButtonDisabled}
                   />
                 ) : (
                   <ChatInputAudioModeButton
                     isRecording={false}
-                    onClick={toggleAudioRecording}
+                    onToggle={toggleAudioRecording}
                     disabled={isAudioModeButtonDisabled}
                   />
                 )

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1580,12 +1580,20 @@ export const ChatInput = ({
                   aria-label={t`Stop`}
                 />
               ) : showAudioModeButton ? (
-                <ChatInputAudioModeButton
-                  onClick={toggleAudioRecording}
-                  isRecording={isRecording}
-                  recordingBars={recordingBars}
-                  disabled={isAudioModeButtonDisabled}
-                />
+                isRecording ? (
+                  <ChatInputAudioModeButton
+                    isRecording
+                    recordingBars={recordingBars}
+                    onClick={toggleAudioRecording}
+                    disabled={isAudioModeButtonDisabled}
+                  />
+                ) : (
+                  <ChatInputAudioModeButton
+                    isRecording={false}
+                    onClick={toggleAudioRecording}
+                    disabled={isAudioModeButtonDisabled}
+                  />
+                )
               ) : (
                 <Button
                   type="submit"

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1529,9 +1529,11 @@ export const ChatInput = ({
                     }
                     ariaLabel={t`Stop dictation`}
                     statusLabel={t`Dictating audio`}
-                    testId="chat-input-record-audio"
-                    waveformTestId="chat-input-dictation-waveform"
-                    stopIconTestId="chat-input-dictation-stop-icon"
+                    testIds={{
+                      root: "chat-input-record-audio",
+                      waveform: "chat-input-dictation-waveform",
+                      stopIcon: "chat-input-dictation-stop-icon",
+                    }}
                   />
                 ) : (
                   <Button

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1528,6 +1528,7 @@ export const ChatInput = ({
                       isAnyTokenLimitExceeded
                     }
                     ariaLabel={t`Stop dictation`}
+                    statusLabel={t`Dictating audio`}
                     testId="chat-input-record-audio"
                     waveformTestId="chat-input-dictation-waveform"
                     stopIconTestId="chat-input-dictation-stop-icon"

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -47,9 +47,11 @@ export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
         disabled={props.disabled}
         ariaLabel={t`Stop audio recording`}
         statusLabel={t`Recording audio`}
-        testId="chat-input-audio-mode-stop"
-        waveformTestId="chat-input-audio-mode-recording-waveform"
-        stopIconTestId="chat-input-audio-mode-stop-icon"
+        testIds={{
+          root: "chat-input-audio-mode-stop",
+          waveform: "chat-input-audio-mode-recording-waveform",
+          stopIcon: "chat-input-audio-mode-stop-icon",
+        }}
       />
     );
   }

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -1,0 +1,69 @@
+import { t } from "@lingui/core/macro";
+
+import { Waveform } from "./Waveform";
+import { WaveformButton } from "./WaveformButton";
+import { Button } from "../Controls/Button";
+
+// Symmetric, gently peaked pattern shown in idle (resting) state. Values
+// flow through the same `max(v, 2) * 2` scale + 14px clamp as live bars,
+// so these map to {6px, 10px, 14px, 10px, 6px}.
+export const AUDIO_MODE_STATIC_BAR_PATTERN: readonly number[] = [3, 5, 7, 5, 3];
+
+interface ChatInputAudioModeButtonProps {
+  /** Click handler — starts a recording when idle, stops one when active. */
+  onClick: () => void;
+  /** True while a transcription recording is active. */
+  isRecording: boolean;
+  /** Live bar heights from `useAudioTranscriptionRecorder.recordingBars`. */
+  recordingBars?: readonly number[];
+  /** Optional override for the resting-state pattern. */
+  staticBars?: readonly number[];
+  disabled?: boolean;
+}
+
+/**
+ * Replaces the send button when the chat input is empty and audio
+ * transcription is enabled. Idle state shows a static waveform; recording
+ * state delegates to `WaveformButton` so it shares the active-audio
+ * interaction with the dictation feature.
+ */
+export function ChatInputAudioModeButton({
+  onClick,
+  isRecording,
+  recordingBars,
+  staticBars = AUDIO_MODE_STATIC_BAR_PATTERN,
+  disabled,
+}: ChatInputAudioModeButtonProps) {
+  if (isRecording) {
+    return (
+      <WaveformButton
+        onClick={onClick}
+        bars={recordingBars ?? staticBars}
+        disabled={disabled}
+        ariaLabel={t`Stop audio recording`}
+        testId="chat-input-audio-mode-stop"
+        waveformTestId="chat-input-audio-mode-recording-waveform"
+        stopIconTestId="chat-input-audio-mode-stop-icon"
+      />
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={t`Start audio mode`}
+      data-testid="chat-input-audio-mode-start"
+      icon={
+        <Waveform
+          bars={staticBars}
+          testId="chat-input-audio-mode-static-waveform"
+          className="text-[var(--theme-fg-primary)]"
+        />
+      }
+    />
+  );
+}

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -10,8 +10,8 @@ import { Button } from "../Controls/Button";
 export const AUDIO_MODE_STATIC_BAR_PATTERN: readonly number[] = [3, 5, 7, 5, 3];
 
 type ChatInputAudioModeButtonCommonProps = {
-  /** Click handler — starts a recording when idle, stops one when active. */
-  onClick: () => void;
+  /** Toggle handler — starts a recording when idle, stops one when active. */
+  onToggle: () => void;
   disabled?: boolean;
 };
 
@@ -42,7 +42,7 @@ export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
   if (props.isRecording) {
     return (
       <WaveformButton
-        onClick={props.onClick}
+        onClick={props.onToggle}
         bars={props.recordingBars}
         disabled={props.disabled}
         ariaLabel={t`Stop audio recording`}
@@ -63,7 +63,7 @@ export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
       type="button"
       variant="secondary"
       size="sm"
-      onClick={props.onClick}
+      onClick={props.onToggle}
       disabled={props.disabled}
       aria-label={t`Start audio mode`}
       data-testid="chat-input-audio-mode-start"

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -9,17 +9,28 @@ import { Button } from "../Controls/Button";
 // so these map to {6px, 10px, 14px, 10px, 6px}.
 export const AUDIO_MODE_STATIC_BAR_PATTERN: readonly number[] = [3, 5, 7, 5, 3];
 
-interface ChatInputAudioModeButtonProps {
+type ChatInputAudioModeButtonCommonProps = {
   /** Click handler — starts a recording when idle, stops one when active. */
   onClick: () => void;
-  /** True while a transcription recording is active. */
-  isRecording: boolean;
-  /** Live bar heights from `useAudioTranscriptionRecorder.recordingBars`. */
-  recordingBars?: readonly number[];
+  disabled?: boolean;
+};
+
+type ChatInputAudioModeButtonIdleProps = ChatInputAudioModeButtonCommonProps & {
+  isRecording: false;
   /** Optional override for the resting-state pattern. */
   staticBars?: readonly number[];
-  disabled?: boolean;
-}
+};
+
+type ChatInputAudioModeButtonRecordingProps =
+  ChatInputAudioModeButtonCommonProps & {
+    isRecording: true;
+    /** Live bar heights from `useAudioTranscriptionRecorder.recordingBars`. */
+    recordingBars: readonly number[];
+  };
+
+type ChatInputAudioModeButtonProps =
+  | ChatInputAudioModeButtonIdleProps
+  | ChatInputAudioModeButtonRecordingProps;
 
 /**
  * Replaces the send button when the chat input is empty and audio
@@ -27,19 +38,13 @@ interface ChatInputAudioModeButtonProps {
  * state delegates to `WaveformButton` so it shares the active-audio
  * interaction with the dictation feature.
  */
-export function ChatInputAudioModeButton({
-  onClick,
-  isRecording,
-  recordingBars,
-  staticBars = AUDIO_MODE_STATIC_BAR_PATTERN,
-  disabled,
-}: ChatInputAudioModeButtonProps) {
-  if (isRecording) {
+export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
+  if (props.isRecording) {
     return (
       <WaveformButton
-        onClick={onClick}
-        bars={recordingBars ?? staticBars}
-        disabled={disabled}
+        onClick={props.onClick}
+        bars={props.recordingBars}
+        disabled={props.disabled}
         ariaLabel={t`Stop audio recording`}
         statusLabel={t`Recording audio`}
         testId="chat-input-audio-mode-stop"
@@ -49,13 +54,15 @@ export function ChatInputAudioModeButton({
     );
   }
 
+  const staticBars = props.staticBars ?? AUDIO_MODE_STATIC_BAR_PATTERN;
+
   return (
     <Button
       type="button"
       variant="secondary"
       size="sm"
-      onClick={onClick}
-      disabled={disabled}
+      onClick={props.onClick}
+      disabled={props.disabled}
       aria-label={t`Start audio mode`}
       data-testid="chat-input-audio-mode-start"
       icon={

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -41,6 +41,7 @@ export function ChatInputAudioModeButton({
         bars={recordingBars ?? staticBars}
         disabled={disabled}
         ariaLabel={t`Stop audio recording`}
+        statusLabel={t`Recording audio`}
         testId="chat-input-audio-mode-stop"
         waveformTestId="chat-input-audio-mode-recording-waveform"
         stopIconTestId="chat-input-audio-mode-stop-icon"

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 
-import { Waveform } from "./Waveform";
+import { Waveform, audioLevelsToBarHeights } from "./Waveform";
 import { WaveformButton } from "./WaveformButton";
 import { Button } from "../Controls/Button";
 
@@ -69,7 +69,7 @@ export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
       data-testid="chat-input-audio-mode-start"
       icon={
         <Waveform
-          bars={staticBars}
+          heights={audioLevelsToBarHeights(staticBars)}
           testId="chat-input-audio-mode-static-waveform"
           className="text-[var(--theme-fg-primary)]"
         />

--- a/frontend/src/components/ui/Chat/Waveform.tsx
+++ b/frontend/src/components/ui/Chat/Waveform.tsx
@@ -68,7 +68,8 @@ export function Waveform({
             className={clsx(
               "rounded-full bg-current",
               barWidthClassName,
-              animated && "transition-[height] duration-75",
+              animated &&
+                "motion-safe:transition-[height] motion-safe:duration-75",
             )}
             style={{ height: `${clampBarHeightPx(rawHeight, maxHeightPx)}px` }}
           />

--- a/frontend/src/components/ui/Chat/Waveform.tsx
+++ b/frontend/src/components/ui/Chat/Waveform.tsx
@@ -1,0 +1,79 @@
+import clsx from "clsx";
+
+export const DEFAULT_WAVEFORM_BAR_COUNT = 5;
+export const DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX = 14;
+
+interface WaveformProps {
+  /**
+   * Per-bar raw values. Indexes beyond `bars.length` fall back to the
+   * minimum height so the component is safe against short arrays.
+   */
+  bars: readonly number[];
+  /** Number of bars to render. Defaults to 5 to match the audio hooks. */
+  barCount?: number;
+  /**
+   * Maximum rendered bar height in pixels. Raw values are scaled with
+   * `max(value, 2) * 2` and then clamped to this cap.
+   */
+  maxHeightPx?: number;
+  /** Tailwind class for the container's vertical box (e.g. "h-5"). */
+  containerHeightClassName?: string;
+  /** Tailwind class for individual bar width (e.g. "w-0.5"). */
+  barWidthClassName?: string;
+  /** Tailwind class for the gap between bars (e.g. "gap-0.5"). */
+  gapClassName?: string;
+  /** When true, bars animate height transitions for live audio levels. */
+  animated?: boolean;
+  className?: string;
+  /** Forwarded data-testid for tests/Storybook. */
+  testId?: string;
+}
+
+function clampBarHeightPx(value: number, maxHeightPx: number): number {
+  return Math.min(Math.max(value, 2) * 2, maxHeightPx);
+}
+
+/**
+ * Pure visual primitive: renders N rounded bars whose heights come from the
+ * `bars` prop. Has no audio knowledge — feed it any numeric array. Used by
+ * `WaveformButton` for live audio levels and by the audio-mode button for
+ * its static resting pattern.
+ */
+export function Waveform({
+  bars,
+  barCount = DEFAULT_WAVEFORM_BAR_COUNT,
+  maxHeightPx = DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX,
+  containerHeightClassName = "h-5",
+  barWidthClassName = "w-0.5",
+  gapClassName = "gap-0.5",
+  animated = false,
+  className,
+  testId,
+}: WaveformProps) {
+  return (
+    <span
+      data-testid={testId}
+      className={clsx(
+        "flex items-center justify-center",
+        containerHeightClassName,
+        gapClassName,
+        className,
+      )}
+    >
+      {Array.from({ length: barCount }).map((_, barIndex) => {
+        const rawHeight = bars[barIndex] ?? 2;
+        return (
+          <span
+            key={barIndex}
+            className={clsx(
+              "rounded-full bg-current",
+              barWidthClassName,
+              animated && "transition-[height] duration-75",
+            )}
+            style={{ height: `${clampBarHeightPx(rawHeight, maxHeightPx)}px` }}
+          />
+        );
+      })}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/Chat/Waveform.tsx
+++ b/frontend/src/components/ui/Chat/Waveform.tsx
@@ -5,17 +5,14 @@ export const DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX = 14;
 
 interface WaveformProps {
   /**
-   * Per-bar raw values. Indexes beyond `bars.length` fall back to the
-   * minimum height so the component is safe against short arrays.
+   * Final per-bar heights in pixels. Indexes beyond `heights.length` fall
+   * back to a 2px minimum so the component is safe against short arrays.
+   * Callers that have raw audio levels should use
+   * `audioLevelsToBarHeights` (or `audioLevelToBarHeightPx`) to convert.
    */
-  bars: readonly number[];
+  heights: readonly number[];
   /** Number of bars to render. Defaults to 5 to match the audio hooks. */
   barCount?: number;
-  /**
-   * Maximum rendered bar height in pixels. Raw values are scaled with
-   * `max(value, 2) * 2` and then clamped to this cap.
-   */
-  maxHeightPx?: number;
   /** Tailwind class for the container's vertical box (e.g. "h-5"). */
   containerHeightClassName?: string;
   /** Tailwind class for individual bar width (e.g. "w-0.5"). */
@@ -29,20 +26,35 @@ interface WaveformProps {
   testId?: string;
 }
 
-function clampBarHeightPx(value: number, maxHeightPx: number): number {
+/**
+ * Maps a single raw audio-level value (the `[2, ~16]` range emitted by the
+ * audio hooks' analyser) to a clamped pixel height. Lives next to
+ * `Waveform` so audio-aware consumers don't have to reinvent the math, but
+ * stays separate so `Waveform` itself remains a pure visual primitive.
+ */
+export function audioLevelToBarHeightPx(
+  value: number,
+  maxHeightPx = DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX,
+): number {
   return Math.min(Math.max(value, 2) * 2, maxHeightPx);
 }
 
+export function audioLevelsToBarHeights(
+  values: readonly number[],
+  maxHeightPx = DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX,
+): number[] {
+  return values.map((value) => audioLevelToBarHeightPx(value, maxHeightPx));
+}
+
 /**
- * Pure visual primitive: renders N rounded bars whose heights come from the
- * `bars` prop. Has no audio knowledge — feed it any numeric array. Used by
+ * Pure visual primitive: renders N rounded bars at the heights given. Has
+ * no audio knowledge — feed it any pre-computed pixel array. Used by
  * `WaveformButton` for live audio levels and by the audio-mode button for
  * its static resting pattern.
  */
 export function Waveform({
-  bars,
+  heights,
   barCount = DEFAULT_WAVEFORM_BAR_COUNT,
-  maxHeightPx = DEFAULT_WAVEFORM_MAX_BAR_HEIGHT_PX,
   containerHeightClassName = "h-5",
   barWidthClassName = "w-0.5",
   gapClassName = "gap-0.5",
@@ -61,7 +73,7 @@ export function Waveform({
       )}
     >
       {Array.from({ length: barCount }).map((_, barIndex) => {
-        const rawHeight = bars[barIndex] ?? 2;
+        const heightPx = heights[barIndex] ?? 2;
         return (
           <span
             key={barIndex}
@@ -71,7 +83,7 @@ export function Waveform({
               animated &&
                 "motion-safe:transition-[height] motion-safe:duration-75",
             )}
-            style={{ height: `${clampBarHeightPx(rawHeight, maxHeightPx)}px` }}
+            style={{ height: `${heightPx}px` }}
           />
         );
       })}

--- a/frontend/src/components/ui/Chat/WaveformButton.tsx
+++ b/frontend/src/components/ui/Chat/WaveformButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "../Controls/Button";
 import { StopIcon } from "../icons";
-import { Waveform } from "./Waveform";
+import { Waveform, audioLevelsToBarHeights } from "./Waveform";
 
 interface WaveformButtonProps {
   /** Click handler — typically stops the active audio session. */
@@ -61,7 +61,7 @@ export function WaveformButton({
         icon={
           <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">
             <Waveform
-              bars={bars}
+              heights={audioLevelsToBarHeights(bars)}
               animated
               testId={testIds?.waveform}
               className="group-hover:opacity-0 group-focus-visible:opacity-0 motion-safe:transition-opacity motion-safe:duration-150"

--- a/frontend/src/components/ui/Chat/WaveformButton.tsx
+++ b/frontend/src/components/ui/Chat/WaveformButton.tsx
@@ -16,12 +16,18 @@ interface WaveformButtonProps {
    * has begun without the user having to focus the button.
    */
   statusLabel: string;
-  /** data-testid forwarded to the button itself. */
-  testId?: string;
-  /** data-testid forwarded to the inner waveform. */
-  waveformTestId?: string;
-  /** data-testid forwarded to the absolute stop-icon overlay. */
-  stopIconTestId?: string;
+  /**
+   * Optional test-ids for the three rendered nodes. Existing tests keep
+   * the legacy strings; new consumers should pick stable names per node.
+   */
+  testIds?: {
+    /** data-testid forwarded to the button itself. */
+    root?: string;
+    /** data-testid forwarded to the inner waveform. */
+    waveform?: string;
+    /** data-testid forwarded to the absolute stop-icon overlay. */
+    stopIcon?: string;
+  };
 }
 
 /**
@@ -39,9 +45,7 @@ export function WaveformButton({
   disabled,
   ariaLabel,
   statusLabel,
-  testId,
-  waveformTestId,
-  stopIconTestId,
+  testIds,
 }: WaveformButtonProps) {
   return (
     <>
@@ -53,17 +57,17 @@ export function WaveformButton({
         disabled={disabled}
         className="group relative overflow-hidden"
         aria-label={ariaLabel}
-        data-testid={testId}
+        data-testid={testIds?.root}
         icon={
           <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">
             <Waveform
               bars={bars}
               animated
-              testId={waveformTestId}
+              testId={testIds?.waveform}
               className="group-hover:opacity-0 group-focus-visible:opacity-0 motion-safe:transition-opacity motion-safe:duration-150"
             />
             <span
-              data-testid={stopIconTestId}
+              data-testid={testIds?.stopIcon}
               className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 motion-safe:transition-opacity motion-safe:duration-150"
             >
               <StopIcon className="size-4" />

--- a/frontend/src/components/ui/Chat/WaveformButton.tsx
+++ b/frontend/src/components/ui/Chat/WaveformButton.tsx
@@ -1,0 +1,67 @@
+import { Button } from "../Controls/Button";
+import { StopIcon } from "../icons";
+import { Waveform } from "./Waveform";
+
+interface WaveformButtonProps {
+  /** Click handler — typically stops the active audio session. */
+  onClick: () => void;
+  /** Live bar values driven by an audio level analyser. */
+  bars: readonly number[];
+  disabled?: boolean;
+  ariaLabel: string;
+  /** data-testid forwarded to the button itself. */
+  testId?: string;
+  /** data-testid forwarded to the inner waveform. */
+  waveformTestId?: string;
+  /** data-testid forwarded to the absolute stop-icon overlay. */
+  stopIconTestId?: string;
+}
+
+/**
+ * Composite control used while an audio session is actively running. Renders
+ * a live waveform that swaps to a StopIcon on hover/focus so the user can
+ * end the session. Built on the shared `Button` so outer geometry matches
+ * sibling icon buttons (send, model selector, etc.).
+ *
+ * Both audio transcription and dictation render this when in their active
+ * state — keeping the "waveform → stop" interaction visually identical.
+ */
+export function WaveformButton({
+  onClick,
+  bars,
+  disabled,
+  ariaLabel,
+  testId,
+  waveformTestId,
+  stopIconTestId,
+}: WaveformButtonProps) {
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      size="sm"
+      onClick={onClick}
+      disabled={disabled}
+      className="group relative overflow-hidden"
+      aria-label={ariaLabel}
+      aria-pressed
+      data-testid={testId}
+      icon={
+        <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">
+          <Waveform
+            bars={bars}
+            animated
+            testId={waveformTestId}
+            className="transition-opacity duration-150 group-hover:opacity-0 group-focus-visible:opacity-0"
+          />
+          <span
+            data-testid={stopIconTestId}
+            className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
+          >
+            <StopIcon className="size-4" />
+          </span>
+        </span>
+      }
+    />
+  );
+}

--- a/frontend/src/components/ui/Chat/WaveformButton.tsx
+++ b/frontend/src/components/ui/Chat/WaveformButton.tsx
@@ -8,7 +8,14 @@ interface WaveformButtonProps {
   /** Live bar values driven by an audio level analyser. */
   bars: readonly number[];
   disabled?: boolean;
+  /** Action name on the button itself (e.g. "Stop dictation"). */
   ariaLabel: string;
+  /**
+   * State announcement for screen readers (e.g. "Dictating", "Recording").
+   * Rendered as `role="status"` so assistive tech is told the audio session
+   * has begun without the user having to focus the button.
+   */
+  statusLabel: string;
   /** data-testid forwarded to the button itself. */
   testId?: string;
   /** data-testid forwarded to the inner waveform. */
@@ -31,37 +38,42 @@ export function WaveformButton({
   bars,
   disabled,
   ariaLabel,
+  statusLabel,
   testId,
   waveformTestId,
   stopIconTestId,
 }: WaveformButtonProps) {
   return (
-    <Button
-      type="button"
-      variant="secondary"
-      size="sm"
-      onClick={onClick}
-      disabled={disabled}
-      className="group relative overflow-hidden"
-      aria-label={ariaLabel}
-      aria-pressed
-      data-testid={testId}
-      icon={
-        <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">
-          <Waveform
-            bars={bars}
-            animated
-            testId={waveformTestId}
-            className="transition-opacity duration-150 group-hover:opacity-0 group-focus-visible:opacity-0"
-          />
-          <span
-            data-testid={stopIconTestId}
-            className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
-          >
-            <StopIcon className="size-4" />
+    <>
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={onClick}
+        disabled={disabled}
+        className="group relative overflow-hidden"
+        aria-label={ariaLabel}
+        data-testid={testId}
+        icon={
+          <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">
+            <Waveform
+              bars={bars}
+              animated
+              testId={waveformTestId}
+              className="group-hover:opacity-0 group-focus-visible:opacity-0 motion-safe:transition-opacity motion-safe:duration-150"
+            />
+            <span
+              data-testid={stopIconTestId}
+              className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 motion-safe:transition-opacity motion-safe:duration-150"
+            >
+              <StopIcon className="size-4" />
+            </span>
           </span>
-        </span>
-      }
-    />
+        }
+      />
+      <span role="status" className="sr-only">
+        {statusLabel}
+      </span>
+    </>
   );
 }

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2341,9 +2341,9 @@ msgstr "Aktuelle Chats"
 msgid "Recording"
 msgstr "Aufnahme läuft"
 
-#: src/components/ui/Chat/ChatInput.tsx
-#~ msgid "Recording audio"
-#~ msgstr "Audio wird aufgenommen"
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Recording audio"
+msgstr "Audio wird aufgenommen"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Recording audio is disabled while uploads are not available."
@@ -2495,6 +2495,10 @@ msgstr "Etwas ist schiefgelaufen"
 msgid "Something went wrong while loading the chat interface."
 msgstr "Beim Laden der Chat-Oberfläche ist ein Fehler aufgetreten."
 
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Start audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Start dictation"
 msgstr "Audiodiktat starten"
@@ -2520,6 +2524,10 @@ msgstr "Audiodiktat wird gestartet"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop"
 msgstr "Stopp"
+
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Stop audio recording"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop dictation"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2341,9 +2341,9 @@ msgstr "Recent Chats"
 msgid "Recording"
 msgstr "Recording"
 
-#: src/components/ui/Chat/ChatInput.tsx
-#~ msgid "Recording audio"
-#~ msgstr "Recording audio"
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Recording audio"
+msgstr "Recording audio"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Recording audio is disabled while uploads are not available."
@@ -2495,6 +2495,10 @@ msgstr "Something went wrong"
 msgid "Something went wrong while loading the chat interface."
 msgstr "Something went wrong while loading the chat interface."
 
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Start audio mode"
+msgstr "Start audio mode"
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Start dictation"
 msgstr "Start dictation"
@@ -2520,6 +2524,10 @@ msgstr "Starting dictation"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop"
 msgstr "Stop"
+
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Stop audio recording"
+msgstr "Stop audio recording"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop dictation"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2341,9 +2341,9 @@ msgstr "Chats recientes"
 msgid "Recording"
 msgstr "Grabando"
 
-#: src/components/ui/Chat/ChatInput.tsx
-#~ msgid "Recording audio"
-#~ msgstr "Grabando audio"
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Recording audio"
+msgstr "Grabando audio"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Recording audio is disabled while uploads are not available."
@@ -2495,6 +2495,10 @@ msgstr "Algo salió mal"
 msgid "Something went wrong while loading the chat interface."
 msgstr "Algo salió mal al cargar la interfaz de chat."
 
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Start audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Start dictation"
 msgstr "Iniciar dictado"
@@ -2520,6 +2524,10 @@ msgstr "Iniciando dictado"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop"
 msgstr "Detener"
+
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Stop audio recording"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop dictation"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2341,9 +2341,9 @@ msgstr "Chats récents"
 msgid "Recording"
 msgstr "Enregistrement"
 
-#: src/components/ui/Chat/ChatInput.tsx
-#~ msgid "Recording audio"
-#~ msgstr "Enregistrement audio"
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Recording audio"
+msgstr "Enregistrement audio"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Recording audio is disabled while uploads are not available."
@@ -2495,6 +2495,10 @@ msgstr "Une erreur s'est produite"
 msgid "Something went wrong while loading the chat interface."
 msgstr "Une erreur s'est produite lors du chargement de l'interface de chat."
 
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Start audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Start dictation"
 msgstr "Démarrer la dictée"
@@ -2520,6 +2524,10 @@ msgstr "Démarrage de la dictée"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop"
 msgstr "Arrêter"
+
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Stop audio recording"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop dictation"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2341,9 +2341,9 @@ msgstr "Ostatnie czaty"
 msgid "Recording"
 msgstr "Nagrywanie"
 
-#: src/components/ui/Chat/ChatInput.tsx
-#~ msgid "Recording audio"
-#~ msgstr "Nagrywanie audio"
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Recording audio"
+msgstr "Nagrywanie audio"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Recording audio is disabled while uploads are not available."
@@ -2495,6 +2495,10 @@ msgstr "Coś poszło nie tak"
 msgid "Something went wrong while loading the chat interface."
 msgstr "Coś poszło nie tak podczas ładowania interfejsu czatu."
 
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Start audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Start dictation"
 msgstr "Rozpocznij dyktowanie"
@@ -2520,6 +2524,10 @@ msgstr "Rozpoczynanie dyktowania"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop"
 msgstr "Zatrzymaj"
+
+#: src/components/ui/Chat/ChatInputAudioModeButton.tsx
+msgid "Stop audio recording"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Stop dictation"

--- a/frontend/src/stories/ChatInput.stories.tsx
+++ b/frontend/src/stories/ChatInput.stories.tsx
@@ -2,6 +2,7 @@ import { action } from "@storybook/addon-actions";
 
 import { ChatInput } from "../components/ui/Chat/ChatInput";
 import { ChatProvider } from "../providers/ChatProvider";
+import { StaticFeatureConfigProvider } from "../providers/FeatureConfigProvider";
 import { FileCapabilitiesProvider } from "../providers/FileCapabilitiesProvider";
 
 import type {
@@ -196,4 +197,89 @@ export const Tablet: Story = {
       defaultViewport: "tablet",
     },
   },
+};
+
+/**
+ * Audio-mode story — overrides the global FeatureConfig so the empty input
+ * shows the new static-waveform audio-mode button. Type into the textarea
+ * to flip the slot back to the regular send button; clear it to flip back.
+ *
+ * The recording flow itself can't be exercised here because the backend
+ * WebSocket isn't reachable from Storybook — see the standalone
+ * `ChatInput/AudioModeButton` stories for the recording visual.
+ */
+export const AudioModeEnabled: Story = {
+  args: {
+    onSendMessage: action("message sent"),
+    showControls: true,
+    handleFileAttachments: action("handle file attachments"),
+    onRegenerate: action("regenerate"),
+    showFileTypes: true,
+    initialFiles: [] as FileUploadItem[],
+  },
+  decorators: [
+    (Story) => (
+      <StaticFeatureConfigProvider
+        config={{
+          upload: { enabled: true },
+          chatInput: { autofocus: false, showUsageAdvisory: false },
+          audioTranscription: {
+            enabled: true,
+            maxRecordingDurationSeconds: 1200,
+          },
+          audioDictation: {
+            enabled: false,
+            maxRecordingDurationSeconds: 1200,
+          },
+        }}
+      >
+        <Story />
+      </StaticFeatureConfigProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Compose mode with audio transcription enabled. Empty input shows the static-waveform 'audio mode' button in the send slot; typing flips it back to the send button.",
+      },
+    },
+  },
+};
+
+/**
+ * Both audio features enabled — the dictation microphone button and the
+ * audio-mode waveform button live side by side. They are mutually
+ * exclusive at runtime: starting dictation disables the audio-mode button
+ * and vice versa.
+ */
+export const AudioModeAndDictationEnabled: Story = {
+  args: {
+    onSendMessage: action("message sent"),
+    showControls: true,
+    handleFileAttachments: action("handle file attachments"),
+    onRegenerate: action("regenerate"),
+    showFileTypes: true,
+    initialFiles: [] as FileUploadItem[],
+  },
+  decorators: [
+    (Story) => (
+      <StaticFeatureConfigProvider
+        config={{
+          upload: { enabled: true },
+          chatInput: { autofocus: false, showUsageAdvisory: false },
+          audioTranscription: {
+            enabled: true,
+            maxRecordingDurationSeconds: 1200,
+          },
+          audioDictation: {
+            enabled: true,
+            maxRecordingDurationSeconds: 1200,
+          },
+        }}
+      >
+        <Story />
+      </StaticFeatureConfigProvider>
+    ),
+  ],
 };

--- a/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
+++ b/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
@@ -36,7 +36,7 @@ export const Idle: Story = {
   render: () => (
     <ChatInputAudioModeButton
       isRecording={false}
-      onClick={action("toggle")}
+      onToggle={action("toggle")}
     />
   ),
 };
@@ -45,7 +45,7 @@ export const IdleDisabled: Story = {
   render: () => (
     <ChatInputAudioModeButton
       isRecording={false}
-      onClick={action("toggle")}
+      onToggle={action("toggle")}
       disabled
     />
   ),
@@ -57,7 +57,7 @@ export const RecordingStaticBars: Story = {
     <ChatInputAudioModeButton
       isRecording
       recordingBars={[3, 5, 7, 5, 3]}
-      onClick={action("toggle")}
+      onToggle={action("toggle")}
     />
   ),
   parameters: {
@@ -97,7 +97,7 @@ function AnimatedRecordingButton({ disabled }: { disabled?: boolean }) {
     <ChatInputAudioModeButton
       isRecording
       recordingBars={bars}
-      onClick={action("toggle")}
+      onToggle={action("toggle")}
       disabled={disabled}
     />
   );

--- a/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
+++ b/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
@@ -3,7 +3,6 @@ import { action } from "@storybook/addon-actions";
 import { useSyntheticBars } from "./helpers/useSyntheticBars";
 import { ChatInputAudioModeButton } from "../components/ui/Chat/ChatInputAudioModeButton";
 
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 // Loose typing because the component's props are a discriminated union and
@@ -35,10 +34,7 @@ type Story = StoryObj;
 
 export const Idle: Story = {
   render: () => (
-    <ChatInputAudioModeButton
-      isRecording={false}
-      onToggle={action("toggle")}
-    />
+    <ChatInputAudioModeButton isRecording={false} onToggle={action("toggle")} />
   ),
 };
 

--- a/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
+++ b/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
@@ -5,7 +5,9 @@ import { ChatInputAudioModeButton } from "../components/ui/Chat/ChatInputAudioMo
 
 import type { Meta, StoryObj } from "@storybook/react";
 
-const meta: Meta<typeof ChatInputAudioModeButton> = {
+// Loose typing because the component's props are a discriminated union and
+// Storybook's `args` inference collapses to `never` for unions.
+const meta: Meta = {
   title: "UI/ChatInput/AudioModeButton",
   component: ChatInputAudioModeButton,
   parameters: {
@@ -18,11 +20,6 @@ const meta: Meta<typeof ChatInputAudioModeButton> = {
     },
   },
   tags: ["autodocs"],
-  argTypes: {
-    onClick: { action: "audio-mode toggled" },
-    isRecording: { control: "boolean" },
-    disabled: { control: "boolean" },
-  },
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center bg-theme-bg-primary p-8">
@@ -33,36 +30,41 @@ const meta: Meta<typeof ChatInputAudioModeButton> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj;
 
 export const Idle: Story = {
-  args: {
-    onClick: action("toggle"),
-    isRecording: false,
-    disabled: false,
-  },
+  render: () => (
+    <ChatInputAudioModeButton
+      isRecording={false}
+      onClick={action("toggle")}
+    />
+  ),
 };
 
 export const IdleDisabled: Story = {
-  args: {
-    onClick: action("toggle"),
-    isRecording: false,
-    disabled: true,
-  },
+  render: () => (
+    <ChatInputAudioModeButton
+      isRecording={false}
+      onClick={action("toggle")}
+      disabled
+    />
+  ),
 };
 
 export const RecordingStaticBars: Story = {
-  name: "Recording (no live bars)",
-  args: {
-    onClick: action("toggle"),
-    isRecording: true,
-    disabled: false,
-  },
+  name: "Recording (frozen bars)",
+  render: () => (
+    <ChatInputAudioModeButton
+      isRecording
+      recordingBars={[3, 5, 7, 5, 3]}
+      onClick={action("toggle")}
+    />
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          "Recording state without `recordingBars` provided — falls back to the static pattern. Hover or focus the button to reveal the StopIcon.",
+          "Recording state with a fixed bar snapshot — useful for visual review. Hover or focus the button to reveal the StopIcon.",
       },
     },
   },
@@ -72,13 +74,7 @@ export const RecordingStaticBars: Story = {
  * Drives `recordingBars` with a synthetic, deterministic waveform so the
  * recording state can be inspected in Storybook without microphone access.
  */
-function AnimatedRecordingButton({
-  onClick,
-  disabled,
-}: {
-  onClick: () => void;
-  disabled?: boolean;
-}) {
+function AnimatedRecordingButton({ disabled }: { disabled?: boolean }) {
   const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
   const tickRef = useRef(0);
 
@@ -99,9 +95,9 @@ function AnimatedRecordingButton({
 
   return (
     <ChatInputAudioModeButton
-      onClick={onClick}
       isRecording
       recordingBars={bars}
+      onClick={action("toggle")}
       disabled={disabled}
     />
   );
@@ -109,17 +105,7 @@ function AnimatedRecordingButton({
 
 export const RecordingAnimated: Story = {
   name: "Recording (live waveform)",
-  render: (args) => (
-    <AnimatedRecordingButton
-      onClick={() => args.onClick()}
-      disabled={args.disabled}
-    />
-  ),
-  args: {
-    onClick: action("toggle"),
-    isRecording: true,
-    disabled: false,
-  },
+  render: () => <AnimatedRecordingButton />,
   parameters: {
     docs: {
       description: {

--- a/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
+++ b/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
@@ -1,0 +1,131 @@
+import { action } from "@storybook/addon-actions";
+import { useEffect, useRef, useState } from "react";
+
+import { ChatInputAudioModeButton } from "../components/ui/Chat/ChatInputAudioModeButton";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof ChatInputAudioModeButton> = {
+  title: "UI/ChatInput/AudioModeButton",
+  component: ChatInputAudioModeButton,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Replaces the chat-input send button when the input is empty and audio transcription is enabled. Idle state shows a static waveform; recording state mirrors the dictation pattern (live bars + StopIcon on hover/focus).",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    onClick: { action: "audio-mode toggled" },
+    isRecording: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-theme-bg-primary p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  args: {
+    onClick: action("toggle"),
+    isRecording: false,
+    disabled: false,
+  },
+};
+
+export const IdleDisabled: Story = {
+  args: {
+    onClick: action("toggle"),
+    isRecording: false,
+    disabled: true,
+  },
+};
+
+export const RecordingStaticBars: Story = {
+  name: "Recording (no live bars)",
+  args: {
+    onClick: action("toggle"),
+    isRecording: true,
+    disabled: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Recording state without `recordingBars` provided — falls back to the static pattern. Hover or focus the button to reveal the StopIcon.",
+      },
+    },
+  },
+};
+
+/**
+ * Drives `recordingBars` with a synthetic, deterministic waveform so the
+ * recording state can be inspected in Storybook without microphone access.
+ */
+function AnimatedRecordingButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
+  const tickRef = useRef(0);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      tickRef.current += 1;
+      const t = tickRef.current;
+      setBars([
+        2 + Math.round(Math.abs(Math.sin(t * 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 1.2)) * 6),
+        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 1.8)) * 6),
+        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 2.4)) * 6),
+      ]);
+    }, 90);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return (
+    <ChatInputAudioModeButton
+      onClick={onClick}
+      isRecording
+      recordingBars={bars}
+      disabled={disabled}
+    />
+  );
+}
+
+export const RecordingAnimated: Story = {
+  name: "Recording (live waveform)",
+  render: (args) => (
+    <AnimatedRecordingButton
+      onClick={() => args.onClick()}
+      disabled={args.disabled}
+    />
+  ),
+  args: {
+    onClick: action("toggle"),
+    isRecording: true,
+    disabled: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Synthetic waveform animates `recordingBars` so the live recording UI can be inspected without microphone permissions. Hover or focus to reveal the StopIcon overlay.",
+      },
+    },
+  },
+};

--- a/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
+++ b/frontend/src/stories/ChatInputAudioModeButton.stories.tsx
@@ -1,7 +1,8 @@
 import { action } from "@storybook/addon-actions";
-import { useEffect, useRef, useState } from "react";
 
+import { useSyntheticBars } from "./helpers/useSyntheticBars";
 import { ChatInputAudioModeButton } from "../components/ui/Chat/ChatInputAudioModeButton";
+
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -75,24 +76,7 @@ export const RecordingStaticBars: Story = {
  * recording state can be inspected in Storybook without microphone access.
  */
 function AnimatedRecordingButton({ disabled }: { disabled?: boolean }) {
-  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
-  const tickRef = useRef(0);
-
-  useEffect(() => {
-    const intervalId = window.setInterval(() => {
-      tickRef.current += 1;
-      const t = tickRef.current;
-      setBars([
-        2 + Math.round(Math.abs(Math.sin(t * 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 1.2)) * 6),
-        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 1.8)) * 6),
-        2 + Math.round(Math.abs(Math.sin(t * 0.6 + 2.4)) * 6),
-      ]);
-    }, 90);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
+  const bars = useSyntheticBars();
   return (
     <ChatInputAudioModeButton
       isRecording

--- a/frontend/src/stories/Waveform.stories.tsx
+++ b/frontend/src/stories/Waveform.stories.tsx
@@ -4,7 +4,6 @@ import {
   audioLevelsToBarHeights,
 } from "../components/ui/Chat/Waveform";
 
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Waveform> = {

--- a/frontend/src/stories/Waveform.stories.tsx
+++ b/frontend/src/stories/Waveform.stories.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { Waveform } from "../components/ui/Chat/Waveform";
+import {
+  Waveform,
+  audioLevelsToBarHeights,
+} from "../components/ui/Chat/Waveform";
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -12,15 +15,14 @@ const meta: Meta<typeof Waveform> = {
     docs: {
       description: {
         component:
-          "Pure visual primitive: N rounded bars with heights driven by the `bars` array. No audio knowledge — feed it any numeric series. Used by `WaveformButton` for live audio levels and by the audio-mode button for its resting pattern.",
+          "Pure visual primitive: N rounded bars at the heights given. No audio knowledge — feed it any pre-computed pixel array. Audio-aware consumers should run their raw analyser values through `audioLevelsToBarHeights` first.",
       },
     },
   },
   tags: ["autodocs"],
   argTypes: {
-    bars: { control: "object" },
+    heights: { control: "object" },
     barCount: { control: { type: "number", min: 1, max: 12, step: 1 } },
-    maxHeightPx: { control: { type: "number", min: 4, max: 64, step: 1 } },
     containerHeightClassName: { control: "text" },
     barWidthClassName: { control: "text" },
     gapClassName: { control: "text" },
@@ -40,25 +42,25 @@ type Story = StoryObj<typeof meta>;
 
 export const StaticPeak: Story = {
   args: {
-    bars: [3, 5, 7, 5, 3],
+    heights: audioLevelsToBarHeights([3, 5, 7, 5, 3]),
   },
 };
 
 export const Flat: Story = {
   args: {
-    bars: [2, 2, 2, 2, 2],
+    heights: audioLevelsToBarHeights([2, 2, 2, 2, 2]),
   },
 };
 
 export const Asymmetric: Story = {
   args: {
-    bars: [2, 3, 5, 7, 4],
+    heights: audioLevelsToBarHeights([2, 3, 5, 7, 4]),
   },
 };
 
 export const Bolder: Story = {
   args: {
-    bars: [3, 5, 7, 5, 3],
+    heights: audioLevelsToBarHeights([3, 5, 7, 5, 3]),
     barWidthClassName: "w-1",
     gapClassName: "gap-1",
   },
@@ -74,10 +76,25 @@ export const Bolder: Story = {
 
 export const SevenBarsTaller: Story = {
   args: {
-    bars: [2, 4, 6, 8, 6, 4, 2],
+    heights: audioLevelsToBarHeights([2, 4, 6, 8, 6, 4, 2], 24),
     barCount: 7,
-    maxHeightPx: 24,
     containerHeightClassName: "h-7",
+  },
+};
+
+export const RawPixelHeights: Story = {
+  args: {
+    heights: [4, 8, 12, 16, 12, 8, 4],
+    barCount: 7,
+    containerHeightClassName: "h-5",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates the primitive's intent: feed it pixel heights directly. Non-audio consumers can synthesize any visual without going through `audioLevelsToBarHeights`.",
+      },
+    },
   },
 };
 
@@ -99,7 +116,7 @@ function AnimatedWaveform() {
     return () => window.clearInterval(intervalId);
   }, []);
 
-  return <Waveform bars={bars} animated />;
+  return <Waveform heights={audioLevelsToBarHeights(bars)} animated />;
 }
 
 export const Animated: Story = {
@@ -108,7 +125,7 @@ export const Animated: Story = {
     docs: {
       description: {
         story:
-          "Synthetic sine-wave drive of the `bars` prop with `animated` enabled — what live audio levels look like.",
+          "Synthetic sine-wave drive of raw audio levels passed through `audioLevelsToBarHeights` — what live audio levels look like.",
       },
     },
   },

--- a/frontend/src/stories/Waveform.stories.tsx
+++ b/frontend/src/stories/Waveform.stories.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+
+import { Waveform } from "../components/ui/Chat/Waveform";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Waveform> = {
+  title: "UI/ChatInput/Waveform",
+  component: Waveform,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Pure visual primitive: N rounded bars with heights driven by the `bars` array. No audio knowledge — feed it any numeric series. Used by `WaveformButton` for live audio levels and by the audio-mode button for its resting pattern.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    bars: { control: "object" },
+    barCount: { control: { type: "number", min: 1, max: 12, step: 1 } },
+    maxHeightPx: { control: { type: "number", min: 4, max: 64, step: 1 } },
+    containerHeightClassName: { control: "text" },
+    barWidthClassName: { control: "text" },
+    gapClassName: { control: "text" },
+    animated: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-theme-bg-primary p-8 text-[var(--theme-fg-primary)]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StaticPeak: Story = {
+  args: {
+    bars: [3, 5, 7, 5, 3],
+  },
+};
+
+export const Flat: Story = {
+  args: {
+    bars: [2, 2, 2, 2, 2],
+  },
+};
+
+export const Asymmetric: Story = {
+  args: {
+    bars: [2, 3, 5, 7, 4],
+  },
+};
+
+export const Bolder: Story = {
+  args: {
+    bars: [3, 5, 7, 5, 3],
+    barWidthClassName: "w-1",
+    gapClassName: "gap-1",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Reverts to the original (pre-cleanup) bolder bar style — useful for comparing density.",
+      },
+    },
+  },
+};
+
+export const SevenBarsTaller: Story = {
+  args: {
+    bars: [2, 4, 6, 8, 6, 4, 2],
+    barCount: 7,
+    maxHeightPx: 24,
+    containerHeightClassName: "h-7",
+  },
+};
+
+function AnimatedWaveform() {
+  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
+
+  useEffect(() => {
+    let tick = 0;
+    const intervalId = window.setInterval(() => {
+      tick += 1;
+      setBars([
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.2)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.8)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 2.4)) * 6),
+      ]);
+    }, 90);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return <Waveform bars={bars} animated />;
+}
+
+export const Animated: Story = {
+  render: () => <AnimatedWaveform />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Synthetic sine-wave drive of the `bars` prop with `animated` enabled — what live audio levels look like.",
+      },
+    },
+  },
+};

--- a/frontend/src/stories/Waveform.stories.tsx
+++ b/frontend/src/stories/Waveform.stories.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-
+import { useSyntheticBars } from "./helpers/useSyntheticBars";
 import {
   Waveform,
   audioLevelsToBarHeights,
 } from "../components/ui/Chat/Waveform";
+
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -99,23 +99,7 @@ export const RawPixelHeights: Story = {
 };
 
 function AnimatedWaveform() {
-  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
-
-  useEffect(() => {
-    let tick = 0;
-    const intervalId = window.setInterval(() => {
-      tick += 1;
-      setBars([
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.2)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.8)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 2.4)) * 6),
-      ]);
-    }, 90);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
+  const bars = useSyntheticBars();
   return <Waveform heights={audioLevelsToBarHeights(bars)} animated />;
 }
 

--- a/frontend/src/stories/WaveformButton.stories.tsx
+++ b/frontend/src/stories/WaveformButton.stories.tsx
@@ -1,7 +1,8 @@
 import { action } from "@storybook/addon-actions";
-import { useEffect, useState } from "react";
 
+import { useSyntheticBars } from "./helpers/useSyntheticBars";
 import { WaveformButton } from "../components/ui/Chat/WaveformButton";
+
 
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -75,23 +76,7 @@ function AnimatedBars({
   statusLabel: string;
   disabled?: boolean;
 }) {
-  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
-
-  useEffect(() => {
-    let tick = 0;
-    const intervalId = window.setInterval(() => {
-      tick += 1;
-      setBars([
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 0.6)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.2)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.8)) * 6),
-        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 2.4)) * 6),
-      ]);
-    }, 90);
-    return () => window.clearInterval(intervalId);
-  }, []);
-
+  const bars = useSyntheticBars();
   return (
     <WaveformButton
       onClick={onClick}

--- a/frontend/src/stories/WaveformButton.stories.tsx
+++ b/frontend/src/stories/WaveformButton.stories.tsx
@@ -42,6 +42,7 @@ export const StaticBars: Story = {
     onClick: action("stop"),
     bars: [3, 5, 7, 5, 3],
     ariaLabel: "Stop audio recording",
+    statusLabel: "Recording audio",
   },
   parameters: {
     docs: {
@@ -58,6 +59,7 @@ export const Disabled: Story = {
     onClick: action("stop"),
     bars: [3, 5, 7, 5, 3],
     ariaLabel: "Stop audio recording",
+    statusLabel: "Recording audio",
     disabled: true,
   },
 };
@@ -65,10 +67,12 @@ export const Disabled: Story = {
 function AnimatedBars({
   onClick,
   ariaLabel,
+  statusLabel,
   disabled,
 }: {
   onClick: () => void;
   ariaLabel: string;
+  statusLabel: string;
   disabled?: boolean;
 }) {
   const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
@@ -93,6 +97,7 @@ function AnimatedBars({
       onClick={onClick}
       bars={bars}
       ariaLabel={ariaLabel}
+      statusLabel={statusLabel}
       disabled={disabled}
     />
   );
@@ -104,6 +109,7 @@ export const Animated: Story = {
     <AnimatedBars
       onClick={() => args.onClick()}
       ariaLabel={args.ariaLabel}
+      statusLabel={args.statusLabel}
       disabled={args.disabled}
     />
   ),
@@ -111,6 +117,7 @@ export const Animated: Story = {
     onClick: action("stop"),
     bars: [3, 5, 7, 5, 3],
     ariaLabel: "Stop audio recording",
+    statusLabel: "Recording audio",
   },
   parameters: {
     docs: {

--- a/frontend/src/stories/WaveformButton.stories.tsx
+++ b/frontend/src/stories/WaveformButton.stories.tsx
@@ -1,0 +1,123 @@
+import { action } from "@storybook/addon-actions";
+import { useEffect, useState } from "react";
+
+import { WaveformButton } from "../components/ui/Chat/WaveformButton";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof WaveformButton> = {
+  title: "UI/ChatInput/WaveformButton",
+  component: WaveformButton,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Button used while an audio session is actively running. Renders a live waveform that swaps to a StopIcon on hover/focus. Both audio transcription and dictation use this for their active state — keeping the interaction visually identical.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    onClick: { action: "stop clicked" },
+    bars: { control: "object" },
+    disabled: { control: "boolean" },
+    ariaLabel: { control: "text" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-theme-bg-primary p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StaticBars: Story = {
+  name: "Static bars (no live drive)",
+  args: {
+    onClick: action("stop"),
+    bars: [3, 5, 7, 5, 3],
+    ariaLabel: "Stop audio recording",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Snapshot of the active state with a fixed bar pattern. Hover or focus to reveal the StopIcon overlay.",
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    onClick: action("stop"),
+    bars: [3, 5, 7, 5, 3],
+    ariaLabel: "Stop audio recording",
+    disabled: true,
+  },
+};
+
+function AnimatedBars({
+  onClick,
+  ariaLabel,
+  disabled,
+}: {
+  onClick: () => void;
+  ariaLabel: string;
+  disabled?: boolean;
+}) {
+  const [bars, setBars] = useState<number[]>([2, 4, 6, 4, 2]);
+
+  useEffect(() => {
+    let tick = 0;
+    const intervalId = window.setInterval(() => {
+      tick += 1;
+      setBars([
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 0.6)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.2)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 1.8)) * 6),
+        2 + Math.round(Math.abs(Math.sin(tick * 0.6 + 2.4)) * 6),
+      ]);
+    }, 90);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  return (
+    <WaveformButton
+      onClick={onClick}
+      bars={bars}
+      ariaLabel={ariaLabel}
+      disabled={disabled}
+    />
+  );
+}
+
+export const Animated: Story = {
+  name: "Live waveform (synthetic)",
+  render: (args) => (
+    <AnimatedBars
+      onClick={() => args.onClick()}
+      ariaLabel={args.ariaLabel}
+      disabled={args.disabled}
+    />
+  ),
+  args: {
+    onClick: action("stop"),
+    bars: [3, 5, 7, 5, 3],
+    ariaLabel: "Stop audio recording",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Synthetic sine-wave drive of `bars` so the recording UI animates without microphone access. Hover or focus to reveal the StopIcon.",
+      },
+    },
+  },
+};

--- a/frontend/src/stories/WaveformButton.stories.tsx
+++ b/frontend/src/stories/WaveformButton.stories.tsx
@@ -3,7 +3,6 @@ import { action } from "@storybook/addon-actions";
 import { useSyntheticBars } from "./helpers/useSyntheticBars";
 import { WaveformButton } from "../components/ui/Chat/WaveformButton";
 
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof WaveformButton> = {

--- a/frontend/src/stories/helpers/useSyntheticBars.ts
+++ b/frontend/src/stories/helpers/useSyntheticBars.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+interface UseSyntheticBarsOptions {
+  /** Number of bars to synthesize. */
+  barCount?: number;
+  /** Update interval in ms. */
+  intervalMs?: number;
+  /** Frequency multiplier — higher values move faster. */
+  speed?: number;
+  /** Amplitude added on top of the 2-unit minimum. */
+  amplitude?: number;
+}
+
+/**
+ * Storybook-only hook that drives a deterministic, sine-based fake audio
+ * level for the `Waveform` / `WaveformButton` stories. Lets us inspect the
+ * recording UI without microphone access.
+ */
+export function useSyntheticBars({
+  barCount = 5,
+  intervalMs = 90,
+  speed = 0.6,
+  amplitude = 6,
+}: UseSyntheticBarsOptions = {}): number[] {
+  const [bars, setBars] = useState<number[]>(() =>
+    Array.from({ length: barCount }, () => 2),
+  );
+
+  useEffect(() => {
+    let tick = 0;
+    const intervalId = window.setInterval(() => {
+      tick += 1;
+      setBars(
+        Array.from({ length: barCount }, (_, barIndex) => {
+          const phase = barIndex * 0.6;
+          return (
+            2 +
+            Math.round(Math.abs(Math.sin(tick * speed + phase)) * amplitude)
+          );
+        }),
+      );
+    }, intervalMs);
+    return () => window.clearInterval(intervalId);
+  }, [barCount, intervalMs, speed, amplitude]);
+
+  return bars;
+}

--- a/frontend/src/stories/helpers/useSyntheticBars.ts
+++ b/frontend/src/stories/helpers/useSyntheticBars.ts
@@ -34,8 +34,7 @@ export function useSyntheticBars({
         Array.from({ length: barCount }, (_, barIndex) => {
           const phase = barIndex * 0.6;
           return (
-            2 +
-            Math.round(Math.abs(Math.sin(tick * speed + phase)) * amplitude)
+            2 + Math.round(Math.abs(Math.sin(tick * speed + phase)) * amplitude)
           );
         }),
       );


### PR DESCRIPTION
This pull request adds comprehensive support and tests for an audio transcription mode button in the `ChatInput` component. The changes introduce a dedicated button for starting and stopping audio transcription, ensure it appears or is disabled under the correct conditions, and add thorough test coverage for its behavior. The implementation also refactors dictation button rendering for clarity and maintainability.

**Audio Transcription Mode Button Implementation:**

* Introduced the `ChatInputAudioModeButton` and integrated it into `ChatInput`, displaying it when audio transcription is enabled, the input is empty, and the user is in compose mode. The button toggles recording and updates its state based on recording status and other conditions. [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R40-R44) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R423-R429) [[3]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1166-R1187) [[4]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1581-R1587)

* Added logic to disable or hide the audio transcription button when dictation is active, an attachment is present or transcribing, or other relevant states (e.g., loading, token limits). [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1166-R1187) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1581-R1587)

**Testing Enhancements:**

* Added extensive tests to `ChatInput.test.tsx` covering all major behaviors of the audio transcription mode button, including visibility, toggling, disabling, and interactions with dictation and attachments.

* Mocked the new `useAudioTranscriptionRecorder` hook and ensured its behavior is properly simulated in tests. [[1]](diffhunk://#diff-ebd85a320bdbd775161f707179c4278967c01b08acac7cc21cd7d840bb3d4623R35) [[2]](diffhunk://#diff-ebd85a320bdbd775161f707179c4278967c01b08acac7cc21cd7d840bb3d4623R67-R71) [[3]](diffhunk://#diff-ebd85a320bdbd775161f707179c4278967c01b08acac7cc21cd7d840bb3d4623R242-R254)

**Dictation Button Refactor:**

* Refactored the dictation button rendering in `ChatInput` to use a dedicated `WaveformButton` component when dictation is active, improving code clarity and separating concerns between dictation and transcription UI. [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L1492-R1541) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L1524-L1563)

**Code Cleanup:**

* Removed unused constant `DICTATION_WAVEFORM_MAX_BAR_HEIGHT_PX` as part of the dictation button refactor.