### PR TITLE
Defer thread .eml synthesis off the render path

### DIFF
--- a/office-addin/src/components/AddinFileSourceSelector.tsx
+++ b/office-addin/src/components/AddinFileSourceSelector.tsx
@@ -48,6 +48,7 @@ export function AddinFileSourceSelector({
     useOutlookMailItem();
   const {
     emailBodyFile,
+    isThreadEmlStale,
     isLoadingEmailBody,
     emailThreadLoadError,
     isEmailBodyDismissed,
@@ -324,7 +325,12 @@ export function AddinFileSourceSelector({
                           </div>
                         </div>
                         <span className="shrink-0 text-xs text-theme-fg-muted">
-                          {formatFileSize(emailBodyFile.size)}
+                          {isThreadEmlStale
+                            ? t({
+                                id: "officeAddin.fileSource.updatingThread",
+                                message: "Updating…",
+                              })
+                            : formatFileSize(emailBodyFile.size)}
                         </span>
                       </button>
                     );

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -140,7 +140,7 @@ msgstr "(kein Betreff)"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.unknownSender"
-msgstr ""
+msgstr "Unbekannter Absender"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
@@ -577,8 +577,8 @@ msgstr "und laden Sie die heruntergeladene Datei dort hoch."
 # ==============================
 #: src/components/AddinChatInput.tsx
 msgid "{messageCount} messages"
-msgstr ""
+msgstr "{messageCount} Nachrichten"
 
 #: src/components/AddinChatInput.tsx
 msgid "1 message"
-msgstr ""
+msgstr "1 Nachricht"

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -258,6 +258,11 @@ msgid "officeAddin.fileSource.show"
 msgstr "Anzeigen"
 
 #. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.updatingThread"
+msgstr "Wird aktualisiert…"
+
+#. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Einstellungen"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -258,6 +258,11 @@ msgid "officeAddin.fileSource.show"
 msgstr "Show"
 
 #. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.updatingThread"
+msgstr "Updating…"
+
+#. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Settings"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -258,6 +258,11 @@ msgid "officeAddin.fileSource.show"
 msgstr "Mostrar"
 
 #. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.updatingThread"
+msgstr "Actualizando…"
+
+#. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Configuración"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -140,7 +140,7 @@ msgstr "(sin asunto)"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.unknownSender"
-msgstr ""
+msgstr "Remitente desconocido"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
@@ -577,8 +577,8 @@ msgstr "y cargue allí el archivo descargado."
 # ==============================
 #: src/components/AddinChatInput.tsx
 msgid "{messageCount} messages"
-msgstr ""
+msgstr "{messageCount} mensajes"
 
 #: src/components/AddinChatInput.tsx
 msgid "1 message"
-msgstr ""
+msgstr "1 mensaje"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -258,6 +258,11 @@ msgid "officeAddin.fileSource.show"
 msgstr "Afficher"
 
 #. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.updatingThread"
+msgstr "Mise à jour…"
+
+#. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Paramètres"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -140,7 +140,7 @@ msgstr "(sans objet)"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.unknownSender"
-msgstr ""
+msgstr "Expéditeur inconnu"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
@@ -577,8 +577,8 @@ msgstr "et téléversez-y le fichier téléchargé."
 # ==============================
 #: src/components/AddinChatInput.tsx
 msgid "{messageCount} messages"
-msgstr ""
+msgstr "{messageCount} messages"
 
 #: src/components/AddinChatInput.tsx
 msgid "1 message"
-msgstr ""
+msgstr "1 message"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -140,7 +140,7 @@ msgstr "(brak tematu)"
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.unknownSender"
-msgstr ""
+msgstr "Nieznany nadawca"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChatInput.tsx
@@ -577,8 +577,8 @@ msgstr "i prześlij tam pobrany plik."
 # ==============================
 #: src/components/AddinChatInput.tsx
 msgid "{messageCount} messages"
-msgstr ""
+msgstr "{messageCount} wiadomości"
 
 #: src/components/AddinChatInput.tsx
 msgid "1 message"
-msgstr ""
+msgstr "1 wiadomość"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -258,6 +258,11 @@ msgid "officeAddin.fileSource.show"
 msgstr "Pokaż"
 
 #. js-lingui-explicit-id
+#: src/components/AddinFileSourceSelector.tsx
+msgid "officeAddin.fileSource.updatingThread"
+msgstr "Aktualizowanie…"
+
+#. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Ustawienia"

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -11,7 +12,7 @@ import {
 import { useMsalNaa } from "./MsalNaaProvider";
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { useCurrentThread } from "../hooks/useCurrentThread";
-import { buildThreadSynthInputs } from "../utils/buildThreadSynthInputs";
+import { buildThreadEmlFile } from "../utils/buildThreadEmlFile";
 import { fetchParentMessageInConversationViaGraph } from "../utils/fetchOutlookMessageGraph";
 import {
   dismissAttachment as applyDismissAttachment,
@@ -19,7 +20,6 @@ import {
   restoreAttachment as applyRestoreAttachment,
   restoreBody as applyRestoreBody,
 } from "../utils/stagedEmailDismissals";
-import { synthesizeThreadEml } from "../utils/synthesizeThreadEml";
 import { trimEmlAttachments } from "../utils/trimEmlAttachments";
 
 import type { ParentMessageMetadata } from "../utils/fetchOutlookMessageGraph";
@@ -34,17 +34,6 @@ const GRAPH_MAIL_SCOPES = ["Mail.Read"];
 
 function generateDroppedKey(): string {
   return `drop-${globalThis.crypto.randomUUID()}`;
-}
-
-/**
- * UTF-8 byte length of whichever body wins (HTML preferred, text fallback).
- * Used to seed the token-estimator placeholder. Cheap text-encoding, no
- * base64 expansion — attachment bytes are added separately by the caller.
- */
-function textByteLength(text: string | null, html: string | null): number {
-  const winning = html ?? text;
-  if (!winning) return 0;
-  return new TextEncoder().encode(winning).length;
 }
 
 function collectDismissedIndices(
@@ -120,6 +109,14 @@ interface OutlookEmailSourceContextValue {
   emailSubject: string;
   isEmailBodyIncluded: boolean;
   emailBodyFile: File | null;
+  /**
+   * True while the synthesized thread `.eml` (and therefore `emailBodyFile`'s
+   * size / token estimate) is being recomputed after a dismissal toggle. The
+   * checkbox state has already updated; this only signals that the derived
+   * file is catching up. Lets the UI show an "Updating…" hint on large threads
+   * instead of appearing frozen.
+   */
+  isThreadEmlStale: boolean;
   isLoadingEmailBody: boolean;
   /**
    * True when the open conversation failed to load entirely (Graph fetch
@@ -153,6 +150,7 @@ const defaultValue: OutlookEmailSourceContextValue = {
   emailSubject: "",
   isEmailBodyIncluded: false,
   emailBodyFile: null,
+  isThreadEmlStale: false,
   isLoadingEmailBody: false,
   emailThreadLoadError: false,
   currentThread: null,
@@ -319,33 +317,46 @@ export function OutlookEmailSourceProvider({
     );
   }, [currentThread, threadStaged]);
 
-  // Approximate size of the synthesised thread .eml without paying the
-  // base64 cost. Used to give the chat-input's token estimator a non-zero
-  // signal via `emailBodyFile.size` — the real synthesis only runs at send
-  // time inside `resolveSelectedFilesForSend`, so checkbox toggles don't
-  // re-encode tens of MB of attachment bytes.
-  const threadPreviewFile = useMemo<File | null>(() => {
+  // Everything `buildThreadEmlFile` needs, bundled into one object so the
+  // thread and its dismissal state always travel together (never a new thread
+  // paired with stale dismissals). New identity whenever the conversation or a
+  // checkbox changes; null in compose mode / before a thread loads.
+  const threadSynthInput = useMemo(() => {
     if (!currentThread || !threadStaged) return null;
-    if (includedThreadMessages.length === 0) return null;
-    let estimatedBytes = 1024; // outer headers + boundaries fixed overhead
-    for (const message of includedThreadMessages) {
-      estimatedBytes += 512; // per-message header block
-      estimatedBytes += textByteLength(message.bodyText, message.bodyHtml);
-      for (const attachment of message.attachments) {
-        if (attachment.isInline) continue;
-        if (threadStaged.dismissedAttachmentIds.has(attachment.id)) continue;
-        // base64 expands content by ~4/3 and adds ~2 bytes per 76-char line.
-        estimatedBytes += Math.ceil(attachment.size * 1.37);
-      }
-    }
-    // The preview File only needs the right `.size`; its bytes are never
-    // read (consumers use it for token estimation). Allocate a zero-filled
-    // placeholder of the right length — far cheaper than base64-encoding
-    // the real attachments on every keystroke.
-    return new File([new Uint8Array(estimatedBytes)], "thread-preview.eml", {
-      type: "message/rfc822",
-    });
+    return {
+      thread: currentThread,
+      includedMessages: includedThreadMessages,
+      dismissedAttachmentIds: threadStaged.dismissedAttachmentIds,
+    };
   }, [currentThread, includedThreadMessages, threadStaged]);
+
+  // The full base64 synthesis is genuinely expensive on large threads (tens of
+  // MB of attachments → a ~1-2s synchronous encode). Running it directly in a
+  // render-phase useMemo would freeze the checkbox the user just clicked. So we
+  // synthesize from a DEFERRED copy of the input: the urgent render (checkbox
+  // tick, body-dismiss state) commits instantly, and React reruns the heavy
+  // memo against the latest input in a follow-up, non-blocking pass.
+  //
+  // `threadEmlFile` is still the single source of truth — the exact bytes we
+  // upload — reused for BOTH the token estimate (as a virtual file) and the
+  // actual send, so the estimate measures byte-for-byte what is sent. It only
+  // lags the live selection by the deferred pass; see `isThreadEmlStale`.
+  // Null when every message is dismissed.
+  const deferredSynthInput = useDeferredValue(threadSynthInput);
+  const threadEmlFile = useMemo<File | null>(() => {
+    if (!deferredSynthInput) return null;
+    return buildThreadEmlFile(
+      deferredSynthInput.thread,
+      deferredSynthInput.includedMessages,
+      deferredSynthInput.dismissedAttachmentIds,
+    );
+  }, [deferredSynthInput]);
+
+  // True while the deferred synthesis is catching up to the latest toggle: the
+  // urgent UI has committed but `threadEmlFile` still reflects the previous
+  // input. Drives an "Updating…" hint so a large-thread re-encode reads as
+  // "recalculating", not a frozen click.
+  const isThreadEmlStale = threadSynthInput !== deferredSynthInput;
 
   const currentStagedDrop = stagedEmails.find(
     (staged): staged is Extract<StagedEmail, { source: "drop" }> =>
@@ -355,7 +366,7 @@ export function OutlookEmailSourceProvider({
     ? includedThreadMessages.length === 0
     : (currentStagedDrop?.bodyDismissed ?? false);
   const emailBodyFile = currentThread
-    ? threadPreviewFile
+    ? threadEmlFile
     : (currentStagedDrop?.parsed.rawEmlFile ?? null);
   const isEmailBodyIncluded = !!emailBodyFile && !isEmailBodyDismissed;
 
@@ -468,26 +479,13 @@ export function OutlookEmailSourceProvider({
   const resolveSelectedFilesForSend = useCallback(async (): Promise<File[]> => {
     const filesToSend: File[] = [];
 
-    // Thread upload: one synthesized .eml carrying every non-dismissed
-    // message + their non-dismissed attachments. The structure preserves
-    // version provenance — three files named "Lastenheft.pdf" land as
-    // attachments inside three different nested message/rfc822 parts.
-    //
-    // We synthesize lazily here (not in a useMemo) so checkbox toggles in
-    // the staged-preview UI don't re-base64-encode every kept attachment
-    // on every click. The cost is paid once, at send time.
-    if (currentThread && threadStaged && includedThreadMessages.length > 0) {
-      const synthInputs = buildThreadSynthInputs(
-        includedThreadMessages,
-        threadStaged.dismissedAttachmentIds,
-        currentThread.incomplete,
-      );
-      filesToSend.push(
-        synthesizeThreadEml({
-          subject: currentThread.subject,
-          messages: synthInputs,
-        }),
-      );
+    // Thread upload: reuse the exact File already built for the estimate, so
+    // what we upload is byte-identical to what the token estimate measured.
+    // It carries every non-dismissed message + their non-dismissed attachments
+    // as nested message/rfc822 parts, preserving version provenance — three
+    // files named "Lastenheft.pdf" land inside three different nested parts.
+    if (threadEmlFile) {
+      filesToSend.push(threadEmlFile);
     }
 
     // Drop uploads: keep the existing per-drop trim path. Each drop is
@@ -546,10 +544,9 @@ export function OutlookEmailSourceProvider({
     currentThread,
     dismissedAttachmentIds,
     getAttachmentFile,
-    includedThreadMessages,
     selectableAttachments,
     stagedEmails,
-    threadStaged,
+    threadEmlFile,
   ]);
 
   const value = useMemo<OutlookEmailSourceContextValue>(
@@ -557,6 +554,7 @@ export function OutlookEmailSourceProvider({
       emailSubject: mailItem?.subject ?? "",
       isEmailBodyIncluded,
       emailBodyFile,
+      isThreadEmlStale,
       isLoadingEmailBody,
       emailThreadLoadError,
       currentThread,
@@ -590,6 +588,7 @@ export function OutlookEmailSourceProvider({
       dismissStagedEmailBody,
       dismissedAttachmentIds,
       emailBodyFile,
+      isThreadEmlStale,
       isEmailBodyDismissed,
       emailThreadLoadError,
       isEmailBodyIncluded,

--- a/office-addin/src/providers/__tests__/OutlookEmailSourceProvider.test.tsx
+++ b/office-addin/src/providers/__tests__/OutlookEmailSourceProvider.test.tsx
@@ -1,0 +1,198 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { parseEmlBytes } from "../../utils/parsedEmail";
+import {
+  OutlookEmailSourceProvider,
+  useOutlookEmailSource,
+} from "../OutlookEmailSourceProvider";
+
+import type { ParsedThread, ThreadMessage } from "../../utils/parsedThread";
+
+// The provider only needs these three hooks; mocking them keeps the test off
+// Office.js / MSAL / Graph and lets us inject a fixed thread.
+const mockUseCurrentThread = vi.fn();
+const mockUseOutlookMailItem = vi.fn();
+
+vi.mock("../MsalNaaProvider", () => ({
+  useMsalNaa: () => ({ acquireToken: vi.fn() }),
+}));
+
+vi.mock("../OutlookMailItemProvider", () => ({
+  useOutlookMailItem: () => mockUseOutlookMailItem(),
+}));
+
+vi.mock("../../hooks/useCurrentThread", () => ({
+  useCurrentThread: () => mockUseCurrentThread(),
+}));
+
+function makeMessage(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: "<m@x>",
+    internetMessageId: "<m@x>",
+    subject: "Project kickoff",
+    from: { name: "Sender", address: "sender@x" },
+    to: [],
+    cc: [],
+    date: "2026-03-01T10:00:00Z",
+    bodyText: "body",
+    bodyHtml: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function makeThread(): ParsedThread {
+  return {
+    conversationId: "conv-1",
+    subject: "Project kickoff",
+    messages: [
+      makeMessage({ id: "<m1@x>", bodyText: "Let's start Monday." }),
+      makeMessage({
+        id: "<m2@x>",
+        from: { name: "Anna", address: "anna@x" },
+        bodyText: "I'll prepare the deck.",
+        attachments: [
+          {
+            id: "<m2@x>:a1",
+            filename: "Deck.pdf",
+            mimeType: "application/pdf",
+            size: 700,
+            contentBytes: new Uint8Array(700).fill(0xab).buffer,
+            isInline: false,
+            contentId: null,
+            unavailableReason: null,
+          },
+        ],
+      }),
+    ],
+    incomplete: false,
+  };
+}
+
+type ContextValue = ReturnType<typeof useOutlookEmailSource>;
+
+let captured: ContextValue | null = null;
+
+function Capture() {
+  captured = useOutlookEmailSource();
+  return null;
+}
+
+function renderProvider() {
+  captured = null;
+  render(
+    <OutlookEmailSourceProvider>
+      <Capture />
+    </OutlookEmailSourceProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("OutlookEmailSourceProvider — current-thread emailBodyFile", () => {
+  function primeReadModeThread() {
+    mockUseOutlookMailItem.mockReturnValue({
+      itemIdentity: "id-1",
+      // itemId set => read mode => the compose reply-context effect early-returns.
+      mailItem: {
+        itemId: "item-1",
+        conversationId: "conv-1",
+        internetMessageId: "<m2@x>",
+        subject: "Project kickoff",
+        isComposeMode: false,
+      },
+      attachments: [],
+      isLoadingAttachments: false,
+      getAttachmentFile: vi.fn(),
+    });
+    mockUseCurrentThread.mockReturnValue({
+      thread: makeThread(),
+      isLoading: false,
+      error: false,
+    });
+  }
+
+  it("exposes the real synthesized .eml as emailBodyFile (real bytes, not a zero-filled placeholder)", async () => {
+    primeReadModeThread();
+    renderProvider();
+
+    const file = captured!.emailBodyFile;
+    expect(file).not.toBeNull();
+    expect(captured!.isEmailBodyIncluded).toBe(true);
+
+    const bytes = new Uint8Array(await file!.arrayBuffer());
+    expect(bytes.some((byte) => byte !== 0)).toBe(true);
+
+    const parsed = await parseEmlBytes(bytes.buffer);
+    expect(parsed).not.toBeNull();
+  });
+
+  it("sends the exact same File it estimated — emailBodyFile IS the file resolveSelectedFilesForSend returns", async () => {
+    primeReadModeThread();
+    renderProvider();
+
+    const estimateFile = captured!.emailBodyFile;
+    expect(estimateFile).not.toBeNull();
+
+    let sent: File[] = [];
+    await act(async () => {
+      sent = await captured!.resolveSelectedFilesForSend();
+    });
+
+    // The invariant the whole refactor exists for: the token estimate measures
+    // byte-for-byte what is uploaded. They are not just equal — they are the
+    // same File instance, so they cannot drift.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toBe(estimateFile);
+  });
+
+  it("keeps the estimate=send identity after a dismissal toggle settles (deferred synthesis)", async () => {
+    primeReadModeThread();
+    renderProvider();
+
+    // Dismiss one of two messages. This re-runs the (deferred) synthesis; once
+    // act() flushes the deferred pass the file is settled, not stale.
+    act(() => {
+      captured!.dismissStagedEmailBody("<m1@x>");
+    });
+
+    expect(captured!.isThreadEmlStale).toBe(false);
+    const estimateFile = captured!.emailBodyFile;
+    expect(estimateFile).not.toBeNull();
+
+    let sent: File[] = [];
+    await act(async () => {
+      sent = await captured!.resolveSelectedFilesForSend();
+    });
+
+    // The deferred recompute does not break the invariant: what we upload is
+    // still the very File instance the estimate measured.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toBe(estimateFile);
+  });
+
+  it("yields no emailBodyFile (and sends nothing) once every message is dismissed", async () => {
+    primeReadModeThread();
+    renderProvider();
+
+    const messageIds = captured!.currentThread!.messages.map(
+      (message) => message.id,
+    );
+    act(() => {
+      messageIds.forEach((id) => captured!.dismissStagedEmailBody(id));
+    });
+
+    expect(captured!.emailBodyFile).toBeNull();
+    expect(captured!.isEmailBodyIncluded).toBe(false);
+
+    let sent: File[] = [];
+    await act(async () => {
+      sent = await captured!.resolveSelectedFilesForSend();
+    });
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/office-addin/src/utils/__tests__/buildThreadEmlFile.test.ts
+++ b/office-addin/src/utils/__tests__/buildThreadEmlFile.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { buildThreadEmlFile } from "../buildThreadEmlFile";
+import { parseEmlBytes } from "../parsedEmail";
+
+import type {
+  ParsedThread,
+  ThreadAttachment,
+  ThreadMessage,
+} from "../parsedThread";
+
+function makeAttachment(
+  overrides: Partial<ThreadAttachment> = {},
+): ThreadAttachment {
+  return {
+    id: "att",
+    filename: "file.bin",
+    mimeType: "application/octet-stream",
+    size: 0,
+    contentBytes: null,
+    isInline: false,
+    contentId: null,
+    unavailableReason: null,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: "<m@x>",
+    internetMessageId: "<m@x>",
+    subject: "Subject",
+    from: { name: "Sender", address: "sender@x" },
+    to: [],
+    cc: [],
+    date: "2026-03-01T10:00:00Z",
+    bodyText: "body",
+    bodyHtml: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function makeThread(
+  messages: ThreadMessage[],
+  overrides: Partial<ParsedThread> = {},
+): ParsedThread {
+  return {
+    conversationId: "conv-1",
+    subject: "Project kickoff",
+    messages,
+    incomplete: false,
+    ...overrides,
+  };
+}
+
+const NO_DISMISSALS = new Set<string>();
+
+describe("buildThreadEmlFile", () => {
+  it("produces a real .eml whose bytes are the actual content (not a zero-filled placeholder)", async () => {
+    const messages = [
+      makeMessage({
+        id: "<m1@x>",
+        subject: "Project kickoff",
+        bodyText: "Let's get started on Monday.",
+      }),
+      makeMessage({
+        id: "<m2@x>",
+        from: { name: "Anna", address: "anna@x" },
+        bodyText: "Sounds good, I'll prepare the deck.",
+        attachments: [
+          makeAttachment({
+            id: "<m2@x>:a1",
+            filename: "Deck.pdf",
+            mimeType: "application/pdf",
+            contentBytes: new Uint8Array(700).fill(0xab).buffer,
+            size: 700,
+          }),
+        ],
+      }),
+    ];
+
+    const file = buildThreadEmlFile(
+      makeThread(messages),
+      messages,
+      NO_DISMISSALS,
+    );
+
+    expect(file).not.toBeNull();
+    const buffer = await file!.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+
+    // Regression guard: the old preview File was `new Uint8Array(size)` — all
+    // zeroes. Real synthesized bytes must carry the MIME scaffolding and the
+    // message content, so they are emphatically not all-zero.
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    expect(bytes.some((byte) => byte !== 0)).toBe(true);
+
+    const text = new TextDecoder().decode(bytes);
+    expect(text).toContain("Content-Type: multipart/mixed");
+    expect(text).toContain("message/rfc822");
+    // Both message bodies are present (base64-encoded bodies decode below via
+    // a full parse, but the envelope subject is ASCII in the header block).
+    expect(file!.type).toBe("message/rfc822");
+  });
+
+  it("round-trips through parseEmlBytes and preserves the nested messages as attachments", async () => {
+    const messages = [
+      makeMessage({ id: "<m1@x>", bodyText: "first" }),
+      makeMessage({ id: "<m2@x>", bodyText: "second" }),
+    ];
+
+    const file = buildThreadEmlFile(
+      makeThread(messages),
+      messages,
+      NO_DISMISSALS,
+    );
+
+    const parsed = await parseEmlBytes(await file!.arrayBuffer());
+    expect(parsed).not.toBeNull();
+    // Each thread member is wrapped as a nested message/rfc822 part, so the
+    // outer envelope exposes one attachment per included message.
+    expect(parsed!.attachments.length).toBe(2);
+  });
+
+  it("excludes attachments whose ids are in dismissedAttachmentIds", async () => {
+    const messages = [
+      makeMessage({
+        id: "<m1@x>",
+        attachments: [
+          makeAttachment({
+            id: "<m1@x>:keep",
+            filename: "Keep.pdf",
+            mimeType: "application/pdf",
+            contentBytes: new Uint8Array(600).fill(0x01).buffer,
+            size: 600,
+          }),
+          makeAttachment({
+            id: "<m1@x>:drop",
+            filename: "Drop.pdf",
+            mimeType: "application/pdf",
+            contentBytes: new Uint8Array(600).fill(0x02).buffer,
+            size: 600,
+          }),
+        ],
+      }),
+    ];
+
+    const file = buildThreadEmlFile(
+      makeThread(messages),
+      messages,
+      new Set(["<m1@x>:drop"]),
+    );
+
+    const text = new TextDecoder().decode(await file!.arrayBuffer());
+    // ASCII filenames are emitted literally in the MIME headers, so a kept
+    // attachment is named in the output and a dismissed one is absent entirely
+    // (no part, no provenance marker — it is skipped before any disclosure).
+    expect(text).toContain("Keep.pdf");
+    expect(text).not.toContain("Drop.pdf");
+  });
+
+  it("propagates thread.incomplete by appending the partial-conversation note", async () => {
+    const messages = [makeMessage({ id: "<m1@x>" })];
+
+    const complete = buildThreadEmlFile(
+      makeThread(messages, { incomplete: false }),
+      messages,
+      NO_DISMISSALS,
+    );
+    const incomplete = buildThreadEmlFile(
+      makeThread(messages, { incomplete: true }),
+      messages,
+      NO_DISMISSALS,
+    );
+
+    const completeText = new TextDecoder().decode(
+      await complete!.arrayBuffer(),
+    );
+    const incompleteText = new TextDecoder().decode(
+      await incomplete!.arrayBuffer(),
+    );
+    // The synthetic note carries the ASCII subject "[Partial conversation]",
+    // emitted literally in the nested message's header block.
+    expect(completeText).not.toContain("[Partial conversation]");
+    expect(incompleteText).toContain("[Partial conversation]");
+  });
+
+  it("returns null when every message is dismissed (nothing to send)", () => {
+    const messages = [makeMessage({ id: "<m1@x>" })];
+    const file = buildThreadEmlFile(makeThread(messages), [], NO_DISMISSALS);
+    expect(file).toBeNull();
+  });
+});

--- a/office-addin/src/utils/buildThreadEmlFile.ts
+++ b/office-addin/src/utils/buildThreadEmlFile.ts
@@ -1,0 +1,44 @@
+/**
+ * Build the single `.eml` File for the current Outlook conversation thread —
+ * the *actual* bytes that will be uploaded on send.
+ *
+ * This is the one source of truth for "the current-thread email file". The
+ * provider memoizes the result and hands the SAME File to both the token
+ * estimator (as a virtual file) and the upload/send path, so the estimate
+ * measures exactly what is sent — no size-proxy placeholder, no divergence.
+ *
+ * Returns `null` when no message is included (every message dismissed), which
+ * the caller treats as "no email body to send".
+ *
+ * Pure and synchronous (composes `buildThreadSynthInputs` + `synthesizeThreadEml`,
+ * both synchronous), so it is safe to call inside a `useMemo`.
+ *
+ * Not byte-deterministic across calls: `synthesizeThreadEml` draws random MIME
+ * boundaries, so the same thread synthesized twice yields different bytes. This
+ * is fine for the estimate=send invariant (the provider memoizes one File and
+ * hands that exact instance to both paths), but it means there is no stable
+ * content hash for the thread — any cross-session dedup/cache keyed on the eml
+ * bytes will not hit.
+ */
+
+import { buildThreadSynthInputs } from "./buildThreadSynthInputs";
+import { synthesizeThreadEml } from "./synthesizeThreadEml";
+
+import type { ParsedThread, ThreadMessage } from "./parsedThread";
+
+export function buildThreadEmlFile(
+  thread: ParsedThread,
+  includedMessages: ThreadMessage[],
+  dismissedAttachmentIds: ReadonlySet<string>,
+): File | null {
+  if (includedMessages.length === 0) return null;
+  const messages = buildThreadSynthInputs(
+    includedMessages,
+    dismissedAttachmentIds,
+    thread.incomplete,
+  );
+  return synthesizeThreadEml({
+    subject: thread.subject,
+    messages,
+  });
+}


### PR DESCRIPTION
This pull request refactors how the synthesized Outlook email thread file (`.eml`) is generated, estimated, and sent. The main improvement is that the actual file used for both the token estimate and the upload is now the same, ensuring byte-for-byte consistency and improving UI responsiveness for large threads. Additionally, the UI now displays an "Updating…" hint when the thread file is being re-synthesized after a dismissal toggle, and comprehensive tests have been added to verify these behaviors.

Key changes include:

**Core logic and performance improvements:**

* Refactored the thread `.eml` file synthesis in `OutlookEmailSourceProvider` to use a deferred value, ensuring the file used for token estimation is exactly the one sent, and improving UI responsiveness by avoiding expensive synchronous recomputation on every checkbox toggle. The previous placeholder/estimate logic was replaced with a real, deferred file synthesis. (`[[1]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL14-L22)`, `[[2]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL322-R360)`, `[[3]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL358-R369)`, `[[4]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL471-R488)`)
* Introduced the `isThreadEmlStale` flag in the context, which indicates when the `.eml` file is being recomputed, allowing the UI to show an "Updating…" hint instead of appearing frozen during large thread recalculations. (`[[1]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR112-R119)`, `[[2]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR153)`, `[[3]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbL549-R557)`, `[[4]](diffhunk://#diff-ab419681d0a6bb8a0c94e1dfd5c2c05db6d4b344bae806edb054700d627208dbR591)`, `[[5]](diffhunk://#diff-df4169a4dde484e468f66329e5aa51f440646dd831a3f54f960435b6f401979aR51)`, `[[6]](diffhunk://#diff-df4169a4dde484e468f66329e5aa51f440646dd831a3f54f960435b6f401979aL327-R333)`)

**UI and internationalization:**

* Updated the UI in `AddinFileSourceSelector` to display a localized "Updating…" message when the thread file is stale, and added the corresponding translation key to all supported locales. (`[[1]](diffhunk://#diff-df4169a4dde484e468f66329e5aa51f440646dd831a3f54f960435b6f401979aL327-R333)`, `[[2]](diffhunk://#diff-4a032116cff86004ecc9a4c8dfb43a7c0ec7de42c7697c16a5cd9275970595d1R260-R264)`, `[[3]](diffhunk://#diff-290f116db4b11b05e1cf7ee6a0c331eeb4996466878c424a4188231f711cb6ceR260-R264)`, `[[4]](diffhunk://#diff-963763776cf9d7386b6ecaa9d41f1981e9b798b116e3bb6bcdf9dff45f98350dR260-R264)`, `[[5]](diffhunk://#diff-2360e1b1a65353e053fefeadf4888bf87b8cc86662aab8fbacd63cc9bd80c451R260-R264)`)

**Testing:**

* Added a comprehensive test suite for `OutlookEmailSourceProvider` to verify that the estimated and sent files are identical, that deferred synthesis works correctly after dismissals, and that nothing is sent when all messages are dismissed. (`[office-addin/src/providers/__tests__/OutlookEmailSourceProvider.test.tsxR1-R198](diffhunk://#diff-06039ed50b586547afd3cbc57c42ee17b6818c889d427923506751ed5652f9c8R1-R198)`)

These changes ensure a more accurate and performant experience when working with Outlook email threads, especially for large conversations with many attachments.Synthesize the thread .eml from a useDeferredValue copy of its inputs so a dismissal toggle commits instantly instead of blocking on the base64 encode. Surfaces isThreadEmlStale and an 'Updating…' hint while the file catches up. Adds buildThreadEmlFile util and tests for dismissal exclusion, incomplete propagation, and the estimate=send identity across the deferred path.