### PR TITLE
fix: resolve `import.meta` CJS warning in frontend and addin dev builds (ERMAIN-312)

### DIFF
--- a/frontend/src/lib/voice-runtime/asset-constants.ts
+++ b/frontend/src/lib/voice-runtime/asset-constants.ts
@@ -1,0 +1,14 @@
+/* eslint-disable lingui/no-unlocalized-strings -- this module is path/URL plumbing only; no user-facing text */
+
+export const VOICE_RUNTIME_DIRECTORY = "voice-runtime";
+export const VOICE_RUNTIME_MANIFEST_FILENAME = "manifest.json";
+export const RICKY0123_VAD_ASSET_DIRECTORY = "ricky0123-vad-web";
+export const ONNX_RUNTIME_WEB_ASSET_DIRECTORY = "onnxruntime-web";
+export const RICKY0123_VAD_WORKLET_FILENAME = "vad.worklet.bundle.min.js";
+export const SILERO_VAD_LEGACY_MODEL_FILENAME = "silero_vad_legacy.onnx";
+export const SILERO_VAD_V5_MODEL_FILENAME = "silero_vad_v5.onnx";
+export const RICKY0123_VAD_DIST_FILES = [
+  RICKY0123_VAD_WORKLET_FILENAME,
+  SILERO_VAD_LEGACY_MODEL_FILENAME,
+  SILERO_VAD_V5_MODEL_FILENAME,
+] as const;

--- a/frontend/src/lib/voice-runtime/assets.ts
+++ b/frontend/src/lib/voice-runtime/assets.ts
@@ -1,17 +1,26 @@
 /* eslint-disable lingui/no-unlocalized-strings -- this module is path/URL plumbing only; no user-facing text */
 
-export const VOICE_RUNTIME_DIRECTORY = "voice-runtime";
-export const VOICE_RUNTIME_MANIFEST_FILENAME = "manifest.json";
-export const RICKY0123_VAD_ASSET_DIRECTORY = "ricky0123-vad-web";
-export const ONNX_RUNTIME_WEB_ASSET_DIRECTORY = "onnxruntime-web";
-export const RICKY0123_VAD_WORKLET_FILENAME = "vad.worklet.bundle.min.js";
-export const SILERO_VAD_LEGACY_MODEL_FILENAME = "silero_vad_legacy.onnx";
-export const SILERO_VAD_V5_MODEL_FILENAME = "silero_vad_v5.onnx";
-export const RICKY0123_VAD_DIST_FILES = [
+import {
+  ONNX_RUNTIME_WEB_ASSET_DIRECTORY,
+  RICKY0123_VAD_ASSET_DIRECTORY,
+  RICKY0123_VAD_DIST_FILES,
   RICKY0123_VAD_WORKLET_FILENAME,
   SILERO_VAD_LEGACY_MODEL_FILENAME,
   SILERO_VAD_V5_MODEL_FILENAME,
-] as const;
+  VOICE_RUNTIME_DIRECTORY,
+  VOICE_RUNTIME_MANIFEST_FILENAME,
+} from "./asset-constants";
+
+export {
+  ONNX_RUNTIME_WEB_ASSET_DIRECTORY,
+  RICKY0123_VAD_ASSET_DIRECTORY,
+  RICKY0123_VAD_DIST_FILES,
+  RICKY0123_VAD_WORKLET_FILENAME,
+  SILERO_VAD_LEGACY_MODEL_FILENAME,
+  SILERO_VAD_V5_MODEL_FILENAME,
+  VOICE_RUNTIME_DIRECTORY,
+  VOICE_RUNTIME_MANIFEST_FILENAME,
+};
 
 export type VoiceRuntimeAssetOverrides = {
   basePath?: string;

--- a/frontend/vite.voice-runtime-assets.ts
+++ b/frontend/vite.voice-runtime-assets.ts
@@ -9,7 +9,7 @@ import {
   RICKY0123_VAD_DIST_FILES,
   VOICE_RUNTIME_DIRECTORY,
   VOICE_RUNTIME_MANIFEST_FILENAME,
-} from "./src/lib/voice-runtime/assets";
+} from "./src/lib/voice-runtime/asset-constants";
 
 const VOICE_RUNTIME_SOURCE_FILES = [VOICE_RUNTIME_MANIFEST_FILENAME];
 const ONNX_RUNTIME_WEB_DIST_EXTENSIONS = new Set([".wasm", ".mjs"]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `[empty-import-meta]` esbuild warning that appeared in both the frontend dev build and the addin dev-linked build.

## Root Cause

`vite.voice-runtime-assets.ts` (a Vite plugin file) imported from `src/lib/voice-runtime/assets.ts`. When Vite processes config files, esbuild bundles them with **CJS output format** (for Node.js). Since `assets.ts` contains `import.meta.env` (in `getDefaultVoiceRuntimeBasePath()`), esbuild emitted:

```
▲ [WARNING] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
    src/lib/voice-runtime/assets.ts:120:24
```

## Fix

Extract the build-time string constants that the Vite plugin needs into a new `asset-constants.ts` file that has no `import.meta` usage.

**Changes:**
- **New** `frontend/src/lib/voice-runtime/asset-constants.ts` — contains only the pure string constants (`VOICE_RUNTIME_DIRECTORY`, `RICKY0123_VAD_DIST_FILES`, etc.) with no browser-runtime code
- **Modified** `frontend/src/lib/voice-runtime/assets.ts` — imports constants from `asset-constants.ts` and re-exports them; `import.meta.env` usage is retained here (only consumed in ESM browser builds)
- **Modified** `frontend/vite.voice-runtime-assets.ts` — imports from `asset-constants.ts` instead of `assets.ts`, removing the `import.meta` reference from the CJS-compiled config context

The public API of `assets.ts` is unchanged — all the same exports are still available from the same module path.

## Testing

- All 571 tests pass (75 test files)
- TypeScript type-check shows no new errors

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-312](https://linear.app/erato-labs/issue/ERMAIN-312/importmeta-warning-in-frontend-and-addin-dev-builds)

<div><a href="https://cursor.com/agents/bc-2550b3a5-f98e-40cc-b084-6033db3c682c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2550b3a5-f98e-40cc-b084-6033db3c682c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

