### PR TITLE
Update Rust toolchain to 1.96.0 and build tools

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,10 @@
-# cargo-chef version = 0.1.73
-# Rust version = 1.91.1 - Should be kept up-to-date with rust-toolchain.toml
+# cargo-chef version = 0.1.77
+# Rust version = 1.96.0 - Should be kept up-to-date with rust-toolchain.toml
 # Trixie = Debian 13 -> LTS support until 2030
 # Pinned for security & build performance reasons
-FROM lukemathwalker/cargo-chef:0.1.73-rust-1.91.1-trixie@sha256:0952ecbcded4600a826cb52277fb662df5c56abecc3acd5475988f88f015e7aa AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.96.0-trixie@sha256:e606721f52d95169364bf39cae726a94ed8b397625011ccfaa8340db488b823b AS chef
 WORKDIR /app
-RUN cargo install --locked cargo-auditable --version 0.7.2
+RUN cargo install --locked cargo-auditable --version 0.7.4
 
 FROM chef AS planner
 COPY . .

--- a/backend/Dockerfile.mock-llm-server
+++ b/backend/Dockerfile.mock-llm-server
@@ -1,8 +1,8 @@
-# cargo-chef version = 0.1.73
-# Rust version = 1.91.1 - Should be kept up-to-date with rust-toolchain.toml
+# cargo-chef version = 0.1.77
+# Rust version = 1.96.0 - Should be kept up-to-date with rust-toolchain.toml
 # Trixie = Debian 13 -> LTS support until 2030
 # Pinned for security & build performance reasons
-FROM lukemathwalker/cargo-chef:0.1.73-rust-1.91.1-trixie@sha256:0952ecbcded4600a826cb52277fb662df5c56abecc3acd5475988f88f015e7aa AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.96.0-trixie@sha256:e606721f52d95169364bf39cae726a94ed8b397625011ccfaa8340db488b823b AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/backend/Dockerfile.mock-mcp-server
+++ b/backend/Dockerfile.mock-mcp-server
@@ -1,8 +1,8 @@
-# cargo-chef version = 0.1.73
-# Rust version = 1.91.1 - Should be kept up-to-date with rust-toolchain.toml
+# cargo-chef version = 0.1.77
+# Rust version = 1.96.0 - Should be kept up-to-date with rust-toolchain.toml
 # Trixie = Debian 13 -> LTS support until 2030
 # Pinned for security & build performance reasons
-FROM lukemathwalker/cargo-chef:0.1.73-rust-1.91.1-trixie@sha256:0952ecbcded4600a826cb52277fb662df5c56abecc3acd5475988f88f015e7aa AS chef
+FROM lukemathwalker/cargo-chef:0.1.77-rust-1.96.0-trixie@sha256:e606721f52d95169364bf39cae726a94ed8b397625011ccfaa8340db488b823b AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/backend/erato/src/models/assistant.rs
+++ b/backend/erato/src/models/assistant.rs
@@ -218,7 +218,7 @@ pub async fn get_user_assistants(
     };
 
     // Sort by updated_at desc
-    all_assistants.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    all_assistants.sort_by_key(|assistant| std::cmp::Reverse(assistant.updated_at));
 
     Ok(all_assistants)
 }

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.96.0"


### PR DESCRIPTION
- Update Rust to 1.96.0
- Update cargo-chef to 0.1.77
- Update cargo-auditable 0.7.4