### PR TITLE
Add dedicated audio chat mode to ChatInput

### DIFF
--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -455,6 +455,10 @@ export const Chat = ({
     null,
   );
   const [isUpdatingChatTitle, setIsUpdatingChatTitle] = useState(false);
+  // ChatInput's audio-mode lives here so it survives the empty-state ↔
+  // messages layout flip below, which renders ChatInput in two different
+  // JSX positions and would otherwise unmount it on the first send.
+  const [isAudioMode, setIsAudioMode] = useState(false);
 
   const handleEditTitleSession = useCallback((sessionId: string) => {
     setTitleDialogChatId(sessionId);
@@ -687,6 +691,8 @@ export const Chat = ({
       onFacetSelectionChange={setActiveSelectedFacetIds}
       uploadFiles={uploadFiles}
       uploadError={uploadError}
+      controlledIsAudioMode={isAudioMode}
+      onControlledIsAudioModeChange={setIsAudioMode}
     />
   );
 

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1576,6 +1576,167 @@ describe("ChatInput", () => {
       expect(screen.getByTestId("chat-input-audio-mode-start")).toBeDisabled();
     });
 
+    it("hides the textarea and shows the exit button after entering audio mode", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const toggleAudioRecording = vi.fn();
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.getByPlaceholderText("Type a message..."),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-start"));
+
+      expect(toggleAudioRecording).toHaveBeenCalledTimes(1);
+      expect(
+        screen.queryByPlaceholderText("Type a message..."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-exit-audio-mode"),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the dictation button while in audio mode", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioDictationFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(screen.getByTestId("chat-input-record-audio")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-start"));
+
+      expect(
+        screen.queryByTestId("chat-input-record-audio"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("exits audio mode and stops an active recording when the exit button is clicked", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const toggleAudioRecording = vi.fn();
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: true,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [3, 6, 9, 6, 3],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      // Enter audio mode (the recorder is mocked as already-recording so
+      // the toggle is rendered as a stop button).
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-stop"));
+      expect(
+        screen.getByTestId("chat-input-exit-audio-mode"),
+      ).toBeInTheDocument();
+
+      // Exit while still recording — should call toggle to stop and remove
+      // the textarea-replacement state.
+      fireEvent.click(screen.getByTestId("chat-input-exit-audio-mode"));
+      expect(toggleAudioRecording).toHaveBeenCalled();
+
+      // Simulate the recorder stopping after the toggle.
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId("chat-input-exit-audio-mode"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Type a message..."),
+      ).toBeInTheDocument();
+    });
+
     it("disables the audio-mode button while an attachment is still transcribing", async () => {
       const queryClient = new QueryClient({
         defaultOptions: {

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1783,5 +1783,324 @@ describe("ChatInput", () => {
       ).not.toBeInTheDocument();
       expect(screen.getByTestId("chat-input-send-message")).toBeDisabled();
     });
+
+    it("hides the model selector in audio mode by default", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+        showModelSelectorInAudioMode: false,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(screen.getByTestId("model-selector")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-start"));
+
+      expect(screen.queryByTestId("model-selector")).not.toBeInTheDocument();
+    });
+
+    it("keeps the model selector in audio mode when the override flag is on", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+        showModelSelectorInAudioMode: true,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-start"));
+
+      expect(screen.getByTestId("model-selector")).toBeInTheDocument();
+    });
+
+    it("auto-submits when transcription completes after a stop in audio mode and stays in audio mode", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const toggleAudioRecording = vi.fn();
+      const onSendMessage = vi.fn();
+      const requestSubmitSpy = vi.spyOn(
+        HTMLFormElement.prototype,
+        "requestSubmit",
+      );
+      // Use a faithful createSubmitHandler mock that actually invokes the
+      // inner submit callback — that is the path that would have flipped
+      // audio mode off if the implicit reset were still in place.
+      const createSubmitHandler =
+        (
+          message: string,
+          attachedFiles: FileUploadItem[],
+          innerOnSendMessage: (
+            message: string,
+            inputFileIds?: string[],
+          ) => void,
+          isLoading: boolean,
+          disabled: boolean,
+          resetMessage: () => void,
+        ) =>
+        (event: FormEvent) => {
+          event.preventDefault();
+          if (isLoading || disabled) return;
+          const trimmed = message.trim();
+          const fileIds = attachedFiles.map((file) => file.id);
+          if (trimmed || fileIds.length > 0) {
+            innerOnSendMessage(
+              trimmed,
+              fileIds.length > 0 ? fileIds : undefined,
+            );
+            resetMessage();
+          }
+        };
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+        showModelSelectorInAudioMode: false,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: true,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [3, 6, 9, 6, 3],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={onSendMessage} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      // Click stop while recording — arms the auto-send latch.
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-stop"));
+      expect(toggleAudioRecording).toHaveBeenCalledTimes(1);
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+
+      // Simulate the recorder finishing: no longer recording, no upload
+      // pending, and a completed transcription attachment is present.
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [
+          {
+            id: "audio-completed",
+            filename: "voice-memo.wav",
+            download_url: "/files/audio-completed",
+            audio_transcription: {
+              status: "completed",
+              transcript: "hello world",
+            },
+          },
+        ] as unknown as FileUploadItem[],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler,
+      });
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={onSendMessage} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(requestSubmitSpy).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "",
+        ["audio-completed"],
+        undefined,
+        [],
+      );
+
+      // After the auto-send completes, the next compose turn must still
+      // be in audio mode: textarea hidden, exit button visible.
+      expect(
+        screen.queryByPlaceholderText("Type a message..."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-exit-audio-mode"),
+      ).toBeInTheDocument();
+      requestSubmitSpy.mockRestore();
+    });
+
+    it("clears the auto-send latch when the user exits audio mode mid-transcription", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const toggleAudioRecording = vi.fn();
+      const requestSubmitSpy = vi.spyOn(
+        HTMLFormElement.prototype,
+        "requestSubmit",
+      );
+      mockUseAudioTranscriptionFeature.mockReturnValue({
+        enabled: true,
+        maxRecordingDurationSeconds: 1200,
+        showModelSelectorInAudioMode: false,
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: true,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [3, 6, 9, 6, 3],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+
+      const { i18n } = await import("@lingui/core");
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      // Stop arms the latch.
+      fireEvent.click(screen.getByTestId("chat-input-audio-mode-stop"));
+
+      // User exits audio mode before transcription completes.
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: true,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      fireEvent.click(screen.getByTestId("chat-input-exit-audio-mode"));
+
+      // Transcription then completes after exit — latch must be cleared, so
+      // requestSubmit must NOT fire.
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [
+          {
+            id: "audio-completed",
+            filename: "voice-memo.wav",
+            download_url: "/files/audio-completed",
+            audio_transcription: {
+              status: "completed",
+              transcript: "hello world",
+            },
+          },
+        ] as unknown as FileUploadItem[],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+      });
+      mockUseAudioTranscriptionRecorder.mockReturnValue({
+        isRecording: false,
+        isRecordingUpload: false,
+        recordingError: null,
+        setRecordingError: vi.fn(),
+        recordingBars: [2, 2, 2, 2, 2],
+        retryingAudioFileId: null,
+        retryAudioTranscription: vi.fn(),
+        removeRecordedAudioFile: vi.fn(),
+        clearRecordedAudioFiles: vi.fn(),
+        hasRecordedAudioFile: () => false,
+        toggleAudioRecording,
+      });
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput onSendMessage={vi.fn()} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+
+      expect(requestSubmitSpy).not.toHaveBeenCalled();
+      requestSubmitSpy.mockRestore();
+    });
   });
 });

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -312,6 +312,7 @@ export const ChatInput = ({
   ref,
 }: ChatInputPropsWithRef) => {
   const [message, setMessage] = useState("");
+  const [isAudioMode, setIsAudioMode] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previousModeRef = useRef<"compose" | "edit">(mode);
   const previousEditMessageIdRef = useRef<string | undefined>(undefined);
@@ -992,6 +993,10 @@ export const ChatInput = ({
           selectedFacetIds,
         );
       }
+
+      // Sending closes audio mode so the user lands back in text input on
+      // the next compose turn. Re-entering is one click away.
+      setIsAudioMode(false);
     },
     isLoading ||
       isPendingResponse ||
@@ -1185,6 +1190,29 @@ export const ChatInput = ({
       isDictating ||
       isDictationStarting ||
       isDictationCompleting);
+
+  // Audio chat mode swaps the typing surfaces (textarea + dictation button)
+  // for a recording-first flow. Entering it both flips the mode and starts
+  // recording, so the user lands directly in the active waveform state.
+  const handleAudioModeButtonToggle = useCallback(() => {
+    if (!isAudioMode) {
+      setIsAudioMode(true);
+    }
+    toggleAudioRecording();
+  }, [isAudioMode, toggleAudioRecording]);
+
+  const exitAudioMode = useCallback(() => {
+    if (isRecording) {
+      toggleAudioRecording();
+    }
+    setIsAudioMode(false);
+  }, [isRecording, toggleAudioRecording]);
+
+  useEffect(() => {
+    if (mode !== "compose" && isAudioMode) {
+      setIsAudioMode(false);
+    }
+  }, [mode, isAudioMode]);
 
   // Log just before rendering the component and its preview section
   logger.log(
@@ -1397,42 +1425,46 @@ export const ChatInput = ({
             />
           )}
 
-          <textarea
-            ref={textareaRef}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onPaste={handleTextareaPaste}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                handleSubmit(e);
+          {!isAudioMode && (
+            <textarea
+              ref={textareaRef}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onPaste={handleTextareaPaste}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit(e);
+                }
+              }}
+              placeholder={
+                isAnyTokenLimitExceeded
+                  ? t`Message exceeds token limit. Please reduce length or remove files.`
+                  : mode === "edit"
+                    ? t`Edit your message...`
+                    : placeholder
               }
-            }}
-            placeholder={
-              isAnyTokenLimitExceeded
-                ? t`Message exceeds token limit. Please reduce length or remove files.`
-                : mode === "edit"
-                  ? t`Edit your message...`
-                  : placeholder
-            }
-            rows={1}
-            disabled={isLoading || isPendingResponse || disabled || isUploading}
-            tabIndex={0}
-            autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
-            className={clsx(
-              "w-full resize-none overflow-y-auto",
-              "chat-input-textarea-geometry",
-              "bg-transparent",
-              "text-[var(--theme-fg-primary)] placeholder:text-[var(--theme-fg-muted)]",
-              "focus:outline-none",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-              "max-h-[200px]",
-              "text-base",
-              "scrollbar-auto-hide",
-              isAnyTokenLimitExceeded &&
-                "border-[var(--theme-error)] placeholder:text-[var(--theme-error-fg)]",
-            )}
-          />
+              rows={1}
+              disabled={
+                isLoading || isPendingResponse || disabled || isUploading
+              }
+              tabIndex={0}
+              autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
+              className={clsx(
+                "w-full resize-none overflow-y-auto",
+                "chat-input-textarea-geometry",
+                "bg-transparent",
+                "text-[var(--theme-fg-primary)] placeholder:text-[var(--theme-fg-muted)]",
+                "focus:outline-none",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                "max-h-[200px]",
+                "text-base",
+                "scrollbar-auto-hide",
+                isAnyTokenLimitExceeded &&
+                  "border-[var(--theme-error)] placeholder:text-[var(--theme-error-fg)]",
+              )}
+            />
+          )}
 
           <div
             className="flex flex-wrap items-center justify-between gap-[calc(var(--theme-spacing-control-gap)/2)]"
@@ -1507,6 +1539,19 @@ export const ChatInput = ({
                   {t`Cancel`}
                 </Button>
               )}
+              {isAudioMode && mode === "compose" && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={exitAudioMode}
+                  disabled={disabled || isLoading || isPendingResponse}
+                  data-testid="chat-input-exit-audio-mode"
+                  aria-label={t`Exit audio mode`}
+                >
+                  {t`Exit audio mode`}
+                </Button>
+              )}
               {!hasTopLeftAccessoryOverride && (
                 <ModelSelector
                   availableModels={availableModels}
@@ -1516,6 +1561,7 @@ export const ChatInput = ({
                 />
               )}
               {audioDictationEnabled &&
+                !isAudioMode &&
                 (isCapturingAudio || isDictating ? (
                   <WaveformButton
                     onClick={toggleDictationForCurrentTarget}
@@ -1595,13 +1641,13 @@ export const ChatInput = ({
                   <ChatInputAudioModeButton
                     isRecording
                     recordingBars={recordingBars}
-                    onToggle={toggleAudioRecording}
+                    onToggle={handleAudioModeButtonToggle}
                     disabled={isAudioModeButtonDisabled}
                   />
                 ) : (
                   <ChatInputAudioModeButton
                     isRecording={false}
-                    onToggle={toggleAudioRecording}
+                    onToggle={handleAudioModeButtonToggle}
                     disabled={isAudioModeButtonDisabled}
                   />
                 )

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -232,6 +232,14 @@ interface ChatInputProps {
   controlledSelectedModel?: ChatModel | null;
   onControlledSelectedModelChange?: (model: ChatModel) => void;
   controlledIsModelSelectionReady?: boolean;
+  /**
+   * Controlled `isAudioMode`. When the parent owns the state (e.g. to
+   * survive `Chat`'s empty-state ↔ messages layout flip that otherwise
+   * unmounts `ChatInput`), pass both this and
+   * `onControlledIsAudioModeChange`. Omit both to use internal state.
+   */
+  controlledIsAudioMode?: boolean;
+  onControlledIsAudioModeChange?: (isAudioMode: boolean) => void;
 }
 
 interface ComposeDraftState {
@@ -309,11 +317,37 @@ export const ChatInput = ({
   controlledSelectedModel,
   onControlledSelectedModelChange,
   controlledIsModelSelectionReady,
+  controlledIsAudioMode,
+  onControlledIsAudioModeChange,
   ref,
 }: ChatInputPropsWithRef) => {
   const [message, setMessage] = useState("");
-  const [isAudioMode, setIsAudioMode] = useState(false);
+  const [internalIsAudioMode, setInternalIsAudioMode] = useState(false);
+  const isAudioMode = controlledIsAudioMode ?? internalIsAudioMode;
+  // Audio mode is the only piece of ChatInput state that needs to survive
+  // the layout flip in `Chat` (empty-state shell → messages shell), which
+  // tears down ChatInput because of position-based reconciliation. When
+  // the parent passes the controlled props, writes go up to the parent
+  // and the internal state stays dormant — same pattern used for the
+  // controlled model selection above.
+  const setIsAudioMode = useCallback(
+    (next: boolean) => {
+      if (onControlledIsAudioModeChange) {
+        onControlledIsAudioModeChange(next);
+        return;
+      }
+      setInternalIsAudioMode(next);
+    },
+    [onControlledIsAudioModeChange],
+  );
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  // Latched intent for "the user pressed stop and wants the resulting
+  // transcript to be sent automatically." Using a ref instead of state
+  // keeps flipping the intent out of the render cycle. The single effect
+  // below is the only reader; cancellation paths (exit audio mode, start
+  // a new recording, transcription error) flip this back to false.
+  const pendingAutoSendRef = useRef(false);
   const previousModeRef = useRef<"compose" | "edit">(mode);
   const previousEditMessageIdRef = useRef<string | undefined>(undefined);
   const composeDraftKey = chatId ?? NEW_CHAT_DRAFT_KEY;
@@ -353,8 +387,11 @@ export const ChatInput = ({
 
   // Get feature configurations
   const { enabled: uploadEnabled } = useUploadFeature();
-  const { enabled: audioTranscriptionEnabled, maxRecordingDurationSeconds } =
-    useAudioTranscriptionFeature();
+  const {
+    enabled: audioTranscriptionEnabled,
+    maxRecordingDurationSeconds,
+    showModelSelectorInAudioMode,
+  } = useAudioTranscriptionFeature();
   const {
     enabled: audioDictationEnabled,
     maxRecordingDurationSeconds: maxDictationDurationSeconds,
@@ -952,6 +989,14 @@ export const ChatInput = ({
 
   // Create the submit handler
   // Use isPendingResponse instead of isStreaming to block submission immediately when send is clicked
+  //
+  // Important: do NOT wrap this in useCallback/useMemo with narrow deps.
+  // `createSubmitHandler` captures `message`, `attachedFiles`, the
+  // disabled flag, and the inner submit callback at call time. The
+  // audio-mode auto-send relies on `handleSubmit` being rebuilt with
+  // fresh values every render so that `formRef.current?.requestSubmit()`
+  // (fired from a post-commit effect) sees the just-committed state.
+  // Memoizing this silently breaks auto-send.
   const handleSubmit = createSubmitHandler(
     message,
     attachedFiles,
@@ -993,10 +1038,6 @@ export const ChatInput = ({
           selectedFacetIds,
         );
       }
-
-      // Sending closes audio mode so the user lands back in text input on
-      // the next compose turn. Re-entering is one click away.
-      setIsAudioMode(false);
     },
     isLoading ||
       isPendingResponse ||
@@ -1194,25 +1235,76 @@ export const ChatInput = ({
   // Audio chat mode swaps the typing surfaces (textarea + dictation button)
   // for a recording-first flow. Entering it both flips the mode and starts
   // recording, so the user lands directly in the active waveform state.
+  // Stopping a recording in audio mode arms `pendingAutoSendRef` so the
+  // message is dispatched the moment transcription completes; starting a
+  // *new* recording clears that intent because the prior recording is now
+  // being replaced.
   const handleAudioModeButtonToggle = useCallback(() => {
     if (!isAudioMode) {
       setIsAudioMode(true);
     }
+    if (isRecording) {
+      pendingAutoSendRef.current = true;
+    } else {
+      pendingAutoSendRef.current = false;
+    }
     toggleAudioRecording();
-  }, [isAudioMode, toggleAudioRecording]);
+  }, [isAudioMode, isRecording, setIsAudioMode, toggleAudioRecording]);
 
   const exitAudioMode = useCallback(() => {
+    pendingAutoSendRef.current = false;
     if (isRecording) {
       toggleAudioRecording();
     }
     setIsAudioMode(false);
-  }, [isRecording, toggleAudioRecording]);
+  }, [isRecording, setIsAudioMode, toggleAudioRecording]);
 
   useEffect(() => {
     if (mode !== "compose" && isAudioMode) {
+      pendingAutoSendRef.current = false;
       setIsAudioMode(false);
     }
-  }, [mode, isAudioMode]);
+  }, [mode, isAudioMode, setIsAudioMode]);
+
+  // Surface any transcription error as a "drop the pending auto-send"
+  // signal so the user has to consciously retry — otherwise a silent
+  // failure would still trigger a stale submit when the next attachment
+  // resolves.
+  useEffect(() => {
+    if (recordingError) {
+      pendingAutoSendRef.current = false;
+    }
+  }, [recordingError]);
+
+  // Auto-send latch: when stop was pressed in audio mode and the resulting
+  // transcription has finished resolving, programmatically submit the form
+  // so the user doesn't have to click send a second time. Gated on
+  // `isAudioMode` belt-and-suspenders against a race where Exit lands in
+  // the same commit batch as transcription completion. Single source of
+  // truth (one ref, one effect) so adding VAD later just means a new
+  // writer to the same ref.
+  useEffect(() => {
+    if (!pendingAutoSendRef.current) {
+      return;
+    }
+    if (!isAudioMode) {
+      return;
+    }
+    if (isRecording || isRecordingUpload || hasIncompleteAudioTranscription) {
+      return;
+    }
+    if (attachedFiles.length === 0) {
+      return;
+    }
+    pendingAutoSendRef.current = false;
+    formRef.current?.requestSubmit();
+  }, [
+    isAudioMode,
+    isRecording,
+    isRecordingUpload,
+    hasIncompleteAudioTranscription,
+    attachedFiles.length,
+  ]);
 
   // Log just before rendering the component and its preview section
   logger.log(
@@ -1251,6 +1343,7 @@ export const ChatInput = ({
   return (
     <div className="mx-auto w-full" style={shellWrapperStyle}>
       <form
+        ref={formRef}
         className={clsx("w-full ", className, {
           "pb-0 sm:pb-0": aiUsageAdvisory,
         })}
@@ -1552,14 +1645,15 @@ export const ChatInput = ({
                   {t`Exit audio mode`}
                 </Button>
               )}
-              {!hasTopLeftAccessoryOverride && (
-                <ModelSelector
-                  availableModels={availableModels}
-                  selectedModel={selectedModel}
-                  onModelChange={setSelectedModel}
-                  disabled={!isSelectionReady}
-                />
-              )}
+              {!hasTopLeftAccessoryOverride &&
+                !(isAudioMode && !showModelSelectorInAudioMode) && (
+                  <ModelSelector
+                    availableModels={availableModels}
+                    selectedModel={selectedModel}
+                    onModelChange={setSelectedModel}
+                    disabled={!isSelectionReady}
+                  />
+                )}
               {audioDictationEnabled &&
                 !isAudioMode &&
                 (isCapturingAudio || isDictating ? (

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -414,10 +414,7 @@ export function useAudioTranscriptionRecorder({
   // ~30 Hz (33 ms) so consumer re-renders halve without a perceptible
   // change in the waveform animation. Resets and idle states still go
   // through the raw setter so they apply immediately.
-  const setRecordingBarsThrottled = useThrottledCallback(
-    setRecordingBars,
-    33,
-  );
+  const setRecordingBarsThrottled = useThrottledCallback(setRecordingBars, 33);
   const [recordingDiagnostics, setRecordingDiagnostics] =
     useState<AudioRecordingDiagnostics | null>(null);
 

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -1,5 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useThrottledCallback } from "use-debounce";
 /* eslint-disable lingui/no-unlocalized-strings */
 
 import {
@@ -8,6 +9,10 @@ import {
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
 
+import {
+  AUDIO_BARS_COUNT,
+  getAudioLevelBarsFromTimeDomainData,
+} from "./audio-pcm-codec";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 
 import type {
@@ -20,7 +25,6 @@ const CANONICAL_AUDIO_SAMPLE_RATE_HZ = 16_000;
 const CANONICAL_AUDIO_WAV_HEADER_BYTES = 44;
 const CANONICAL_AUDIO_BYTES_PER_SAMPLE = 2;
 const DEFAULT_AUDIO_TRANSCRIPTION_CHUNK_DURATION_MS = 30_000;
-const AUDIO_BARS_COUNT = 5;
 
 function formatAudioRecordingFilename(date: Date): string {
   const year = date.getFullYear().toString();
@@ -406,6 +410,14 @@ export function useAudioTranscriptionRecorder({
   const [recordingBars, setRecordingBars] = useState<number[]>(
     Array.from({ length: AUDIO_BARS_COUNT }, () => 2),
   );
+  // The analyser RAF tick fires at ~60 Hz. Throttle setRecordingBars to
+  // ~30 Hz (33 ms) so consumer re-renders halve without a perceptible
+  // change in the waveform animation. Resets and idle states still go
+  // through the raw setter so they apply immediately.
+  const setRecordingBarsThrottled = useThrottledCallback(
+    setRecordingBars,
+    33,
+  );
   const [recordingDiagnostics, setRecordingDiagnostics] =
     useState<AudioRecordingDiagnostics | null>(null);
 
@@ -508,8 +520,11 @@ export function useAudioTranscriptionRecorder({
       void audioContextRef.current.close();
     }
     audioContextRef.current = null;
+    // Drop any pending throttled bar updates before resetting to the idle
+    // pattern, so a stale RAF frame can't overwrite the reset.
+    setRecordingBarsThrottled.cancel();
     setRecordingBars(Array.from({ length: AUDIO_BARS_COUNT }, () => 2));
-  }, []);
+  }, [setRecordingBarsThrottled]);
 
   const clearRecordingDurationTimer = useCallback(() => {
     if (recordingDurationTimerRef.current !== null) {
@@ -1019,7 +1034,12 @@ export function useAudioTranscriptionRecorder({
         const analyser = audioContext.createAnalyser();
         const processor = audioContext.createScriptProcessor(4096, 1, 1);
         const processorSink = audioContext.createGain();
-        analyser.fftSize = 64;
+        // Match the dictation recorder: time-domain sampling with a
+        // 256-sample FFT and a touch of smoothing reads voice energy
+        // across the whole window instead of bucketing it into one
+        // low-frequency bin, so all five bars react to speech.
+        analyser.fftSize = 256;
+        analyser.smoothingTimeConstant = 0.65;
         processorSink.gain.value = 0;
         source.connect(analyser);
         source.connect(processor);
@@ -1039,43 +1059,20 @@ export function useAudioTranscriptionRecorder({
           flushLiveAudioSamples(false);
         };
 
-        const levelData = new Uint8Array(analyser.frequencyBinCount);
+        const levelData = new Uint8Array(analyser.fftSize);
 
         const analyzeLevel = () => {
           if (!audioAnalyserRef.current || !audioLevelDataRef.current) {
             return;
           }
 
-          audioAnalyserRef.current.getByteFrequencyData(
+          audioAnalyserRef.current.getByteTimeDomainData(
             audioLevelDataRef.current,
           );
 
-          const audioLevelData = audioLevelDataRef.current;
-          const binsPerBar = Math.max(
-            1,
-            Math.floor(audioLevelData.length / AUDIO_BARS_COUNT),
+          setRecordingBarsThrottled(
+            getAudioLevelBarsFromTimeDomainData(audioLevelDataRef.current),
           );
-
-          const nextBars = Array.from(
-            { length: AUDIO_BARS_COUNT },
-            (_, barIndex) => {
-              const startBin = barIndex * binsPerBar;
-              const endBin =
-                barIndex + 1 === AUDIO_BARS_COUNT
-                  ? audioLevelData.length
-                  : (barIndex + 1) * binsPerBar;
-              let total = 0;
-
-              for (let index = startBin; index < endBin; index++) {
-                total += audioLevelData[index];
-              }
-
-              const average = total / (endBin - startBin);
-              return Math.max(2, Math.round((average / 255) * 16));
-            },
-          );
-
-          setRecordingBars(nextBars);
           audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
         };
 
@@ -1211,6 +1208,7 @@ export function useAudioTranscriptionRecorder({
     flushLiveAudioSamples,
     removeAudioTranscriptionAttachment,
     selectedAudioInputDeviceId,
+    setRecordingBarsThrottled,
   ]);
 
   const toggleAudioRecording = useCallback(() => {

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2108,6 +2108,10 @@ msgstr "Fehler:"
 msgid "Estimating token usage..."
 msgstr "Tokennutzung wird geschätzt..."
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Exit audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 msgid "Expand {title}"
 msgstr ""

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2108,6 +2108,10 @@ msgstr "Error:"
 msgid "Estimating token usage..."
 msgstr "Estimating token usage..."
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Exit audio mode"
+msgstr "Exit audio mode"
+
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 msgid "Expand {title}"
 msgstr "Expand {title}"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2108,6 +2108,10 @@ msgstr "Error:"
 msgid "Estimating token usage..."
 msgstr "Estimando uso de tokens..."
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Exit audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 msgid "Expand {title}"
 msgstr ""

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2108,6 +2108,10 @@ msgstr "Erreur :"
 msgid "Estimating token usage..."
 msgstr "Estimation de l'utilisation des tokens..."
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Exit audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 msgid "Expand {title}"
 msgstr ""

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2108,6 +2108,10 @@ msgstr "Błąd:"
 msgid "Estimating token usage..."
 msgstr "Szacowanie użycia tokenów..."
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Exit audio mode"
+msgstr ""
+
 #: src/components/ui/Chat/ChatHistorySidebar.tsx
 msgid "Expand {title}"
 msgstr ""

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -263,7 +263,8 @@ function createFeatureConfig(
       maxRecordingDurationSeconds:
         environment.audioTranscriptionMaxRecordingDurationSeconds,
       showModelSelectorInAudioMode:
-        defaultStaticFeatureConfig.audioTranscription.showModelSelectorInAudioMode,
+        defaultStaticFeatureConfig.audioTranscription
+          .showModelSelectorInAudioMode,
     },
     audioDictation: {
       enabled: Boolean(environment.audioDictationEnabled),

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -36,6 +36,12 @@ interface AudioTranscriptionFeatureConfig {
   enabled: boolean;
   /** Maximum recording duration in seconds for audio transcription captures */
   maxRecordingDurationSeconds: number;
+  /**
+   * When the chat input is in dedicated audio mode, the model selector
+   * is hidden by default to keep the surface uncluttered. Flip this to
+   * `true` if a deployment needs the selector visible while recording.
+   */
+  showModelSelectorInAudioMode: boolean;
 }
 
 /** Configuration for audio dictation features */
@@ -177,6 +183,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   audioTranscription: {
     enabled: false,
     maxRecordingDurationSeconds: 20 * 60,
+    showModelSelectorInAudioMode: false,
   },
   audioDictation: {
     enabled: false,
@@ -255,6 +262,8 @@ function createFeatureConfig(
       enabled: Boolean(environment.audioTranscriptionEnabled),
       maxRecordingDurationSeconds:
         environment.audioTranscriptionMaxRecordingDurationSeconds,
+      showModelSelectorInAudioMode:
+        defaultStaticFeatureConfig.audioTranscription.showModelSelectorInAudioMode,
     },
     audioDictation: {
       enabled: Boolean(environment.audioDictationEnabled),

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -122,6 +122,7 @@ describe("FeatureConfigProvider", () => {
         audioTranscription: {
           enabled: false,
           maxRecordingDurationSeconds: 1200,
+          showModelSelectorInAudioMode: false,
         },
         audioDictation: {
           enabled: false,
@@ -491,6 +492,7 @@ describe("FeatureConfigProvider", () => {
       expect(result.current).toEqual({
         enabled: false,
         maxRecordingDurationSeconds: 1200,
+        showModelSelectorInAudioMode: false,
       });
     });
 


### PR DESCRIPTION
This pull request introduces a new "audio mode" to the `ChatInput` component, allowing users to switch between text and audio input more seamlessly. It includes UI and logic updates to support entering, exiting, and managing the audio input state, as well as new tests and translation keys.

**Audio Mode Feature Implementation:**

* Added an `isAudioMode` state to `ChatInput`, toggled by a new handler, to control whether the user is in audio input mode. Entering audio mode hides the text area and dictation button, and shows an "Exit audio mode" button. Exiting audio mode stops any active recording and returns to text input. [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R315) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1193-R1215) [[3]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1427) [[4]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1466) [[5]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1541-R1553) [[6]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1563) [[7]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L1589-R1641)

* The audio mode state is reset when a message is sent or when the component mode changes (e.g., switching from compose to edit). [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R995-R998) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R1193-R1215)

**Testing:**

* Added tests to verify the correct UI and behavior when entering and exiting audio mode, including hiding/showing the text area, dictation button, and exit button, and ensuring recordings are properly stopped.

**Internationalization:**

* Added the "Exit audio mode" translation key to all supported languages. [[1]](diffhunk://#diff-f3692cc86953d46bd49c31b095918f1d0099d3448fc73d8654b39e50fba43a31R2057-R2060) [[2]](diffhunk://#diff-62c9b815ddf02e79819e14c84686a33295a4c0d51985a9f04050e41852684135R2057-R2060) [[3]](diffhunk://#diff-33760c7ea2126edcfb026b66b5b08f9b6e8cceae3fc8fbbe76b5b741a4d52541R2057-R2060) [[4]](diffhunk://#diff-e509b94f5b6cd71ad8275e89c957829bea492a5004c95df4829096d78042293fR2057-R2060) [[5]](diffhunk://#diff-42a9c2224b50dfae036f7aff8ac4d073fdd5ac372833daf3a851fc4b82a5ba95R2057-R2060)

These changes improve the user experience for audio input in chat by making the mode switch explicit and user-friendly.