### PR TITLE
feat: add language-file-driven hover titles to audio dictation and conversational mode buttons

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2104,6 +2104,7 @@ export const ChatInput = ({
                     disabled
                     data-testid="chat-input-record-audio-transcript"
                     aria-label={t`Finishing audio transcript`}
+                    title={t`Finishing audio transcript`}
                   />
                 )}
               {audioDictationEnabled &&
@@ -2166,6 +2167,13 @@ export const ChatInput = ({
                     }
                     data-testid="chat-input-record-audio"
                     aria-label={
+                      isDictationStarting
+                        ? t`Starting dictation`
+                        : isDictationCompleting
+                          ? t`Finishing dictation`
+                          : t`Start dictation`
+                    }
+                    title={
                       isDictationStarting
                         ? t`Starting dictation`
                         : isDictationCompleting

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -65,6 +65,7 @@ export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
       onClick={props.onToggle}
       disabled={props.disabled}
       aria-label={t`Start audio mode`}
+      title={t`Start audio mode`}
       data-testid="chat-input-audio-mode-start"
       icon={
         <Waveform

--- a/frontend/src/components/ui/Chat/WaveformButton.tsx
+++ b/frontend/src/components/ui/Chat/WaveformButton.tsx
@@ -66,6 +66,7 @@ export function WaveformButton({
         disabled={disabled}
         className="group relative overflow-hidden"
         aria-label={ariaLabel}
+        title={ariaLabel}
         data-testid={testIds?.root}
         icon={
           <span className="relative flex size-5 items-center justify-center text-[var(--theme-fg-primary)]">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validates and fixes hover-title coverage for the optional audio dictation and audio conversational mode features.

### Problem

The audio-related icon buttons in the chat input lacked `title` attributes, so hovering over them showed no tooltip. All other icon buttons in the UI (e.g. copy/edit/regenerate in `DefaultMessageControls`) set both `aria-label` **and** `title` to the same Lingui-translated string, creating a consistent browser-native hover tooltip. The audio buttons were inconsistent with this pattern.

### Changes

| File | Change |
|---|---|
| `WaveformButton.tsx` | Added `title={ariaLabel}` — covers every "stop" waveform button (stop dictation, stop audio mode, stop transcript, stop-while-pending-response) |
| `ChatInputAudioModeButton.tsx` | Added `title={t\`Start audio mode\`}` to the idle-state waveform button |
| `ChatInput.tsx` | Added `title` to the dictation start/starting/finishing idle button, and to the finishing-transcript loading button |

All title strings are driven by the Lingui `t\`...\`` macro, matching the existing pattern in `DefaultMessageControls`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-313](https://linear.app/erato-labs/issue/ERMAIN-313/validate-hover-titles-for-optional-audio-features)

<div><a href="https://cursor.com/agents/bc-2525b2ed-bdc6-4b97-a454-ccbc20420eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2525b2ed-bdc6-4b97-a454-ccbc20420eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

