### PR TITLE
Fix Outlook thread content loss; add attachment-byte dedup

### DIFF
--- a/office-addin/src/components/AddinFileSourceSelector.tsx
+++ b/office-addin/src/components/AddinFileSourceSelector.tsx
@@ -49,6 +49,7 @@ export function AddinFileSourceSelector({
   const {
     emailBodyFile,
     isLoadingEmailBody,
+    emailThreadLoadError,
     isEmailBodyDismissed,
     dismissedAttachmentIds,
     restoreEmailBody,
@@ -284,6 +285,16 @@ export function AddinFileSourceSelector({
                   </div>
                 )}
 
+                {!isLoadingEmailBody && emailThreadLoadError && (
+                  <div className="px-3 py-2 text-xs text-theme-error-fg">
+                    {t({
+                      id: "officeAddin.fileSource.emailThreadLoadError",
+                      message:
+                        "Couldn't load this conversation from the server. Some messages or attachments may be missing — try reopening the item.",
+                    })}
+                  </div>
+                )}
+
                 {emailBodyFile &&
                   (() => {
                     const isAlreadyAdded =
@@ -376,6 +387,7 @@ export function AddinFileSourceSelector({
 
                 {!isLoadingEmailBody &&
                   !isLoadingAttachments &&
+                  !emailThreadLoadError &&
                   !emailBodyFile &&
                   selectableAttachments.length === 0 && (
                     <div className="px-3 py-2 text-xs text-theme-fg-muted">

--- a/office-addin/src/hooks/__tests__/useCurrentThread.test.ts
+++ b/office-addin/src/hooks/__tests__/useCurrentThread.test.ts
@@ -28,13 +28,21 @@ describe("useCurrentThread", () => {
     const { result } = renderHook(() =>
       useCurrentThread(null, "conv-1", acquireToken, { transport }),
     );
-    expect(result.current).toEqual({ thread: null, isLoading: false });
+    expect(result.current).toEqual({
+      thread: null,
+      isLoading: false,
+      error: false,
+    });
     expect(transport).not.toHaveBeenCalled();
 
     const { result: result2 } = renderHook(() =>
       useCurrentThread("item-1", null, acquireToken, { transport }),
     );
-    expect(result2.current).toEqual({ thread: null, isLoading: false });
+    expect(result2.current).toEqual({
+      thread: null,
+      isLoading: false,
+      error: false,
+    });
     expect(transport).not.toHaveBeenCalled();
   });
 
@@ -108,18 +116,19 @@ describe("useCurrentThread", () => {
     });
   });
 
-  it("returns null thread when the Graph request fails", async () => {
+  it("sets error=true (not a silent null) when the Graph request fails outright", async () => {
     const transport = buildResponder({ value: [] }, false, 500);
 
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { result } = renderHook(() =>
       useCurrentThread("item-1", "conv-1", acquireToken, { transport }),
     );
 
-    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
     consoleWarn.mockRestore();
     expect(result.current.thread).toBeNull();
+    expect(result.current.error).toBe(true);
   });
 });

--- a/office-addin/src/hooks/useCurrentThread.ts
+++ b/office-addin/src/hooks/useCurrentThread.ts
@@ -75,7 +75,10 @@ export function useCurrentThread(
         if (cancelled) return;
         // Total fetch failure (ThreadFetchError) — surface it loudly instead
         // of degrading to a silent empty thread.
-        console.warn("[useCurrentThread] conversation fetch failed:", fetchError);
+        console.warn(
+          "[useCurrentThread] conversation fetch failed:",
+          fetchError,
+        );
         setThread(null);
         setError(true);
       })

--- a/office-addin/src/hooks/useCurrentThread.ts
+++ b/office-addin/src/hooks/useCurrentThread.ts
@@ -10,6 +10,13 @@ import type {
 export interface UseCurrentThreadResult {
   thread: ParsedThread | null;
   isLoading: boolean;
+  /**
+   * True when the conversation fetch failed outright (first page errored, so
+   * nothing was retrieved). Consumers surface this rather than silently
+   * showing "no thread" — distinct from a genuinely empty conversation, which
+   * leaves `thread === null` with `error === false` (INV-7).
+   */
+  error: boolean;
 }
 
 /**
@@ -41,6 +48,7 @@ export function useCurrentThread(
 ): UseCurrentThreadResult {
   const [thread, setThread] = useState<ParsedThread | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(false);
   // Stable transport reference avoids re-running the effect on every render
   // when the consumer passes an inline transport closure.
   const { transport } = options;
@@ -49,17 +57,27 @@ export function useCurrentThread(
     if (!itemId || !conversationId) {
       setThread(null);
       setIsLoading(false);
+      setError(false);
       return;
     }
 
     let cancelled = false;
     setIsLoading(true);
     setThread(null);
+    setError(false);
 
     void fetchCurrentThread(conversationId, acquireGraphToken, { transport })
       .then((result) => {
         if (cancelled) return;
         setThread(result);
+      })
+      .catch((fetchError) => {
+        if (cancelled) return;
+        // Total fetch failure (ThreadFetchError) — surface it loudly instead
+        // of degrading to a silent empty thread.
+        console.warn("[useCurrentThread] conversation fetch failed:", fetchError);
+        setThread(null);
+        setError(true);
       })
       .finally(() => {
         if (cancelled) return;
@@ -71,5 +89,5 @@ export function useCurrentThread(
     };
   }, [acquireGraphToken, conversationId, itemId, transport]);
 
-  return { thread, isLoading };
+  return { thread, isLoading, error };
 }

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -214,6 +214,11 @@ msgstr "E-Mail-Verlauf"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.emailThreadLoadError"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.fromComputer"
 msgstr "Vom Computer hochladen"
 

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -215,7 +215,7 @@ msgstr "E-Mail-Verlauf"
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.emailThreadLoadError"
-msgstr ""
+msgstr "Diese Unterhaltung konnte nicht vom Server geladen werden. Einige Nachrichten oder Anhänge fehlen möglicherweise – versuche, die E-Mail erneut zu öffnen."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -214,6 +214,11 @@ msgstr "Email thread"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.emailThreadLoadError"
+msgstr "Couldn't load this conversation from the server. Some messages or attachments may be missing — try reopening the item."
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.fromComputer"
 msgstr "Upload from Computer"
 

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -214,6 +214,11 @@ msgstr "Hilo de correo"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.emailThreadLoadError"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.fromComputer"
 msgstr "Cargar desde el equipo"
 

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -215,7 +215,7 @@ msgstr "Hilo de correo"
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.emailThreadLoadError"
-msgstr ""
+msgstr "No se pudo cargar esta conversación desde el servidor. Es posible que falten algunos mensajes o archivos adjuntos: prueba a volver a abrir el correo electrónico."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -215,7 +215,7 @@ msgstr "Fil d’e-mails"
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.emailThreadLoadError"
-msgstr ""
+msgstr "Impossible de charger cette conversation depuis le serveur. Certains messages ou pièces jointes sont peut-être manquants — essayez de rouvrir l'e-mail."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -214,6 +214,11 @@ msgstr "Fil d’e-mails"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.emailThreadLoadError"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.fromComputer"
 msgstr "Téléverser depuis l’ordinateur"
 

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -215,7 +215,7 @@ msgstr "Wątek wiadomości"
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.emailThreadLoadError"
-msgstr ""
+msgstr "Nie udało się załadować tej konwersacji z serwera. Niektóre wiadomości lub załączniki mogą być niedostępne — spróbuj ponownie otworzyć wiadomość."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -214,6 +214,11 @@ msgstr "Wątek wiadomości"
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.emailThreadLoadError"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
 msgid "officeAddin.fileSource.fromComputer"
 msgstr "Prześlij z komputera"
 

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -11,6 +11,7 @@ import {
 import { useMsalNaa } from "./MsalNaaProvider";
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { useCurrentThread } from "../hooks/useCurrentThread";
+import { buildThreadSynthInputs } from "../utils/buildThreadSynthInputs";
 import { fetchParentMessageInConversationViaGraph } from "../utils/fetchOutlookMessageGraph";
 import {
   dismissAttachment as applyDismissAttachment,
@@ -23,16 +24,8 @@ import { trimEmlAttachments } from "../utils/trimEmlAttachments";
 
 import type { ParentMessageMetadata } from "../utils/fetchOutlookMessageGraph";
 import type { ParsedEmail } from "../utils/parsedEmail";
-import type {
-  ParsedThread,
-  ThreadAttachment,
-  ThreadMessage,
-} from "../utils/parsedThread";
+import type { ParsedThread, ThreadMessage } from "../utils/parsedThread";
 import type { StagedEmailDismissalsMap } from "../utils/stagedEmailDismissals";
-import type {
-  ThreadAttachmentInput,
-  ThreadMessageInput,
-} from "../utils/synthesizeThreadEml";
 import type { LocalFilePreviewItem } from "@erato/frontend/library";
 import type { ReactNode } from "react";
 
@@ -128,6 +121,12 @@ interface OutlookEmailSourceContextValue {
   isEmailBodyIncluded: boolean;
   emailBodyFile: File | null;
   isLoadingEmailBody: boolean;
+  /**
+   * True when the open conversation failed to load entirely (Graph fetch
+   * errored on the first page). Surfaced so the UI can warn the user rather
+   * than silently presenting an empty thread (INV-7).
+   */
+  emailThreadLoadError: boolean;
   currentThread: ParsedThread | null;
   stagedEmails: StagedEmail[];
   dismissStagedEmailBody: (key: string) => void;
@@ -155,6 +154,7 @@ const defaultValue: OutlookEmailSourceContextValue = {
   isEmailBodyIncluded: false,
   emailBodyFile: null,
   isLoadingEmailBody: false,
+  emailThreadLoadError: false,
   currentThread: null,
   stagedEmails: [],
   dismissStagedEmailBody: () => {},
@@ -219,8 +219,11 @@ export function OutlookEmailSourceProvider({
 
   // Conversation fetch lives in its own hook so it can be unit-tested in
   // isolation against an injected Graph transport.
-  const { thread: currentThread, isLoading: isLoadingEmailBody } =
-    useCurrentThread(itemId, conversationId, acquireGraphToken);
+  const {
+    thread: currentThread,
+    isLoading: isLoadingEmailBody,
+    error: emailThreadLoadError,
+  } = useCurrentThread(itemId, conversationId, acquireGraphToken);
 
   // Reply-context chip for compose mode (drafts have no itemId but do have a
   // conversationId). Display-only — the parent body reaches the LLM via the
@@ -474,29 +477,10 @@ export function OutlookEmailSourceProvider({
     // the staged-preview UI don't re-base64-encode every kept attachment
     // on every click. The cost is paid once, at send time.
     if (currentThread && threadStaged && includedThreadMessages.length > 0) {
-      const synthInputs = includedThreadMessages.map<ThreadMessageInput>(
-        (message) => ({
-          internetMessageId: message.internetMessageId,
-          subject: message.subject,
-          from: message.from
-            ? { name: message.from.name, address: message.from.address }
-            : null,
-          to: message.to.map((addr) => ({
-            name: addr.name,
-            address: addr.address,
-          })),
-          cc: message.cc.map((addr) => ({
-            name: addr.name,
-            address: addr.address,
-          })),
-          date: message.date,
-          bodyText: message.bodyText,
-          bodyHtml: message.bodyHtml,
-          attachments: filterAttachments(
-            message.attachments,
-            threadStaged.dismissedAttachmentIds,
-          ),
-        }),
+      const synthInputs = buildThreadSynthInputs(
+        includedThreadMessages,
+        threadStaged.dismissedAttachmentIds,
+        currentThread.incomplete,
       );
       filesToSend.push(
         synthesizeThreadEml({
@@ -574,6 +558,7 @@ export function OutlookEmailSourceProvider({
       isEmailBodyIncluded,
       emailBodyFile,
       isLoadingEmailBody,
+      emailThreadLoadError,
       currentThread,
       stagedEmails,
       dismissStagedEmailBody,
@@ -606,6 +591,7 @@ export function OutlookEmailSourceProvider({
       dismissedAttachmentIds,
       emailBodyFile,
       isEmailBodyDismissed,
+      emailThreadLoadError,
       isEmailBodyIncluded,
       isLoadingAttachments,
       isLoadingEmailBody,
@@ -630,22 +616,4 @@ export function OutlookEmailSourceProvider({
       {children}
     </OutlookEmailSourceContext.Provider>
   );
-}
-
-function filterAttachments(
-  attachments: ThreadAttachment[],
-  dismissedAttachmentIds: ReadonlySet<string>,
-): ThreadAttachmentInput[] {
-  const output: ThreadAttachmentInput[] = [];
-  for (const attachment of attachments) {
-    if (attachment.isInline) continue;
-    if (attachment.contentBytes === null) continue;
-    if (dismissedAttachmentIds.has(attachment.id)) continue;
-    output.push({
-      filename: attachment.filename,
-      mimeType: attachment.mimeType,
-      contentBytes: attachment.contentBytes,
-    });
-  }
-  return output;
 }

--- a/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
+++ b/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
@@ -35,8 +35,6 @@ function makeMessage(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
     date: "2026-03-01T10:00:00Z",
     bodyText: "body",
     bodyHtml: null,
-    fullBodyText: "body",
-    fullBodyHtml: null,
     attachments: [],
     ...overrides,
   };
@@ -148,8 +146,6 @@ describe("buildThreadSynthInputs", () => {
       makeMessage({
         bodyText: null,
         bodyHtml: "<p>Hallo</p>",
-        fullBodyText: null,
-        fullBodyHtml: "<p>Hallo</p>",
         attachments: [
           makeAttachment({
             id: "<m@x>:ref",
@@ -175,8 +171,6 @@ describe("buildThreadSynthInputs", () => {
       makeMessage({
         bodyText: "",
         bodyHtml: null,
-        fullBodyText: "",
-        fullBodyHtml: null,
         attachments: [
           makeAttachment({
             id: "<m@x>:img",

--- a/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
+++ b/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
@@ -155,7 +155,8 @@ describe("buildThreadSynthInputs", () => {
             id: "<m@x>:ref",
             filename: "a&b.docx",
             contentBytes: null,
-            unavailableReason: "cloud attachment (OneDrive/SharePoint): a&b.docx — not inlined",
+            unavailableReason:
+              "cloud attachment (OneDrive/SharePoint): a&b.docx — not inlined",
           }),
         ],
       }),
@@ -213,12 +214,126 @@ describe("buildThreadSynthInputs", () => {
     expect(inputs[0].bodyText).not.toContain("identical to");
   });
 
-  it("appends a synthetic partial-thread note when the thread is incomplete", () => {
-    const inputs = buildThreadSynthInputs(
-      [makeMessage()],
-      NO_DISMISSALS,
-      true,
+  it("keeps every byte-distinct attachment exactly once across a long chain, collapsing only re-forwards", () => {
+    const A = () => bytes(600, 0xaa); // the file re-forwarded down the whole chain
+    const messages = [
+      makeMessage({
+        id: "<m1@x>",
+        from: { name: "Anna", address: "anna@x" },
+        attachments: [
+          makeAttachment({
+            id: "<m1@x>:A",
+            filename: "spec.pdf",
+            contentBytes: A(),
+            size: 600,
+          }),
+        ],
+      }),
+      makeMessage({
+        id: "<m2@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m2@x>:A",
+            filename: "spec.pdf",
+            contentBytes: A(),
+            size: 600,
+          }), // dup
+          makeAttachment({
+            id: "<m2@x>:B",
+            filename: "review.docx",
+            contentBytes: bytes(700, 0xbb),
+            size: 700,
+          }), // unique
+        ],
+      }),
+      makeMessage({
+        id: "<m3@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m3@x>:A",
+            filename: "spec.pdf",
+            contentBytes: A(),
+            size: 600,
+          }), // dup
+          makeAttachment({
+            id: "<m3@x>:C",
+            filename: "budget.xlsx",
+            contentBytes: bytes(800, 0xcc),
+            size: 800,
+          }), // unique
+        ],
+      }),
+      makeMessage({
+        id: "<m4@x>",
+        attachments: [
+          // same filename as spec.pdf but DIFFERENT bytes → a real new version, must be kept
+          makeAttachment({
+            id: "<m4@x>:A2",
+            filename: "spec.pdf",
+            contentBytes: bytes(600, 0xdd),
+            size: 600,
+          }),
+        ],
+      }),
+      makeMessage({
+        id: "<m5@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m5@x>:D",
+            filename: "minutes.pdf",
+            contentBytes: bytes(900, 0xee),
+            size: 900,
+          }), // unique
+        ],
+      }),
+      makeMessage({
+        id: "<m6@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m6@x>:A",
+            filename: "spec.pdf",
+            contentBytes: A(),
+            size: 600,
+          }), // dup again
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    // Collect every emitted attachment across the whole chain.
+    const emitted = inputs.flatMap((input) => input.attachments);
+    // 5 byte-distinct streams: A, B, C, A2 (new version), D — each exactly once.
+    expect(emitted).toHaveLength(5);
+
+    const emittedBytes = emitted.map(
+      (att) =>
+        new Uint8Array(
+          att.contentBytes instanceof Uint8Array
+            ? att.contentBytes
+            : new Uint8Array(att.contentBytes),
+        )[0],
     );
+    // First byte of each distinct stream's fill — proves all five survive.
+    expect(emittedBytes.sort()).toEqual([0xaa, 0xbb, 0xcc, 0xdd, 0xee]);
+
+    // The canonical spec.pdf is the earliest copy (m1); later identical
+    // re-forwards (m2, m3, m6) are dropped and markered.
+    expect(inputs[0].attachments.map((a) => a.filename)).toEqual(["spec.pdf"]);
+    expect(inputs[1].attachments.map((a) => a.filename)).toEqual([
+      "review.docx",
+    ]);
+    expect(inputs[1].bodyText).toContain("identical to");
+    expect(inputs[2].attachments.map((a) => a.filename)).toEqual([
+      "budget.xlsx",
+    ]);
+    expect(inputs[3].attachments.map((a) => a.filename)).toEqual(["spec.pdf"]); // new version kept
+    expect(inputs[5].attachments).toHaveLength(0);
+    expect(inputs[5].bodyText).toContain("identical to");
+  });
+
+  it("appends a synthetic partial-thread note when the thread is incomplete", () => {
+    const inputs = buildThreadSynthInputs([makeMessage()], NO_DISMISSALS, true);
 
     expect(inputs).toHaveLength(2);
     expect(inputs[1].subject).toBe("[Partial conversation]");

--- a/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
+++ b/office-addin/src/utils/__tests__/buildThreadSynthInputs.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { buildThreadSynthInputs } from "../buildThreadSynthInputs";
+
+import type { ThreadAttachment, ThreadMessage } from "../parsedThread";
+
+function bytes(length: number, fill: number): ArrayBuffer {
+  return new Uint8Array(length).fill(fill).buffer;
+}
+
+function makeAttachment(
+  overrides: Partial<ThreadAttachment> = {},
+): ThreadAttachment {
+  return {
+    id: "att",
+    filename: "file.bin",
+    mimeType: "application/octet-stream",
+    size: 0,
+    contentBytes: null,
+    isInline: false,
+    contentId: null,
+    unavailableReason: null,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: "<m@x>",
+    internetMessageId: "<m@x>",
+    subject: "Subject",
+    from: { name: "Sender", address: "sender@x" },
+    to: [],
+    cc: [],
+    date: "2026-03-01T10:00:00Z",
+    bodyText: "body",
+    bodyHtml: null,
+    fullBodyText: "body",
+    fullBodyHtml: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+const NO_DISMISSALS = new Set<string>();
+
+describe("buildThreadSynthInputs", () => {
+  it("keeps one canonical copy of byte-identical attachments and marks the duplicates", () => {
+    const shared = () => bytes(600, 0xaa);
+    const messages = [
+      makeMessage({
+        id: "<m1@x>",
+        from: { name: "Anna", address: "anna@x" },
+        attachments: [
+          makeAttachment({
+            id: "<m1@x>:a1",
+            filename: "Lastenheft.pdf",
+            contentBytes: shared(),
+            size: 600,
+          }),
+        ],
+      }),
+      makeMessage({
+        id: "<m2@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m2@x>:a1",
+            filename: "Lastenheft.pdf",
+            contentBytes: shared(),
+            size: 600,
+          }),
+        ],
+      }),
+      makeMessage({
+        id: "<m3@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m3@x>:a1",
+            filename: "Lastenheft.pdf",
+            contentBytes: bytes(600, 0xbb), // different version → kept
+            size: 600,
+          }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    // Earliest message keeps the real copy.
+    expect(inputs[0].attachments).toHaveLength(1);
+    // Identical duplicate dropped, disclosed by a provenance marker.
+    expect(inputs[1].attachments).toHaveLength(0);
+    expect(inputs[1].bodyText).toContain("identical to");
+    expect(inputs[1].bodyText).toContain("Lastenheft.pdf");
+    expect(inputs[1].bodyText).toContain("Anna"); // canonical holder's label
+    // A different version of the same filename is real content → kept.
+    expect(inputs[2].attachments).toHaveLength(1);
+  });
+
+  it("does not dedup attachments below the minimum size (marker would cost more than the bytes)", () => {
+    const tiny = () => bytes(64, 0x01);
+    const messages = [
+      makeMessage({
+        id: "<m1@x>",
+        attachments: [
+          makeAttachment({ id: "<m1@x>:a", contentBytes: tiny(), size: 64 }),
+        ],
+      }),
+      makeMessage({
+        id: "<m2@x>",
+        attachments: [
+          makeAttachment({ id: "<m2@x>:a", contentBytes: tiny(), size: 64 }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    expect(inputs[0].attachments).toHaveLength(1);
+    expect(inputs[1].attachments).toHaveLength(1);
+    expect(inputs[1].bodyText).not.toContain("identical to");
+  });
+
+  it("discloses byte-less attachments (cloud / un-fetchable items) as markers", () => {
+    const messages = [
+      makeMessage({
+        attachments: [
+          makeAttachment({
+            id: "<m@x>:ref",
+            filename: "shared.docx",
+            contentBytes: null,
+            unavailableReason:
+              "cloud attachment (OneDrive/SharePoint): shared.docx — not inlined",
+          }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    expect(inputs[0].attachments).toHaveLength(0);
+    expect(inputs[0].bodyText).toContain("cloud attachment");
+    expect(inputs[0].bodyText).toContain("shared.docx");
+  });
+
+  it("appends markers into an html body as escaped paragraphs", () => {
+    const messages = [
+      makeMessage({
+        bodyText: null,
+        bodyHtml: "<p>Hallo</p>",
+        fullBodyText: null,
+        fullBodyHtml: "<p>Hallo</p>",
+        attachments: [
+          makeAttachment({
+            id: "<m@x>:ref",
+            filename: "a&b.docx",
+            contentBytes: null,
+            unavailableReason: "cloud attachment (OneDrive/SharePoint): a&b.docx — not inlined",
+          }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    expect(inputs[0].bodyHtml).toContain("<p>Hallo</p>");
+    expect(inputs[0].bodyHtml).toContain("<p>[cloud attachment");
+    expect(inputs[0].bodyHtml).toContain("a&amp;b.docx"); // html-escaped
+    expect(inputs[0].bodyText).toBeNull();
+  });
+
+  it("marks an image-only message so it isn't invisibly empty", () => {
+    const messages = [
+      makeMessage({
+        bodyText: "",
+        bodyHtml: null,
+        fullBodyText: "",
+        fullBodyHtml: null,
+        attachments: [
+          makeAttachment({
+            id: "<m@x>:img",
+            filename: "logo.png",
+            isInline: true,
+            contentBytes: bytes(10, 0x01),
+          }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, NO_DISMISSALS);
+
+    expect(inputs[0].bodyText).toContain("image-only message");
+    expect(inputs[0].bodyText).toContain("logo.png");
+  });
+
+  it("skips dismissed attachments", () => {
+    const messages = [
+      makeMessage({
+        attachments: [
+          makeAttachment({
+            id: "<m@x>:a",
+            filename: "secret.pdf",
+            contentBytes: bytes(600, 0x09),
+            size: 600,
+          }),
+        ],
+      }),
+    ];
+
+    const inputs = buildThreadSynthInputs(messages, new Set(["<m@x>:a"]));
+
+    expect(inputs[0].attachments).toHaveLength(0);
+    expect(inputs[0].bodyText).not.toContain("identical to");
+  });
+
+  it("appends a synthetic partial-thread note when the thread is incomplete", () => {
+    const inputs = buildThreadSynthInputs(
+      [makeMessage()],
+      NO_DISMISSALS,
+      true,
+    );
+
+    expect(inputs).toHaveLength(2);
+    expect(inputs[1].subject).toBe("[Partial conversation]");
+    expect(inputs[1].bodyText).toContain("partial");
+  });
+});

--- a/office-addin/src/utils/__tests__/parsedThread.test.ts
+++ b/office-addin/src/utils/__tests__/parsedThread.test.ts
@@ -107,7 +107,6 @@ describe("fetchCurrentThread", () => {
     // Full body kept (forwarded content survives), not the signature-only uniqueBody.
     expect(thread?.messages[0].bodyHtml).toContain("full thread quote");
     expect(thread?.messages[0].bodyText).toBeNull();
-    expect(thread?.messages[0].fullBodyHtml).toContain("full thread quote");
     expect(thread?.messages[1].bodyText).toContain("fallback wins");
     expect(thread?.messages[1].bodyHtml).toBeNull();
   });
@@ -145,6 +144,57 @@ describe("fetchCurrentThread", () => {
     expect(thread?.messages[0].bodyText).toBe("Reply text");
     // Not a subset → keep the full body (never risk dropping content).
     expect(thread?.messages[1].bodyText).toBe("The real full body");
+  });
+
+  it("does NOT collapse a plaintext subset when the thread is incomplete (dropped tail may be the only copy)", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // First page succeeds with a collapsible plaintext message, but a later
+    // page fails → thread is partial → the quoted tail must be retained.
+    let call = 0;
+    const transport: GraphTransport = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            value: [
+              {
+                id: "subset",
+                internetMessageId: "<subset@x>",
+                subject: "reply quoting an earlier (unfetched) message",
+                body: {
+                  contentType: "text",
+                  content:
+                    "Reply text\n\n> On 1 Jan, X wrote:\n> quoted history",
+                },
+                uniqueBody: { contentType: "text", content: "Reply text" },
+                receivedDateTime: "2026-03-02T10:00:00Z",
+                isDraft: false,
+              },
+            ],
+            "@odata.nextLink":
+              "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=PAGE2",
+          }),
+        } as unknown as Response;
+      }
+      return {
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        json: async () => ({}),
+      } as unknown as Response;
+    });
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+    consoleWarn.mockRestore();
+
+    expect(thread?.incomplete).toBe(true);
+    // Full body kept despite the subset being collapsible on a complete thread.
+    expect(thread?.messages[0].bodyText).toContain("quoted history");
   });
 
   it("reads isHtml from the chosen source so an empty html uniqueBody can't mislabel a plaintext body", async () => {

--- a/office-addin/src/utils/__tests__/parsedThread.test.ts
+++ b/office-addin/src/utils/__tests__/parsedThread.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { fetchCurrentThread } from "../parsedThread";
+import { fetchCurrentThread, ThreadFetchError } from "../parsedThread";
 
 import type {
   GraphConversationMessage,
@@ -67,14 +67,23 @@ describe("fetchCurrentThread", () => {
     expect(thread?.messages[0].id).toBe("<m1@x>");
   });
 
-  it("prefers uniqueBody over body and tracks html vs text content-type", async () => {
+  it("defaults to the full html body so forwarded content is never lost", async () => {
+    // The forward bug: uniqueBody is just the signature, the forwarded payload
+    // lives only in `body`. HTML uniqueBody is an independent fragment (not a
+    // substring of `body`), so we must keep the full body.
     const transport = makeTransport([
       {
         id: "m1",
         internetMessageId: "<m1@x>",
-        subject: "html with unique body",
-        body: { contentType: "html", content: "<p>full thread quote</p>" },
-        uniqueBody: { contentType: "html", content: "<p>just my reply</p>" },
+        subject: "forward with only a signature in uniqueBody",
+        body: {
+          contentType: "html",
+          content: "<p>full thread quote</p><p>Sent from Outlook for Mac</p>",
+        },
+        uniqueBody: {
+          contentType: "html",
+          content: "<p>Sent from Outlook for Mac</p>",
+        },
         receivedDateTime: "2026-03-01T10:00:00Z",
         isDraft: false,
       },
@@ -95,13 +104,77 @@ describe("fetchCurrentThread", () => {
       transport,
     });
 
-    expect(thread?.messages[0].bodyHtml).toContain("just my reply");
+    // Full body kept (forwarded content survives), not the signature-only uniqueBody.
+    expect(thread?.messages[0].bodyHtml).toContain("full thread quote");
     expect(thread?.messages[0].bodyText).toBeNull();
+    expect(thread?.messages[0].fullBodyHtml).toContain("full thread quote");
     expect(thread?.messages[1].bodyText).toContain("fallback wins");
     expect(thread?.messages[1].bodyHtml).toBeNull();
   });
 
-  it("keeps only fileAttachments with contentBytes; skips itemAttachment and referenceAttachment", async () => {
+  it("collapses to a plaintext uniqueBody only when it is a provable subset of the full body", async () => {
+    const transport = makeTransport([
+      {
+        id: "subset",
+        internetMessageId: "<subset@x>",
+        subject: "plaintext reply with quoted tail",
+        body: {
+          contentType: "text",
+          content: "Reply text\n\n> On 1 Jan, X wrote:\n> quoted history",
+        },
+        uniqueBody: { contentType: "text", content: "Reply text" },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+      },
+      {
+        id: "notsubset",
+        internetMessageId: "<notsubset@x>",
+        subject: "plaintext uniqueBody NOT contained in full",
+        body: { contentType: "text", content: "The real full body" },
+        uniqueBody: { contentType: "text", content: "something entirely else" },
+        receivedDateTime: "2026-03-02T10:00:00Z",
+        isDraft: false,
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    // Provable subset → collapse to the smaller copy (token win, loss-free).
+    expect(thread?.messages[0].bodyText).toBe("Reply text");
+    // Not a subset → keep the full body (never risk dropping content).
+    expect(thread?.messages[1].bodyText).toBe("The real full body");
+  });
+
+  it("reads isHtml from the chosen source so an empty html uniqueBody can't mislabel a plaintext body", async () => {
+    const transport = makeTransport([
+      {
+        id: "m1",
+        internetMessageId: "<m1@x>",
+        subject: "isHtml decoupling",
+        // uniqueBody is typed html but empty; body is the real plaintext.
+        uniqueBody: { contentType: "html", content: "" },
+        body: {
+          contentType: "text",
+          content: "a<b and R&D, List<String> survive intact",
+        },
+        receivedDateTime: "2026-03-01T10:00:00Z",
+        isDraft: false,
+      },
+    ]);
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    expect(thread?.messages[0].bodyHtml).toBeNull();
+    expect(thread?.messages[0].bodyText).toBe(
+      "a<b and R&D, List<String> survive intact",
+    );
+  });
+
+  it("surfaces itemAttachment and referenceAttachment as disclosure markers instead of dropping them", async () => {
     const transport = makeTransport([
       {
         id: "m1",
@@ -144,12 +217,76 @@ describe("fetchCurrentThread", () => {
       transport,
     });
 
-    expect(thread?.messages[0].attachments).toHaveLength(1);
-    const [keptAttachment] = thread!.messages[0].attachments;
-    expect(keptAttachment.filename).toBe("report.pdf");
-    expect(keptAttachment.contentBytes).not.toBeNull();
-    expect(keptAttachment.contentBytes!.byteLength).toBe(11); // "hello world"
-    expect(keptAttachment.id).toBe("<m1@x>:att-1");
+    // All three are kept (none silently dropped, INV-9).
+    expect(thread?.messages[0].attachments).toHaveLength(3);
+    const [file, item, reference] = thread!.messages[0].attachments;
+
+    expect(file.filename).toBe("report.pdf");
+    expect(file.contentBytes).not.toBeNull();
+    expect(file.contentBytes!.byteLength).toBe(11); // "hello world"
+    expect(file.unavailableReason).toBeNull();
+    expect(file.id).toBe("<m1@x>:att-1");
+
+    // The transport stub returns no arrayBuffer, so item $value enrichment
+    // fails gracefully → disclosed as a marker rather than dropped.
+    expect(item.contentBytes).toBeNull();
+    expect(item.unavailableReason).toContain("could not be retrieved");
+
+    expect(reference.contentBytes).toBeNull();
+    expect(reference.unavailableReason).toContain("cloud attachment");
+  });
+
+  it("decodes an itemAttachment whose bytes the fetch layer enriched via /$value", async () => {
+    // Transport that serves the conversation list, then the item's $value MIME.
+    const transport: GraphTransport = vi.fn(async (url: string) => {
+      if (url.includes("/attachments/") && url.endsWith("/$value")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          arrayBuffer: async () =>
+            new TextEncoder().encode("Forwarded .eml bytes").buffer,
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          value: [
+            {
+              id: "graph-m1",
+              internetMessageId: "<m1@x>",
+              subject: "with forwarded item",
+              body: { contentType: "text", content: "see forwarded" },
+              receivedDateTime: "2026-03-01T10:00:00Z",
+              isDraft: false,
+              attachments: [
+                {
+                  "@odata.type": ITEM_ATTACHMENT,
+                  id: "item-1",
+                  name: "Forwarded.eml",
+                  contentType: "message/rfc822",
+                  size: 20,
+                  isInline: false,
+                },
+              ],
+            },
+          ],
+        }),
+      } as unknown as Response;
+    });
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+
+    const [att] = thread!.messages[0].attachments;
+    expect(att.contentBytes).not.toBeNull();
+    expect(att.unavailableReason).toBeNull();
+    expect(new TextDecoder().decode(new Uint8Array(att.contentBytes!))).toBe(
+      "Forwarded .eml bytes",
+    );
   });
 
   it("preserves the isInline flag on attachments so the provider can filter them", async () => {
@@ -225,16 +362,65 @@ describe("fetchCurrentThread", () => {
     expect(thread?.subject).toBe("Re: Re: Original");
   });
 
-  it("returns null when Graph returns no messages or errors out", async () => {
+  it("returns null for a genuinely empty conversation (no messages, no error)", async () => {
     expect(
       await fetchCurrentThread("missing-conv", acquireToken, {
         transport: makeTransport([]),
       }),
     ).toBeNull();
-    expect(
-      await fetchCurrentThread("missing-conv", acquireToken, {
+  });
+
+  it("throws ThreadFetchError when the first-page fetch fails (loud, not silent null)", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      fetchCurrentThread("conv-1", acquireToken, {
         transport: makeFailingTransport(500),
       }),
-    ).toBeNull();
+    ).rejects.toBeInstanceOf(ThreadFetchError);
+    consoleWarn.mockRestore();
+  });
+
+  it("marks the thread incomplete when a later page fails after the first succeeds", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let call = 0;
+    const transport: GraphTransport = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            value: [
+              {
+                id: "m1",
+                internetMessageId: "<m1@x>",
+                subject: "page one",
+                body: { contentType: "text", content: "first page body" },
+                receivedDateTime: "2026-03-01T10:00:00Z",
+                isDraft: false,
+              },
+            ],
+            "@odata.nextLink":
+              "https://graph.microsoft.com/v1.0/me/messages?$skiptoken=PAGE2",
+          }),
+        } as unknown as Response;
+      }
+      return {
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        json: async () => ({}),
+      } as unknown as Response;
+    });
+
+    const thread = await fetchCurrentThread("conv-1", acquireToken, {
+      transport,
+    });
+    consoleWarn.mockRestore();
+
+    expect(thread).not.toBeNull();
+    expect(thread?.messages).toHaveLength(1);
+    expect(thread?.incomplete).toBe(true);
   });
 });

--- a/office-addin/src/utils/buildThreadSynthInputs.ts
+++ b/office-addin/src/utils/buildThreadSynthInputs.ts
@@ -1,0 +1,205 @@
+/**
+ * Turns the fetched, included thread messages into the `ThreadMessageInput[]`
+ * that `synthesizeThreadEml` serializes — applying the one verified token
+ * win (exact attachment-byte dedup) and surfacing every content-loss-relevant
+ * fact as an LLM-visible marker.
+ *
+ * Governing asymmetry (see the design doc): never lose content; deduping is a
+ * best-effort token layer that may only drop a unit it can PROVE is identical
+ * to one already emitted. Concretely:
+ *
+ *   - Attachment bytes are deduped only on full byte-equality (length bucket
+ *     then byte-for-byte). The earliest message holding a given byte stream is
+ *     canonical and keeps the real copy; later identical copies become a
+ *     provenance marker naming where the full copy lives. Three different
+ *     versions of `Lastenheft.pdf` = three byte streams = all kept.
+ *   - Attachments with no retrievable bytes (cloud references, un-fetchable
+ *     items) are disclosed as markers, never silently dropped (INV-9).
+ *   - An image-only message (no body text, only inline images) gets a marker
+ *     so it isn't invisibly empty.
+ *   - A partial thread appends a synthetic note disclosing incompleteness
+ *     (INV-7).
+ *
+ * Bodies are never mutated for dedup — markers are appended, respecting the
+ * message's html-vs-text body type.
+ */
+
+import type { ThreadMessage } from "./parsedThread";
+import type {
+  ThreadAttachmentInput,
+  ThreadMessageInput,
+} from "./synthesizeThreadEml";
+
+/**
+ * Below this size deduping doesn't pay: the base64 of the bytes is no larger
+ * than the provenance marker that would replace it, so we just keep the copy.
+ */
+const MIN_DEDUP_BYTES = 512;
+
+interface SeenAttachment {
+  byteLength: number;
+  bytes: Uint8Array;
+  filename: string;
+  label: string;
+}
+
+export function buildThreadSynthInputs(
+  messages: ThreadMessage[],
+  dismissedAttachmentIds: ReadonlySet<string>,
+  incomplete = false,
+): ThreadMessageInput[] {
+  const seen: SeenAttachment[] = [];
+  const inputs: ThreadMessageInput[] = [];
+
+  for (const message of messages) {
+    const markers: string[] = [];
+    const attachments: ThreadAttachmentInput[] = [];
+    const label = messageLabel(message);
+
+    for (const attachment of message.attachments) {
+      if (attachment.isInline) continue; // inline images handled below, not byte-deduped
+      if (dismissedAttachmentIds.has(attachment.id)) continue;
+
+      if (attachment.contentBytes === null) {
+        markers.push(
+          `[${attachment.unavailableReason ?? `attachment "${attachment.filename}" had no retrievable content`}]`,
+        );
+        continue;
+      }
+
+      const bytes = new Uint8Array(attachment.contentBytes);
+      if (bytes.byteLength >= MIN_DEDUP_BYTES) {
+        const duplicate = seen.find(
+          (candidate) =>
+            candidate.byteLength === bytes.byteLength &&
+            bytesEqual(candidate.bytes, bytes),
+        );
+        if (duplicate) {
+          markers.push(
+            `[attachment "${attachment.filename}" — identical to "${duplicate.filename}" from ${duplicate.label}; full copy included there]`,
+          );
+          continue;
+        }
+        seen.push({
+          byteLength: bytes.byteLength,
+          bytes,
+          filename: attachment.filename,
+          label,
+        });
+      }
+
+      attachments.push({
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        contentBytes: attachment.contentBytes,
+      });
+    }
+
+    const hasBody =
+      (message.bodyHtml ?? message.bodyText ?? "").trim().length > 0;
+    if (!hasBody) {
+      const inlineImages = message.attachments.filter(
+        (attachment) => attachment.isInline,
+      );
+      if (inlineImages.length > 0) {
+        markers.push(
+          `[image-only message: ${inlineImages
+            .map((attachment) => attachment.filename)
+            .join(", ")}; no extractable text]`,
+        );
+      }
+    }
+
+    const { bodyText, bodyHtml } = appendMarkers(
+      message.bodyText,
+      message.bodyHtml,
+      markers,
+    );
+
+    inputs.push({
+      internetMessageId: message.internetMessageId,
+      subject: message.subject,
+      from: message.from
+        ? { name: message.from.name, address: message.from.address }
+        : null,
+      to: message.to.map((address) => ({
+        name: address.name,
+        address: address.address,
+      })),
+      cc: message.cc.map((address) => ({
+        name: address.name,
+        address: address.address,
+      })),
+      date: message.date,
+      bodyText,
+      bodyHtml,
+      attachments,
+    });
+  }
+
+  if (incomplete) {
+    inputs.push(partialThreadNote());
+  }
+
+  return inputs;
+}
+
+/** A stable, human-readable handle for the message that holds a canonical
+ * attachment copy — used inside provenance markers. */
+function messageLabel(message: ThreadMessage): string {
+  const who = message.from?.name?.trim() || message.from?.address?.trim();
+  const when = message.date ? ` (${message.date})` : "";
+  if (who) return `${who}${when}`;
+  if (message.subject.trim()) return `"${message.subject.trim()}"${when}`;
+  return `an earlier message${when}`;
+}
+
+function appendMarkers(
+  bodyText: string | null,
+  bodyHtml: string | null,
+  markers: string[],
+): { bodyText: string | null; bodyHtml: string | null } {
+  if (markers.length === 0) return { bodyText, bodyHtml };
+
+  if (bodyHtml !== null) {
+    const appended = markers
+      .map((marker) => `<p>${escapeHtml(marker)}</p>`)
+      .join("");
+    return { bodyText, bodyHtml: `${bodyHtml}${appended}` };
+  }
+
+  const block = markers.join("\n");
+  const base = bodyText ?? "";
+  const joined = base.length > 0 ? `${base}\n\n${block}` : block;
+  return { bodyText: joined, bodyHtml: null };
+}
+
+function partialThreadNote(): ThreadMessageInput {
+  return {
+    internetMessageId: null,
+    subject: "[Partial conversation]",
+    from: null,
+    to: [],
+    cc: [],
+    date: null,
+    bodyText:
+      "[Some messages in this conversation could not be retrieved — this thread is partial.]",
+    bodyHtml: null,
+    attachments: [],
+  };
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -154,9 +154,10 @@ export async function fetchParentMessageInConversationViaGraph(
 
 /**
  * Fetches every non-draft message in a conversation thread, with each
- * message's attachments expanded inline. One Graph call covers the entire
- * thread + attachment bytes within the Graph response envelope cap (~4 MB),
- * avoiding the throttle hazard of N parallel `/$value` fetches.
+ * message's `fileAttachment` bytes expanded inline. Paginates `@odata.nextLink`
+ * up to `MAX_CONVERSATION_PAGES` (declaring the thread `partial` past the cap),
+ * then enriches any `itemAttachment` bytes via bounded-concurrency `/$value`
+ * fetches (see `enrichItemAttachments`) to stay under Graph's throttle.
  *
  * `uniqueBody` is included alongside `body`: the former contains only the
  * portion of the body unique to that message (Graph strips prior quoted
@@ -243,6 +244,10 @@ const ITEM_ATTACHMENT_TYPE = "#microsoft.graph.itemAttachment";
  * many pages (50 × 20 = 1000 messages) before declaring the thread partial. */
 const MAX_CONVERSATION_PAGES = 20;
 const CONVERSATION_PAGE_SIZE = 50;
+/** Max simultaneous item-attachment `/$value` fetches (Graph throttle guard). */
+const ITEM_ENRICH_CONCURRENCY = 5;
+/** Upper bound on an honored `Retry-After`, so a bad header can't hang us. */
+const MAX_RETRY_AFTER_SECONDS = 10;
 
 export async function fetchConversationMessagesViaGraph(
   conversationId: string,
@@ -373,7 +378,7 @@ async function enrichItemAttachments(
   token: string,
   transport: GraphTransport,
 ): Promise<void> {
-  const fetches: Promise<void>[] = [];
+  const tasks: Array<() => Promise<void>> = [];
   for (const message of messages) {
     const messageId = message.id;
     if (!messageId || !message.attachments) continue;
@@ -381,37 +386,91 @@ async function enrichItemAttachments(
       if (attachment["@odata.type"] !== ITEM_ATTACHMENT_TYPE) continue;
       if (attachment.contentBytes || !attachment.id) continue;
       const attachmentId = attachment.id;
-      fetches.push(
-        (async () => {
-          try {
-            const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/$value`;
-            const response = await transport(url, {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: "application/octet-stream",
-              },
-            });
-            if (!response.ok) return;
-            const buffer = await response.arrayBuffer();
-            if (!buffer || buffer.byteLength === 0) return;
-            attachment.contentBytes = arrayBufferToBase64(buffer);
-            if (!attachment.contentType) {
-              attachment.contentType = "message/rfc822";
-            }
-            if (!attachment.name) {
-              attachment.name = "attached-item.eml";
-            }
-          } catch (error) {
-            console.warn(
-              "[enrichItemAttachments] item $value fetch failed:",
-              error,
-            );
-          }
-        })(),
+      tasks.push(() =>
+        enrichOneItemAttachment(
+          messageId,
+          attachmentId,
+          attachment,
+          token,
+          transport,
+        ),
       );
     }
   }
-  await Promise.all(fetches);
+  // Bounded fan-out: a thread that forwarded many items would otherwise fire
+  // one /$value GET per item simultaneously and trip Graph's per-app throttle.
+  await runWithConcurrency(tasks, ITEM_ENRICH_CONCURRENCY);
+}
+
+async function enrichOneItemAttachment(
+  messageId: string,
+  attachmentId: string,
+  attachment: GraphAttachment,
+  token: string,
+  transport: GraphTransport,
+): Promise<void> {
+  const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/$value`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/octet-stream",
+  };
+  try {
+    let response = await transport(url, { headers });
+    // Honor a single Retry-After on throttle before giving up to a marker.
+    if (response.status === 429) {
+      const retryMs = retryAfterMs(response);
+      if (retryMs !== null) {
+        await sleep(retryMs);
+        response = await transport(url, { headers });
+      }
+    }
+    if (!response.ok) return;
+    const buffer = await response.arrayBuffer();
+    if (!buffer || buffer.byteLength === 0) return;
+    attachment.contentBytes = arrayBufferToBase64(buffer);
+    if (!attachment.contentType) {
+      attachment.contentType = "message/rfc822";
+    }
+    if (!attachment.name) {
+      attachment.name = "attached-item.eml";
+    }
+  } catch (error) {
+    console.warn("[enrichItemAttachments] item $value fetch failed:", error);
+  }
+}
+
+/** Run thunks with at most `limit` in flight at once. Each thunk is expected to
+ * swallow its own errors (these do), so the pool never rejects. */
+async function runWithConcurrency(
+  tasks: Array<() => Promise<void>>,
+  limit: number,
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, tasks.length) },
+    async () => {
+      while (cursor < tasks.length) {
+        const index = cursor;
+        cursor += 1;
+        await tasks[index]();
+      }
+    },
+  );
+  await Promise.all(workers);
+}
+
+/** Parse a `Retry-After` (delta-seconds) header into a clamped ms delay, or
+ * null when absent/unparseable. Clamped so a hostile header can't stall us. */
+function retryAfterMs(response: Response): number | null {
+  const header = response.headers?.get?.("Retry-After");
+  if (!header) return null;
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return Math.min(seconds, MAX_RETRY_AFTER_SECONDS) * 1000;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -160,15 +160,16 @@ export async function fetchParentMessageInConversationViaGraph(
  *
  * `uniqueBody` is included alongside `body`: the former contains only the
  * portion of the body unique to that message (Graph strips prior quoted
- * history), the latter contains the message as it would render in Outlook.
- * Callers pick whichever they prefer; today we prefer `uniqueBody` for
- * synthesized thread .emls so the LLM doesn't see N copies of the same
- * quoted history.
+ * history), the latter the message as it would render in Outlook. We carry
+ * BOTH and let `parsedThread.chooseBody` decide — defaulting to the full
+ * `body` so forwarded content (whose `uniqueBody` is often just a signature)
+ * is never lost; see `parsedThread.ts`.
  *
  * Attachments returned here are typed loosely: `fileAttachment` carries
- * `contentBytes` (base64), but `itemAttachment` / `referenceAttachment`
- * subtypes are pointers and won't have content inline. Callers must check
- * the `@odata.type` discriminator.
+ * `contentBytes` (base64), `itemAttachment` is a nested message/item whose
+ * bytes we fetch best-effort via `/$value` (see `enrichItemAttachments`),
+ * and `referenceAttachment` is a cloud pointer with no inline bytes. Callers
+ * discriminate on the `@odata.type` discriminator; nothing is silently dropped.
  */
 export interface GraphRecipient {
   emailAddress?: { name?: string; address?: string };
@@ -219,73 +220,204 @@ export interface FetchConversationOptions {
   transport?: GraphTransport;
 }
 
+/**
+ * Outcome of a conversation fetch — distinguishes the three cases the caller
+ * must treat differently (a bare `[]` conflates them):
+ *   - `ok`      — every page fetched successfully.
+ *   - `partial` — at least one page succeeded but a later page failed or the
+ *                 hard page cap was hit. Some messages may be missing; the
+ *                 caller should mark the thread incomplete (INV-7).
+ *   - `error`   — the very first page failed; `messages` is empty and the
+ *                 caller must surface a load error rather than silently
+ *                 producing "no thread".
+ */
+export type ConversationFetchState = "ok" | "partial" | "error";
+
+export interface FetchConversationResult {
+  messages: GraphConversationMessage[];
+  state: ConversationFetchState;
+}
+
+const ITEM_ATTACHMENT_TYPE = "#microsoft.graph.itemAttachment";
+/** Graph paginates at server discretion; follow `@odata.nextLink` up to this
+ * many pages (50 × 20 = 1000 messages) before declaring the thread partial. */
+const MAX_CONVERSATION_PAGES = 20;
+const CONVERSATION_PAGE_SIZE = 50;
+
 export async function fetchConversationMessagesViaGraph(
   conversationId: string,
   acquireToken: AcquireGraphToken,
   options: FetchConversationOptions = {},
-): Promise<GraphConversationMessage[]> {
+): Promise<FetchConversationResult> {
   const transport = options.transport ?? globalThis.fetch.bind(globalThis);
+  let token: string;
   try {
-    const token = await acquireToken();
-    const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
-    const select = [
-      "id",
-      "internetMessageId",
-      "subject",
-      "from",
-      "toRecipients",
-      "ccRecipients",
-      "sentDateTime",
-      "receivedDateTime",
-      "body",
-      "uniqueBody",
-      "isDraft",
-      "hasAttachments",
-    ].join(",");
-    // Both `contentBytes` AND `contentId` live only on the
-    // `microsoft.graph.fileAttachment` subtype — the polymorphic
-    // `attachment` base type defines just `id`, `name`, `contentType`,
-    // `size`, `isInline`, and `lastModifiedDateTime`. Selecting either
-    // unqualified trips `BadRequest: Could not find a property named '…'
-    // on type 'microsoft.graph.attachment'`. OData's derived-type-property
-    // syntax `<namespace.subtype>/<property>` projects the field only when
-    // the row materializes as that subtype; itemAttachment and
-    // referenceAttachment items still come back (without those fields), so
-    // callers can discriminate on `@odata.type` and skip non-file rows.
-    // See microsoftgraph/microsoft-graph-explorer-v4#3916.
-    const attachmentSelect = [
-      "id",
-      "name",
-      "contentType",
-      "size",
-      "isInline",
-      "microsoft.graph.fileAttachment/contentId",
-      "microsoft.graph.fileAttachment/contentBytes",
-    ].join(",");
-    const expand = `attachments($select=${attachmentSelect})`;
-    const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=25&$select=${select}&$expand=${expand}`;
-    const response = await transport(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-    });
+    token = await acquireToken();
+  } catch (error) {
+    console.warn("[fetchConversationMessagesViaGraph] token acquire failed:", error);
+    return { messages: [], state: "error" };
+  }
+
+  const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
+  const select = [
+    "id",
+    "internetMessageId",
+    "subject",
+    "from",
+    "toRecipients",
+    "ccRecipients",
+    "sentDateTime",
+    "receivedDateTime",
+    "body",
+    "uniqueBody",
+    "isDraft",
+    "hasAttachments",
+  ].join(",");
+  // Both `contentBytes` AND `contentId` live only on the
+  // `microsoft.graph.fileAttachment` subtype — the polymorphic
+  // `attachment` base type defines just `id`, `name`, `contentType`,
+  // `size`, `isInline`, and `lastModifiedDateTime`. Selecting either
+  // unqualified trips `BadRequest: Could not find a property named '…'
+  // on type 'microsoft.graph.attachment'`. OData's derived-type-property
+  // syntax `<namespace.subtype>/<property>` projects the field only when
+  // the row materializes as that subtype; itemAttachment and
+  // referenceAttachment items still come back (without those fields), so
+  // callers can discriminate on `@odata.type` and skip non-file rows.
+  // See microsoftgraph/microsoft-graph-explorer-v4#3916.
+  const attachmentSelect = [
+    "id",
+    "name",
+    "contentType",
+    "size",
+    "isInline",
+    "microsoft.graph.fileAttachment/contentId",
+    "microsoft.graph.fileAttachment/contentBytes",
+  ].join(",");
+  const expand = `attachments($select=${attachmentSelect})`;
+
+  const messages: GraphConversationMessage[] = [];
+  let nextUrl: string | null = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=${CONVERSATION_PAGE_SIZE}&$select=${select}&$expand=${expand}`;
+  let pages = 0;
+  let state: ConversationFetchState = "ok";
+
+  while (nextUrl && pages < MAX_CONVERSATION_PAGES) {
+    let response: Response;
+    try {
+      response = await transport(nextUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+      });
+    } catch (error) {
+      console.warn("[fetchConversationMessagesViaGraph] fetch failed:", error);
+      state = pages === 0 ? "error" : "partial";
+      break;
+    }
     if (!response.ok) {
       console.warn(
         "[fetchConversationMessagesViaGraph] non-OK status:",
         response.status,
         response.statusText,
       );
-      return [];
+      state = pages === 0 ? "error" : "partial";
+      break;
     }
-    const payload = (await response.json()) as {
+    let payload: {
       value?: GraphConversationMessage[];
+      "@odata.nextLink"?: string;
     };
-    return payload.value ?? [];
-  } catch (error) {
-    console.warn("[fetchConversationMessagesViaGraph] failed:", error);
-    return [];
+    try {
+      payload = await response.json();
+    } catch (error) {
+      console.warn("[fetchConversationMessagesViaGraph] JSON parse failed:", error);
+      state = pages === 0 ? "error" : "partial";
+      break;
+    }
+    messages.push(...(payload.value ?? []));
+    nextUrl = payload["@odata.nextLink"] ?? null;
+    pages += 1;
   }
+  // More pages remained but we stopped at the cap → the window is incomplete.
+  if (nextUrl && state === "ok") {
+    state = "partial";
+  }
+
+  // Best-effort: pull the bytes of any itemAttachment (forwarded .msg/.eml)
+  // so its content reaches the LLM. Failures degrade to a disclosure marker
+  // downstream (parsedThread.transformAttachment), never a silent drop.
+  if (messages.length > 0) {
+    await enrichItemAttachments(messages, token, transport);
+  }
+
+  return { messages, state };
+}
+
+/**
+ * For every `itemAttachment` lacking inline bytes, fetch the item as raw MIME
+ * via `/messages/{id}/attachments/{attId}/$value` and splice the base64 onto
+ * the attachment's `contentBytes` so the existing fileAttachment decode path
+ * picks it up. Each fetch is independently guarded — one failure (or a
+ * transport that doesn't implement `arrayBuffer`) leaves that attachment
+ * byte-less, to be disclosed as a marker rather than dropped.
+ */
+async function enrichItemAttachments(
+  messages: GraphConversationMessage[],
+  token: string,
+  transport: GraphTransport,
+): Promise<void> {
+  const fetches: Promise<void>[] = [];
+  for (const message of messages) {
+    const messageId = message.id;
+    if (!messageId || !message.attachments) continue;
+    for (const attachment of message.attachments) {
+      if (attachment["@odata.type"] !== ITEM_ATTACHMENT_TYPE) continue;
+      if (attachment.contentBytes || !attachment.id) continue;
+      const attachmentId = attachment.id;
+      fetches.push(
+        (async () => {
+          try {
+            const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/$value`;
+            const response = await transport(url, {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: "application/octet-stream",
+              },
+            });
+            if (!response.ok) return;
+            const buffer = await response.arrayBuffer();
+            if (!buffer || buffer.byteLength === 0) return;
+            attachment.contentBytes = arrayBufferToBase64(buffer);
+            if (!attachment.contentType) {
+              attachment.contentType = "message/rfc822";
+            }
+            if (!attachment.name) {
+              attachment.name = "attached-item.eml";
+            }
+          } catch (error) {
+            console.warn(
+              "[enrichItemAttachments] item $value fetch failed:",
+              error,
+            );
+          }
+        })(),
+      );
+    }
+  }
+  await Promise.all(fetches);
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunk)),
+    );
+  }
+  return btoa(binary);
 }
 
 /**

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -254,7 +254,10 @@ export async function fetchConversationMessagesViaGraph(
   try {
     token = await acquireToken();
   } catch (error) {
-    console.warn("[fetchConversationMessagesViaGraph] token acquire failed:", error);
+    console.warn(
+      "[fetchConversationMessagesViaGraph] token acquire failed:",
+      error,
+    );
     return { messages: [], state: "error" };
   }
 
@@ -296,7 +299,8 @@ export async function fetchConversationMessagesViaGraph(
   const expand = `attachments($select=${attachmentSelect})`;
 
   const messages: GraphConversationMessage[] = [];
-  let nextUrl: string | null = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=${CONVERSATION_PAGE_SIZE}&$select=${select}&$expand=${expand}`;
+  let nextUrl: string | null =
+    `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=${CONVERSATION_PAGE_SIZE}&$select=${select}&$expand=${expand}`;
   let pages = 0;
   let state: ConversationFetchState = "ok";
 
@@ -330,7 +334,10 @@ export async function fetchConversationMessagesViaGraph(
     try {
       payload = await response.json();
     } catch (error) {
-      console.warn("[fetchConversationMessagesViaGraph] JSON parse failed:", error);
+      console.warn(
+        "[fetchConversationMessagesViaGraph] JSON parse failed:",
+        error,
+      );
       state = pages === 0 ? "error" : "partial";
       break;
     }

--- a/office-addin/src/utils/parsedThread.ts
+++ b/office-addin/src/utils/parsedThread.ts
@@ -220,7 +220,11 @@ function chooseBody(message: GraphConversationMessage): ChosenBody {
   // is treated as text. Mislabeling text as HTML would let a downstream tag
   // stripper delete content between `<…>`; the reverse merely leaves a few
   // literal tags. Bias the tie to text/plain.
-  if (chosenIsHtml && chosenContent !== null && !/<\w[\s\S]*>/.test(chosenContent)) {
+  if (
+    chosenIsHtml &&
+    chosenContent !== null &&
+    !/<\w[\s\S]*>/.test(chosenContent)
+  ) {
     chosenIsHtml = false;
   }
 

--- a/office-addin/src/utils/parsedThread.ts
+++ b/office-addin/src/utils/parsedThread.ts
@@ -21,6 +21,8 @@ import {
 import type { ParsedEmailAddress } from "./parsedEmail";
 
 const FILE_ATTACHMENT_TYPE = "#microsoft.graph.fileAttachment";
+const ITEM_ATTACHMENT_TYPE = "#microsoft.graph.itemAttachment";
+const REFERENCE_ATTACHMENT_TYPE = "#microsoft.graph.referenceAttachment";
 
 export interface ThreadAttachment {
   /** Stable within the thread; concatenates messageId + Graph attachment id. */
@@ -31,6 +33,13 @@ export interface ThreadAttachment {
   contentBytes: ArrayBuffer | null;
   isInline: boolean;
   contentId: string | null;
+  /**
+   * When `contentBytes` is null, a human-readable reason the bytes are
+   * unavailable (cloud reference, un-retrievable item, unsupported subtype).
+   * Surfaced to the LLM as a disclosure marker so the attachment's existence
+   * is never silently dropped (INV-9). Null when bytes are present.
+   */
+  unavailableReason: string | null;
 }
 
 export interface ThreadMessage {
@@ -43,8 +52,16 @@ export interface ThreadMessage {
   cc: ParsedEmailAddress[];
   /** ISO 8601; prefers sentDateTime, falls back to receivedDateTime. */
   date: string | null;
+  /** The chosen body (see `chooseBody`) — what synthesis emits. */
   bodyText: string | null;
   bodyHtml: string | null;
+  /**
+   * The full Graph `body` (never the stripped `uniqueBody`), retained so the
+   * complete content is always available even when `bodyText`/`bodyHtml`
+   * carry a collapsed uniqueBody. One of these is null per the body's type.
+   */
+  fullBodyText: string | null;
+  fullBodyHtml: string | null;
   attachments: ThreadAttachment[];
 }
 
@@ -53,6 +70,25 @@ export interface ParsedThread {
   /** Outer-envelope subject; today the latest message's subject. */
   subject: string;
   messages: ThreadMessage[];
+  /**
+   * True when the conversation could not be fully fetched (a later page
+   * failed or the page cap was hit). Consumers disclose this to the LLM
+   * (INV-7) and disable cross-message dedup, since a canonical copy may be
+   * outside the fetched window.
+   */
+  incomplete: boolean;
+}
+
+/**
+ * Thrown when the conversation fetch fails on its very first page — i.e. we
+ * have nothing, as opposed to a genuinely empty conversation. Callers must
+ * surface this loudly rather than rendering "no thread" (INV-7).
+ */
+export class ThreadFetchError extends Error {
+  constructor(conversationId: string) {
+    super(`Failed to load Outlook conversation ${conversationId} from Graph`);
+    this.name = "ThreadFetchError";
+  }
 }
 
 export async function fetchCurrentThread(
@@ -60,11 +96,16 @@ export async function fetchCurrentThread(
   acquireToken: AcquireGraphToken,
   options: FetchConversationOptions = {},
 ): Promise<ParsedThread | null> {
-  const raw = await fetchConversationMessagesViaGraph(
+  const { messages: raw, state } = await fetchConversationMessagesViaGraph(
     conversationId,
     acquireToken,
     options,
   );
+  // Total failure (first page errored → nothing fetched) must be loud, not a
+  // silent null that looks identical to "this conversation has no messages".
+  if (state === "error") {
+    throw new ThreadFetchError(conversationId);
+  }
   if (raw.length === 0) return null;
 
   const messages = raw
@@ -85,6 +126,7 @@ export async function fetchCurrentThread(
     conversationId,
     subject: latestSubject,
     messages,
+    incomplete: state === "partial",
   };
 }
 
@@ -100,11 +142,7 @@ function transformMessage(
       (attachment): attachment is ThreadAttachment => attachment !== null,
     );
 
-  const uniqueBodyContent = nullIfEmpty(message.uniqueBody?.content);
-  const fullBodyContent = nullIfEmpty(message.body?.content);
-  const preferredBody = uniqueBodyContent ?? fullBodyContent;
-  const isHtml =
-    (message.uniqueBody?.contentType ?? message.body?.contentType) === "html";
+  const body = chooseBody(message);
 
   return {
     id,
@@ -118,33 +156,142 @@ function transformMessage(
       .map(normaliseAddress)
       .filter((address): address is ParsedEmailAddress => address !== null),
     date: message.sentDateTime ?? message.receivedDateTime ?? null,
-    bodyText: isHtml ? null : preferredBody,
-    bodyHtml: isHtml ? preferredBody : null,
+    ...body,
     attachments,
   };
+}
+
+interface ChosenBody {
+  bodyText: string | null;
+  bodyHtml: string | null;
+  fullBodyText: string | null;
+  fullBodyHtml: string | null;
+}
+
+/**
+ * Decide which body to emit for a message.
+ *
+ * Correctness first: default to the full Graph `body`, so forwarded content —
+ * whose `uniqueBody` is frequently just the sender's signature — is never
+ * lost (the original "forward shows only the signature" bug). The smaller
+ * `uniqueBody` is chosen ONLY when it is a provable, loss-free subset of the
+ * full body, which in practice holds only for plaintext (HTML `uniqueBody` is
+ * an independently-generated fragment, not a substring of `body`, so it stays
+ * full — accepted). `isHtml` is always read from the SAME source object that
+ * supplied the chosen string, closing the decoupling bug where an empty-but-
+ * typed `uniqueBody` mislabeled a plaintext `body` as HTML.
+ */
+function chooseBody(message: GraphConversationMessage): ChosenBody {
+  const uniqContent = nullIfEmpty(message.uniqueBody?.content);
+  const fullContent = nullIfEmpty(message.body?.content);
+  const uniqIsHtml = message.uniqueBody?.contentType === "html";
+  const fullIsHtml = message.body?.contentType === "html";
+
+  const fullBodyText = fullContent !== null && !fullIsHtml ? fullContent : null;
+  const fullBodyHtml = fullContent !== null && fullIsHtml ? fullContent : null;
+
+  let chosenContent: string | null;
+  let chosenIsHtml: boolean;
+  if (fullContent === null) {
+    // Full body empty → fall back to uniqueBody, reading its OWN type (INV-4).
+    chosenContent = uniqContent;
+    chosenIsHtml = uniqContent !== null ? uniqIsHtml : false;
+  } else if (uniqContent === null) {
+    chosenContent = fullContent;
+    chosenIsHtml = fullIsHtml;
+  } else if (uniqIsHtml !== fullIsHtml) {
+    // Type disagreement → keep full (never risk the smaller one).
+    chosenContent = fullContent;
+    chosenIsHtml = fullIsHtml;
+  } else if (
+    !uniqIsHtml &&
+    normalize(fullContent).includes(normalize(uniqContent))
+  ) {
+    // Plaintext and uniqueBody is a provable loss-free substring of full →
+    // collapse to the smaller copy (the only safe token win here).
+    chosenContent = uniqContent;
+    chosenIsHtml = false;
+  } else {
+    chosenContent = fullContent;
+    chosenIsHtml = fullIsHtml;
+  }
+
+  // Defense-in-depth: a body declared html but containing no tag-like markup
+  // is treated as text. Mislabeling text as HTML would let a downstream tag
+  // stripper delete content between `<…>`; the reverse merely leaves a few
+  // literal tags. Bias the tie to text/plain.
+  if (chosenIsHtml && chosenContent !== null && !/<\w[\s\S]*>/.test(chosenContent)) {
+    chosenIsHtml = false;
+  }
+
+  return {
+    bodyText: chosenContent !== null && !chosenIsHtml ? chosenContent : null,
+    bodyHtml: chosenContent !== null && chosenIsHtml ? chosenContent : null,
+    fullBodyText,
+    fullBodyHtml,
+  };
+}
+
+/** Collapse insignificant whitespace for a loss-free comparison key only
+ * (never serialized): CRLF→LF, runs of whitespace → single space, trimmed. */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
 }
 
 function transformAttachment(
   attachment: GraphAttachment,
   messageId: string,
 ): ThreadAttachment | null {
-  // Only fileAttachments carry contentBytes inline. itemAttachment and
-  // referenceAttachment subtypes would need follow-up calls — out of scope
-  // for the first iteration (the user's reported thread uses regular file
-  // attachments).
-  if (attachment["@odata.type"] !== FILE_ATTACHMENT_TYPE) return null;
-  if (!attachment.id || !attachment.name) return null;
+  if (!attachment.id) return null;
+  const id = `${messageId}:${attachment.id}`;
+  const name = attachment.name ?? null;
+  const isInline = attachment.isInline === true;
+  const mimeType = attachment.contentType ?? "application/octet-stream";
+
+  // fileAttachment, or an itemAttachment the fetch layer enriched with bytes.
   const bytes = attachment.contentBytes
     ? decodeBase64(attachment.contentBytes)
     : null;
+  if (bytes) {
+    return {
+      id,
+      filename: name ?? "attachment",
+      mimeType,
+      size: attachment.size ?? bytes.byteLength,
+      contentBytes: bytes,
+      isInline,
+      contentId: attachment.contentId ?? null,
+      unavailableReason: null,
+    };
+  }
+
+  // No bytes available. Rather than the old silent `return null`, disclose the
+  // attachment's existence so its content is never invisibly dropped (INV-9).
+  const named = name ? `: ${name}` : "";
+  let unavailableReason: string;
+  switch (attachment["@odata.type"]) {
+    case REFERENCE_ATTACHMENT_TYPE:
+      unavailableReason = `cloud attachment (OneDrive/SharePoint)${named} — not inlined`;
+      break;
+    case ITEM_ATTACHMENT_TYPE:
+      unavailableReason = `attached item could not be retrieved${named}`;
+      break;
+    case FILE_ATTACHMENT_TYPE:
+      unavailableReason = `attachment had no retrievable content${named}`;
+      break;
+    default:
+      unavailableReason = `attachment of unsupported type was present${named}`;
+      break;
+  }
   return {
-    id: `${messageId}:${attachment.id}`,
-    filename: attachment.name,
-    mimeType: attachment.contentType ?? "application/octet-stream",
-    size: attachment.size ?? bytes?.byteLength ?? 0,
-    contentBytes: bytes,
-    isInline: attachment.isInline === true,
+    id,
+    filename: name ?? "attachment",
+    mimeType,
+    size: attachment.size ?? 0,
+    contentBytes: null,
+    isInline,
     contentId: attachment.contentId ?? null,
+    unavailableReason,
   };
 }
 

--- a/office-addin/src/utils/parsedThread.ts
+++ b/office-addin/src/utils/parsedThread.ts
@@ -55,13 +55,6 @@ export interface ThreadMessage {
   /** The chosen body (see `chooseBody`) — what synthesis emits. */
   bodyText: string | null;
   bodyHtml: string | null;
-  /**
-   * The full Graph `body` (never the stripped `uniqueBody`), retained so the
-   * complete content is always available even when `bodyText`/`bodyHtml`
-   * carry a collapsed uniqueBody. One of these is null per the body's type.
-   */
-  fullBodyText: string | null;
-  fullBodyHtml: string | null;
   attachments: ThreadAttachment[];
 }
 
@@ -73,8 +66,11 @@ export interface ParsedThread {
   /**
    * True when the conversation could not be fully fetched (a later page
    * failed or the page cap was hit). Consumers disclose this to the LLM
-   * (INV-7) and disable cross-message dedup, since a canonical copy may be
-   * outside the fetched window.
+   * (INV-7), and `chooseBody` suppresses the plaintext-body collapse so
+   * quoted history that may live only in an unfetched earlier message is
+   * retained. (Attachment dedup stays safe even when incomplete: the
+   * canonical copy a marker points to is always the first occurrence within
+   * the fetched window, so the reference is never dangling.)
    */
   incomplete: boolean;
 }
@@ -108,9 +104,10 @@ export async function fetchCurrentThread(
   }
   if (raw.length === 0) return null;
 
+  const incomplete = state === "partial";
   const messages = raw
     .filter((message) => message.isDraft !== true)
-    .map((message) => transformMessage(message))
+    .map((message) => transformMessage(message, incomplete))
     .filter((message): message is ThreadMessage => message !== null);
 
   if (messages.length === 0) return null;
@@ -126,12 +123,13 @@ export async function fetchCurrentThread(
     conversationId,
     subject: latestSubject,
     messages,
-    incomplete: state === "partial",
+    incomplete,
   };
 }
 
 function transformMessage(
   message: GraphConversationMessage,
+  incomplete: boolean,
 ): ThreadMessage | null {
   const id = message.internetMessageId ?? message.id ?? null;
   if (!id) return null;
@@ -142,7 +140,7 @@ function transformMessage(
       (attachment): attachment is ThreadAttachment => attachment !== null,
     );
 
-  const body = chooseBody(message);
+  const body = chooseBody(message, incomplete);
 
   return {
     id,
@@ -164,8 +162,6 @@ function transformMessage(
 interface ChosenBody {
   bodyText: string | null;
   bodyHtml: string | null;
-  fullBodyText: string | null;
-  fullBodyHtml: string | null;
 }
 
 /**
@@ -180,15 +176,19 @@ interface ChosenBody {
  * full — accepted). `isHtml` is always read from the SAME source object that
  * supplied the chosen string, closing the decoupling bug where an empty-but-
  * typed `uniqueBody` mislabeled a plaintext `body` as HTML.
+ *
+ * When the thread is `incomplete`, the collapse is suppressed entirely: the
+ * dropped quoted history might be the only surviving copy of an unfetched
+ * earlier message, so we keep the full body and pay the tokens.
  */
-function chooseBody(message: GraphConversationMessage): ChosenBody {
+function chooseBody(
+  message: GraphConversationMessage,
+  incomplete: boolean,
+): ChosenBody {
   const uniqContent = nullIfEmpty(message.uniqueBody?.content);
   const fullContent = nullIfEmpty(message.body?.content);
   const uniqIsHtml = message.uniqueBody?.contentType === "html";
   const fullIsHtml = message.body?.contentType === "html";
-
-  const fullBodyText = fullContent !== null && !fullIsHtml ? fullContent : null;
-  const fullBodyHtml = fullContent !== null && fullIsHtml ? fullContent : null;
 
   let chosenContent: string | null;
   let chosenIsHtml: boolean;
@@ -204,11 +204,13 @@ function chooseBody(message: GraphConversationMessage): ChosenBody {
     chosenContent = fullContent;
     chosenIsHtml = fullIsHtml;
   } else if (
+    !incomplete &&
     !uniqIsHtml &&
     normalize(fullContent).includes(normalize(uniqContent))
   ) {
     // Plaintext and uniqueBody is a provable loss-free substring of full →
-    // collapse to the smaller copy (the only safe token win here).
+    // collapse to the smaller copy (the only safe token win here). Skipped on
+    // incomplete threads, where the dropped tail may be the sole copy.
     chosenContent = uniqContent;
     chosenIsHtml = false;
   } else {
@@ -231,8 +233,6 @@ function chooseBody(message: GraphConversationMessage): ChosenBody {
   return {
     bodyText: chosenContent !== null && !chosenIsHtml ? chosenContent : null,
     bodyHtml: chosenContent !== null && chosenIsHtml ? chosenContent : null,
-    fullBodyText,
-    fullBodyHtml,
   };
 }
 


### PR DESCRIPTION
- Default to full Graph body, collapse to uniqueBody only on a provable
  plaintext subset (fixes forwards showing only the signature; isHtml fix)
- Disclose item/reference attachments as markers instead of dropping them
- Paginate the conversation fetch; distinguish empty vs total failure
- Dedup byte-identical attachments with provenance markers; partial-thread note
This pull request enhances error handling and attachment processing in the Outlook email integration. It introduces a clear distinction between an empty thread and a failed thread fetch, improves how attachment deduplication and markers are handled, and adds comprehensive unit tests for the new logic. The most important changes are grouped below:

**Error Handling Improvements:**

* The `useCurrentThread` hook and its consumers now explicitly surface a thread fetch failure via a new `error` property, allowing the UI to distinguish between a genuinely empty thread and a failed fetch (INV-7). This property is propagated through context and used in the provider and tests. [[1]](diffhunk://#diff-5bf291a8cb76747293cb0a30942f481d37eb3794c1431279b27334cba20c3319R13-R19) [[2]](diffhunk://#diff-5bf291a8cb76747293cb0a30942f481d37eb3794c1431279b27334cba20c3319R51) [[3]](diffhunk://#diff-5bf291a8cb76747293cb0a30942f481d37eb3794c1431279b27334cba20c3319R60-R84) [[4]](diffhunk://#diff-5bf291a8cb76747293cb0a30942f481d37eb3794c1431279b27334cba20c3319L74-R95) [[5]](diffhunk://#diff-e6f8e78315f882d2126dde038014f0d3d8a7eb9a558fef40bbca64e07d339ca6L31-R45) [[6]](diffhunk://#diff-e6f8e78315f882d2126dde038014f0d3d8a7eb9a558fef40bbca64e07d339ca6L111-R132) [[7]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR124-R129) [[8]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR157) [[9]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL222-R226) [[10]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR561) [[11]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR594)

**Attachment Deduplication and Synthesis:**

* The logic for synthesizing thread inputs for EML export is refactored: a new utility, `buildThreadSynthInputs`, deduplicates byte-identical attachments across messages, marks duplicates, handles unavailable/cloud attachments, and appends partial-thread notes when needed. The previous inline logic and `filterAttachments` function are removed in favor of this utility. [[1]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR14) [[2]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL26-L35) [[3]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL477-R483) [[4]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL634-L651)

**Testing Enhancements:**

* Adds comprehensive unit tests for `buildThreadSynthInputs`, verifying deduplication, marker insertion, handling of dismissed attachments, and partial-thread notes.

**Minor Improvements:**

* Updates test imports and type usage for improved clarity and correctness.