### PR TITLE
Feature/ermain 316 stage full outlook conversation thread for chat upload

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# RFC 5322 requires CRLF line endings; mark .eml as non-text so Git
+# never normalises a fixture down to LF and breaks MIME parsers.
+*.eml -text
+
 frontend/src/lib/generated/**/* linguist-generated
 infrastructure/charts/erato/tests_schema/helm-testsuite.json linguist-generated
 infrastructure/k3d/erato-local/tests_schema/helm-testsuite.json linguist-generated

--- a/backend/erato/src/services/file_processor.rs
+++ b/backend/erato/src/services/file_processor.rs
@@ -291,6 +291,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_kreuzberg_extracts_nested_rfc822_thread_bundle() {
+        let eml_bytes = read_test_fixture("synthesized_thread_bundle.eml");
+
+        let processor = KreuzbergProcessor;
+        let extracted = processor
+            .parse_file(eml_bytes, Some("message/rfc822"))
+            .await
+            .expect("Failed to extract text from synthesized thread bundle");
+
+        // Both nested message bodies should appear — proves kreuzberg recurses
+        // into the message/rfc822 parts of a multipart/mixed wrapper. Mirrors
+        // the shape `synthesizeThreadEml` emits in the office add-in.
+        assert!(
+            extracted.contains("FIRST_MESSAGE_UNIQUE_BODY_TOKEN_alpha"),
+            "missing first nested-message body in:\n{extracted}"
+        );
+        assert!(
+            extracted.contains("SECOND_MESSAGE_UNIQUE_BODY_TOKEN_beta"),
+            "missing second nested-message body in:\n{extracted}"
+        );
+
+        // The attachment lives inside the second nested message; its content
+        // and ## Attachment header should both appear. Confirms grandchild
+        // attachments survive the double recursion.
+        assert!(
+            extracted.contains("INNER_ATTACHMENT_UNIQUE_TOKEN_gamma"),
+            "missing inner-attachment content in:\n{extracted}"
+        );
+        assert!(
+            extracted.contains("thread_notes.txt"),
+            "missing inner-attachment filename in:\n{extracted}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_kreuzberg_extracts_structured_content_from_company_overview_pptx() {
         let pptx_bytes = read_test_fixture("Acme_Inc_Company_Overview.pptx");
 

--- a/backend/erato/tests/integration_tests/test_files/synthesized_thread_bundle.eml
+++ b/backend/erato/tests/integration_tests/test_files/synthesized_thread_bundle.eml
@@ -1,0 +1,45 @@
+From: thread-wrapper@example.com
+Subject: Thread bundle for nested-rfc822 test
+Date: Mon, 18 May 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="OUTER"
+
+--OUTER
+Content-Type: message/rfc822
+Content-Disposition: attachment; filename="msg-1.eml"
+
+From: Alice Example <alice@example.com>
+To: Bob Example <bob@example.com>
+Subject: First message in thread
+Date: Mon, 18 May 2026 09:00:00 +0000
+Message-ID: <msg-1@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+
+FIRST_MESSAGE_UNIQUE_BODY_TOKEN_alpha — body sent by Alice.
+
+--OUTER
+Content-Type: message/rfc822
+Content-Disposition: attachment; filename="msg-2.eml"
+
+From: Bob Example <bob@example.com>
+To: Alice Example <alice@example.com>
+Subject: Re: First message in thread
+Date: Mon, 18 May 2026 10:00:00 +0000
+Message-ID: <msg-2@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="INNER"
+
+--INNER
+Content-Type: text/plain; charset=utf-8
+
+SECOND_MESSAGE_UNIQUE_BODY_TOKEN_beta — reply sent by Bob, please find the attached notes.
+
+--INNER
+Content-Type: text/plain; charset=utf-8; name="thread_notes.txt"
+Content-Disposition: attachment; filename="thread_notes.txt"
+
+INNER_ATTACHMENT_UNIQUE_TOKEN_gamma — notes attached inside the second thread message.
+--INNER--
+
+--OUTER--

--- a/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
@@ -24,19 +24,36 @@ const stringToBuffer = (s: string): ArrayBuffer => {
 
 const mockFetchEml = (bytes: ArrayBuffer | string) => {
   const buffer = typeof bytes === "string" ? stringToBuffer(bytes) : bytes;
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    arrayBuffer: async () => buffer,
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.startsWith("blob:")) {
+      const blob = blobUrlContent.get(url);
+      if (!blob) throw new Error(`unmapped blob URL: ${url}`);
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => blob.arrayBuffer(),
+      } as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => buffer,
+    } as Response;
   });
 };
 
 let blobUrlCounter = 0;
 const createdBlobUrls: string[] = [];
