### PR TITLE
feat: show explicit empty state label for missing default model (ERMAIN-326)

### DIFF
--- a/frontend/src/components/ui/Assistant/AssistantForm.test.tsx
+++ b/frontend/src/components/ui/Assistant/AssistantForm.test.tsx
@@ -362,7 +362,7 @@ describe("AssistantForm", () => {
     expect(screen.getByText("Used context: 40%")).toBeInTheDocument();
   });
 
-  it("defaults the assistant model selector to '-' and submits a null model", async () => {
+  it("defaults the assistant model selector to 'No default model' and submits a null model", async () => {
     const onSubmit = vi.fn();
 
     render(
@@ -380,7 +380,7 @@ describe("AssistantForm", () => {
       </StaticFeatureConfigProvider>,
     );
 
-    expect(screen.getByTitle("-")).toBeInTheDocument();
+    expect(screen.getByTitle("No default model")).toBeInTheDocument();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText(/name/i), {

--- a/frontend/src/components/ui/Chat/ModelSelector.tsx
+++ b/frontend/src/components/ui/Chat/ModelSelector.tsx
@@ -103,7 +103,7 @@ export const ModelSelector = ({
   const _modelDescriptionMarker = t`chat_models.<chat-provider-id>.description`;
   const noneLabel = t({
     id: "assistant.form.model.none",
-    message: "-",
+    message: "No default model",
   });
   // Track dropdown open state for chevron rotation
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -75,7 +75,7 @@ msgstr "Optional: Wählen Sie aus, welches Modell dieser Assistent standardmäß
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ModelSelector.tsx
 msgid "assistant.form.model.none"
-msgstr "-"
+msgstr "Kein Standardmodell"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -75,7 +75,7 @@ msgstr "Optional: Choose which model this assistant should use by default"
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ModelSelector.tsx
 msgid "assistant.form.model.none"
-msgstr "-"
+msgstr "No default model"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -75,7 +75,7 @@ msgstr "Opcional: Elija qué modelo debe usar este asistente de forma predetermi
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ModelSelector.tsx
 msgid "assistant.form.model.none"
-msgstr "-"
+msgstr "Sin modelo predeterminado"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -75,7 +75,7 @@ msgstr "Optionnel : Choisissez quel modèle cet assistant doit utiliser par déf
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ModelSelector.tsx
 msgid "assistant.form.model.none"
-msgstr "-"
+msgstr "Aucun modèle par défaut"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -75,7 +75,7 @@ msgstr "Opcjonalnie: Wybierz, który model ten asystent powinien domyślnie uży
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ModelSelector.tsx
 msgid "assistant.form.model.none"
-msgstr "-"
+msgstr "Brak domyślnego modelu"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When no default model is configured in the assistant form, the model selector previously displayed a bare `-` dash. This PR replaces that with a clear, translated label: **"No default model"**.

## Changes

- **`ModelSelector.tsx`**: Updated the `noneLabel` fallback string from `"-"` to `"No default model"` in the `assistant.form.model.none` Lingui translation call.
- **Locale `.po` files** (en, de, es, fr, pl): Updated the `assistant.form.model.none` `msgstr` with locale-appropriate translations:
  - `en`: `No default model`
  - `de`: `Kein Standardmodell`
  - `es`: `Sin modelo predeterminado`
  - `fr`: `Aucun modèle par défaut`
  - `pl`: `Brak domyślnego modelu`
- **`AssistantForm.test.tsx`**: Updated test assertion from `getByTitle("-")` to `getByTitle("No default model")` to match the new label.

## Testing

All 586 tests pass (76 test files).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-326](https://linear.app/erato-labs/issue/ERMAIN-326/show-explicit-empty-state-for-missing-default-model)

<div><a href="https://cursor.com/agents/bc-bbcde032-18fc-4613-b7ab-24aca510f628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbcde032-18fc-4613-b7ab-24aca510f628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

