### PR TITLE
Portal CloudFilePicker to document.body (ERMAIN-254)

### DIFF
--- a/frontend/src/components/ui/CloudFilePicker/CloudFilePicker.tsx
+++ b/frontend/src/components/ui/CloudFilePicker/CloudFilePicker.tsx
@@ -7,6 +7,7 @@
 
 import { t } from "@lingui/core/macro";
 import { memo, useCallback, useState } from "react";
+import { createPortal } from "react-dom";
 import { useDebounce } from "use-debounce";
 
 import { useCloudData } from "@/hooks/cloud/useCloudData";
@@ -194,7 +195,7 @@ export const CloudFilePicker = memo<CloudFilePickerProps>(
     const showDriveList = driveId === null;
     const showItemBrowser = driveId !== null;
 
-    return (
+    return createPortal(
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
       <div
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
@@ -360,7 +361,8 @@ export const CloudFilePicker = memo<CloudFilePickerProps>(
             </div>
           </div>
         </div>
-      </div>
+      </div>,
+      document.body,
     );
   },
 );


### PR DESCRIPTION
This pull request updates the `CloudFilePicker` component to render its modal content using a React portal. This ensures the modal overlays the entire application UI correctly, regardless of where the component is mounted in the DOM.

**Modal rendering improvements:**

* Changed the `CloudFilePicker` component to use `createPortal`, rendering the modal directly into `document.body` for more reliable overlay behavior. [[1]](diffhunk://#diff-82dceb8f72ba06689b7e35e6fed9b92bd339597c948a349ba03b0540d4cddfa5R10) [[2]](diffhunk://#diff-82dceb8f72ba06689b7e35e6fed9b92bd339597c948a349ba03b0540d4cddfa5L197-R198) [[3]](diffhunk://#diff-82dceb8f72ba06689b7e35e6fed9b92bd339597c948a349ba03b0540d4cddfa5L363-R365)