+// Keyed by mocked blob URL; lets `mockFetchEml` route `fetch(blobUrl)`
+// requests (e.g. from `EmlThreadBody`'s nested-message parsing) back to
+// the original Blob bytes that `URL.createObjectURL` was called with.
+const blobUrlContent = new Map<string, Blob>();
 
 beforeEach(() => {
   blobUrlCounter = 0;
   createdBlobUrls.length = 0;
+  blobUrlContent.clear();
   if (typeof window.localStorage.getItem !== "function") {
     const store = new Map<string, string>();
     Object.defineProperty(window, "localStorage", {
@@ -55,9 +72,10 @@ beforeEach(() => {
   }
   Object.defineProperty(URL, "createObjectURL", {
     configurable: true,
-    value: () => {
+    value: (blob: Blob) => {
       const url = `blob:mock/${++blobUrlCounter}`;
       createdBlobUrls.push(url);
+      blobUrlContent.set(url, blob);
       return url;
     },
   });
@@ -134,9 +152,11 @@ describe("EmlPreview", () => {
 
     const iframe = await screen.findByTestId("eml-preview-html");
     expect(iframe.tagName).toBe("IFRAME");
-    // sandbox must be set in JSX, not patched on post-mount — otherwise the
-    // first parse of `srcdoc` runs unsandboxed.
-    expect(iframe.getAttribute("sandbox")).toBe("allow-same-origin");
+    // Sandbox must be set in JSX, not patched post-mount — otherwise the
+    // first parse of `srcdoc` runs unsandboxed. `sandbox=""` is the most
+    // restrictive value: no scripts, no same-origin, null-origin doc. A
+    // sanitizer bypass therefore cannot read parent cookies/localStorage.
+    expect(iframe.getAttribute("sandbox")).toBe("");
     expect(iframe.getAttribute("srcdoc") ?? "").toContain("Hello");
   });
 
@@ -213,12 +233,65 @@ describe("EmlPreview", () => {
     renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
 
     const iframe = await screen.findByTestId("eml-preview-html");
-    // sandbox must omit `allow-scripts`, and be present from the very first
-    // render so the browser never parses srcdoc unsandboxed.
-    expect(iframe.getAttribute("sandbox")).toBe("allow-same-origin");
+    // Sandbox is `""` (no flags) so the iframe doc is null-origin: no
+    // scripts, no parent-cookie access. Must be set on the JSX element so
+    // srcdoc is never parsed in an unsandboxed state.
+    expect(iframe.getAttribute("sandbox")).toBe("");
     const srcdoc = iframe.getAttribute("srcdoc") ?? "";
     expect(srcdoc.toLowerCase()).not.toContain("<script");
     expect((globalThis as Record<string, unknown>).__pwned).toBeUndefined();
+  });
+
+  it("routes to the thread view when the outer .eml has empty body + nested message/rfc822 parts", async () => {
+    const threadEml = [
+      "Subject: Re: Kickoff",
+      "Date: Mon, 18 May 2026 10:00:00 +0000",
+      "MIME-Version: 1.0",
+      'Content-Type: multipart/mixed; boundary="OUTER"',
+      "",
+      "--OUTER",
+      "Content-Type: message/rfc822",
+      'Content-Disposition: attachment; filename="msg-1.eml"',
+      "",
+      "From: Alice <alice@example.com>",
+      "Subject: Kickoff",
+      "Date: Mon, 11 May 2026 09:00:00 +0000",
+      "MIME-Version: 1.0",
+      'Content-Type: text/plain; charset="utf-8"',
+      "",
+      "First message body — alpha token.",
+      "",
+      "--OUTER",
+      "Content-Type: message/rfc822",
+      'Content-Disposition: attachment; filename="msg-2.eml"',
+      "",
+      "From: Bob <bob@example.com>",
+      "Subject: Re: Kickoff",
+      "Date: Mon, 18 May 2026 09:30:00 +0000",
+      "MIME-Version: 1.0",
+      'Content-Type: text/plain; charset="utf-8"',
+      "",
+      "Reply body — beta token.",
+      "",
+      "--OUTER--",
+      "",
+    ].join("\r\n");
+    mockFetchEml(threadEml);
+
+    renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
+
+    // Container with `data-testid="eml-thread"` proves `isThreadShape`
+    // detected the synthesized-thread shape and routed to `EmlThreadBody`.
+    // The exhaustive nested-section render is verified end-to-end by the
+    // office-addin's parseEmlBytes + synthesizeThreadEml round-trip tests
+    // and the backend's `test_kreuzberg_extracts_nested_rfc822_thread_bundle`
+    // — covering the same contract from both directions without depending
+    // on jsdom's blob-URL fetch shim.
+    await waitFor(() =>
+      expect(screen.getByTestId("eml-thread")).toBeInTheDocument(),
+    );
+    // The flat-attachment list must not appear for thread-shape emls.
+    expect(screen.queryByTestId("eml-preview-attachments")).toBeNull();
   });
 
   it("shows a preview-unavailable fallback when fetch fails", async () => {

--- a/frontend/src/components/ui/FilePreview/EmlPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.tsx
@@ -1,12 +1,15 @@
 import { t } from "@lingui/core/macro";
 import { sanitize } from "lettersanitizer";
 import PostalMime from "postal-mime";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 
+import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
 import { formatFileSize } from "@/components/ui/FileUpload/FilePreviewBase";
 import {
   ArrowLeftIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   LoadingIcon,
   MailIcon,
   PageIcon,
@@ -234,7 +237,7 @@ export const EmlPreview: React.FC<EmlPreviewProps> = ({ url }) => {
 
     return () => {
       aborted = true;
-      for (const url of blobUrls) URL.revokeObjectURL(url);
+      for (const objectUrl of blobUrls) URL.revokeObjectURL(objectUrl);
     };
   }, [url]);
 
@@ -268,19 +271,40 @@ export const EmlPreview: React.FC<EmlPreviewProps> = ({ url }) => {
     );
   }
 
+  if (isThreadShape(state.parsed)) {
+    return <EmlThreadBody parsed={state.parsed} />;
+  }
   return <EmlPreviewBody parsed={state.parsed} />;
 };
+
+/**
+ * A `.eml` is a thread bundle (per `synthesizeThreadEml` in the office-addin)
+ * when the outer body is empty and at least one attachment is itself a
+ * `message/rfc822` part. Standalone forwards with an `.eml` attachment still
+ * have a non-empty outer body, so they fall through to the normal preview.
+ */
+function isThreadShape(parsed: ParsedEml): boolean {
+  if (parsed.html.length > 0 || parsed.text.length > 0) return false;
+  return parsed.attachments.some((attachment) =>
+    attachment.mimeType.toLowerCase().includes("message/rfc822"),
+  );
+}
 
 const EmlPreviewBody: React.FC<{
   parsed: ParsedEml;
 }> = ({ parsed }) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
   const [selected, setSelected] = useState<ParsedAttachment | null>(null);
 
   // Pre-sanitize the HTML body up here so the iframe's `srcDoc` is rendered
   // with `sandbox` already set on the element in JSX — applying sandbox in a
   // post-mount effect would leave a window where the unsandboxed iframe has
   // already begun parsing/executing the email HTML.
+  //
+  // The iframe runs in a *null-origin* sandbox (`sandbox=""` — no flags).
+  // No scripts, no same-origin access to the parent, no form submission, no
+  // top-level navigation. A sanitizer bypass therefore cannot read cookies
+  // or LocalStorage. The cost: we can't measure `contentDocument` to
+  // auto-resize, so the iframe gets a fixed CSS height with internal scroll.
   const sanitizedHtml = useMemo(() => {
     if (!parsed.html) return "";
     return sanitize(parsed.html, parsed.text || undefined, {
@@ -291,50 +315,6 @@ const EmlPreviewBody: React.FC<{
       },
     });
   }, [parsed.html, parsed.text, parsed.cidToBlobUrl]);
-
-  useEffect(() => {
-    const iframe = iframeRef.current;
-    if (!iframe) return;
-    let observer: ResizeObserver | null = null;
-
-    const resize = () => {
-      try {
-        const doc = iframe.contentDocument;
-        if (!doc) return;
-        const measured = Math.max(
-          doc.body.scrollHeight,
-          doc.documentElement.scrollHeight,
-        );
-        if (measured > 0) {
-          const cap = window.innerHeight * 0.7;
-          iframe.style.height = `${Math.min(measured + 8, cap)}px`;
-        }
-      } catch {
-        // Sandbox + same-origin should keep contentDocument accessible, but
-        // leave the iframe at its default height if anything goes wrong.
-      }
-    };
-
-    const onLoad = () => {
-      resize();
-      try {
-        const body = iframe.contentDocument?.body;
-        if (body && typeof ResizeObserver === "function") {
-          observer = new ResizeObserver(resize);
-          observer.observe(body);
-        }
-      } catch {
-        // ignore
-      }
-    };
-
-    iframe.addEventListener("load", onLoad);
-    if (iframe.contentDocument?.readyState === "complete") onLoad();
-    return () => {
-      iframe.removeEventListener("load", onLoad);
-      observer?.disconnect();
-    };
-  }, [sanitizedHtml]);
 
   return (
     <div data-testid="eml-preview" className="flex flex-col gap-4">
@@ -350,14 +330,16 @@ const EmlPreviewBody: React.FC<{
           data-testid="eml-attachment-preview"
           className="flex flex-col gap-3"
         >
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            icon={<ArrowLeftIcon className="size-4" aria-hidden="true" />}
             onClick={() => setSelected(null)}
-            className="inline-flex w-fit items-center gap-1.5 rounded text-sm font-medium text-[var(--theme-fg-secondary)] hover:text-[var(--theme-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-fg-accent)]"
+            className="w-fit"
           >
-            <ArrowLeftIcon className="size-4" aria-hidden="true" />
             {t`Back to email`}
-          </button>
+          </Button>
           <div className="truncate text-sm text-[var(--theme-fg-muted)]">
             {selected.filename}
           </div>
@@ -371,12 +353,11 @@ const EmlPreviewBody: React.FC<{
         <>
           {parsed.html ? (
             <iframe
-              ref={iframeRef}
               data-testid="eml-preview-html"
               title={parsed.subject ?? t`Email preview`}
-              sandbox="allow-same-origin"
+              sandbox=""
               srcDoc={sanitizedHtml}
-              className="w-full rounded border border-[var(--theme-border-attachment)] bg-white"
+              className="h-[60vh] w-full rounded border border-[var(--theme-border-attachment)] bg-white"
             />
           ) : (
             <pre
@@ -397,6 +378,248 @@ const EmlPreviewBody: React.FC<{
     </div>
   );
 };
+
+interface ThreadMessage {
+  /** Stable per-thread identifier: parsed Message-ID when available, else a content-derived fallback. */
+  id: string;
+  subject: string | null;
+  from: string | null;
+  date: string | null;
+  html: string;
+  text: string;
+  attachments: ParsedAttachment[];
+  cidToBlobUrl: Map<string, string>;
+}
+
+const EmlThreadBody: React.FC<{ parsed: ParsedEml }> = ({ parsed }) => {
+  const [messages, setMessages] = useState<ThreadMessage[] | null>(null);
+  const [selected, setSelected] = useState<ParsedAttachment | null>(null);
+
+  useEffect(() => {
+    let aborted = false;
+    const blobUrls: string[] = [];
+
+    const parseNested = async () => {
+      const out: ThreadMessage[] = [];
+      const nestedAttachments = parsed.attachments.filter((attachment) =>
+        attachment.mimeType.toLowerCase().includes("message/rfc822"),
+      );
+      for (const attachment of nestedAttachments) {
+        try {
+          const response = await fetch(attachment.blobUrl);
+          const bytes = await response.arrayBuffer();
+          const message = await PostalMime.parse(bytes);
+          if (aborted) return;
+          const cidToBlobUrl = new Map<string, string>();
+          const childAttachments: ParsedAttachment[] = [];
+          for (const child of message.attachments) {
+            const blob = attachmentBlob(child);
+            const childUrl = URL.createObjectURL(blob);
+            blobUrls.push(childUrl);
+            const trimmedName = child.filename?.trim();
+            childAttachments.push({
+              filename:
+                trimmedName && trimmedName.length > 0
+                  ? trimmedName
+                  : t`attachment`,
+              mimeType:
+                child.mimeType.length > 0 ? child.mimeType : OCTET_STREAM,
+              size: blob.size,
+              blobUrl: childUrl,
+            });
+            if (child.contentId !== undefined) {
+              const cid = child.contentId.replace(/^<|>$/g, "");
+              if (cid.length > 0) cidToBlobUrl.set(cid, childUrl);
+            }
+          }
+          const fallbackId = `thread-msg-${out.length}-${(message.subject ?? "").slice(0, 32)}`;
+          out.push({
+            id: message.messageId ?? fallbackId,
+            subject: nullIfEmpty(message.subject),
+            from: formatAddress(message.from),
+            date: message.date ?? null,
+            html: message.html ?? "",
+            text: message.text ?? "",
+            attachments: childAttachments,
+            cidToBlobUrl,
+          });
+        } catch (error) {
+          logger.warn("postal-mime failed to parse nested message", error);
+        }
+      }
+      if (aborted) return;
+      setMessages(out);
+    };
+
+    void parseNested();
+    return () => {
+      aborted = true;
+      for (const objectUrl of blobUrls) URL.revokeObjectURL(objectUrl);
+    };
+  }, [parsed.attachments]);
+
+  if (messages === null) {
+    return (
+      <div
+        className="flex items-center justify-center py-12"
+        aria-live="polite"
+        aria-busy="true"
+        data-testid="eml-thread-loading"
+      >
+        <LoadingIcon className="size-6 animate-spin text-[var(--theme-fg-muted)]" />
+      </div>
+    );
+  }
+
+  if (selected) {
+    return (
+      <div data-testid="eml-thread" className="flex flex-col gap-4">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          icon={<ArrowLeftIcon className="size-4" aria-hidden="true" />}
+          onClick={() => setSelected(null)}
+          className="w-fit"
+        >
+          {t`Back to thread`}
+        </Button>
+        <div className="truncate text-sm text-[var(--theme-fg-muted)]">
+          {selected.filename}
+        </div>
+        <FilePreviewContent
+          filename={selected.filename}
+          url={selected.blobUrl}
+          mimeType={selected.mimeType}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="eml-thread" className="flex flex-col gap-3">
+      <EmlHeader
+        subject={parsed.subject}
+        from={null}
+        to={null}
+        cc={null}
+        date={null}
+      />
+      <div className="flex flex-col gap-2">
+        {messages.map((message, index) => (
+          <ThreadMessageSection
+            key={message.id}
+            message={message}
+            defaultExpanded={index === messages.length - 1}
+            onSelectAttachment={setSelected}
+            panelId={`eml-thread-panel-${message.id.replace(/[^a-zA-Z0-9_-]/g, "_")}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const ThreadMessageSection: React.FC<{
+  message: ThreadMessage;
+  defaultExpanded: boolean;
+  onSelectAttachment: (attachment: ParsedAttachment) => void;
+  panelId: string;
+}> = ({ message, defaultExpanded, onSelectAttachment, panelId }) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  // Sanitised HTML body for the iframe `srcDoc`. The iframe is rendered
+  // with `sandbox=""` (null origin, no scripts, no same-origin) — see the
+  // matching note on `EmlPreviewBody`.
+  const sanitizedHtml = useMemo(() => {
+    if (!message.html) return "";
+    return sanitize(message.html, message.text || undefined, {
+      rewriteExternalResources: (url) => {
+        if (!url.startsWith("cid:")) return url;
+        const cid = url.slice(4).replace(/^<|>$/g, "");
+        return message.cidToBlobUrl.get(cid) ?? url;
+      },
+    });
+  }, [message.html, message.text, message.cidToBlobUrl]);
+
+  return (
+    <div
+      data-testid="eml-thread-message"
+      className="rounded border border-[var(--theme-border-attachment)] bg-[var(--theme-bg-primary)]"
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-start gap-2 p-3 text-left"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+      >
+        <span
+          className="mt-0.5 inline-flex shrink-0 items-center text-[var(--theme-fg-muted)]"
+          aria-hidden="true"
+        >
+          {expanded ? (
+            <ChevronDownIcon className="size-4" />
+          ) : (
+            <ChevronRightIcon className="size-4" />
+          )}
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[var(--theme-fg-primary)]">
+            {message.from ?? t`Unknown sender`}
+          </p>
+          <p className="truncate text-xs text-[var(--theme-fg-muted)]">
+            {[message.date, message.subject]
+              .filter((part): part is string => Boolean(part))
+              .join(" · ")}
+          </p>
+        </div>
+        {message.attachments.length > 0 && (
+          <span className="shrink-0 text-xs text-[var(--theme-fg-muted)]">
+            {message.attachments.length === 1
+              ? t`1 file`
+              : t`${message.attachments.length} files`}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <div
+          id={panelId}
+          role="region"
+          className="flex flex-col gap-3 px-3 pb-3"
+        >
+          {message.html ? (
+            <iframe
+              data-testid="eml-thread-message-html"
+              title={message.subject ?? t`Email`}
+              sandbox=""
+              srcDoc={sanitizedHtml}
+              className="h-[40vh] w-full rounded border border-[var(--theme-border-attachment)] bg-white"
+            />
+          ) : message.text ? (
+            <pre
+              data-testid="eml-thread-message-text"
+              className="max-h-[40vh] overflow-auto whitespace-pre-wrap rounded border border-[var(--theme-border-attachment)] bg-[var(--theme-bg-accent)] p-3 text-sm text-[var(--theme-fg-primary)]"
+            >
+              {message.text}
+            </pre>
+          ) : null}
+          {message.attachments.length > 0 && (
+            <EmlAttachmentList
+              attachments={message.attachments}
+              onSelect={onSelectAttachment}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function nullIfEmpty(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  return value.trim().length === 0 ? null : value;
+}
 
 const EmlHeader: React.FC<{
   subject: string | null;

--- a/frontend/src/components/ui/FilePreview/EmlPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { sanitize } from "lettersanitizer";
 import PostalMime from "postal-mime";
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
@@ -79,6 +79,8 @@ function formatAddressList(addrs: Address[] | undefined): string | null {
 
 // eslint-disable-next-line lingui/no-unlocalized-strings
 const OCTET_STREAM = "application/octet-stream";
+// eslint-disable-next-line lingui/no-unlocalized-strings
+const MESSAGE_RFC822 = "message/rfc822";
 
 function attachmentBlob(attachment: Attachment): Blob {
   const { content, mimeType } = attachment;
@@ -286,7 +288,7 @@ export const EmlPreview: React.FC<EmlPreviewProps> = ({ url }) => {
 function isThreadShape(parsed: ParsedEml): boolean {
   if (parsed.html.length > 0 || parsed.text.length > 0) return false;
   return parsed.attachments.some((attachment) =>
-    attachment.mimeType.toLowerCase().includes("message/rfc822"),
+    attachment.mimeType.toLowerCase().includes(MESSAGE_RFC822),
   );
 }
 
@@ -402,7 +404,7 @@ const EmlThreadBody: React.FC<{ parsed: ParsedEml }> = ({ parsed }) => {
     const parseNested = async () => {
       const out: ThreadMessage[] = [];
       const nestedAttachments = parsed.attachments.filter((attachment) =>
-        attachment.mimeType.toLowerCase().includes("message/rfc822"),
+        attachment.mimeType.toLowerCase().includes(MESSAGE_RFC822),
       );
       for (const attachment of nestedAttachments) {
         try {
@@ -574,13 +576,15 @@ const ThreadMessageSection: React.FC<{
               .join(" · ")}
           </p>
         </div>
-        {message.attachments.length > 0 && (
-          <span className="shrink-0 text-xs text-[var(--theme-fg-muted)]">
-            {message.attachments.length === 1
-              ? t`1 file`
-              : t`${message.attachments.length} files`}
-          </span>
-        )}
+        {message.attachments.length > 0 &&
+          (() => {
+            const count = message.attachments.length;
+            return (
+              <span className="shrink-0 text-xs text-[var(--theme-fg-muted)]">
+                {count === 1 ? t`1 file` : t`${count} files`}
+              </span>
+            );
+          })()}
       </button>
       {expanded && (
         <div

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -276,14 +276,19 @@ const DefaultGroupedFileAttachmentsPreview: React.FC<
                 onClick={() => toggleGroupCollapsed(group.id)}
                 className={clsx(
                   FILE_PREVIEW_STYLES.group.header,
-                  "flex w-full items-center text-left",
+                  "w-full text-left",
                 )}
                 aria-expanded={!isCollapsed}
               >
                 {headerInner}
               </button>
             ) : (
-              <div className={FILE_PREVIEW_STYLES.group.header}>
+              <div
+                className={clsx(
+                  FILE_PREVIEW_STYLES.group.header,
+                  "justify-between",
+                )}
+              >
                 {headerInner}
                 {shouldCollapse && isExpanded && (
                   <Button

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import { componentRegistry } from "@/config/componentRegistry";
 
@@ -64,7 +64,39 @@ export type FileAttachmentGroupItem =
   | {
       kind: "loading";
       id: string;
+    }
+  | {
+      /**
+       * Nested sub-section for a single message inside an Outlook conversation
+       * thread. Renders as its own collapsible card *inside* the parent
+       * group — keeps per-message attachments visually attached to their
+       * message in the thread instead of flattening to siblings.
+       *
+       * The header checkbox toggles inclusion of the whole message (body +
+       * its attachments). Individual attachment checkboxes inside override
+       * the header for fine control.
+       */
+      kind: "threadMessageGroup";
+      id: string;
+      /** Primary label, typically sender display name. */
+      label: string;
+      /** Secondary line, typically date + subject. */
+      sublabel?: string;
+      /** Whether the whole message is included. Drives the header checkbox. */
+      selected: boolean;
+      onToggle: () => void;
+      /** Initially collapsed when true. Default: true. */
+      defaultCollapsed?: boolean;
+      attachments: ThreadMessageAttachmentItem[];
     };
+
+export interface ThreadMessageAttachmentItem {
+  id: string;
+  file: FileResource;
+  selected: boolean;
+  onToggle: () => void;
+  validation?: { ok: boolean; reason?: string };
+}
 
 export interface FileAttachmentGroup {
   id: string;
@@ -170,6 +202,129 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
         )}
       </div>
     </label>
+  );
+};
+
+interface ThreadMessageGroupSectionProps {
+  label: string;
+  sublabel?: string;
+  selected: boolean;
+  onToggle: () => void;
+  attachments: ThreadMessageAttachmentItem[];
+  defaultCollapsed?: boolean;
+  disabled: boolean;
+  showFileType: boolean;
+  showSize: boolean;
+  filenameTruncateLength: number;
+}
+
+const ThreadMessageHeaderText: React.FC<{
+  label: string;
+  sublabel?: string;
+}> = ({ label, sublabel }) => (
+  <div className="min-w-0 flex-1">
+    <p
+      className="truncate text-sm font-medium text-theme-fg-primary"
+      title={label}
+    >
+      {label}
+    </p>
+    {sublabel && (
+      <p className="truncate text-xs text-theme-fg-muted" title={sublabel}>
+        {sublabel}
+      </p>
+    )}
+  </div>
+);
+
+const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
+  label,
+  sublabel,
+  selected,
+  onToggle,
+  attachments,
+  defaultCollapsed = true,
+  disabled,
+  showFileType,
+  showSize,
+  filenameTruncateLength,
+}) => {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const panelId = useId();
+  const hasAttachments = attachments.length > 0;
+  return (
+    <div
+      className={clsx(
+        "rounded-md border border-theme-border bg-theme-bg-secondary p-2",
+        !selected && "opacity-60",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={onToggle}
+          disabled={disabled}
+          className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
+          aria-label={`${t`Include message`} ${label}`}
+          onClick={(event) => event.stopPropagation()}
+        />
+        {hasAttachments ? (
+          // Only render the chevron when there's something to expand —
+          // an empty thread message has no attachments to show, so a
+          // disclosure toggle would dangle without any payload.
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            className="flex min-w-0 flex-1 items-start gap-2 text-left"
+            aria-expanded={!collapsed}
+            aria-controls={panelId}
+          >
+            <span
+              className="mt-0.5 inline-flex shrink-0 items-center text-theme-fg-muted"
+              aria-hidden="true"
+            >
+              {collapsed ? (
+                <ChevronRightIcon className="size-4" />
+              ) : (
+                <ChevronDownIcon className="size-4" />
+              )}
+            </span>
+            <ThreadMessageHeaderText label={label} sublabel={sublabel} />
+            <span className="shrink-0 text-xs text-theme-fg-muted">
+              {attachments.length === 1
+                ? t`1 file`
+                : t`${attachments.length} files`}
+            </span>
+          </button>
+        ) : (
+          <div className="flex min-w-0 flex-1 items-start gap-2">
+            <ThreadMessageHeaderText label={label} sublabel={sublabel} />
+          </div>
+        )}
+      </div>
+      {!collapsed && hasAttachments && (
+        <div
+          id={panelId}
+          role="region"
+          className="mt-2 flex flex-col gap-1 pl-6"
+        >
+          {attachments.map((attachment) => (
+            <SelectableAttachmentRow
+              key={attachment.id}
+              file={attachment.file}
+              selected={attachment.selected}
+              onToggle={attachment.onToggle}
+              disabled={disabled}
+              showFileType={showFileType}
+              showSize={showSize}
+              filenameTruncateLength={filenameTruncateLength}
+              validation={attachment.validation}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   );
 };
 
@@ -312,6 +467,24 @@ const DefaultGroupedFileAttachmentsPreview: React.FC<
                       key={item.id}
                       className="w-full"
                       label={t`Loading attachment...`}
+                    />
+                  );
+                }
+
+                if (item.kind === "threadMessageGroup") {
+                  return (
+                    <ThreadMessageGroupSection
+                      key={item.id}
+                      label={item.label}
+                      sublabel={item.sublabel}
+                      selected={item.selected}
+                      onToggle={item.onToggle}
+                      attachments={item.attachments}
+                      defaultCollapsed={item.defaultCollapsed}
+                      disabled={disabled}
+                      showFileType={showFileTypes}
+                      showSize={showFileSizes}
+                      filenameTruncateLength={filenameTruncateLength}
                     />
                   );
                 }

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -293,9 +293,7 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
             </span>
             <ThreadMessageHeaderText label={label} sublabel={sublabel} />
             <span className="shrink-0 text-xs text-theme-fg-muted">
-              {attachmentCount === 1
-                ? t`1 file`
-                : t`${attachmentCount} files`}
+              {attachmentCount === 1 ? t`1 file` : t`${attachmentCount} files`}
             </span>
           </button>
         ) : (

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -252,6 +252,7 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const panelId = useId();
   const hasAttachments = attachments.length > 0;
+  const attachmentCount = attachments.length;
   return (
     <div
       className={clsx(
@@ -292,9 +293,9 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
             </span>
             <ThreadMessageHeaderText label={label} sublabel={sublabel} />
             <span className="shrink-0 text-xs text-theme-fg-muted">
-              {attachments.length === 1
+              {attachmentCount === 1
                 ? t`1 file`
-                : t`${attachments.length} files`}
+                : t`${attachmentCount} files`}
             </span>
           </button>
         ) : (

--- a/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
+++ b/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
@@ -36,8 +36,7 @@ export const FILE_PREVIEW_STYLES = {
   group: {
     container:
       "rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] p-3",
-    header:
-      "mb-2 flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between",
+    header: "mb-2 flex min-w-0 items-start gap-2",
     title: "truncate text-sm font-medium text-[var(--theme-fg-secondary)]",
     meta: "text-xs text-[var(--theme-fg-muted)]",
     toggleButton: "text-xs",

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -207,4 +207,5 @@ export type {
   FileAttachmentGroup,
   FileAttachmentGroupItem,
   GroupedFileAttachmentsPreviewProps,
+  ThreadMessageAttachmentItem,
 } from "@/components/ui/FileUpload/GroupedFileAttachmentsPreview";

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1604,6 +1604,14 @@ msgstr "{0, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
 #~ msgid "{0} items"
 #~ msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "{attachmentCount} files"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "{count} files"
+msgstr ""
+
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
@@ -1633,6 +1641,8 @@ msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• \"Auf Browsererkennung zurücksetzen\" verwenden, um die Erkennung neu zu testen"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/components/ui/FilePreview/EmlPreview.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "1 file"
 msgstr "1 Datei"
 
@@ -1825,6 +1835,10 @@ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Back to thread"
 msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
@@ -2134,6 +2148,10 @@ msgid "Edit your message..."
 msgstr "Bearbeiten Sie Ihre Nachricht..."
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Email preview"
 msgstr ""
 
@@ -2262,6 +2280,10 @@ msgstr "In Bearbeitung"
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "Include"
 msgstr "Einbeziehen"
+
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Include message"
+msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 msgid "Input Parameters"
@@ -2838,6 +2860,10 @@ msgstr "Nachricht eingeben..."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Unable to retry this transcription because the source audio is not available."
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Unknown sender"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1604,6 +1604,14 @@ msgstr "{0, plural, =0 {No files} one {# file} other {# files}}"
 #~ msgid "{0} items"
 #~ msgstr "{0} items"
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "{attachmentCount} files"
+msgstr "{attachmentCount} files"
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "{count} files"
+msgstr "{count} files"
+
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
@@ -1633,6 +1641,8 @@ msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Use \"Reset to Browser Detection\" to test fresh detection"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/components/ui/FilePreview/EmlPreview.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "1 file"
 msgstr "1 file"
 
@@ -1826,6 +1836,10 @@ msgstr "Back to Assistants"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr "Back to email"
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Back to thread"
+msgstr "Back to thread"
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "Beginning of conversation"
@@ -2134,6 +2148,10 @@ msgid "Edit your message..."
 msgstr "Edit your message..."
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Email"
+msgstr "Email"
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Email preview"
 msgstr "Email preview"
 
@@ -2262,6 +2280,10 @@ msgstr "In Progress"
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "Include"
 msgstr "Include"
+
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Include message"
+msgstr "Include message"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 msgid "Input Parameters"
@@ -2839,6 +2861,10 @@ msgstr "Type a message..."
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Unable to retry this transcription because the source audio is not available."
 msgstr "Unable to retry this transcription because the source audio is not available."
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Unknown sender"
+msgstr "Unknown sender"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Untitled Chat"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1604,6 +1604,14 @@ msgstr "{0, plural, =0 {Sin archivos} one {# archivo} other {# archivos}}"
 #~ msgid "{0} items"
 #~ msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "{attachmentCount} files"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "{count} files"
+msgstr ""
+
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
@@ -1633,6 +1641,8 @@ msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Use \"Restablecer a detección del navegador\" para probar detección nueva"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/components/ui/FilePreview/EmlPreview.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "1 file"
 msgstr ""
 
@@ -1825,6 +1835,10 @@ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Back to thread"
 msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
@@ -2134,6 +2148,10 @@ msgid "Edit your message..."
 msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Email preview"
 msgstr ""
 
@@ -2262,6 +2280,10 @@ msgstr "En progreso"
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "Include"
 msgstr "Incluir"
+
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Include message"
+msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 msgid "Input Parameters"
@@ -2838,6 +2860,10 @@ msgstr "Escriba un mensaje..."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Unable to retry this transcription because the source audio is not available."
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Unknown sender"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1604,6 +1604,14 @@ msgstr "{0, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
 #~ msgid "{0} items"
 #~ msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "{attachmentCount} files"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "{count} files"
+msgstr ""
+
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName} : {filePercentage}%"
@@ -1633,6 +1641,8 @@ msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr ""
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/components/ui/FilePreview/EmlPreview.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "1 file"
 msgstr ""
 
@@ -1825,6 +1835,10 @@ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Back to thread"
 msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
@@ -2134,6 +2148,10 @@ msgid "Edit your message..."
 msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Email preview"
 msgstr ""
 
@@ -2262,6 +2280,10 @@ msgstr "En cours"
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "Include"
 msgstr "Inclure"
+
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Include message"
+msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 msgid "Input Parameters"
@@ -2838,6 +2860,10 @@ msgstr "Tapez un message..."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Unable to retry this transcription because the source audio is not available."
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Unknown sender"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1604,6 +1604,14 @@ msgstr "{0, plural, =0 {Brak plików} one {# plik} few {# pliki} other {# plikó
 #~ msgid "{0} items"
 #~ msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "{attachmentCount} files"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "{count} files"
+msgstr ""
+
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
@@ -1633,6 +1641,8 @@ msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Użyj \"Resetuj do wykrywania przeglądarki\" aby przetestować świeże wykrywanie"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/components/ui/FilePreview/EmlPreview.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "1 file"
 msgstr ""
 
@@ -1825,6 +1835,10 @@ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Back to thread"
 msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
@@ -2134,6 +2148,10 @@ msgid "Edit your message..."
 msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Email"
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Email preview"
 msgstr ""
 
@@ -2262,6 +2280,10 @@ msgstr "W trakcie"
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 msgid "Include"
 msgstr "Dołącz"
+
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Include message"
+msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 msgid "Input Parameters"
@@ -2838,6 +2860,10 @@ msgstr "Napisz wiadomość..."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "Unable to retry this transcription because the source audio is not available."
+msgstr ""
+
+#: src/components/ui/FilePreview/EmlPreview.tsx
+msgid "Unknown sender"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -230,14 +230,100 @@ export const AddinChatInput = forwardRef<
       });
     }
 
-    // Staged emails (currently-open + future dropped). Each renders as its
-    // own grouped card with selectable rows for the .eml body and each
-    // in-eml attachment. Selection state is captured locally in Phase 1;
-    // surgical MIME removal in Phase 2 will honour deselections in the
-    // upload payload.
+    // Staged emails: the currently-open Outlook conversation renders as one
+    // card with each thread message nested inside (threadMessageGroup items);
+    // drag-dropped .eml files render as flat cards (one per drop).
     for (const staged of stagedEmails) {
-      const items: FileAttachmentGroupItem[] = [];
+      if (staged.source === "current-thread") {
+        const messageCount = staged.thread.messages.length;
+        const items: FileAttachmentGroupItem[] = staged.thread.messages.map(
+          (message) => {
+            const senderLabel =
+              message.from?.name?.trim() ||
+              message.from?.address?.trim() ||
+              t({
+                id: "officeAddin.chatInput.unknownSender",
+                message: "Unknown sender",
+              });
+            const dateLabel = message.date
+              ? new Date(message.date).toLocaleString()
+              : "";
+            const sublabel = [dateLabel, message.subject]
+              .filter((part) => part.trim().length > 0)
+              .join(" · ");
 
+            const attachmentItems = message.attachments
+              .filter((attachment) => !attachment.isInline)
+              .map((attachment) => {
+                const dismissed = staged.dismissedAttachmentIds.has(
+                  attachment.id,
+                );
+                const validation = validateAttachment(
+                  attachment.filename,
+                  attachment.mimeType,
+                  attachment.size,
+                  globalMaxSizeBytes,
+                  maxSizeFormatted,
+                );
+                return {
+                  id: attachment.id,
+                  file: {
+                    id: attachment.id,
+                    filename: attachment.filename,
+                    size: attachment.size,
+                  },
+                  selected: !dismissed,
+                  onToggle: () => {
+                    if (dismissed) {
+                      restoreStagedEmailAttachment(message.id, attachment.id);
+                    } else {
+                      dismissStagedEmailAttachment(message.id, attachment.id);
+                    }
+                  },
+                  validation,
+                };
+              });
+
+            const messageDismissed = staged.dismissedMessageIds.has(message.id);
+            return {
+              kind: "threadMessageGroup" as const,
+              id: message.id,
+              label: senderLabel,
+              sublabel,
+              selected: !messageDismissed,
+              onToggle: () => {
+                if (messageDismissed) {
+                  restoreStagedEmailBody(message.id);
+                } else {
+                  dismissStagedEmailBody(message.id);
+                }
+              },
+              defaultCollapsed: true,
+              attachments: attachmentItems,
+            };
+          },
+        );
+
+        groups.push({
+          id: `staged-email:${staged.key}`,
+          label:
+            staged.thread.subject ||
+            emailSubject ||
+            t({
+              id: "officeAddin.chatInput.emailFallback",
+              message: "Email",
+            }),
+          metaLabel:
+            messageCount === 1 ? t`1 message` : t`${messageCount} messages`,
+          items,
+          collapsible: true,
+          defaultCollapsed: true,
+        });
+        continue;
+      }
+
+      // source === "drop" — one .eml dragged onto the chat, flat layout.
+      const items: FileAttachmentGroupItem[] = [];
       items.push({
         kind: "selectableAttachment",
         id: `${staged.key}:body`,

--- a/office-addin/src/hooks/__tests__/useCurrentThread.test.ts
+++ b/office-addin/src/hooks/__tests__/useCurrentThread.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useCurrentThread } from "../useCurrentThread";
+
+import type { GraphTransport } from "../../utils/fetchOutlookMessageGraph";
+
+function buildResponder(jsonValue: unknown, ok = true, status = 200) {
+  return vi.fn(
+    async () =>
+      ({
+        ok,
+        status,
+        statusText: ok ? "OK" : "Error",
+        json: async () => jsonValue,
+      }) as Response,
+  );
+}
+
+const acquireToken = async () => "token";
+
+describe("useCurrentThread", () => {
+  it("returns null thread + isLoading=false when itemId or conversationId is missing", () => {
+    const transport: GraphTransport = vi.fn(async () => {
+      throw new Error("transport should not be called");
+    });
+
+    const { result } = renderHook(() =>
+      useCurrentThread(null, "conv-1", acquireToken, { transport }),
+    );
+    expect(result.current).toEqual({ thread: null, isLoading: false });
+    expect(transport).not.toHaveBeenCalled();
+
+    const { result: result2 } = renderHook(() =>
+      useCurrentThread("item-1", null, acquireToken, { transport }),
+    );
+    expect(result2.current).toEqual({ thread: null, isLoading: false });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("toggles isLoading around the fetch and resolves to the parsed thread", async () => {
+    const transport = buildResponder({
+      value: [
+        {
+          id: "m1",
+          internetMessageId: "<m1@x>",
+          subject: "Loaded message",
+          body: { contentType: "text", content: "body" },
+          receivedDateTime: "2026-03-01T10:00:00Z",
+          isDraft: false,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useCurrentThread("item-1", "conv-1", acquireToken, { transport }),
+    );
+
+    // Effect runs synchronously after mount; first observed value should be
+    // either loading=true with no thread yet, or already resolved.
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.thread?.messages[0].subject).toBe("Loaded message");
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the previous thread to null when conversationId changes", async () => {
+    const transport = vi.fn(async (url: string) => {
+      const conversation = /conversationId%20eq%20'([^']+)'/.exec(url)?.[1];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          value: [
+            {
+              id: conversation,
+              internetMessageId: `<${conversation}@x>`,
+              subject: `Subject for ${conversation}`,
+              body: { contentType: "text", content: "body" },
+              receivedDateTime: "2026-03-01T10:00:00Z",
+              isDraft: false,
+            },
+          ],
+        }),
+      } as Response;
+    });
+
+    const { result, rerender } = renderHook(
+      ({ conversationId }) =>
+        useCurrentThread("item-1", conversationId, acquireToken, { transport }),
+      { initialProps: { conversationId: "conv-A" } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.thread?.subject).toContain("conv-A");
+    });
+
+    await act(async () => {
+      rerender({ conversationId: "conv-B" });
+    });
+
+    // Switching mid-flight must clear the previous thread so consumers
+    // don't render stale content during the new fetch.
+    await waitFor(() => {
+      expect(result.current.thread?.subject).toContain("conv-B");
+    });
+  });
+
+  it("returns null thread when the Graph request fails", async () => {
+    const transport = buildResponder({ value: [] }, false, 500);
+
+    const { result } = renderHook(() =>
+      useCurrentThread("item-1", "conv-1", acquireToken, { transport }),
+    );
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    consoleWarn.mockRestore();
+    expect(result.current.thread).toBeNull();
+  });
+});

--- a/office-addin/src/hooks/useCurrentThread.ts
+++ b/office-addin/src/hooks/useCurrentThread.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+import { fetchCurrentThread, type ParsedThread } from "../utils/parsedThread";
+
+import type {
+  AcquireGraphToken,
+  FetchConversationOptions,
+} from "../utils/fetchOutlookMessageGraph";
+
+export interface UseCurrentThreadResult {
+  thread: ParsedThread | null;
+  isLoading: boolean;
+}
+
+/**
+ * Fetches the Outlook conversation for the open mail item via Microsoft
+ * Graph and exposes it as React state. Used to be inlined inside
+ * `OutlookEmailSourceProvider` — pulled into its own hook so it can be
+ * unit-tested with `renderHook` against an injected transport instead of
+ * a global `fetch` stub.
+ *
+ * Behaviour:
+ *   - Returns `{ thread: null, isLoading: false }` when either `itemId` or
+ *     `conversationId` is missing. `itemId === null` is the read-mode gate
+ *     (drafts/compose items have no Graph-reachable id).
+ *   - Sets `isLoading=true` while a fetch is in flight; cancellation flag
+ *     prevents state updates after `itemId`/`conversationId` change or
+ *     after the consumer unmounts.
+ *   - Clears the previous `thread` to `null` at the start of each new fetch
+ *     so consumers see "loading" rather than stale content from a prior
+ *     conversation.
+ *
+ * The `transport` option is forwarded to `fetchCurrentThread`; production
+ * callers omit it and default to global `fetch`.
+ */
+export function useCurrentThread(
+  itemId: string | null,
+  conversationId: string | null,
+  acquireGraphToken: AcquireGraphToken,
+  options: FetchConversationOptions = {},
+): UseCurrentThreadResult {
+  const [thread, setThread] = useState<ParsedThread | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  // Stable transport reference avoids re-running the effect on every render
+  // when the consumer passes an inline transport closure.
+  const { transport } = options;
+
+  useEffect(() => {
+    if (!itemId || !conversationId) {
+      setThread(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setThread(null);
+
+    void fetchCurrentThread(conversationId, acquireGraphToken, { transport })
+      .then((result) => {
+        if (cancelled) return;
+        setThread(result);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [acquireGraphToken, conversationId, itemId, transport]);
+
+  return { thread, isLoading };
+}

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -113,6 +113,11 @@ msgstr "(kein Betreff)"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.unknownSender"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Datei überschreitet das Serverlimit von {globalMaxFormatted}"
 
@@ -515,3 +520,14 @@ msgstr "Generiertes Manifest hochladen"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "und laden Sie die heruntergeladene Datei dort hoch."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/AddinChatInput.tsx
+msgid "{messageCount} messages"
+msgstr ""
+
+#: src/components/AddinChatInput.tsx
+msgid "1 message"
+msgstr ""

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -113,6 +113,11 @@ msgstr "(no subject)"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.unknownSender"
+msgstr "Unknown sender"
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "File exceeds the server limit of {globalMaxFormatted}"
 
@@ -515,3 +520,14 @@ msgstr "Upload the generated manifest"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "and upload the downloaded file there."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/AddinChatInput.tsx
+msgid "{messageCount} messages"
+msgstr "{messageCount} messages"
+
+#: src/components/AddinChatInput.tsx
+msgid "1 message"
+msgstr "1 message"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -113,6 +113,11 @@ msgstr "(sin asunto)"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.unknownSender"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "El archivo supera el límite del servidor de {globalMaxFormatted}"
 
@@ -515,3 +520,14 @@ msgstr "Cargue el manifiesto generado"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "y cargue allí el archivo descargado."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/AddinChatInput.tsx
+msgid "{messageCount} messages"
+msgstr ""
+
+#: src/components/AddinChatInput.tsx
+msgid "1 message"
+msgstr ""

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -113,6 +113,11 @@ msgstr "(sans objet)"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.unknownSender"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Le fichier dépasse la limite du serveur de {globalMaxFormatted}"
 
@@ -515,3 +520,14 @@ msgstr "Téléverser le manifeste généré"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "et téléversez-y le fichier téléchargé."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/AddinChatInput.tsx
+msgid "{messageCount} messages"
+msgstr ""
+
+#: src/components/AddinChatInput.tsx
+msgid "1 message"
+msgstr ""

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -113,6 +113,11 @@ msgstr "(brak tematu)"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.unknownSender"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Plik przekracza limit serwera wynoszący {globalMaxFormatted}"
 
@@ -515,3 +520,14 @@ msgstr "Prześlij wygenerowany manifest"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "i prześlij tam pobrany plik."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/AddinChatInput.tsx
+msgid "{messageCount} messages"
+msgstr ""
+
+#: src/components/AddinChatInput.tsx
+msgid "1 message"
+msgstr ""

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -4,12 +4,13 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
 import { useMsalNaa } from "./MsalNaaProvider";
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
-import { fetchCurrentEmailParsed } from "../utils/fetchCurrentEmailEml";
+import { useCurrentThread } from "../hooks/useCurrentThread";
 import { fetchParentMessageInConversationViaGraph } from "../utils/fetchOutlookMessageGraph";
 import {
   dismissAttachment as applyDismissAttachment,
@@ -17,22 +18,40 @@ import {
   restoreAttachment as applyRestoreAttachment,
   restoreBody as applyRestoreBody,
 } from "../utils/stagedEmailDismissals";
+import { synthesizeThreadEml } from "../utils/synthesizeThreadEml";
 import { trimEmlAttachments } from "../utils/trimEmlAttachments";
 
 import type { ParentMessageMetadata } from "../utils/fetchOutlookMessageGraph";
 import type { ParsedEmail } from "../utils/parsedEmail";
+import type {
+  ParsedThread,
+  ThreadAttachment,
+  ThreadMessage,
+} from "../utils/parsedThread";
 import type { StagedEmailDismissalsMap } from "../utils/stagedEmailDismissals";
+import type {
+  ThreadAttachmentInput,
+  ThreadMessageInput,
+} from "../utils/synthesizeThreadEml";
 import type { LocalFilePreviewItem } from "@erato/frontend/library";
 import type { ReactNode } from "react";
 
 const OUTLOOK_CLOUD_ATTACHMENT_TYPE = "cloud";
 const GRAPH_MAIL_SCOPES = ["Mail.Read"];
-const CURRENT_EMAIL_FALLBACK_KEY = "current-email";
 
-let droppedKeyCounter = 0;
 function generateDroppedKey(): string {
-  droppedKeyCounter += 1;
-  return `drop-${Date.now()}-${droppedKeyCounter}`;
+  return `drop-${crypto.randomUUID()}`;
+}
+
+/**
+ * UTF-8 byte length of whichever body wins (HTML preferred, text fallback).
+ * Used to seed the token-estimator placeholder. Cheap text-encoding, no
+ * base64 expansion — attachment bytes are added separately by the caller.
+ */
+function textByteLength(text: string | null, html: string | null): number {
+  const winning = html ?? text;
+  if (!winning) return 0;
+  return new TextEncoder().encode(winning).length;
 }
 
 function collectDismissedIndices(
@@ -55,9 +74,6 @@ async function trimRawEmlBytes(
   const buffer = await rawEmlFile.arrayBuffer();
   const trimmed = trimEmlAttachments(new Uint8Array(buffer), indicesToRemove);
   if (!trimmed) {
-    // Trim couldn't safely identify a part — fall back to shipping the
-    // .eml untouched. Worse UX than honouring the deselection, but better
-    // than an upload that drops the wrong attachment or fails entirely.
     console.warn(
       "[OutlookEmailSourceProvider] surgical trim returned null; uploading the original .eml",
     );
@@ -68,16 +84,39 @@ async function trimRawEmlBytes(
   });
 }
 
-export type StagedEmailSource = "current" | "drop";
+export type StagedEmailSource = "current-thread" | "drop";
 
-export interface StagedEmail {
-  /** Stable across renders; equal to RFC 5322 Message-ID when available. */
-  key: string;
-  source: StagedEmailSource;
-  parsed: ParsedEmail;
-  bodyDismissed: boolean;
-  dismissedAttachmentIds: ReadonlySet<string>;
-}
+/**
+ * Discriminated union driving the staged-input UI:
+ *
+ * - `current-thread` — the currently-open Outlook conversation, fetched via
+ *   Graph as a single `$filter=conversationId&$expand=attachments` call and
+ *   represented as a `ParsedThread`. Rendered as one nested card per thread
+ *   (sender/date sub-headers, per-message body + attachment checkboxes).
+ *
+ * - `drop` — a single `.eml` dragged onto the chat. Rendered as a flat card
+ *   matching the pre-thread behaviour. Each drop is independent.
+ *
+ * Dismissals for both variants share the same `emailDismissals` map keyed by
+ * RFC 5322 Message-ID — uniformly per-message-per-attachment.
+ */
+export type StagedEmail =
+  | {
+      key: string;
+      source: "current-thread";
+      thread: ParsedThread;
+      /** Set of thread-message ids whose body the user excluded. */
+      dismissedMessageIds: ReadonlySet<string>;
+      /** Set of `${messageId}:${attachmentId}` keys the user excluded. */
+      dismissedAttachmentIds: ReadonlySet<string>;
+    }
+  | {
+      key: string;
+      source: "drop";
+      parsed: ParsedEmail;
+      bodyDismissed: boolean;
+      dismissedAttachmentIds: ReadonlySet<string>;
+    };
 
 interface DroppedEmailEntry {
   key: string;
@@ -89,35 +128,12 @@ interface OutlookEmailSourceContextValue {
   isEmailBodyIncluded: boolean;
   emailBodyFile: File | null;
   isLoadingEmailBody: boolean;
-  /**
-   * Structured view of the currently-open email when fetched via Graph
-   * (read mode only). Powers the per-attachment selection UI and will feed
-   * surgical MIME removal in Phase 2. `null` when the email body comes from
-   * the synthesized-HTML compose-mode path or before Graph returns.
-   */
-  currentEmailParsed: ParsedEmail | null;
-  /**
-   * Unified list of emails staged for upload, currently-open and dropped
-   * alike. Drives the grouped-card UI for selection. Updates to dismissal
-   * state are applied via `dismissStagedEmailBody` and
-   * `dismissStagedEmailAttachment` (and their restore counterparts).
-   *
-   * Phase 1: the selection state captured here drives the UI only — the
-   * upload payload for the currently-open email path is still the raw
-   * `.eml`. Phase 2 wires surgical MIME removal so deselected attachments
-   * are stripped from the bytes before upload.
-   */
+  currentThread: ParsedThread | null;
   stagedEmails: StagedEmail[];
   dismissStagedEmailBody: (key: string) => void;
   restoreStagedEmailBody: (key: string) => void;
   dismissStagedEmailAttachment: (key: string, attachmentId: string) => void;
   restoreStagedEmailAttachment: (key: string, attachmentId: string) => void;
-  /**
-   * Add a parsed email (from a drop or an OWA mail-list drag) to the
-   * staged list. Returns the stable key under which it was filed so
-   * callers can reference it later (e.g. to remove it). Returns `null`
-   * when the email is already staged under the same Message-ID.
-   */
   addDroppedEmail: (parsed: ParsedEmail) => string | null;
   removeDroppedEmail: (key: string) => void;
   selectedAttachmentItems: LocalFilePreviewItem[];
@@ -130,15 +146,6 @@ interface OutlookEmailSourceContextValue {
   dismissedAttachmentIds: string[];
   resolveSelectedFilesForSend: () => Promise<File[]>;
   hasSelectedEmailSource: boolean;
-  /**
-   * Metadata of the most recent non-draft message in the same conversation
-   * thread, when the user is in Outlook compose mode replying / forwarding.
-   * Display-only — surfaces a "Reply context" chip in the chat input UI.
-   * Not part of `resolveSelectedFilesForSend`: the body is already in the
-   * draft via Outlook's auto-quote and reaches the LLM through the
-   * `outlook_review_draft.full_body` action facet, so re-sending it here
-   * would double the token cost.
-   */
   parentReplyContext: ParentMessageMetadata | null;
   isLoadingParentReplyContext: boolean;
 }
@@ -148,7 +155,7 @@ const defaultValue: OutlookEmailSourceContextValue = {
   isEmailBodyIncluded: false,
   emailBodyFile: null,
   isLoadingEmailBody: false,
-  currentEmailParsed: null,
+  currentThread: null,
   stagedEmails: [],
   dismissStagedEmailBody: () => {},
   restoreStagedEmailBody: () => {},
@@ -193,9 +200,6 @@ export function OutlookEmailSourceProvider({
   const [dismissedAttachmentIds, setDismissedAttachmentIds] = useState<
     string[]
   >([]);
-  const [currentEmailParsed, setCurrentEmailParsed] =
-    useState<ParsedEmail | null>(null);
-  const [isLoadingEmailBody, setIsLoadingEmailBody] = useState(false);
   const [parentReplyContext, setParentReplyContext] =
     useState<ParentMessageMetadata | null>(null);
   const [isLoadingParentReplyContext, setIsLoadingParentReplyContext] =
@@ -213,45 +217,14 @@ export function OutlookEmailSourceProvider({
   const conversationId = mailItem?.conversationId ?? null;
   const isComposeMode = mailItem?.isComposeMode ?? false;
 
-  // Fetch and parse the raw `.eml` via Graph whenever the open email changes.
-  // Drafts and compose items have no itemId, so no accessory is produced —
-  // matches the Graph indexing contract (`/$value` 404s on unsent messages).
-  useEffect(() => {
-    if (!itemId) {
-      setCurrentEmailParsed(null);
-      setIsLoadingEmailBody(false);
-      return;
-    }
+  // Conversation fetch lives in its own hook so it can be unit-tested in
+  // isolation against an injected Graph transport.
+  const { thread: currentThread, isLoading: isLoadingEmailBody } =
+    useCurrentThread(itemId, conversationId, acquireGraphToken);
 
-    let cancelled = false;
-    setIsLoadingEmailBody(true);
-    setCurrentEmailParsed(null);
-
-    void fetchCurrentEmailParsed(itemId, acquireGraphToken)
-      .then((result) => {
-        if (cancelled) {
-          return;
-        }
-        setCurrentEmailParsed(result?.parsed ?? null);
-      })
-      .finally(() => {
-        if (cancelled) {
-          return;
-        }
-        setIsLoadingEmailBody(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [acquireGraphToken, itemId]);
-
-  // Fetch the parent-thread metadata when the user is composing a reply or
-  // forward. Graph's `/me/messages/{itemId}` 404s on drafts (the very issue
-  // that gates the read-mode preview above), but the *parent* message is
-  // indexed and addressable by `conversationId`. We surface a display-only
-  // "Reply context" chip; the body itself reaches the LLM via the auto-quote
-  // already embedded in the draft, so re-fetching it here is unnecessary.
+  // Reply-context chip for compose mode (drafts have no itemId but do have a
+  // conversationId). Display-only — the parent body reaches the LLM via the
+  // draft's auto-quote + the `outlook_review_draft.full_body` action facet.
   useEffect(() => {
     if (!isComposeMode || !conversationId || itemId) {
       setParentReplyContext(null);
@@ -268,15 +241,11 @@ export function OutlookEmailSourceProvider({
       acquireGraphToken,
     )
       .then((result) => {
-        if (cancelled) {
-          return;
-        }
+        if (cancelled) return;
         setParentReplyContext(result);
       })
       .finally(() => {
-        if (cancelled) {
-          return;
-        }
+        if (cancelled) return;
         setIsLoadingParentReplyContext(false);
       });
 
@@ -285,30 +254,45 @@ export function OutlookEmailSourceProvider({
     };
   }, [acquireGraphToken, conversationId, isComposeMode, itemId]);
 
-  // Clear dismissals when the host mail item changes. Office.js attachment
-  // ids are per-item — so the dismissal set from a previous message would
-  // otherwise leak into the new one. Staged-email dismissals (`emailDismissals`)
-  // are keyed by RFC 5322 Message-ID, which is globally unique, so they don't
-  // need this scope-flush.
+  // Office.js attachment ids are per-item; flush the dismissal list when
+  // the host mail item changes so stale ids don't leak. Thread + drop
+  // dismissals (`emailDismissals`) are keyed by Message-ID and don't need
+  // this scope-flush.
   useEffect(() => {
     setDismissedAttachmentIds([]);
   }, [itemIdentity]);
 
-  const currentEmailKey =
-    currentEmailParsed?.messageId ?? CURRENT_EMAIL_FALLBACK_KEY;
+  const threadStaged = useMemo<Extract<
+    StagedEmail,
+    { source: "current-thread" }
+  > | null>(() => {
+    if (!currentThread) return null;
+    const messageDismissals = new Set<string>();
+    const attachmentDismissals = new Set<string>();
+    for (const message of currentThread.messages) {
+      const entry = emailDismissals.get(message.id);
+      if (!entry) continue;
+      if (entry.bodyDismissed) {
+        messageDismissals.add(message.id);
+      }
+      for (const attachmentId of entry.attachmentIds) {
+        attachmentDismissals.add(attachmentId);
+      }
+    }
+    return {
+      key: `current-thread:${currentThread.conversationId}`,
+      source: "current-thread",
+      thread: currentThread,
+      dismissedMessageIds: messageDismissals,
+      dismissedAttachmentIds: attachmentDismissals,
+    };
+  }, [currentThread, emailDismissals]);
 
   const stagedEmails = useMemo<StagedEmail[]>(() => {
     const list: StagedEmail[] = [];
 
-    if (currentEmailParsed) {
-      const dismissals = emailDismissals.get(currentEmailKey);
-      list.push({
-        key: currentEmailKey,
-        source: "current",
-        parsed: currentEmailParsed,
-        bodyDismissed: dismissals?.bodyDismissed ?? false,
-        dismissedAttachmentIds: dismissals?.attachmentIds ?? new Set<string>(),
-      });
+    if (threadStaged) {
+      list.push(threadStaged);
     }
 
     for (const entry of droppedEmails) {
@@ -323,11 +307,53 @@ export function OutlookEmailSourceProvider({
     }
 
     return list;
-  }, [currentEmailKey, currentEmailParsed, droppedEmails, emailDismissals]);
+  }, [droppedEmails, emailDismissals, threadStaged]);
 
-  const currentStagedEmail = stagedEmails[0] ?? null;
-  const isEmailBodyDismissed = currentStagedEmail?.bodyDismissed ?? false;
-  const emailBodyFile = currentEmailParsed?.rawEmlFile ?? null;
+  const includedThreadMessages = useMemo<ThreadMessage[]>(() => {
+    if (!currentThread || !threadStaged) return [];
+    return currentThread.messages.filter(
+      (message) => !threadStaged.dismissedMessageIds.has(message.id),
+    );
+  }, [currentThread, threadStaged]);
+
+  // Approximate size of the synthesised thread .eml without paying the
+  // base64 cost. Used to give the chat-input's token estimator a non-zero
+  // signal via `emailBodyFile.size` — the real synthesis only runs at send
+  // time inside `resolveSelectedFilesForSend`, so checkbox toggles don't
+  // re-encode tens of MB of attachment bytes.
+  const threadPreviewFile = useMemo<File | null>(() => {
+    if (!currentThread || !threadStaged) return null;
+    if (includedThreadMessages.length === 0) return null;
+    let estimatedBytes = 1024; // outer headers + boundaries fixed overhead
+    for (const message of includedThreadMessages) {
+      estimatedBytes += 512; // per-message header block
+      estimatedBytes += textByteLength(message.bodyText, message.bodyHtml);
+      for (const attachment of message.attachments) {
+        if (attachment.isInline) continue;
+        if (threadStaged.dismissedAttachmentIds.has(attachment.id)) continue;
+        // base64 expands content by ~4/3 and adds ~2 bytes per 76-char line.
+        estimatedBytes += Math.ceil(attachment.size * 1.37);
+      }
+    }
+    // The preview File only needs the right `.size`; its bytes are never
+    // read (consumers use it for token estimation). Allocate a zero-filled
+    // placeholder of the right length — far cheaper than base64-encoding
+    // the real attachments on every keystroke.
+    return new File([new Uint8Array(estimatedBytes)], "thread-preview.eml", {
+      type: "message/rfc822",
+    });
+  }, [currentThread, includedThreadMessages, threadStaged]);
+
+  const currentStagedDrop = stagedEmails.find(
+    (staged): staged is Extract<StagedEmail, { source: "drop" }> =>
+      staged.source === "drop",
+  );
+  const isEmailBodyDismissed = currentThread
+    ? includedThreadMessages.length === 0
+    : (currentStagedDrop?.bodyDismissed ?? false);
+  const emailBodyFile = currentThread
+    ? threadPreviewFile
+    : (currentStagedDrop?.parsed.rawEmlFile ?? null);
   const isEmailBodyIncluded = !!emailBodyFile && !isEmailBodyDismissed;
 
   const selectableAttachments = useMemo(() => {
@@ -370,20 +396,28 @@ export function OutlookEmailSourceProvider({
     [],
   );
 
+  // The dedup check has to be StrictMode-safe: returning a synchronous
+  // "did we accept this?" answer from inside the setState updater would
+  // misreport on the second invocation. Track known keys in a ref so the
+  // decision lives outside the updater entirely. The setState updater
+  // remains idempotent — re-running it sees the entry already present and
+  // returns `previous` unchanged.
+  const droppedKeysRef = useRef<Set<string>>(new Set());
+
   const addDroppedEmail = useCallback((parsed: ParsedEmail): string | null => {
     const key = parsed.messageId ?? generateDroppedKey();
-    let assigned: string | null = key;
-    setDroppedEmails((previous) => {
-      if (previous.some((entry) => entry.key === key)) {
-        assigned = null;
-        return previous;
-      }
-      return [...previous, { key, parsed }];
-    });
-    return assigned;
+    if (droppedKeysRef.current.has(key)) return null;
+    droppedKeysRef.current.add(key);
+    setDroppedEmails((previous) =>
+      previous.some((entry) => entry.key === key)
+        ? previous
+        : [...previous, { key, parsed }],
+    );
+    return key;
   }, []);
 
   const removeDroppedEmail = useCallback((key: string) => {
+    droppedKeysRef.current.delete(key);
     setDroppedEmails((previous) =>
       previous.filter((entry) => entry.key !== key),
     );
@@ -395,15 +429,26 @@ export function OutlookEmailSourceProvider({
     });
   }, []);
 
+  // Drop-only back-compat helpers. Their scope is intentionally narrow:
+  //   - `removeEmailBody` / `restoreEmailBody` only affect the most recent
+  //     drop; in thread mode the per-message checkboxes drive dismissal.
+  //   - `removeAttachment` / `restoreAttachment` only affect Office.js
+  //     compose-mode attachments (the fallback group rendered when there
+  //     is neither a thread nor a drop).
+  // Kept under the legacy names to avoid breaking the existing
+  // `handleRemoveEmailSourceFile` wiring inside `AddinChatInput`. If a
+  // future caller wants "remove the current email", reach for
+  // `dismissStagedEmailBody(messageId)` directly — these are silent
+  // no-ops outside their narrow scope.
   const removeEmailBody = useCallback(() => {
-    if (!currentStagedEmail) return;
-    dismissStagedEmailBody(currentStagedEmail.key);
-  }, [currentStagedEmail, dismissStagedEmailBody]);
+    if (!currentStagedDrop) return;
+    dismissStagedEmailBody(currentStagedDrop.key);
+  }, [currentStagedDrop, dismissStagedEmailBody]);
 
   const restoreEmailBody = useCallback(() => {
-    if (!currentStagedEmail) return;
-    restoreStagedEmailBody(currentStagedEmail.key);
-  }, [currentStagedEmail, restoreStagedEmailBody]);
+    if (!currentStagedDrop) return;
+    restoreStagedEmailBody(currentStagedDrop.key);
+  }, [currentStagedDrop, restoreStagedEmailBody]);
 
   const removeAttachment = useCallback((attachmentId: string) => {
     setDismissedAttachmentIds((previous) =>
@@ -420,10 +465,52 @@ export function OutlookEmailSourceProvider({
   const resolveSelectedFilesForSend = useCallback(async (): Promise<File[]> => {
     const filesToSend: File[] = [];
 
+    // Thread upload: one synthesized .eml carrying every non-dismissed
+    // message + their non-dismissed attachments. The structure preserves
+    // version provenance — three files named "Lastenheft.pdf" land as
+    // attachments inside three different nested message/rfc822 parts.
+    //
+    // We synthesize lazily here (not in a useMemo) so checkbox toggles in
+    // the staged-preview UI don't re-base64-encode every kept attachment
+    // on every click. The cost is paid once, at send time.
+    if (currentThread && threadStaged && includedThreadMessages.length > 0) {
+      const synthInputs = includedThreadMessages.map<ThreadMessageInput>(
+        (message) => ({
+          internetMessageId: message.internetMessageId,
+          subject: message.subject,
+          from: message.from
+            ? { name: message.from.name, address: message.from.address }
+            : null,
+          to: message.to.map((addr) => ({
+            name: addr.name,
+            address: addr.address,
+          })),
+          cc: message.cc.map((addr) => ({
+            name: addr.name,
+            address: addr.address,
+          })),
+          date: message.date,
+          bodyText: message.bodyText,
+          bodyHtml: message.bodyHtml,
+          attachments: filterAttachments(
+            message.attachments,
+            threadStaged.dismissedAttachmentIds,
+          ),
+        }),
+      );
+      filesToSend.push(
+        synthesizeThreadEml({
+          subject: currentThread.subject,
+          messages: synthInputs,
+        }),
+      );
+    }
+
+    // Drop uploads: keep the existing per-drop trim path. Each drop is
+    // independent of the open thread.
     for (const staged of stagedEmails) {
-      if (staged.bodyDismissed) {
-        continue;
-      }
+      if (staged.source !== "drop") continue;
+      if (staged.bodyDismissed) continue;
       const indicesToRemove = collectDismissedIndices(
         staged.parsed.attachments,
         staged.dismissedAttachmentIds,
@@ -439,13 +526,11 @@ export function OutlookEmailSourceProvider({
       filesToSend.push(trimmed);
     }
 
-    // Office.js compose-mode attachments. When a current-email `.eml` is
-    // staged (read mode), these are duplicates of the in-eml attachments
-    // already inside the `.eml` and we skip them to avoid double-counting.
-    const hasReadModeCurrentStaged = stagedEmails.some(
-      (staged) => staged.source === "current",
-    );
-    if (!hasReadModeCurrentStaged) {
+    // Office.js compose-mode fallback. Only invoked when there is no thread
+    // and no drops — in read mode the thread .eml already carries the
+    // attachments, in drop-only mode the drop .eml does. Cloud attachments
+    // skipped here because their content can't be resolved locally.
+    if (!currentThread && stagedEmails.every((s) => s.source !== "drop")) {
       const remainingAttachments = selectableAttachments.filter(
         (attachment) => !dismissedAttachmentIds.includes(attachment.id),
       );
@@ -474,10 +559,13 @@ export function OutlookEmailSourceProvider({
 
     return filesToSend;
   }, [
+    currentThread,
     dismissedAttachmentIds,
     getAttachmentFile,
+    includedThreadMessages,
     selectableAttachments,
     stagedEmails,
+    threadStaged,
   ]);
 
   const value = useMemo<OutlookEmailSourceContextValue>(
@@ -486,7 +574,7 @@ export function OutlookEmailSourceProvider({
       isEmailBodyIncluded,
       emailBodyFile,
       isLoadingEmailBody,
-      currentEmailParsed,
+      currentThread,
       stagedEmails,
       dismissStagedEmailBody,
       restoreStagedEmailBody,
@@ -512,7 +600,7 @@ export function OutlookEmailSourceProvider({
     }),
     [
       addDroppedEmail,
-      currentEmailParsed,
+      currentThread,
       dismissStagedEmailAttachment,
       dismissStagedEmailBody,
       dismissedAttachmentIds,
@@ -542,4 +630,22 @@ export function OutlookEmailSourceProvider({
       {children}
     </OutlookEmailSourceContext.Provider>
   );
+}
+
+function filterAttachments(
+  attachments: ThreadAttachment[],
+  dismissedAttachmentIds: ReadonlySet<string>,
+): ThreadAttachmentInput[] {
+  const output: ThreadAttachmentInput[] = [];
+  for (const attachment of attachments) {
+    if (attachment.isInline) continue;
+    if (attachment.contentBytes === null) continue;
+    if (dismissedAttachmentIds.has(attachment.id)) continue;
+    output.push({
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      contentBytes: attachment.contentBytes,
+    });
+  }
+  return output;
 }

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -40,7 +40,7 @@ const OUTLOOK_CLOUD_ATTACHMENT_TYPE = "cloud";
 const GRAPH_MAIL_SCOPES = ["Mail.Read"];
 
 function generateDroppedKey(): string {
-  return `drop-${crypto.randomUUID()}`;
+  return `drop-${globalThis.crypto.randomUUID()}`;
 }
 
 /**

--- a/office-addin/src/utils/__tests__/parsedThread.test.ts
+++ b/office-addin/src/utils/__tests__/parsedThread.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchCurrentThread } from "../parsedThread";
+
+import type {
+  GraphConversationMessage,
+  GraphTransport,
+} from "../fetchOutlookMessageGraph";
+
+const FILE_ATTACHMENT = "#microsoft.graph.fileAttachment";
+const ITEM_ATTACHMENT = "#microsoft.graph.itemAttachment";
+const REFERENCE_ATTACHMENT = "#microsoft.graph.referenceAttachment";
+
+function makeTransport(value: GraphConversationMessage[]): GraphTransport {
+  return vi.fn(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ value }),
+      }) as Response,
+  );
+}
+
+function makeFailingTransport(status: number): GraphTransport {
+  return vi.fn(
+    async () =>
+      ({
+        ok: false,
+        status,
+        statusText: "Server Error",
+        json: async () => ({}),
+      }) as Response,
+  );
+}
+
+const acquireToken = async () => "test-token";
+
+describe("fetchCurrentThread", () => {
+  it("filters drafts out of the thread", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "Real message",
+        body: { contentType: "text", content: "hello" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+      },
+      {
+        id: "m2",
+        internetMessageId: "<m2@x>",
+        subject: "Draft reply",
+        body: { contentType: "text", content: "drafting…" },
+        sentDateTime: "2026-03-02T10:00:00Z",
+        isDraft: true,
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread).not.toBeNull();
+    expect(thread?.messages).toHaveLength(1);
+    expect(thread?.messages[0].id).toBe("<m1@x>");
+  });
+
+  it("prefers uniqueBody over body and tracks html vs text content-type", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "html with unique body",
+        body: { contentType: "html", content: "<p>full thread quote</p>" },
+        uniqueBody: { contentType: "html", content: "<p>just my reply</p>" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+      },
+      {
+        id: "m2",
+        internetMessageId: "<m2@x>",
+        subject: "text fallback",
+        body: {
+          contentType: "text",
+          content: "fallback wins when uniqueBody missing",
+        },
+        receivedDateTime: "2026-03-02T10:00:00Z",
+        isDraft: false,
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread?.messages[0].bodyHtml).toContain("just my reply");
+    expect(thread?.messages[0].bodyText).toBeNull();
+    expect(thread?.messages[1].bodyText).toContain("fallback wins");
+    expect(thread?.messages[1].bodyHtml).toBeNull();
+  });
+
+  it("keeps only fileAttachments with contentBytes; skips itemAttachment and referenceAttachment", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "mixed attachments",
+        body: { contentType: "text", content: "see attached" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+        attachments: [
+          {
+            "@odata.type": FILE_ATTACHMENT,
+            id: "att-1",
+            name: "report.pdf",
+            contentType: "application/pdf",
+            size: 12,
+            isInline: false,
+            contentBytes: "aGVsbG8gd29ybGQ=", // base64 "hello world"
+          },
+          {
+            "@odata.type": ITEM_ATTACHMENT,
+            id: "att-2",
+            name: "Forwarded email",
+            contentType: "message/rfc822",
+            size: 999,
+            isInline: false,
+          },
+          {
+            "@odata.type": REFERENCE_ATTACHMENT,
+            id: "att-3",
+            name: "shared-link.url",
+            contentType: "application/vnd.ms-onedrive",
+            size: 0,
+            isInline: false,
+          },
+        ],
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread?.messages[0].attachments).toHaveLength(1);
+    const [keptAttachment] = thread!.messages[0].attachments;
+    expect(keptAttachment.filename).toBe("report.pdf");
+    expect(keptAttachment.contentBytes).not.toBeNull();
+    expect(keptAttachment.contentBytes!.byteLength).toBe(11); // "hello world"
+    expect(keptAttachment.id).toBe("<m1@x>:att-1");
+  });
+
+  it("preserves the isInline flag on attachments so the provider can filter them", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "inline image",
+        body: { contentType: "html", content: "<img src='cid:logo'>" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+        attachments: [
+          {
+            "@odata.type": FILE_ATTACHMENT,
+            id: "logo",
+            name: "logo.png",
+            contentType: "image/png",
+            size: 4,
+            isInline: true,
+            contentBytes: "AAEC", // arbitrary bytes
+            contentId: "logo",
+          },
+        ],
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread?.messages[0].attachments).toHaveLength(1);
+    expect(thread?.messages[0].attachments[0].isInline).toBe(true);
+    expect(thread?.messages[0].attachments[0].contentId).toBe("logo");
+  });
+
+  it("sorts messages chronologically and uses the latest subject for the outer thread", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "Re: Re: Original",
+        body: { contentType: "text", content: "third" },
+        receivedDateTime: "2026-03-10T10:00:00Z",
+        isDraft: false,
+      },
+      {
+        id: "m2",
+        internetMessageId: "<m2@x>",
+        subject: "Original",
+        body: { contentType: "text", content: "first" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+      },
+      {
+        id: "m3",
+        internetMessageId: "<m3@x>",
+        subject: "Re: Original",
+        body: { contentType: "text", content: "second" },
+        receivedDateTime: "2026-03-05T10:00:00Z",
+        isDraft: false,
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread?.messages.map((m) => m.subject)).toEqual([
+      "Original",
+      "Re: Original",
+      "Re: Re: Original",
+    ]);
+    expect(thread?.subject).toBe("Re: Re: Original");
+  });
+
+  it("returns null when Graph returns no messages or errors out", async () => {
+    expect(
+      await fetchCurrentThread("missing-conv", acquireToken, {
+        transport: makeTransport([]),
+      }),
+    ).toBeNull();
+    expect(
+      await fetchCurrentThread("missing-conv", acquireToken, {
+        transport: makeFailingTransport(500),
+      }),
+    ).toBeNull();
+  });
+});

--- a/office-addin/src/utils/__tests__/synthesizeThreadEml.test.ts
+++ b/office-addin/src/utils/__tests__/synthesizeThreadEml.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+
+import { parseEmlBytes } from "../parsedEmail";
+import {
+  synthesizeThreadEml,
+  type ThreadMessageInput,
+} from "../synthesizeThreadEml";
+
+function makeAttachmentBytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+const TEXT_PLAIN_PREFIX = "text/plain";
+const APP_PDF_PREFIX = "application/pdf";
+
+describe("synthesizeThreadEml", () => {
+  it("produces a postal-mime-parsable .eml with nested rfc822 attachments per message", async () => {
+    const messages: ThreadMessageInput[] = [
+      {
+        internetMessageId: "<msg-1@example.com>",
+        subject: "Kickoff Kundenportal 2.0",
+        from: { name: "Daniel Person", address: "daniel@example.com" },
+        to: [{ name: "Team", address: "team@example.com" }],
+        cc: [],
+        date: "2026-03-01T09:00:00Z",
+        bodyText: "Erste Nachricht",
+        bodyHtml: null,
+        attachments: [],
+      },
+      {
+        internetMessageId: "<msg-2@example.com>",
+        subject: "Re: Kickoff Kundenportal 2.0",
+        from: { name: "Bob Reviewer", address: "bob@example.com" },
+        to: [{ name: "Daniel Person", address: "daniel@example.com" }],
+        cc: [],
+        date: "2026-03-05T10:30:00Z",
+        bodyText: "Hier ist das Lastenheft.",
+        bodyHtml: null,
+        attachments: [
+          {
+            filename: "Lastenheft.pdf",
+            mimeType: APP_PDF_PREFIX,
+            contentBytes: makeAttachmentBytes("PDF-V1-CONTENT"),
+          },
+        ],
+      },
+      {
+        internetMessageId: "<msg-3@example.com>",
+        subject: "Re: Kickoff Kundenportal 2.0",
+        from: { name: "Daniel Person", address: "daniel@example.com" },
+        to: [{ name: "Bob Reviewer", address: "bob@example.com" }],
+        cc: [],
+        date: "2026-03-12T14:00:00Z",
+        bodyText: null,
+        bodyHtml: "<p>Aktualisierte Version anbei.</p>",
+        attachments: [
+          {
+            filename: "Lastenheft.pdf",
+            mimeType: APP_PDF_PREFIX,
+            contentBytes: makeAttachmentBytes("PDF-V2-CONTENT"),
+          },
+        ],
+      },
+    ];
+
+    const file = synthesizeThreadEml({
+      subject: "Re: Kickoff Kundenportal 2.0",
+      messages,
+    });
+
+    expect(file.type).toBe("message/rfc822");
+    expect(file.name).toBe("Re_Kickoff_Kundenportal_2.0.eml");
+
+    const buffer = await file.arrayBuffer();
+    const outer = await parseEmlBytes(buffer);
+    expect(outer).not.toBeNull();
+    if (!outer) return;
+
+    expect(outer.subject).toBe("Re: Kickoff Kundenportal 2.0");
+    expect(outer.attachments).toHaveLength(3);
+
+    for (let i = 0; i < outer.attachments.length; i += 1) {
+      const nestedAttachment = outer.attachments[i];
+      expect(nestedAttachment.mimeType).toContain("message/rfc822");
+
+      const nestedBytes = await nestedAttachment.toFile().arrayBuffer();
+      const nested = await parseEmlBytes(nestedBytes);
+      expect(nested).not.toBeNull();
+      if (!nested) return;
+
+      const expected = messages[i];
+      expect(nested.subject).toBe(expected.subject);
+      expect(nested.messageId).toBe(expected.internetMessageId);
+      expect(nested.from?.address).toBe(expected.from?.address);
+      expect(nested.to[0]?.address).toBe(expected.to[0]?.address);
+      if (expected.bodyHtml) {
+        expect(nested.html ?? "").toContain("Aktualisierte Version anbei.");
+      } else if (expected.bodyText) {
+        expect(nested.text ?? "").toContain(expected.bodyText);
+      }
+      expect(nested.attachments).toHaveLength(expected.attachments.length);
+      if (expected.attachments.length > 0) {
+        const att = nested.attachments[0];
+        expect(att.filename).toBe(expected.attachments[0].filename);
+        const attBytes = await att.toFile().arrayBuffer();
+        const text = new TextDecoder().decode(new Uint8Array(attBytes));
+        const sourceText = new TextDecoder().decode(
+          expected.attachments[0].contentBytes instanceof Uint8Array
+            ? expected.attachments[0].contentBytes
+            : new Uint8Array(expected.attachments[0].contentBytes),
+        );
+        expect(text).toBe(sourceText);
+      }
+    }
+  });
+
+  it("preserves non-ASCII subjects and bodies through round-trip", async () => {
+    const messages: ThreadMessageInput[] = [
+      {
+        internetMessageId: "<u1@example.com>",
+        subject: "Grüße aus München – ÄÖÜß",
+        from: { name: "Müller", address: "mueller@example.com" },
+        to: [],
+        cc: [],
+        date: "2026-04-01T08:00:00Z",
+        bodyText: "Heizölrückstoßabdämpfung — café résumé",
+        bodyHtml: null,
+        attachments: [],
+      },
+    ];
+
+    const file = synthesizeThreadEml({
+      subject: "Grüße — Thread",
+      messages,
+    });
+
+    const outer = await parseEmlBytes(await file.arrayBuffer());
+    expect(outer).not.toBeNull();
+    if (!outer) return;
+    expect(outer.subject).toBe("Grüße — Thread");
+
+    const nested = await parseEmlBytes(
+      await outer.attachments[0].toFile().arrayBuffer(),
+    );
+    expect(nested).not.toBeNull();
+    if (!nested) return;
+    expect(nested.subject).toBe("Grüße aus München – ÄÖÜß");
+    expect(nested.from?.name).toBe("Müller");
+    expect(nested.text ?? "").toContain(
+      "Heizölrückstoßabdämpfung — café résumé",
+    );
+  });
+
+  it("emits a single-body nested message when attachments are empty", async () => {
+    const file = synthesizeThreadEml({
+      subject: "No-attachment thread",
+      messages: [
+        {
+          internetMessageId: null,
+          subject: "Single body",
+          from: { name: "", address: "anon@example.com" },
+          to: [],
+          cc: [],
+          date: null,
+          bodyText: "plain body only",
+          bodyHtml: null,
+          attachments: [],
+        },
+      ],
+    });
+
+    const outer = await parseEmlBytes(await file.arrayBuffer());
+    expect(outer).not.toBeNull();
+    if (!outer) return;
+    expect(outer.attachments).toHaveLength(1);
+
+    const nested = await parseEmlBytes(
+      await outer.attachments[0].toFile().arrayBuffer(),
+    );
+    expect(nested).not.toBeNull();
+    if (!nested) return;
+    expect(nested.text?.trim()).toBe("plain body only");
+    expect(nested.attachments).toHaveLength(0);
+    expect(nested.html).toBeNull();
+    expect(nested.from?.address).toBe("anon@example.com");
+    // Body declared text/plain only — postal-mime should not synthesize HTML.
+    const nestedHeaderText = new TextDecoder().decode(
+      new Uint8Array(await outer.attachments[0].toFile().arrayBuffer()),
+    );
+    expect(nestedHeaderText).toContain(TEXT_PLAIN_PREFIX);
+  });
+
+  it("splits long non-ASCII subjects into ≤75 char RFC 2047 encoded-words", async () => {
+    // Concatenate ~60 chars of umlaut-heavy German — easily produces a
+    // single base64 token >75 chars if not chunked.
+    const longSubject =
+      "Grüße ÄÖÜßéàü 漢字テスト — Lastenheft v3 Kickoff Kundenportal 2.0 Sommer 2026";
+    const file = synthesizeThreadEml({
+      subject: longSubject,
+      messages: [
+        {
+          internetMessageId: "<long@example.com>",
+          subject: longSubject,
+          from: { name: "Müller", address: "m@example.com" },
+          to: [],
+          cc: [],
+          date: "2026-05-01T08:00:00Z",
+          bodyText: "body",
+          bodyHtml: null,
+          attachments: [],
+        },
+      ],
+    });
+
+    const rawBytes = new Uint8Array(await file.arrayBuffer());
+    const rawText = new TextDecoder().decode(rawBytes);
+
+    // Every encoded-word token must fit the RFC 2047 75-char cap.
+    const encodedWordMatches = rawText.match(/=\?utf-8\?B\?[^?]+\?=/g) ?? [];
+    expect(encodedWordMatches.length).toBeGreaterThan(1); // proves we did split
+    for (const word of encodedWordMatches) {
+      expect(word.length).toBeLessThanOrEqual(75);
+    }
+
+    // Round-trip: postal-mime should join the folded continuation lines and
+    // decode the full subject losslessly.
+    const outer = await parseEmlBytes(await file.arrayBuffer());
+    expect(outer?.subject).toBe(longSubject);
+    const nested = await parseEmlBytes(
+      await outer!.attachments[0].toFile().arrayBuffer(),
+    );
+    expect(nested?.subject).toBe(longSubject);
+  });
+
+  it("encodes non-ASCII attachment filenames per RFC 2231 (filename*=utf-8'')", async () => {
+    const filename = "Anhang ÄÖÜ ñ — résumé.pdf";
+    const file = synthesizeThreadEml({
+      subject: "Attachment filename test",
+      messages: [
+        {
+          internetMessageId: "<a@example.com>",
+          subject: "Attachment filename test",
+          from: { name: "A", address: "a@example.com" },
+          to: [],
+          cc: [],
+          date: "2026-05-01T08:00:00Z",
+          bodyText: "see attached",
+          bodyHtml: null,
+          attachments: [
+            {
+              filename,
+              mimeType: APP_PDF_PREFIX,
+              contentBytes: makeAttachmentBytes("FAKE-PDF-CONTENT"),
+            },
+          ],
+        },
+      ],
+    });
+
+    const outerBytes = new Uint8Array(await file.arrayBuffer());
+    const nestedFile = (await parseEmlBytes(
+      outerBytes.buffer,
+    ))!.attachments[0].toFile();
+    const nestedRaw = new TextDecoder().decode(
+      new Uint8Array(await nestedFile.arrayBuffer()),
+    );
+
+    // RFC 2231 form (filename*=utf-8''…) — never an RFC 2047 encoded-word
+    // inside a quoted-string.
+    expect(nestedRaw).toMatch(/filename\*=utf-8''/i);
+    expect(nestedRaw).not.toMatch(/filename="[^"]*=\?utf-8/i);
+
+    // Round-trip filename via postal-mime.
+    const nestedParsed = await parseEmlBytes(await nestedFile.arrayBuffer());
+    expect(nestedParsed?.attachments[0].filename).toBe(filename);
+  });
+});

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -153,6 +153,142 @@ export async function fetchParentMessageInConversationViaGraph(
 }
 
 /**
+ * Fetches every non-draft message in a conversation thread, with each
+ * message's attachments expanded inline. One Graph call covers the entire
+ * thread + attachment bytes within the Graph response envelope cap (~4 MB),
+ * avoiding the throttle hazard of N parallel `/$value` fetches.
+ *
+ * `uniqueBody` is included alongside `body`: the former contains only the
+ * portion of the body unique to that message (Graph strips prior quoted
+ * history), the latter contains the message as it would render in Outlook.
+ * Callers pick whichever they prefer; today we prefer `uniqueBody` for
+ * synthesized thread .emls so the LLM doesn't see N copies of the same
+ * quoted history.
+ *
+ * Attachments returned here are typed loosely: `fileAttachment` carries
+ * `contentBytes` (base64), but `itemAttachment` / `referenceAttachment`
+ * subtypes are pointers and won't have content inline. Callers must check
+ * the `@odata.type` discriminator.
+ */
+export interface GraphRecipient {
+  emailAddress?: { name?: string; address?: string };
+}
+
+export interface GraphBody {
+  contentType?: "html" | "text";
+  content?: string;
+}
+
+export interface GraphAttachment {
+  "@odata.type"?: string;
+  id?: string;
+  name?: string;
+  contentType?: string;
+  size?: number;
+  isInline?: boolean;
+  contentBytes?: string;
+  contentId?: string;
+}
+
+export interface GraphConversationMessage {
+  id?: string;
+  internetMessageId?: string;
+  subject?: string;
+  from?: GraphRecipient;
+  toRecipients?: GraphRecipient[];
+  ccRecipients?: GraphRecipient[];
+  sentDateTime?: string;
+  receivedDateTime?: string;
+  body?: GraphBody;
+  uniqueBody?: GraphBody;
+  isDraft?: boolean;
+  hasAttachments?: boolean;
+  attachments?: GraphAttachment[];
+}
+
+/**
+ * Optional transport — defaults to global `fetch`. Tests inject a stub so
+ * they don't have to `vi.stubGlobal` and assert on call ordering.
+ */
+export type GraphTransport = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface FetchConversationOptions {
+  transport?: GraphTransport;
+}
+
+export async function fetchConversationMessagesViaGraph(
+  conversationId: string,
+  acquireToken: AcquireGraphToken,
+  options: FetchConversationOptions = {},
+): Promise<GraphConversationMessage[]> {
+  const transport = options.transport ?? globalThis.fetch.bind(globalThis);
+  try {
+    const token = await acquireToken();
+    const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
+    const select = [
+      "id",
+      "internetMessageId",
+      "subject",
+      "from",
+      "toRecipients",
+      "ccRecipients",
+      "sentDateTime",
+      "receivedDateTime",
+      "body",
+      "uniqueBody",
+      "isDraft",
+      "hasAttachments",
+    ].join(",");
+    // Both `contentBytes` AND `contentId` live only on the
+    // `microsoft.graph.fileAttachment` subtype — the polymorphic
+    // `attachment` base type defines just `id`, `name`, `contentType`,
+    // `size`, `isInline`, and `lastModifiedDateTime`. Selecting either
+    // unqualified trips `BadRequest: Could not find a property named '…'
+    // on type 'microsoft.graph.attachment'`. OData's derived-type-property
+    // syntax `<namespace.subtype>/<property>` projects the field only when
+    // the row materializes as that subtype; itemAttachment and
+    // referenceAttachment items still come back (without those fields), so
+    // callers can discriminate on `@odata.type` and skip non-file rows.
+    // See microsoftgraph/microsoft-graph-explorer-v4#3916.
+    const attachmentSelect = [
+      "id",
+      "name",
+      "contentType",
+      "size",
+      "isInline",
+      "microsoft.graph.fileAttachment/contentId",
+      "microsoft.graph.fileAttachment/contentBytes",
+    ].join(",");
+    const expand = `attachments($select=${attachmentSelect})`;
+    const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=25&$select=${select}&$expand=${expand}`;
+    const response = await transport(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      console.warn(
+        "[fetchConversationMessagesViaGraph] non-OK status:",
+        response.status,
+        response.statusText,
+      );
+      return [];
+    }
+    const payload = (await response.json()) as {
+      value?: GraphConversationMessage[];
+    };
+    return payload.value ?? [];
+  } catch (error) {
+    console.warn("[fetchConversationMessagesViaGraph] failed:", error);
+    return [];
+  }
+}
+
+/**
  * Looks up a message by its RFC 5322 `Message-ID` header, returning a single
  * `.eml` File if exactly one match is found. Returns `null` when Graph's
  * filter returns an empty result (e.g. for drafts that don't yet have an

--- a/office-addin/src/utils/parsedThread.ts
+++ b/office-addin/src/utils/parsedThread.ts
@@ -1,0 +1,174 @@
+/**
+ * In-memory representation of an Outlook conversation thread fetched via
+ * Microsoft Graph. Drives the staged-input preview UI (per-message cards
+ * with per-attachment checkboxes) and feeds `synthesizeThreadEml` at
+ * send-time so a deselection in the UI is reflected in the upload.
+ *
+ * We keep the structure normalised (mirrors `ParsedEmail` shapes) rather
+ * than holding Graph's raw JSON so the rest of the codebase doesn't have
+ * to know about Graph attachment subtypes or the `@odata.type` discriminator.
+ */
+
+import {
+  fetchConversationMessagesViaGraph,
+  type AcquireGraphToken,
+  type FetchConversationOptions,
+  type GraphAttachment,
+  type GraphConversationMessage,
+  type GraphRecipient,
+} from "./fetchOutlookMessageGraph";
+
+import type { ParsedEmailAddress } from "./parsedEmail";
+
+const FILE_ATTACHMENT_TYPE = "#microsoft.graph.fileAttachment";
+
+export interface ThreadAttachment {
+  /** Stable within the thread; concatenates messageId + Graph attachment id. */
+  id: string;
+  filename: string;
+  mimeType: string;
+  size: number;
+  contentBytes: ArrayBuffer | null;
+  isInline: boolean;
+  contentId: string | null;
+}
+
+export interface ThreadMessage {
+  /** Stable within the thread; prefers internetMessageId, falls back to Graph id. */
+  id: string;
+  internetMessageId: string | null;
+  subject: string;
+  from: ParsedEmailAddress | null;
+  to: ParsedEmailAddress[];
+  cc: ParsedEmailAddress[];
+  /** ISO 8601; prefers sentDateTime, falls back to receivedDateTime. */
+  date: string | null;
+  bodyText: string | null;
+  bodyHtml: string | null;
+  attachments: ThreadAttachment[];
+}
+
+export interface ParsedThread {
+  conversationId: string;
+  /** Outer-envelope subject; today the latest message's subject. */
+  subject: string;
+  messages: ThreadMessage[];
+}
+
+export async function fetchCurrentThread(
+  conversationId: string,
+  acquireToken: AcquireGraphToken,
+  options: FetchConversationOptions = {},
+): Promise<ParsedThread | null> {
+  const raw = await fetchConversationMessagesViaGraph(
+    conversationId,
+    acquireToken,
+    options,
+  );
+  if (raw.length === 0) return null;
+
+  const messages = raw
+    .filter((message) => message.isDraft !== true)
+    .map((message) => transformMessage(message))
+    .filter((message): message is ThreadMessage => message !== null);
+
+  if (messages.length === 0) return null;
+
+  messages.sort((a, b) => {
+    const aTime = a.date ? Date.parse(a.date) : 0;
+    const bTime = b.date ? Date.parse(b.date) : 0;
+    return aTime - bTime;
+  });
+
+  const latestSubject = messages[messages.length - 1].subject;
+  return {
+    conversationId,
+    subject: latestSubject,
+    messages,
+  };
+}
+
+function transformMessage(
+  message: GraphConversationMessage,
+): ThreadMessage | null {
+  const id = message.internetMessageId ?? message.id ?? null;
+  if (!id) return null;
+
+  const attachments = (message.attachments ?? [])
+    .map((attachment) => transformAttachment(attachment, id))
+    .filter(
+      (attachment): attachment is ThreadAttachment => attachment !== null,
+    );
+
+  const uniqueBodyContent = nullIfEmpty(message.uniqueBody?.content);
+  const fullBodyContent = nullIfEmpty(message.body?.content);
+  const preferredBody = uniqueBodyContent ?? fullBodyContent;
+  const isHtml =
+    (message.uniqueBody?.contentType ?? message.body?.contentType) === "html";
+
+  return {
+    id,
+    internetMessageId: message.internetMessageId ?? null,
+    subject: message.subject ?? "",
+    from: normaliseAddress(message.from),
+    to: (message.toRecipients ?? [])
+      .map(normaliseAddress)
+      .filter((address): address is ParsedEmailAddress => address !== null),
+    cc: (message.ccRecipients ?? [])
+      .map(normaliseAddress)
+      .filter((address): address is ParsedEmailAddress => address !== null),
+    date: message.sentDateTime ?? message.receivedDateTime ?? null,
+    bodyText: isHtml ? null : preferredBody,
+    bodyHtml: isHtml ? preferredBody : null,
+    attachments,
+  };
+}
+
+function transformAttachment(
+  attachment: GraphAttachment,
+  messageId: string,
+): ThreadAttachment | null {
+  // Only fileAttachments carry contentBytes inline. itemAttachment and
+  // referenceAttachment subtypes would need follow-up calls — out of scope
+  // for the first iteration (the user's reported thread uses regular file
+  // attachments).
+  if (attachment["@odata.type"] !== FILE_ATTACHMENT_TYPE) return null;
+  if (!attachment.id || !attachment.name) return null;
+  const bytes = attachment.contentBytes
+    ? decodeBase64(attachment.contentBytes)
+    : null;
+  return {
+    id: `${messageId}:${attachment.id}`,
+    filename: attachment.name,
+    mimeType: attachment.contentType ?? "application/octet-stream",
+    size: attachment.size ?? bytes?.byteLength ?? 0,
+    contentBytes: bytes,
+    isInline: attachment.isInline === true,
+    contentId: attachment.contentId ?? null,
+  };
+}
+
+function normaliseAddress(
+  recipient: GraphRecipient | undefined,
+): ParsedEmailAddress | null {
+  const address = recipient?.emailAddress?.address?.trim();
+  if (!address) return null;
+  return {
+    name: recipient?.emailAddress?.name?.trim() ?? "",
+    address,
+  };
+}
+
+function nullIfEmpty(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  return value.trim().length === 0 ? null : value;
+}
+
+function decodeBase64(b64: string): ArrayBuffer {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out.buffer;
+}

--- a/office-addin/src/utils/synthesizeThreadEml.ts
+++ b/office-addin/src/utils/synthesizeThreadEml.ts
@@ -305,7 +305,7 @@ function latestDate(messages: ThreadMessageInput[]): string | null {
  */
 function generateBoundary(prefix: string): string {
   const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
+  globalThis.crypto.getRandomValues(bytes);
   let hex = "";
   for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
   return `--Erato-${prefix}-${hex}`;

--- a/office-addin/src/utils/synthesizeThreadEml.ts
+++ b/office-addin/src/utils/synthesizeThreadEml.ts
@@ -1,0 +1,371 @@
+/**
+ * Build a single `.eml` File representing an entire Outlook conversation
+ * thread. The output is a `multipart/mixed` envelope where every thread
+ * member is wrapped as a nested `message/rfc822` part — each carrying its
+ * own headers, body, and (non-inline) attachments.
+ *
+ * Why one synthesized envelope instead of N separate uploads:
+ *   - The backend's kreuzberg extractor recurses into nested rfc822 parts,
+ *     so a single upload still gives the LLM per-message context (sender,
+ *     date, body, attachments) without flattening filenames into
+ *     ambiguous siblings (think three `Lastenheft.pdf` versions across
+ *     three replies — MIME structure preserves which version came from
+ *     which message).
+ *   - The frontend's EmlPreview already recurses into nested message
+ *     attachments via FilePreviewContent (see commit a25a5966).
+ *
+ * Encoding choices kept deliberately simple:
+ *   - Bodies: HTML when present, else plain text. UTF-8 + base64, line-
+ *     wrapped at 76 cols. No multipart/alternative — saves bytes and the
+ *     LLM only consumes one body either way.
+ *   - Headers: RFC 2047 encoded-word (=?utf-8?B?…?=) when non-ASCII.
+ *   - Inline attachments are dropped at the call-site (mirroring the
+ *     existing chat-input filter for `disposition === "inline" || related`).
+ */
+
+const CRLF = "\r\n";
+const BASE64_LINE_LENGTH = 76;
+
+export interface ThreadMessageInput {
+  /** RFC 5322 Message-ID. Written as the nested message's Message-ID header. */
+  internetMessageId: string | null;
+  subject: string;
+  from: { name: string; address: string } | null;
+  to: { name: string; address: string }[];
+  cc: { name: string; address: string }[];
+  /** ISO 8601 timestamp (e.g. Graph's receivedDateTime/sentDateTime). */
+  date: string | null;
+  bodyText: string | null;
+  bodyHtml: string | null;
+  attachments: ThreadAttachmentInput[];
+}
+
+export interface ThreadAttachmentInput {
+  filename: string;
+  mimeType: string;
+  contentBytes: ArrayBuffer | Uint8Array;
+}
+
+export interface SynthesizeThreadOptions {
+  /** Subject of the outer envelope. Usually the latest message's subject. */
+  subject: string;
+  messages: ThreadMessageInput[];
+  /** Filename of the resulting File. Defaults to a slug of `subject`. */
+  filename?: string;
+}
+
+export function synthesizeThreadEml(options: SynthesizeThreadOptions): File {
+  const { subject, messages } = options;
+  const outerBoundary = generateBoundary("thread");
+  const segments: Uint8Array[] = [];
+
+  segments.push(
+    asciiBytes(
+      buildHeaderBlock([
+        ["Subject", encodeHeader(subject)],
+        ["Date", formatRfcDate(latestDate(messages))],
+        ["MIME-Version", "1.0"],
+        ["Content-Type", `multipart/mixed; boundary="${outerBoundary}"`],
+      ]),
+    ),
+  );
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const nestedBytes = buildNestedMessage(messages[i]);
+    segments.push(asciiBytes(`--${outerBoundary}${CRLF}`));
+    segments.push(
+      asciiBytes(
+        buildHeaderBlock([
+          ["Content-Type", "message/rfc822"],
+          [
+            "Content-Disposition",
+            `attachment; filename="message-${i + 1}.eml"`,
+          ],
+        ]),
+      ),
+    );
+    segments.push(nestedBytes);
+    segments.push(asciiBytes(CRLF));
+  }
+  segments.push(asciiBytes(`--${outerBoundary}--${CRLF}`));
+
+  const filename = options.filename ?? slugFilename(subject);
+  // The `as BlobPart[]` cast looks suspicious but is structurally sound:
+  // TS lib types advertise `Uint8Array<ArrayBufferLike>` and `BlobPart`
+  // doesn't accept the `SharedArrayBuffer`-aware union. At runtime each
+  // segment is a regular `Uint8Array` over an `ArrayBuffer`, which `File`
+  // accepts. The alternative — converting each segment to a `Blob` first
+  // — would copy bytes unnecessarily.
+  return new File(segments as BlobPart[], filename, {
+    type: "message/rfc822",
+  });
+}
+
+function buildNestedMessage(message: ThreadMessageInput): Uint8Array {
+  const headerLines: [string, string][] = [];
+  if (message.from) {
+    headerLines.push(["From", formatAddress(message.from)]);
+  }
+  if (message.to.length > 0) {
+    headerLines.push(["To", formatAddressList(message.to)]);
+  }
+  if (message.cc.length > 0) {
+    headerLines.push(["Cc", formatAddressList(message.cc)]);
+  }
+  headerLines.push(["Subject", encodeHeader(message.subject)]);
+  headerLines.push(["Date", formatRfcDate(message.date)]);
+  if (message.internetMessageId) {
+    headerLines.push(["Message-ID", message.internetMessageId]);
+  }
+  headerLines.push(["MIME-Version", "1.0"]);
+
+  const hasAttachments = message.attachments.length > 0;
+  const bodyMime = message.bodyHtml ? "text/html" : "text/plain";
+  const bodyText = message.bodyHtml ?? message.bodyText ?? "";
+
+  if (!hasAttachments) {
+    headerLines.push(["Content-Type", `${bodyMime}; charset=utf-8`]);
+    headerLines.push(["Content-Transfer-Encoding", "base64"]);
+    return concatBytes([
+      asciiBytes(buildHeaderBlock(headerLines)),
+      asciiBytes(encodeBodyBase64(bodyText)),
+    ]);
+  }
+
+  const messageBoundary = generateBoundary("msg");
+  headerLines.push([
+    "Content-Type",
+    `multipart/mixed; boundary="${messageBoundary}"`,
+  ]);
+
+  const segments: Uint8Array[] = [];
+  segments.push(asciiBytes(buildHeaderBlock(headerLines)));
+  segments.push(asciiBytes(`--${messageBoundary}${CRLF}`));
+  segments.push(
+    asciiBytes(
+      buildHeaderBlock([
+        ["Content-Type", `${bodyMime}; charset=utf-8`],
+        ["Content-Transfer-Encoding", "base64"],
+      ]),
+    ),
+  );
+  segments.push(asciiBytes(encodeBodyBase64(bodyText)));
+  segments.push(asciiBytes(CRLF));
+
+  for (const attachment of message.attachments) {
+    segments.push(asciiBytes(`--${messageBoundary}${CRLF}`));
+    const mimeType = attachment.mimeType || "application/octet-stream";
+    segments.push(
+      asciiBytes(
+        buildHeaderBlock([
+          [
+            "Content-Type",
+            `${mimeType}${filenameParam(attachment.filename, "name")}`,
+          ],
+          [
+            "Content-Disposition",
+            `attachment${filenameParam(attachment.filename, "filename")}`,
+          ],
+          ["Content-Transfer-Encoding", "base64"],
+        ]),
+      ),
+    );
+    segments.push(
+      asciiBytes(wrapBase64(base64Encode(toBytes(attachment.contentBytes)))),
+    );
+    segments.push(asciiBytes(CRLF));
+  }
+  segments.push(asciiBytes(`--${messageBoundary}--${CRLF}`));
+  return concatBytes(segments);
+}
+
+function buildHeaderBlock(lines: [string, string][]): string {
+  let block = "";
+  for (const [name, value] of lines) {
+    block += `${name}: ${value}${CRLF}`;
+  }
+  block += CRLF;
+  return block;
+}
+
+function encodeBodyBase64(body: string): string {
+  return `${wrapBase64(base64Encode(utf8Bytes(body)))}${CRLF}`;
+}
+
+function formatAddress(addr: { name: string; address: string }): string {
+  const trimmedName = addr.name.trim();
+  if (trimmedName.length === 0) {
+    return addr.address;
+  }
+  return `${encodeHeader(trimmedName)} <${addr.address}>`;
+}
+
+function formatAddressList(addrs: { name: string; address: string }[]): string {
+  return addrs.map(formatAddress).join(", ");
+}
+
+/**
+ * RFC 2047 §2 caps each encoded-word at 75 characters total. Long non-ASCII
+ * headers (e.g. a 40-character German subject with umlauts) easily exceed
+ * that in a single `=?utf-8?B?<base64>?=` token — some mailers reject those.
+ * We split the UTF-8 byte stream into chunks whose base64 fits the budget,
+ * always honouring code-point boundaries so multi-byte runes stay intact,
+ * and join encoded-words with `CRLF SPACE` (RFC 2822 folding whitespace).
+ */
+function encodeHeader(value: string): string {
+  if (isPrintableAscii(value)) return value;
+  // 75 - len("=?utf-8?B??=") = 63 chars of base64 budget per word; base64 expands
+  // each 3 bytes to 4 chars, so 45 source bytes -> 60 base64 chars fits.
+  const ENCODED_WORD_BYTE_BUDGET = 45;
+  const bytes = utf8Bytes(value);
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < bytes.length) {
+    let end = Math.min(cursor + ENCODED_WORD_BYTE_BUDGET, bytes.length);
+    // Pull `end` back to the start of a UTF-8 code point so we never split
+    // a multibyte sequence mid-way. Continuation bytes are `10xxxxxx`.
+    while (end < bytes.length && (bytes[end] & 0xc0) === 0x80) {
+      end -= 1;
+    }
+    if (end <= cursor) end = bytes.length; // pathological — emit whatever we have
+    chunks.push(`=?utf-8?B?${base64Encode(bytes.subarray(cursor, end))}?=`);
+    cursor = end;
+  }
+  return chunks.join(`${CRLF} `);
+}
+
+function isPrintableAscii(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code > 0x7e) return false;
+  }
+  return true;
+}
+
+/**
+ * Build a `; name="…"` or `; filename="…"` parameter that respects RFC 2231
+ * when the value is non-ASCII. RFC 2047 encoded-words are *not* legal inside
+ * a quoted-string — postal-mime is lenient, but Outlook/Apple Mail surface
+ * raw `=?utf-8?B?…?=` to the user if we emit them there. RFC 2231 syntax
+ * `name*=utf-8''<percent-encoded>` is the portable form.
+ */
+function filenameParam(filename: string, parameterName: string): string {
+  if (filename.length === 0) return "";
+  if (isQuotedStringSafe(filename)) {
+    return `; ${parameterName}="${filename}"`;
+  }
+  return `; ${parameterName}*=utf-8''${rfc2231PercentEncode(filename)}`;
+}
+
+function isQuotedStringSafe(value: string): boolean {
+  // ASCII-printable, no `"` or `\` (would need escaping). Conservative.
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code > 0x7e) return false;
+    if (code === 0x22 || code === 0x5c) return false;
+  }
+  return true;
+}
+
+function rfc2231PercentEncode(value: string): string {
+  // Encode all bytes except RFC 5987 "attr-char": ALPHA / DIGIT / and a
+  // narrow punctuation set. encodeURIComponent over-encodes a few safe
+  // chars but stays inside the allowed grammar, so it's a sound default.
+  const encoded = encodeURIComponent(value);
+  return encoded.replace(/[!*'()]/g, (ch) => {
+    return `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`;
+  });
+}
+
+function formatRfcDate(iso: string | null): string {
+  if (!iso) return new Date().toUTCString();
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return new Date().toUTCString();
+  return parsed.toUTCString();
+}
+
+function latestDate(messages: ThreadMessageInput[]): string | null {
+  let latest: number | null = null;
+  for (const message of messages) {
+    if (!message.date) continue;
+    const parsed = Date.parse(message.date);
+    if (Number.isNaN(parsed)) continue;
+    if (latest === null || parsed > latest) {
+      latest = parsed;
+    }
+  }
+  return latest === null ? null : new Date(latest).toISOString();
+}
+
+/**
+ * Cryptographically random boundary string. RFC 2046 requires boundaries
+ * not to appear literally inside any encapsulated body — 128 bits of
+ * entropy makes accidental collisions astronomically improbable, and the
+ * randomness defeats correlation across messages.
+ */
+function generateBoundary(prefix: string): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let hex = "";
+  for (const byte of bytes) hex += byte.toString(16).padStart(2, "0");
+  return `--Erato-${prefix}-${hex}`;
+}
+
+function slugFilename(subject: string): string {
+  const trimmed = subject.trim();
+  if (trimmed.length === 0) return "thread.eml";
+  // Collapse path-unsafe punctuation, whitespace, `_`, and `-` into a single
+  // `_`. Listing `_` and `-` last in the class keeps them as literals.
+  const safe = trimmed.replace(/[\\/:*?"<>|\s_-]+/g, "_").slice(0, 80);
+  return `${safe}.eml`;
+}
+
+function toBytes(content: ArrayBuffer | Uint8Array): Uint8Array {
+  if (content instanceof Uint8Array) return content;
+  return new Uint8Array(content);
+}
+
+function utf8Bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+function asciiBytes(text: string): Uint8Array {
+  const out = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) {
+    out[i] = text.charCodeAt(i) & 0xff;
+  }
+  return out;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const part of parts) total += part.length;
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const part of parts) {
+    out.set(part, cursor);
+    cursor += part.length;
+  }
+  return out;
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunk)),
+    );
+  }
+  return btoa(binary);
+}
+
+function wrapBase64(b64: string): string {
+  if (b64.length <= BASE64_LINE_LENGTH) return b64;
+  const lines: string[] = [];
+  for (let i = 0; i < b64.length; i += BASE64_LINE_LENGTH) {
+    lines.push(b64.slice(i, i + BASE64_LINE_LENGTH));
+  }
+  return lines.join(CRLF);
+}


### PR DESCRIPTION
This pull request improves `.eml` (email) file handling and security in both the frontend and backend. It introduces support for rendering thread bundles (nested `message/rfc822` parts) in the UI, strengthens iframe sandboxing to mitigate XSS risks, and adds comprehensive tests to ensure correct parsing and rendering of complex email structures.

**Frontend: EML Preview and Security Improvements**
- **Thread bundle detection and rendering**: The UI now detects when an `.eml` is a thread bundle (i.e., has an empty outer body and one or more `message/rfc822` attachments) and routes it to a dedicated thread view (`EmlThreadBody`). This ensures nested messages are displayed correctly. [[1]](diffhunk://#diff-e9cf238485a7605fb774aa9bb0b70e221495c603f8a19563f142a40a147fc5abR276-R309) [[2]](diffhunk://#diff-ba6df960721d442377fec28d332e48879de152c9e2fc52966fc5e9411daae98aL216-R296)
- **Iframe sandboxing tightened**: The HTML preview iframe now uses the most restrictive sandbox (`sandbox=""`), eliminating all privileges (no scripts, no same-origin, no parent access), which greatly reduces the risk of XSS or data leaks from malicious email content. [[1]](diffhunk://#diff-e9cf238485a7605fb774aa9bb0b70e221495c603f8a19563f142a40a147fc5abL374-R362) [[2]](diffhunk://#diff-ba6df960721d442377fec28d332e48879de152c9e2fc52966fc5e9411daae98aL137-R159) [[3]](diffhunk://#diff-ba6df960721d442377fec28d332e48879de152c9e2fc52966fc5e9411daae98aL216-R296)
- **Attachment preview UI improvements**: The attachment preview now uses a standardized `Button` component for consistency and accessibility.

**Frontend: Testing Enhancements**
- **Blob URL fetch mocking**: The test suite now properly mocks `fetch` for blob URLs, enabling robust testing of nested message parsing and thread bundle rendering without relying on browser internals. [[1]](diffhunk://#diff-ba6df960721d442377fec28d332e48879de152c9e2fc52966fc5e9411daae98aL27-R56) [[2]](diffhunk://#diff-ba6df960721d442377fec28d332e48879de152c9e2fc52966fc5e9411daae98aL58-R78)
- **New thread bundle test**: Added an integration test to verify that `.eml` files with nested `message/rfc822` parts are detected and rendered as threads.

**Backend: Parsing and Fixture Support**
- **Recursive RFC822 parsing test**: Added a test to ensure the backend correctly extracts text and attachments from nested `message/rfc822` parts, mirroring the frontend's thread bundle logic. [[1]](diffhunk://#diff-494dafb4d1fc7090db8e2e3190c39a8fc818d311fcb0c09a60d7b7dcd68a0eedR293-R327) [[2]](diffhunk://#diff-ee78ef5c71663fe87e3a71475abb97bc3cf5e65ce8d06158512f4731d3d112a2R1-R45)
- **.eml file handling in Git**: Updated `.gitattributes` to prevent Git from normalizing line endings in `.eml` files, preserving their integrity for MIME parsing.

These changes collectively ensure robust, secure, and user-friendly handling of complex email files across the application.