### PR TITLE
Fix .eml token-estimate bloat from unstripped HTML/CSS

### DIFF
--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -2583,19 +2583,11 @@ pub(super) fn effective_upload_content_type(
 ) -> Option<String> {
     let provided_content_type = provided_content_type.map(content_type_essence);
 
-    let needs_eml_override = is_eml_filename(filename)
-        && match provided_content_type {
-            None => true,
-            Some(content_type) => {
-                content_type.eq_ignore_ascii_case("application/octet-stream")
-                    || content_type
-                        .split('/')
-                        .next()
-                        .is_some_and(|type_| type_.eq_ignore_ascii_case("text"))
-            }
-        };
-
-    if needs_eml_override {
+    // The `.eml` extension is authoritative: an `.eml` is always an RFC822 message, so force
+    // `message/rfc822` regardless of the provided type. A client that sends the file's own inner
+    // header (`multipart/alternative`/`multipart/mixed`) would otherwise have it preserved, and
+    // kreuzberg cannot parse those — the raw content then gets counted, inflating the estimate.
+    if is_eml_filename(filename) {
         return Some("message/rfc822".to_string());
     }
 
@@ -3043,9 +3035,24 @@ mod tests {
     }
 
     #[test]
-    fn effective_upload_content_type_preserves_specific_multipart_type() {
+    fn effective_upload_content_type_preserves_message_rfc822() {
         assert_eq!(
             effective_upload_content_type("message.eml", Some("message/rfc822")),
+            Some("message/rfc822".to_string())
+        );
+    }
+
+    #[test]
+    fn effective_upload_content_type_forces_eml_with_multipart_type() {
+        // Regression: a client sending the `.eml`'s own inner header must not bypass the override.
+        // kreuzberg errors on `multipart/*`, so the raw bytes used to be counted (~600k tokens for
+        // a newsletter whose real content is ~6k).
+        assert_eq!(
+            effective_upload_content_type("message.eml", Some("multipart/alternative")),
+            Some("message/rfc822".to_string())
+        );
+        assert_eq!(
+            effective_upload_content_type("thread.eml", Some("multipart/mixed; boundary=abc")),
             Some("message/rfc822".to_string())
         );
     }

--- a/backend/erato/src/services/file_processing_cached.rs
+++ b/backend/erato/src/services/file_processing_cached.rs
@@ -60,23 +60,14 @@ fn content_type_essence(content_type: &str) -> &str {
         .trim()
 }
 
-fn is_generic_or_text_mime_type(mime_type: Option<&str>) -> bool {
-    match mime_type {
-        None => true,
-        Some(mime_type) => {
-            mime_type.eq_ignore_ascii_case("application/octet-stream")
-                || mime_type
-                    .split('/')
-                    .next()
-                    .is_some_and(|type_| type_.eq_ignore_ascii_case("text"))
-        }
-    }
-}
-
 fn effective_text_mime_type(filename: &str, storage_mime_type: Option<&str>) -> Option<String> {
     let storage_mime_type = storage_mime_type.map(content_type_essence);
 
-    if is_eml_file(filename) && is_generic_or_text_mime_type(storage_mime_type) {
+    // The `.eml` extension is authoritative: an `.eml` is always an RFC822 message, so force
+    // `message/rfc822` regardless of the stored type. Trusting the stored type breaks extraction
+    // when it is the file's own inner header (`multipart/alternative`/`multipart/mixed`), which
+    // kreuzberg cannot parse and which fell through to a raw, hugely-inflated token count.
+    if is_eml_file(filename) {
         return Some("message/rfc822".to_string());
     }
 
@@ -637,6 +628,22 @@ mod tests {
     fn effective_text_mime_type_treats_eml_text_html_as_email() {
         assert_eq!(
             effective_text_mime_type("message.eml", Some("text/html")).as_deref(),
+            Some("message/rfc822")
+        );
+    }
+
+    #[test]
+    fn effective_text_mime_type_forces_eml_with_multipart_storage_type() {
+        // Regression: a real `.eml` is often persisted under its own inner header
+        // (`multipart/alternative`/`multipart/mixed`). kreuzberg cannot parse those and the raw
+        // content used to be counted, inflating a ~6k-token newsletter to hundreds of thousands.
+        assert_eq!(
+            effective_text_mime_type("digest.eml", Some("multipart/alternative")).as_deref(),
+            Some("message/rfc822")
+        );
+        assert_eq!(
+            effective_text_mime_type("thread.eml", Some("multipart/mixed; boundary=abc"))
+                .as_deref(),
             Some("message/rfc822")
         );
     }

--- a/backend/erato/src/services/file_processor.rs
+++ b/backend/erato/src/services/file_processor.rs
@@ -317,6 +317,171 @@ fn extract_email_plain_text(file_bytes: &[u8]) -> Option<String> {
     }
 }
 
+/// A byte that legitimately follows an HTML tag name (so `<style` is a `<style>` open tag and not
+/// the start of a custom element like `<styled-list>`).
+fn is_tag_name_boundary(byte: Option<u8>) -> bool {
+    matches!(
+        byte,
+        None | Some(b' ' | b'\t' | b'\r' | b'\n' | b'>' | b'/')
+    )
+}
+
+/// Find the next `tag` (e.g. `"<style"`) at or after `from` whose tag name actually ends there —
+/// i.e. the following byte is a tag-name boundary. Avoids matching `<styled-...>`/`<scripture>`.
+fn find_tag_open(lower: &str, from: usize, tag: &str) -> Option<usize> {
+    let bytes = lower.as_bytes();
+    let mut search = from;
+    while let Some(rel) = lower[search..].find(tag) {
+        let start = search + rel;
+        if is_tag_name_boundary(bytes.get(start + tag.len()).copied()) {
+            return Some(start);
+        }
+        search = start + tag.len();
+    }
+    None
+}
+
+/// Remove `<style>`/`<script>` blocks and HTML comments (which may wrap MSO CSS) from an HTML
+/// fragment. kreuzberg's email extractor renders `<style>` block *contents* as text (it drops
+/// inline `style=` attributes but keeps style blocks), so a CSS-heavy newsletter leaks tens of
+/// thousands of tokens of CSS. Stripping these blocks removes the leak without touching real text.
+fn strip_html_style_and_script(html: &str) -> String {
+    // `to_ascii_lowercase` preserves byte length and only changes ASCII bytes, so byte offsets
+    // found in `lower` map onto valid char boundaries in `html` (the markers are all ASCII).
+    let lower = html.to_ascii_lowercase();
+    let mut out = String::with_capacity(html.len());
+    let mut pos = 0;
+
+    while pos < html.len() {
+        let next = [
+            find_tag_open(&lower, pos, "<style").map(|start| (start, "</style>")),
+            find_tag_open(&lower, pos, "<script").map(|start| (start, "</script>")),
+            lower[pos..].find("<!--").map(|rel| (pos + rel, "-->")),
+        ]
+        .into_iter()
+        .flatten()
+        .min_by_key(|(start, _)| *start);
+
+        match next {
+            None => {
+                out.push_str(&html[pos..]);
+                break;
+            }
+            Some((start, close)) => {
+                out.push_str(&html[pos..start]);
+                match lower[start..].find(close) {
+                    // Skip past the close tag. The block (CSS/JS/comment body) is dropped.
+                    Some(rel) => pos = start + rel + close.len(),
+                    // Unterminated tag: keep the original text from here so we never lose content.
+                    None => {
+                        out.push_str(&html[start..]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Base64-encode bytes as a MIME body wrapped at 76 columns with CRLF line endings.
+fn base64_mime_body(data: &[u8]) -> String {
+    let encoded = general_purpose::STANDARD.encode(data);
+    let mut out = String::with_capacity(encoded.len() + encoded.len() / 76 + 2);
+    let mut index = 0;
+    while index < encoded.len() {
+        let end = (index + 76).min(encoded.len());
+        out.push_str(&encoded[index..end]);
+        out.push_str("\r\n");
+        index = end;
+    }
+    out
+}
+
+/// Rebuild a leaf entity's header block, replacing any Content-Transfer-Encoding with `base64`
+/// (the re-emitted body is always base64-encoded for safe, encoding-agnostic transport).
+fn headers_with_base64_encoding(raw_headers: &[u8]) -> String {
+    let header_text = String::from_utf8_lossy(raw_headers);
+    let mut out = String::with_capacity(header_text.len() + 40);
+    for line in header_text.replace("\r\n", "\n").split('\n') {
+        if line.is_empty() {
+            continue;
+        }
+        let is_transfer_encoding = line.split_once(':').is_some_and(|(name, _)| {
+            name.trim()
+                .eq_ignore_ascii_case("content-transfer-encoding")
+        });
+        if is_transfer_encoding {
+            continue;
+        }
+        out.push_str(line.trim_end_matches('\r'));
+        out.push_str("\r\n");
+    }
+    out.push_str("Content-Transfer-Encoding: base64\r\n");
+    out
+}
+
+/// Walk the MIME tree and rewrite `text/html` parts with their `<style>`/`<script>` blocks removed,
+/// leaving every other part byte-identical. Returns the original bytes for non-multipart,
+/// non-HTML, or unparseable input. Nested `message/rfc822` parts are treated as opaque.
+fn sanitize_email_html_blocks(entity: &[u8]) -> Vec<u8> {
+    let (headers_raw, body) = split_mime_headers_body(entity);
+    let headers = parse_mime_headers(headers_raw);
+    let content_type = header_value(&headers, "content-type").unwrap_or("text/plain");
+    let (content_type_essence, boundary) = content_type_essence_and_param(content_type, "boundary");
+
+    if content_type_essence.starts_with("multipart/") {
+        let Some(boundary) = boundary else {
+            return entity.to_vec();
+        };
+
+        let mut rebuilt_body = Vec::new();
+        for part in split_multipart_body(body, &boundary) {
+            rebuilt_body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            let mut sanitized_part = sanitize_email_html_blocks(part);
+            if !sanitized_part.ends_with(b"\r\n") {
+                sanitized_part.extend_from_slice(b"\r\n");
+            }
+            rebuilt_body.extend_from_slice(&sanitized_part);
+        }
+        rebuilt_body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        let mut out = Vec::with_capacity(headers_raw.len() + rebuilt_body.len() + 4);
+        out.extend_from_slice(headers_raw);
+        out.extend_from_slice(b"\r\n\r\n");
+        out.extend_from_slice(&rebuilt_body);
+        return out;
+    }
+
+    if content_type_essence == "text/html" {
+        // Only rewrite UTF-8/ASCII HTML: decoding other charsets (UTF-16, Latin-1, …) through
+        // `from_utf8_lossy` would corrupt the text, so leave those parts untouched. kreuzberg still
+        // decodes them itself via the charset header; the CSS leak is overwhelmingly a UTF-8 case.
+        let (_, charset) = content_type_essence_and_param(content_type, "charset");
+        let is_utf8_or_ascii = charset.as_deref().is_none_or(|charset| {
+            matches!(
+                charset.to_ascii_lowercase().as_str(),
+                "utf-8" | "utf8" | "us-ascii" | "ascii"
+            )
+        });
+        if !is_utf8_or_ascii {
+            return entity.to_vec();
+        }
+
+        let transfer_encoding = header_value(&headers, "content-transfer-encoding");
+        let decoded = decode_mime_body(body, transfer_encoding);
+        let cleaned = strip_html_style_and_script(&String::from_utf8_lossy(&decoded));
+
+        let mut out = headers_with_base64_encoding(headers_raw).into_bytes();
+        out.extend_from_slice(b"\r\n");
+        out.extend_from_slice(base64_mime_body(cleaned.as_bytes()).as_bytes());
+        return out;
+    }
+
+    entity.to_vec()
+}
+
 fn content_already_contains_plain_text(content: &str, plain_text: &str) -> bool {
     if content.contains(plain_text.trim()) {
         return true;
@@ -448,11 +613,31 @@ impl FileProcessor for KreuzbergProcessor {
                 {
                     mime_type = kreuzberg::DOCX_MIME_TYPE.to_string();
                 }
+
+                // kreuzberg rejects bare `multipart/*` types ("Unsupported format"), but those are
+                // the inner header of an RFC822 message (a `.eml` whose Content-Type is
+                // `multipart/alternative`/`multipart/mixed`). Route them through the email
+                // extractor instead of failing and falling back to a raw, hugely-inflated count.
+                if mime_type.starts_with("multipart/") {
+                    mime_type = "message/rfc822".to_string();
+                }
                 tracing::debug!("Final decided MIME type: {:?}", &mime_type);
                 let email_plain_text = if is_message_rfc822_mime_type(&mime_type) {
                     extract_email_plain_text(&file_bytes)
                 } else {
                     None
+                };
+
+                // For emails, strip `<style>`/`<script>` blocks from HTML parts before extraction:
+                // kreuzberg renders style-block contents as text, which otherwise leaks a CSS-heavy
+                // newsletter's stylesheet into the token count. Other parts are left untouched.
+                let sanitized_email_bytes;
+                let did_sanitize = is_message_rfc822_mime_type(&mime_type);
+                let extraction_bytes: &[u8] = if did_sanitize {
+                    sanitized_email_bytes = sanitize_email_html_blocks(&file_bytes);
+                    &sanitized_email_bytes
+                } else {
+                    &file_bytes
                 };
 
                 // Configure kreuzberg for page-aware markdown extraction
@@ -469,9 +654,23 @@ impl FileProcessor for KreuzbergProcessor {
                     ..Default::default()
                 };
 
-                // Extract content using kreuzberg
-                let result = kreuzberg::extract_bytes_sync(&file_bytes, &mime_type, &config)
-                    .wrap_err("Kreuzberg extraction failed")?;
+                // Extract content using kreuzberg. If HTML sanitization rewrote the email and the
+                // rewritten bytes somehow fail to parse, fall back to the original bytes so we never
+                // regress a previously-extractable email into a silent drop (a higher token count is
+                // strictly better than losing the file).
+                let result = match kreuzberg::extract_bytes_sync(extraction_bytes, &mime_type, &config)
+                {
+                    Ok(result) => result,
+                    Err(err) if did_sanitize => {
+                        tracing::warn!(
+                            error = %err,
+                            "Email HTML sanitization produced unparseable output; retrying with original bytes"
+                        );
+                        kreuzberg::extract_bytes_sync(&file_bytes, &mime_type, &config)
+                            .wrap_err("Kreuzberg extraction failed")?
+                    }
+                    Err(err) => return Err(err).wrap_err("Kreuzberg extraction failed"),
+                };
 
                 let mut content =
                     content_with_page_markers(result.content, result.pages, &marker_format);
@@ -547,6 +746,162 @@ mod tests {
         assert!(extracted.contains(
             "could you please take a quick look at the attached draft document and let me know whether it looks fine from your side."
         ));
+    }
+
+    #[tokio::test]
+    async fn test_kreuzberg_coerces_multipart_alternative_eml_and_strips_css() {
+        // A styled newsletter is `multipart/alternative` in its own header, and its HTML body is
+        // dominated by inline `style="..."` attributes (the real case: ~600 KB of inline CSS).
+        // Clients sometimes forward that inner type verbatim; kreuzberg rejects it
+        // ("Unsupported format") and the raw CSS-heavy bytes used to be counted (~600k tokens for
+        // ~6k of real text). parse_file must coerce `multipart/*` to `message/rfc822` so the email
+        // extractor runs and drops the inline CSS.
+        let bloat_cell = "<td style=\"font-family:Helvetica;color:#ff0000;font-size:13px;\
+             line-height:18px;padding:8px;border:1px solid #cccccc;CSSSENTINEL:1\"></td>"
+            .repeat(400);
+        let raw_len_marker = bloat_cell.len();
+        let eml = format!(
+            "From: News <news@example.com>\r\n\
+             To: Recipient <recipient@example.com>\r\n\
+             Subject: Weekly digest\r\n\
+             MIME-Version: 1.0\r\n\
+             Content-Type: multipart/alternative; boundary=\"BOUND\"\r\n\
+             \r\n\
+             --BOUND\r\n\
+             Content-Type: text/plain; charset=utf-8\r\n\
+             \r\n\
+             Readable digest body marker.\r\n\
+             --BOUND\r\n\
+             Content-Type: text/html; charset=utf-8\r\n\
+             \r\n\
+             <html><body><p style=\"color:#ff0000;font-size:13px\">Readable digest body marker.</p>\
+             <table>{bloat_cell}</table></body></html>\r\n\
+             --BOUND--\r\n"
+        );
+
+        let processor = KreuzbergProcessor;
+        let extracted = processor
+            .parse_file(eml.into_bytes(), Some("multipart/alternative"))
+            .await
+            .expect("multipart/alternative .eml should be coerced to message/rfc822 and parse");
+
+        assert!(
+            extracted.contains("Readable digest body marker."),
+            "readable body missing from extracted content:\n{extracted}"
+        );
+        assert!(
+            !extracted.contains("CSSSENTINEL"),
+            "inline CSS leaked into extracted content:\n{extracted}"
+        );
+        assert!(
+            extracted.len() < raw_len_marker,
+            "extracted content ({} bytes) not smaller than the inline-CSS payload ({} bytes) — \
+             the email extractor did not run (raw passthrough)",
+            extracted.len(),
+            raw_len_marker
+        );
+    }
+
+    #[test]
+    fn strip_html_style_and_script_removes_blocks_but_keeps_content() {
+        let cleaned = strip_html_style_and_script(
+            "<p>keep me</p><style>.a{color:red}</style><script>alert(1)</script>\
+             <!-- comment --><p>also keep</p>",
+        );
+        assert_eq!(cleaned, "<p>keep me</p><p>also keep</p>");
+    }
+
+    #[test]
+    fn strip_html_style_and_script_preserves_custom_elements_and_unterminated_tags() {
+        // Custom elements that merely start with the tag name must not be treated as style/script.
+        assert_eq!(
+            strip_html_style_and_script("<styled-list>important</styled-list> tail"),
+            "<styled-list>important</styled-list> tail"
+        );
+        assert_eq!(
+            strip_html_style_and_script("before <scripture>verse</scripture> after"),
+            "before <scripture>verse</scripture> after"
+        );
+        // An unterminated <style> must keep the remaining text rather than dropping it.
+        assert_eq!(
+            strip_html_style_and_script("head <style>.a{color:red} no close and important tail"),
+            "head <style>.a{color:red} no close and important tail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_kreuzberg_leaves_non_utf8_html_email_untouched() {
+        // A UTF-16 HTML part must not be run through the lossy UTF-8 sanitizer (it would corrupt
+        // the text); the sanitizer should leave it for kreuzberg to decode via the charset header.
+        let mut body = Vec::new();
+        for unit in "<html><body><p>UTF16 body marker works</p></body></html>".encode_utf16() {
+            body.extend_from_slice(&unit.to_le_bytes());
+        }
+        let mut eml = b"From: a@example.com\r\nTo: b@example.com\r\nSubject: utf16\r\n\
+            MIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-16\r\n\r\n"
+            .to_vec();
+        eml.extend_from_slice(&body);
+
+        let processor = KreuzbergProcessor;
+        let extracted = processor
+            .parse_file(eml, Some("message/rfc822"))
+            .await
+            .expect("UTF-16 html email should still extract");
+        assert!(
+            extracted.contains("UTF16 body marker works"),
+            "UTF-16 content was corrupted or dropped:\n{extracted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_kreuzberg_reduces_production_scale_styled_newsletter_without_leaking() {
+        // Production-scale regression: a ~950 KB synthetic Microsoft-style weekly digest
+        // (`multipart/alternative`, quoted-printable HTML, a large `<style>` block, hundreds of
+        // inline-styled nested tables, MSO conditionals, tracking URLs). The CSS carries a
+        // `ZZCSSLEAKZZ` sentinel; the clean text/plain twin carries readable markers. Before the
+        // fix this estimated at ~628k tokens (raw passthrough) or errored; with MIME coercion alone
+        // it still leaked the `<style>` block (~27.5k tokens, 451 CSS fragments). The HTML
+        // sanitizer must drop the CSS while preserving the readable content.
+        let eml_bytes = read_test_fixture("styled_newsletter_multipart_alternative.eml");
+        let raw_len = eml_bytes.len();
+        assert!(
+            raw_len > 800_000,
+            "fixture unexpectedly small ({raw_len} bytes)"
+        );
+
+        let processor = KreuzbergProcessor;
+        // The bug case: a client forwards the `.eml`'s own inner `multipart/alternative` type.
+        let extracted = processor
+            .parse_file(eml_bytes, Some("multipart/alternative"))
+            .await
+            .expect("styled newsletter should be coerced, sanitized, and parsed");
+
+        // Readable content survives (the text/plain twin is appended when the HTML lacks it).
+        for marker in [
+            "readable item ONE",
+            "readable item TWO",
+            "readable item THREE",
+        ] {
+            assert!(
+                extracted.contains(marker),
+                "readable marker {marker:?} missing from extracted content"
+            );
+        }
+        // The CSS sentinel must not appear anywhere — no `<style>` leak.
+        assert_eq!(
+            extracted.matches("ZZCSSLEAKZZ").count(),
+            0,
+            "CSS leaked from the <style> block into extracted content"
+        );
+
+        // Token count must collapse to the real-content range, far below the pre-fix ~27.5k leak.
+        let bpe = tiktoken_rs::o200k_base().expect("o200k_base tokenizer");
+        let tokens = bpe.encode_with_special_tokens(&extracted).len();
+        assert!(
+            tokens < 15_000,
+            "expected the styled newsletter to reduce to real-content size, got {tokens} tokens \
+             ({raw_len} raw bytes)"
+        );
     }
 
     #[tokio::test]

--- a/backend/erato/tests/integration_tests/test_files/styled_newsletter_multipart_alternative.eml
+++ b/backend/erato/tests/integration_tests/test_files/styled_newsletter_multipart_alternative.eml
@@ -1,0 +1,13069 @@
+From: Microsoft 365 Message center <o365mc@synthetic.example.com>
+To: Tenant Admin <admin@contoso.example>
+Subject: Weekly digest: Microsoft service updates
+Date: Mon, 08 Jun 2026 06:00:00 +0000
+Message-ID: <synthetic-weekly-digest@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="=-SyntheticBoundary42=="
+
+--=-SyntheticBoundary42==
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Microsoft 365 service updates - synthetic sample
+
+Weekly digest readable item ONE about service retirement. Action required b=
+y the listed date.
+Weekly digest readable item TWO about new admin controls. No action require=
+d.
+Weekly digest readable item THREE about rollout timing. Rollout begins in e=
+arly stages and completes over several weeks.
+
+Update MC100000: A synthetic change notice describing a feature update numb=
+er 0 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100001: A synthetic change notice describing a feature update numb=
+er 1 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100002: A synthetic change notice describing a feature update numb=
+er 2 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100003: A synthetic change notice describing a feature update numb=
+er 3 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100004: A synthetic change notice describing a feature update numb=
+er 4 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100005: A synthetic change notice describing a feature update numb=
+er 5 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100006: A synthetic change notice describing a feature update numb=
+er 6 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100007: A synthetic change notice describing a feature update numb=
+er 7 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100008: A synthetic change notice describing a feature update numb=
+er 8 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100009: A synthetic change notice describing a feature update numb=
+er 9 that administrators may want to review for their tenant configuration =
+and end-user impact.
+Update MC100010: A synthetic change notice describing a feature update numb=
+er 10 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100011: A synthetic change notice describing a feature update numb=
+er 11 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100012: A synthetic change notice describing a feature update numb=
+er 12 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100013: A synthetic change notice describing a feature update numb=
+er 13 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100014: A synthetic change notice describing a feature update numb=
+er 14 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100015: A synthetic change notice describing a feature update numb=
+er 15 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100016: A synthetic change notice describing a feature update numb=
+er 16 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100017: A synthetic change notice describing a feature update numb=
+er 17 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100018: A synthetic change notice describing a feature update numb=
+er 18 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100019: A synthetic change notice describing a feature update numb=
+er 19 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100020: A synthetic change notice describing a feature update numb=
+er 20 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100021: A synthetic change notice describing a feature update numb=
+er 21 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100022: A synthetic change notice describing a feature update numb=
+er 22 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100023: A synthetic change notice describing a feature update numb=
+er 23 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100024: A synthetic change notice describing a feature update numb=
+er 24 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100025: A synthetic change notice describing a feature update numb=
+er 25 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100026: A synthetic change notice describing a feature update numb=
+er 26 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100027: A synthetic change notice describing a feature update numb=
+er 27 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100028: A synthetic change notice describing a feature update numb=
+er 28 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100029: A synthetic change notice describing a feature update numb=
+er 29 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100030: A synthetic change notice describing a feature update numb=
+er 30 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100031: A synthetic change notice describing a feature update numb=
+er 31 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100032: A synthetic change notice describing a feature update numb=
+er 32 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100033: A synthetic change notice describing a feature update numb=
+er 33 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100034: A synthetic change notice describing a feature update numb=
+er 34 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100035: A synthetic change notice describing a feature update numb=
+er 35 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100036: A synthetic change notice describing a feature update numb=
+er 36 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100037: A synthetic change notice describing a feature update numb=
+er 37 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100038: A synthetic change notice describing a feature update numb=
+er 38 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100039: A synthetic change notice describing a feature update numb=
+er 39 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100040: A synthetic change notice describing a feature update numb=
+er 40 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100041: A synthetic change notice describing a feature update numb=
+er 41 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100042: A synthetic change notice describing a feature update numb=
+er 42 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100043: A synthetic change notice describing a feature update numb=
+er 43 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100044: A synthetic change notice describing a feature update numb=
+er 44 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100045: A synthetic change notice describing a feature update numb=
+er 45 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100046: A synthetic change notice describing a feature update numb=
+er 46 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100047: A synthetic change notice describing a feature update numb=
+er 47 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100048: A synthetic change notice describing a feature update numb=
+er 48 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100049: A synthetic change notice describing a feature update numb=
+er 49 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100050: A synthetic change notice describing a feature update numb=
+er 50 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100051: A synthetic change notice describing a feature update numb=
+er 51 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100052: A synthetic change notice describing a feature update numb=
+er 52 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100053: A synthetic change notice describing a feature update numb=
+er 53 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100054: A synthetic change notice describing a feature update numb=
+er 54 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100055: A synthetic change notice describing a feature update numb=
+er 55 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100056: A synthetic change notice describing a feature update numb=
+er 56 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100057: A synthetic change notice describing a feature update numb=
+er 57 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100058: A synthetic change notice describing a feature update numb=
+er 58 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100059: A synthetic change notice describing a feature update numb=
+er 59 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100060: A synthetic change notice describing a feature update numb=
+er 60 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100061: A synthetic change notice describing a feature update numb=
+er 61 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100062: A synthetic change notice describing a feature update numb=
+er 62 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100063: A synthetic change notice describing a feature update numb=
+er 63 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100064: A synthetic change notice describing a feature update numb=
+er 64 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100065: A synthetic change notice describing a feature update numb=
+er 65 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100066: A synthetic change notice describing a feature update numb=
+er 66 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100067: A synthetic change notice describing a feature update numb=
+er 67 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100068: A synthetic change notice describing a feature update numb=
+er 68 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100069: A synthetic change notice describing a feature update numb=
+er 69 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100070: A synthetic change notice describing a feature update numb=
+er 70 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100071: A synthetic change notice describing a feature update numb=
+er 71 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100072: A synthetic change notice describing a feature update numb=
+er 72 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100073: A synthetic change notice describing a feature update numb=
+er 73 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100074: A synthetic change notice describing a feature update numb=
+er 74 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100075: A synthetic change notice describing a feature update numb=
+er 75 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100076: A synthetic change notice describing a feature update numb=
+er 76 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100077: A synthetic change notice describing a feature update numb=
+er 77 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100078: A synthetic change notice describing a feature update numb=
+er 78 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100079: A synthetic change notice describing a feature update numb=
+er 79 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100080: A synthetic change notice describing a feature update numb=
+er 80 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100081: A synthetic change notice describing a feature update numb=
+er 81 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100082: A synthetic change notice describing a feature update numb=
+er 82 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100083: A synthetic change notice describing a feature update numb=
+er 83 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100084: A synthetic change notice describing a feature update numb=
+er 84 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100085: A synthetic change notice describing a feature update numb=
+er 85 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100086: A synthetic change notice describing a feature update numb=
+er 86 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100087: A synthetic change notice describing a feature update numb=
+er 87 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100088: A synthetic change notice describing a feature update numb=
+er 88 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100089: A synthetic change notice describing a feature update numb=
+er 89 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100090: A synthetic change notice describing a feature update numb=
+er 90 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100091: A synthetic change notice describing a feature update numb=
+er 91 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100092: A synthetic change notice describing a feature update numb=
+er 92 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100093: A synthetic change notice describing a feature update numb=
+er 93 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100094: A synthetic change notice describing a feature update numb=
+er 94 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100095: A synthetic change notice describing a feature update numb=
+er 95 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100096: A synthetic change notice describing a feature update numb=
+er 96 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100097: A synthetic change notice describing a feature update numb=
+er 97 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100098: A synthetic change notice describing a feature update numb=
+er 98 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100099: A synthetic change notice describing a feature update numb=
+er 99 that administrators may want to review for their tenant configuration=
+ and end-user impact.
+Update MC100100: A synthetic change notice describing a feature update numb=
+er 100 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100101: A synthetic change notice describing a feature update numb=
+er 101 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100102: A synthetic change notice describing a feature update numb=
+er 102 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100103: A synthetic change notice describing a feature update numb=
+er 103 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100104: A synthetic change notice describing a feature update numb=
+er 104 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100105: A synthetic change notice describing a feature update numb=
+er 105 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100106: A synthetic change notice describing a feature update numb=
+er 106 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100107: A synthetic change notice describing a feature update numb=
+er 107 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100108: A synthetic change notice describing a feature update numb=
+er 108 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100109: A synthetic change notice describing a feature update numb=
+er 109 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100110: A synthetic change notice describing a feature update numb=
+er 110 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100111: A synthetic change notice describing a feature update numb=
+er 111 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100112: A synthetic change notice describing a feature update numb=
+er 112 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100113: A synthetic change notice describing a feature update numb=
+er 113 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100114: A synthetic change notice describing a feature update numb=
+er 114 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100115: A synthetic change notice describing a feature update numb=
+er 115 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100116: A synthetic change notice describing a feature update numb=
+er 116 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100117: A synthetic change notice describing a feature update numb=
+er 117 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100118: A synthetic change notice describing a feature update numb=
+er 118 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+Update MC100119: A synthetic change notice describing a feature update numb=
+er 119 that administrators may want to review for their tenant configuratio=
+n and end-user impact.
+--=-SyntheticBoundary42==
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE html><html xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"u=
+rn:schemas-microsoft-com:office:office"><head><meta charset=3D"utf-8"><meta=
+ name=3D"viewport" content=3D"width=3Ddevice-width"><!--[if mso]><xml><o:Of=
+ficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumen=
+tSettings></xml><![endif]--><style type=3D"text/css">.m_0 td, .m_0 p { font=
+-family:'Segoe UI',Helvetica,Arial,sans-serif; color:#000000; font-size:13p=
+x; line-height:18px; margin:0; padding:0; /*ZZCSSLEAKZZ*/ }
+.m_1 td, .m_1 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_2 td, .m_2 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_3 td, .m_3 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_4 td, .m_4 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_5 td, .m_5 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_6 td, .m_6 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_7 td, .m_7 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_8 td, .m_8 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_9 td, .m_9 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; color:=
+#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLEAK=
+ZZ*/ }
+.m_10 td, .m_10 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_11 td, .m_11 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_12 td, .m_12 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_13 td, .m_13 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_14 td, .m_14 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_15 td, .m_15 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_16 td, .m_16 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_17 td, .m_17 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_18 td, .m_18 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_19 td, .m_19 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_20 td, .m_20 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_21 td, .m_21 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_22 td, .m_22 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_23 td, .m_23 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_24 td, .m_24 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_25 td, .m_25 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_26 td, .m_26 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_27 td, .m_27 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_28 td, .m_28 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_29 td, .m_29 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_30 td, .m_30 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_31 td, .m_31 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_32 td, .m_32 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_33 td, .m_33 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_34 td, .m_34 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_35 td, .m_35 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_36 td, .m_36 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_37 td, .m_37 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_38 td, .m_38 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_39 td, .m_39 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_40 td, .m_40 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_41 td, .m_41 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_42 td, .m_42 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_43 td, .m_43 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_44 td, .m_44 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_45 td, .m_45 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_46 td, .m_46 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_47 td, .m_47 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_48 td, .m_48 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_49 td, .m_49 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_50 td, .m_50 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_51 td, .m_51 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_52 td, .m_52 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_53 td, .m_53 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_54 td, .m_54 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_55 td, .m_55 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_56 td, .m_56 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_57 td, .m_57 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_58 td, .m_58 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_59 td, .m_59 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_60 td, .m_60 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_61 td, .m_61 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_62 td, .m_62 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_63 td, .m_63 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_64 td, .m_64 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_65 td, .m_65 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_66 td, .m_66 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_67 td, .m_67 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_68 td, .m_68 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_69 td, .m_69 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_70 td, .m_70 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_71 td, .m_71 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_72 td, .m_72 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_73 td, .m_73 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_74 td, .m_74 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_75 td, .m_75 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_76 td, .m_76 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_77 td, .m_77 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_78 td, .m_78 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_79 td, .m_79 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_80 td, .m_80 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_81 td, .m_81 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_82 td, .m_82 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_83 td, .m_83 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_84 td, .m_84 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_85 td, .m_85 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_86 td, .m_86 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_87 td, .m_87 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_88 td, .m_88 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_89 td, .m_89 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_90 td, .m_90 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_91 td, .m_91 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_92 td, .m_92 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_93 td, .m_93 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_94 td, .m_94 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_95 td, .m_95 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_96 td, .m_96 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_97 td, .m_97 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_98 td, .m_98 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_99 td, .m_99 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; colo=
+r:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSSLE=
+AKZZ*/ }
+.m_100 td, .m_100 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_101 td, .m_101 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_102 td, .m_102 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_103 td, .m_103 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_104 td, .m_104 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_105 td, .m_105 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_106 td, .m_106 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_107 td, .m_107 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_108 td, .m_108 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_109 td, .m_109 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_110 td, .m_110 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_111 td, .m_111 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_112 td, .m_112 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_113 td, .m_113 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_114 td, .m_114 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_115 td, .m_115 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_116 td, .m_116 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_117 td, .m_117 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_118 td, .m_118 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_119 td, .m_119 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_120 td, .m_120 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_121 td, .m_121 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_122 td, .m_122 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_123 td, .m_123 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_124 td, .m_124 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_125 td, .m_125 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_126 td, .m_126 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_127 td, .m_127 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_128 td, .m_128 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_129 td, .m_129 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_130 td, .m_130 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_131 td, .m_131 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_132 td, .m_132 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_133 td, .m_133 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_134 td, .m_134 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_135 td, .m_135 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_136 td, .m_136 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_137 td, .m_137 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_138 td, .m_138 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_139 td, .m_139 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_140 td, .m_140 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_141 td, .m_141 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_142 td, .m_142 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_143 td, .m_143 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_144 td, .m_144 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_145 td, .m_145 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_146 td, .m_146 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_147 td, .m_147 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_148 td, .m_148 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_149 td, .m_149 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_150 td, .m_150 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_151 td, .m_151 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_152 td, .m_152 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_153 td, .m_153 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_154 td, .m_154 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_155 td, .m_155 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_156 td, .m_156 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_157 td, .m_157 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_158 td, .m_158 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_159 td, .m_159 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_160 td, .m_160 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_161 td, .m_161 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_162 td, .m_162 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_163 td, .m_163 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_164 td, .m_164 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_165 td, .m_165 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_166 td, .m_166 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_167 td, .m_167 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_168 td, .m_168 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_169 td, .m_169 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_170 td, .m_170 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_171 td, .m_171 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_172 td, .m_172 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_173 td, .m_173 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_174 td, .m_174 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_175 td, .m_175 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_176 td, .m_176 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_177 td, .m_177 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_178 td, .m_178 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_179 td, .m_179 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_180 td, .m_180 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_181 td, .m_181 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_182 td, .m_182 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_183 td, .m_183 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_184 td, .m_184 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_185 td, .m_185 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_186 td, .m_186 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_187 td, .m_187 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_188 td, .m_188 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_189 td, .m_189 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_190 td, .m_190 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_191 td, .m_191 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_192 td, .m_192 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_193 td, .m_193 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_194 td, .m_194 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_195 td, .m_195 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_196 td, .m_196 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_197 td, .m_197 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_198 td, .m_198 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_199 td, .m_199 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_200 td, .m_200 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_201 td, .m_201 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_202 td, .m_202 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_203 td, .m_203 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_204 td, .m_204 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_205 td, .m_205 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_206 td, .m_206 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_207 td, .m_207 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_208 td, .m_208 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_209 td, .m_209 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_210 td, .m_210 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_211 td, .m_211 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_212 td, .m_212 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_213 td, .m_213 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_214 td, .m_214 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_215 td, .m_215 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_216 td, .m_216 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_217 td, .m_217 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_218 td, .m_218 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_219 td, .m_219 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_220 td, .m_220 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_221 td, .m_221 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_222 td, .m_222 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_223 td, .m_223 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_224 td, .m_224 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_225 td, .m_225 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_226 td, .m_226 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_227 td, .m_227 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_228 td, .m_228 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_229 td, .m_229 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_230 td, .m_230 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_231 td, .m_231 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_232 td, .m_232 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_233 td, .m_233 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_234 td, .m_234 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_235 td, .m_235 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_236 td, .m_236 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_237 td, .m_237 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_238 td, .m_238 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_239 td, .m_239 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_240 td, .m_240 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_241 td, .m_241 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_242 td, .m_242 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_243 td, .m_243 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_244 td, .m_244 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_245 td, .m_245 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_246 td, .m_246 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_247 td, .m_247 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_248 td, .m_248 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_249 td, .m_249 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_250 td, .m_250 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_251 td, .m_251 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_252 td, .m_252 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_253 td, .m_253 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_254 td, .m_254 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_255 td, .m_255 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_256 td, .m_256 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_257 td, .m_257 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_258 td, .m_258 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_259 td, .m_259 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_260 td, .m_260 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_261 td, .m_261 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_262 td, .m_262 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_263 td, .m_263 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_264 td, .m_264 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_265 td, .m_265 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_266 td, .m_266 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_267 td, .m_267 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_268 td, .m_268 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_269 td, .m_269 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_270 td, .m_270 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_271 td, .m_271 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_272 td, .m_272 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_273 td, .m_273 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_274 td, .m_274 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_275 td, .m_275 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_276 td, .m_276 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_277 td, .m_277 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_278 td, .m_278 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_279 td, .m_279 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_280 td, .m_280 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_281 td, .m_281 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_282 td, .m_282 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_283 td, .m_283 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_284 td, .m_284 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_285 td, .m_285 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_286 td, .m_286 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_287 td, .m_287 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_288 td, .m_288 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_289 td, .m_289 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_290 td, .m_290 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_291 td, .m_291 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_292 td, .m_292 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_293 td, .m_293 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_294 td, .m_294 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_295 td, .m_295 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_296 td, .m_296 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_297 td, .m_297 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_298 td, .m_298 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_299 td, .m_299 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_300 td, .m_300 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_301 td, .m_301 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_302 td, .m_302 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_303 td, .m_303 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_304 td, .m_304 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_305 td, .m_305 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_306 td, .m_306 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_307 td, .m_307 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_308 td, .m_308 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_309 td, .m_309 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_310 td, .m_310 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_311 td, .m_311 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_312 td, .m_312 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_313 td, .m_313 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_314 td, .m_314 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_315 td, .m_315 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_316 td, .m_316 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_317 td, .m_317 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_318 td, .m_318 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_319 td, .m_319 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_320 td, .m_320 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_321 td, .m_321 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_322 td, .m_322 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_323 td, .m_323 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_324 td, .m_324 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_325 td, .m_325 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_326 td, .m_326 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_327 td, .m_327 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_328 td, .m_328 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_329 td, .m_329 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_330 td, .m_330 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_331 td, .m_331 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_332 td, .m_332 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_333 td, .m_333 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_334 td, .m_334 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_335 td, .m_335 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_336 td, .m_336 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_337 td, .m_337 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_338 td, .m_338 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_339 td, .m_339 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_340 td, .m_340 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_341 td, .m_341 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_342 td, .m_342 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_343 td, .m_343 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_344 td, .m_344 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_345 td, .m_345 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_346 td, .m_346 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_347 td, .m_347 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_348 td, .m_348 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_349 td, .m_349 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_350 td, .m_350 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_351 td, .m_351 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_352 td, .m_352 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_353 td, .m_353 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_354 td, .m_354 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_355 td, .m_355 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_356 td, .m_356 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_357 td, .m_357 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_358 td, .m_358 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_359 td, .m_359 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_360 td, .m_360 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_361 td, .m_361 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_362 td, .m_362 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_363 td, .m_363 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_364 td, .m_364 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_365 td, .m_365 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_366 td, .m_366 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_367 td, .m_367 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_368 td, .m_368 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_369 td, .m_369 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_370 td, .m_370 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_371 td, .m_371 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_372 td, .m_372 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_373 td, .m_373 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_374 td, .m_374 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_375 td, .m_375 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_376 td, .m_376 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_377 td, .m_377 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_378 td, .m_378 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_379 td, .m_379 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_380 td, .m_380 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_381 td, .m_381 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_382 td, .m_382 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_383 td, .m_383 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_384 td, .m_384 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_385 td, .m_385 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_386 td, .m_386 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_387 td, .m_387 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_388 td, .m_388 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_389 td, .m_389 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_390 td, .m_390 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_391 td, .m_391 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_392 td, .m_392 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_393 td, .m_393 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_394 td, .m_394 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_395 td, .m_395 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_396 td, .m_396 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_397 td, .m_397 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_398 td, .m_398 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_399 td, .m_399 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_400 td, .m_400 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_401 td, .m_401 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_402 td, .m_402 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_403 td, .m_403 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_404 td, .m_404 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_405 td, .m_405 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_406 td, .m_406 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_407 td, .m_407 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_408 td, .m_408 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_409 td, .m_409 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_410 td, .m_410 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_411 td, .m_411 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_412 td, .m_412 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_413 td, .m_413 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_414 td, .m_414 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_415 td, .m_415 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_416 td, .m_416 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_417 td, .m_417 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_418 td, .m_418 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_419 td, .m_419 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_420 td, .m_420 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_421 td, .m_421 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_422 td, .m_422 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_423 td, .m_423 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_424 td, .m_424 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_425 td, .m_425 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_426 td, .m_426 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_427 td, .m_427 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_428 td, .m_428 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_429 td, .m_429 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_430 td, .m_430 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_431 td, .m_431 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_432 td, .m_432 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_433 td, .m_433 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_434 td, .m_434 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_435 td, .m_435 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_436 td, .m_436 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_437 td, .m_437 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_438 td, .m_438 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_439 td, .m_439 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_440 td, .m_440 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_441 td, .m_441 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#000000; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_442 td, .m_442 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#111111; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_443 td, .m_443 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#222222; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_444 td, .m_444 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#333333; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_445 td, .m_445 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#444444; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_446 td, .m_446 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#555555; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_447 td, .m_447 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#666666; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_448 td, .m_448 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#777777; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }
+.m_449 td, .m_449 p { font-family:'Segoe UI',Helvetica,Arial,sans-serif; co=
+lor:#888888; font-size:13px; line-height:18px; margin:0; padding:0; /*ZZCSS=
+LEAKZZ*/ }</style></head><body style=3D"margin:0;padding:0;background:#f3f2=
+f1;"><span style=3D"display:none;font-size:1px;color:#f3f2f1;">Synthetic pr=
+eheader preview text</span><p style=3D"font-size:13px;color:#323130;ZZCSSLE=
+AKZZ">Weekly digest readable item ONE about service retirement</p><table ro=
+le=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=
+=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-seri=
+f;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactl=
+y;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSL=
+EAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3746317213&u=3D969=
+7354961&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_di=
+gest&seg=3D0" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;co=
+lor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pa=
+dding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZ=
+Z"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D2181241943&u=3D1958682846&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D1" style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table=
+><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D=
+"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D416311978=
+5&u=3D9963334018&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3D=
+weekly_digest&seg=3D2" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cell=
+padding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2812140441&u=3D1127978094&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D3" style=3D"=
+font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:1=
+3px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1=
+px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></t=
+r></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" =
+border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helveti=
+ca,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-=
+height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-co=
+lor:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D=
+1939042955&u=3D9703905715&utm_source=3Dnewsletter&utm_medium=3Demail&utm_ca=
+mpaign=3Dweekly_digest&seg=3D4" style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Ar=
+ial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heigh=
+t-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#=
+faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentat=
+ion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><t=
+d style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D7635473142&u=3D6241752544&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D5" =
+style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;fo=
+nt-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px=
+;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span s=
+tyle=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;fon=
+t-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;=
+border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span=
+></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspaci=
+ng=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com=
+/r/?id=3D7825844140&u=3D4460967357&utm_source=3Dnewsletter&utm_medium=3Dema=
+il&utm_campaign=3Dweekly_digest&seg=3D6" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8293453178&u=3D6756332150=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D7" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D1667779376&u=3D2445662585&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D8" style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table r=
+ole=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=
+=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-seri=
+f;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactl=
+y;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSL=
+EAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5693307665&u=3D571=
+0360983&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_di=
+gest&seg=3D9" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;co=
+lor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pa=
+dding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZ=
+Z"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D8934927891&u=3D7887950851&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D10" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">Weekly digest readable item =
+ONE about service retirement</a><span style=3D"font-family:'Segoe UI',Helve=
+tica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-lin=
+e-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-=
+color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"pr=
+esentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"=
+><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a=
+ href=3D"https://click.example-news.com/r/?id=3D4466589567&u=3D8429141456&u=
+tm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D11" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D3303082117&u=3D2625792787&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D12" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7665963761&u=3D89=
+95970241&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D13" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D3479708607&u=3D4026113008&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D14" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D978674=
+8825&u=3D5728765136&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D15" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D6488854841&u=3D2566942273&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D16" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6884882440&u=3D3783290795&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D17" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D4131575764&u=3D5996775663&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D18" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D6924716023&u=3D3392080953&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D19" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8235363119&u=3D43=
+32894265&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D20" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D6649827836&u=3D2149938334&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D21" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D235153=
+1223&u=3D8110054933&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D22" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D2970753705&u=3D2137651678&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D23" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7805745017&u=3D7010379415&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D24" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D5284391408&u=3D7483366056&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D25" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D1470939445&u=3D3694860228&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D26" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5567816720&u=3D95=
+73276057&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D27" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D7567496105&u=3D9639245200&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D28" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D409547=
+6665&u=3D8047877267&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D29" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D5774080233&u=3D2867302554&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D30" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2948728483&u=3D4919706735&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D31" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D3615507143&u=3D5951406973&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D32" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D4274958945&u=3D9592390865&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D33" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6687206971&u=3D10=
+83651970&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D34" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D9285415473&u=3D2320763135&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D35" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D124878=
+6714&u=3D5067116918&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D36" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D9957813353&u=3D4289233844&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D37" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3361388464&u=3D6633778586&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D38" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D8086172302&u=3D7517938612&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D39" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D1519709079&u=3D1965067727&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D40" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2452066459&u=3D19=
+45826486&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D41" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D9894847574&u=3D3710566582&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D42" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D198329=
+7492&u=3D4888749350&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D43" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D8987073217&u=3D9894264595&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D44" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6317189421&u=3D8168204967&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D45" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D3030106617&u=3D8664882079&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D46" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D8763140509&u=3D1817804383&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D47" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7146318035&u=3D71=
+14223633&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D48" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D4131356954&u=3D1422701550&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D49" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D470085=
+5390&u=3D2067970820&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D50" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D2926780541&u=3D2811967841&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D51" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6491309593&u=3D4965395580&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D52" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D3363629219&u=3D9807209816&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D53" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D4590711152&u=3D5161807235&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D54" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4645120421&u=3D60=
+09268066&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D55" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D7380780055&u=3D1251837136&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D56" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D262767=
+7155&u=3D9526836552&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D57" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D7249213370&u=3D8380507338&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D58" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D1664847319&u=3D2274350418&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D59" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D5160575046&u=3D3328710672&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D60" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D8507497883&u=3D1245522987&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D61" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7803990970&u=3D16=
+76168421&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D62" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D1798112150&u=3D3555656321&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D63" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D630516=
+0342&u=3D3553440342&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D64" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D3660223333&u=3D7540301973&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D65" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9309500117&u=3D8370987661&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D66" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D6320115677&u=3D2699887270&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D67" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D6583444930&u=3D1311570307&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D68" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5278201677&u=3D99=
+04586976&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D69" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D2139027119&u=3D9303285822&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D70" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D478328=
+2817&u=3D4776436931&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D71" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D6882074066&u=3D5972484792&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D72" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8316648259&u=3D9623534576&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D73" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D3849232839&u=3D5871743247&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D74" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D3376077463&u=3D6464693977&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D75" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3597724331&u=3D83=
+77088167&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D76" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D7393195616&u=3D4633987776&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D77" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D998635=
+3481&u=3D2188332531&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D78" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D5310195918&u=3D4311931853&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D79" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2125089309&u=3D8478529823&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D80" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D1041531046&u=3D4882343658&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D81" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D3343292475&u=3D8879525611&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D82" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5931025271&u=3D15=
+47374338&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D83" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D6618926823&u=3D4696689457&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D84" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D915581=
+9200&u=3D5736462531&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D85" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D4993808565&u=3D4713453204&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D86" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4482238042&u=3D9080621072&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D87" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D1106456634&u=3D9292791081&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D88" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D4482141802&u=3D2145921803&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D89" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5759234471&u=3D47=
+45927824&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D90" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D8982597239&u=3D1955345537&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D91" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D727195=
+4644&u=3D1977515194&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D92" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D9691572571&u=3D6124453431&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D93" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6704841644&u=3D4712367625&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D94" style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helv=
+etica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-li=
+ne-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background=
+-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"p=
+resentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%=
+"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:=
+#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddin=
+g:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><=
+a href=3D"https://click.example-news.com/r/?id=3D6493800024&u=3D7597996327&=
+utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=
+=3D95" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#32=
+3130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8=
+px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a>=
+<span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323=
+130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8p=
+x 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp=
+;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" ce=
+llspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-n=
+ews.com/r/?id=3D5033992825&u=3D9462806178&utm_source=3Dnewsletter&utm_mediu=
+m=3Demail&utm_campaign=3Dweekly_digest&seg=3D96" style=3D"font-family:'Sego=
+e UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:1=
+8px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;=
+background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2140169349&u=3D71=
+61404428&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D97" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=
+=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.=
+example-news.com/r/?id=3D6642201119&u=3D3196545325&utm_source=3Dnewsletter&=
+utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D98" style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fami=
+ly:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-=
+height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid =
+#edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></tabl=
+e><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D347642=
+6797&u=3D2094024844&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D99" style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" =
+cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"htt=
+ps://click.example-news.com/r/?id=3D8339176912&u=3D9597198563&utm_source=3D=
+newsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D100" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3880327491&u=3D6859286614&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D101" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4642197907&u=3D7049001493=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D102" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1546696950&u=3D9333798503&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D103" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4877520294&u=
+=3D6587537178&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D104" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5296710795&u=3D2232285036&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D105" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+106906538&u=3D7292076361&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D106" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5659161352&u=3D2439622619&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D107=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4226113732&u=3D8184602688&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D108" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1855256552&u=3D110490=
+6255&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D109" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5607762160&u=3D8285786023&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D110" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7418301077=
+&u=3D2047905204&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D111" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2825989011&u=3D7519578899&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D112" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9805620900&u=3D4643576871&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D113" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2960488639&u=3D8737025391=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D114" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7852415525&u=3D9123612497&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D115" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7462972995&u=
+=3D7648059419&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D116" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4853479481&u=3D7333678472&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D117" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+033702319&u=3D7533932947&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D118" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3691864041&u=3D6474354351&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D119=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9922723063&u=3D2227193073&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D120" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6461974809&u=3D331993=
+6135&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D121" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1594312071&u=3D6288227800&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D122" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3980491761=
+&u=3D4034047118&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D123" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5570828113&u=3D7045593274&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D124" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7625464411&u=3D2785736751&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D125" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7099469983&u=3D3987248494=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D126" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6928691380&u=3D6805759868&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D127" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8531118333&u=
+=3D6242173772&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D128" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6237376063&u=3D7166868574&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D129" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5=
+419627962&u=3D1116402431&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D130" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8055556030&u=3D2982979741&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D131=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5510938155&u=3D6923206003&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D132" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6204041308&u=3D669875=
+9353&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D133" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6923301988&u=3D8868054898&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D134" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5646751885=
+&u=3D9673185158&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D135" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3316787198&u=3D2503068227&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D136" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3792347639&u=3D3799264931&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D137" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4239406957&u=3D5078551333=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D138" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9677466102&u=3D1654477195&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D139" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5837082260&u=
+=3D3875303857&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D140" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6231117883&u=3D8299146480&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D141" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+588769565&u=3D4518871744&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D142" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9438411468&u=3D9410288290&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D143=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4070964768&u=3D9916336966&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D144" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3693985578&u=3D861274=
+7444&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D145" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4361393222&u=3D2591589823&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D146" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2465576748=
+&u=3D8943866829&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D147" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8826851692&u=3D5748253283&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D148" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9421518487&u=3D8854238082&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D149" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4037867512&u=3D2870403050=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D150" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7371573279&u=3D6447717367&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D151" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4658080160&u=
+=3D5667181604&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D152" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9081544414&u=3D6922713963&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D153" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5=
+418232833&u=3D8949781901&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D154" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6075963527&u=3D6206015111&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D155=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8721631198&u=3D6756711494&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D156" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9633533290&u=3D507189=
+7791&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D157" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1367704871&u=3D8387664437&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D158" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4256292393=
+&u=3D8261111839&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D159" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7403028869&u=3D4405620755&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D160" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5694628398&u=3D6246716604&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D161" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3971203213&u=3D7792729530=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D162" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7575259637&u=3D6715705115&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D163" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8313706299&u=
+=3D6458544482&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D164" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2079770569&u=3D6122110529&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D165" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+795212538&u=3D7374584386&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D166" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6128695961&u=3D6272000062&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D167=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6065662867&u=3D9650701349&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D168" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3294092753&u=3D217815=
+8203&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D169" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5184564874&u=3D7671625956&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D170" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3108307952=
+&u=3D4748302739&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D171" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7760554363&u=3D7311011808&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D172" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7186766399&u=3D5515628633&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D173" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3051831252&u=3D4530959836=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D174" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7015992643&u=3D9908115095&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D175" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1230249217&u=
+=3D2304963614&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D176" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5268845844&u=3D8578226896&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D177" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+539399243&u=3D7196439534&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D178" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9547119184&u=3D3667292043&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D179=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4178659381&u=3D6201313620&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D180" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3836517266&u=3D167455=
+5072&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D181" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1322401182&u=3D5306459450&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D182" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7845366946=
+&u=3D2250949136&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D183" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D6289150149&u=3D8331319481&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D184" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2950049698&u=3D3952295757&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D185" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9263135031&u=3D5010075517=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D186" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2825957977&u=3D3338877621&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D187" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3781569954&u=
+=3D9196564761&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D188" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4550353803&u=3D1306702926&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D189" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+534540349&u=3D5829062179&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D190" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8252816758&u=3D8300300577&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D191=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9343730920&u=3D7415801613&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D192" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9935429720&u=3D207532=
+1966&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D193" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1392245997&u=3D5083595988&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D194" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4248149900=
+&u=3D8093179263&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D195" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D9229469952&u=3D7808938880&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D196" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5686850445&u=3D6789448659&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D197" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6726515966&u=3D3878201524=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D198" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4683935600&u=3D6711463258&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D199" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8274273035&u=
+=3D9354542654&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D200" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3362646960&u=3D2953462417&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D201" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+645808194&u=3D2388450337&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D202" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5243939720&u=3D7625389037&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D203=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2774884818&u=3D8543865915&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D204" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7981077394&u=3D426413=
+4512&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D205" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6169243284&u=3D3358880404&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D206" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9279291478=
+&u=3D8293928340&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D207" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1521521078&u=3D5975196341&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D208" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3365835550&u=3D7666869046&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D209" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1400330495&u=3D4921003983=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D210" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4574027737&u=3D8372755146&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D211" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6469318275&u=
+=3D8880079328&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D212" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9505085936&u=3D6341783555&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D213" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+367665472&u=3D2647489402&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D214" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4776677517&u=3D4710967433&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D215=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7077131430&u=3D7475684019&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D216" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4524233168&u=3D593317=
+9746&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D217" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7608153267&u=3D6777263354&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D218" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7628981661=
+&u=3D3995732958&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D219" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7750819485&u=3D8625905455&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D220" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5482431018&u=3D8493451569&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D221" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8779941999&u=3D5212581851=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D222" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1158998032&u=3D7829772942&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D223" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4735334423&u=
+=3D2891100776&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D224" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2962491159&u=3D4102872611&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D225" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+662976399&u=3D9457665185&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D226" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8270110908&u=3D3791027186&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D227=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8953271391&u=3D8556573246&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D228" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9744120054&u=3D129386=
+4877&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D229" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D9250327663&u=3D5283911723&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D230" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4207337120=
+&u=3D4747699292&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D231" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2905584866&u=3D8275679594&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D232" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4880176825&u=3D5492496998&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D233" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4419410162&u=3D6554972315=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D234" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6904897514&u=3D1625217504&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D235" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7576309274&u=
+=3D4403845222&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D236" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D1730074215&u=3D9929101065&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D237" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+035194895&u=3D6329323383&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D238" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1614685938&u=3D6385791669&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D239=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8750840032&u=3D9165632300&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D240" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1678500147&u=3D781856=
+8548&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D241" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6369130994&u=3D8925520026&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D242" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3075362821=
+&u=3D6313758032&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D243" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7751356568&u=3D7763765757&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D244" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2268006448&u=3D8122042835&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D245" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2178884276&u=3D4431078106=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D246" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2513206988&u=3D3734252963&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D247" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7961674558&u=
+=3D4600630513&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D248" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3698305085&u=3D3776011793&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D249" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+893321208&u=3D7784217828&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D250" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4145461251&u=3D6562457052&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D251=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8505373158&u=3D1754368373&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D252" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9467483275&u=3D921836=
+3978&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D253" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4566852761&u=3D8758809005&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D254" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5789617427=
+&u=3D5135595227&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D255" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5151086814&u=3D9503787171&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D256" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2570991899&u=3D8690920484&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D257" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5354747485&u=3D3304560537=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D258" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7248258423&u=3D8182649048&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D259" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7805633786&u=
+=3D9333490239&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D260" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6299224734&u=3D9697414638&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D261" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+706193636&u=3D9861449701&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D262" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8833399096&u=3D2753617371&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D263=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D1600337712&u=3D5064162365&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D264" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3115806625&u=3D141743=
+6465&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D265" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5877639950&u=3D7243352390&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D266" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9381721143=
+&u=3D9730449971&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D267" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2591414076&u=3D7199283151&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D268" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5082603360&u=3D8969097897&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D269" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8239941612&u=3D2540492440=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D270" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7004964045&u=3D2952996248&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D271" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3846570058&u=
+=3D1091729577&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D272" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D8674224347&u=3D3424843951&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D273" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4=
+735313433&u=3D5307145891&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D274" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1749459431&u=3D1110724913&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D275=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5358791907&u=3D2390587865&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D276" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6043349038&u=3D122505=
+2083&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D277" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D8480622107&u=3D3259520140&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D278" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4202607993=
+&u=3D7340428136&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D279" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8636525027&u=3D5763350700&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D280" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3163970710&u=3D9776185998&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D281" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7534583219&u=3D5140460939=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D282" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7019900273&u=3D3946766309&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D283" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9202102595&u=
+=3D5641959772&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D284" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3612617557&u=3D1282103057&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D285" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+691628146&u=3D7573691558&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D286" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D7895255573&u=3D4014119648&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D287=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6218484323&u=3D6276339732&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D288" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7242730249&u=3D570335=
+7871&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D289" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7127904756&u=3D8151583833&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D290" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9259157845=
+&u=3D1288335378&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D291" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4572433066&u=3D5695387521&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D292" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8468071953&u=3D4486522557&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D293" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3389594115&u=3D5819946657=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D294" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8517413631&u=3D4096932037&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D295" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9454207717&u=
+=3D7873709012&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D296" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2510308881&u=3D1913706213&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D297" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+115628227&u=3D5759761714&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D298" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2578662692&u=3D8570333548&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D299=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3465740756&u=3D8761956684&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D300" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9702693937&u=3D214867=
+9234&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D301" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6069848439&u=3D6754503097&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D302" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1026224160=
+&u=3D4736031885&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D303" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2721355673&u=3D1131671246&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D304" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6218955985&u=3D7098134112&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D305" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2464137110&u=3D6884333221=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D306" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8394198376&u=3D1225953184&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D307" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3653594796&u=
+=3D3894673596&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D308" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6463640105&u=3D8137972345&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D309" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+193532615&u=3D2173242669&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D310" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5783809766&u=3D2846465000&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D311=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8160279830&u=3D1195066088&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D312" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3574081104&u=3D103301=
+5788&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D313" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6392415228&u=3D2409274786&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D314" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5328166990=
+&u=3D8503368512&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D315" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1754603440&u=3D4022245086&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D316" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8757570742&u=3D5604529187&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D317" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5476654128&u=3D5375461598=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D318" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4956362540&u=3D8997701619&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D319" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7767834064&u=
+=3D7757700186&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D320" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7088949191&u=3D5789633176&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D321" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+394868732&u=3D7949795085&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D322" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9245348297&u=3D5673482258&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D323=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4627032705&u=3D6340003593&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D324" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7824150224&u=3D325040=
+2001&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D325" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2458198451&u=3D1722124509&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D326" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3190227431=
+&u=3D6795522649&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D327" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4500557310&u=3D2014766981&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D328" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5923940434&u=3D1847275937&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D329" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3587283948&u=3D3815389788=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D330" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7417183769&u=3D7977267911&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D331" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7988845536&u=
+=3D5943324387&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D332" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5588254555&u=3D5536224717&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D333" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+178995337&u=3D6628158856&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D334" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2940955281&u=3D5539308214&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D335=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8867077130&u=3D9919491730&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D336" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4673457063&u=3D747280=
+6994&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D337" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4847761430&u=3D3799620568&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D338" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5560712830=
+&u=3D4067961943&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D339" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1741134891&u=3D5976777081&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D340" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6509985983&u=3D3567900251&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D341" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8075122626&u=3D5578056564=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D342" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9995834531&u=3D8208584394&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D343" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6515369278&u=
+=3D4750707607&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D344" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2431779064&u=3D6797436140&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D345" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+683446724&u=3D5028688786&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D346" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8695129534&u=3D4492602049&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D347=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3260842187&u=3D2554039848&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D348" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6852312425&u=3D621491=
+7780&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D349" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3088517710&u=3D1590838716&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D350" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5626388820=
+&u=3D9752058817&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D351" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2617999521&u=3D1696846464&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D352" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2879792991&u=3D7059591606&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D353" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2928130926&u=3D3293560436=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D354" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4586784711&u=3D9523104008&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D355" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7560389844&u=
+=3D5150090143&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D356" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4508521152&u=3D2073755632&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D357" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+048810275&u=3D9049270990&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D358" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4655730355&u=3D2224336336&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D359=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4277561834&u=3D6466597005&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D360" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D2878930355&u=3D540951=
+4899&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D361" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5523703900&u=3D7451071432&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D362" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6307626407=
+&u=3D5271453859&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D363" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2610237679&u=3D5416031878&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D364" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4997866845&u=3D8086527181&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D365" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4398953973&u=3D1590985753=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D366" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8858766173&u=3D8325222092&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D367" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1340272119&u=
+=3D2099184899&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D368" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4586139213&u=3D7561728644&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D369" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+237386857&u=3D2293434554&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D370" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1205082311&u=3D2963288053&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D371=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9182543558&u=3D9660523876&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D372" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D5911625145&u=3D284356=
+7009&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D373" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7935554354&u=3D2789144223&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D374" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9957643727=
+&u=3D9481076448&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D375" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3380064537&u=3D3019214800&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D376" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8025152555&u=3D9508499533&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D377" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5364727160&u=3D4386667704=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D378" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2480915452&u=3D3698343112&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D379" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2428156550&u=
+=3D5485387618&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D380" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7640078465&u=3D8281641403&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D381" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+713284816&u=3D4485356009&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D382" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9860949331&u=3D2965718821&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D383=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2260326267&u=3D5474951950&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D384" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9303765140&u=3D750852=
+2951&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D385" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7627266377&u=3D2087974350&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D386" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6115750294=
+&u=3D4353689019&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D387" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D6720572969&u=3D6875597607&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D388" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9115282784&u=3D8487449580&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D389" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6955593943&u=3D5182110973=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D390" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7431813987&u=3D7525240100&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D391" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4440904834&u=
+=3D8417757797&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D392" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5633956194&u=3D4531928910&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D393" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+637761996&u=3D2379592595&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D394" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5638860656&u=3D8133593748&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D395=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6611356986&u=3D2830154607&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D396" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8257484586&u=3D680485=
+0108&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D397" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D9771848610&u=3D9581991473&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D398" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5071218314=
+&u=3D9912233947&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D399" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8033062794&u=3D3918046336&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D400" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">Weekly digest re=
+adable item TWO about new admin controls</a><span style=3D"font-family:'Seg=
+oe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:=
+18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9=
+;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tabl=
+e role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" wi=
+dth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5092199300&u=3D=
+8650676663&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly=
+_digest&seg=3D401" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-seri=
+f;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactl=
+y;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSL=
+EAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadd=
+ing=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://cli=
+ck.example-news.com/r/?id=3D1149460439&u=3D1288765093&utm_source=3Dnewslett=
+er&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D402" style=3D"font=
+-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;=
+line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px s=
+olid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-=
+family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;l=
+ine-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px so=
+lid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></=
+table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" bord=
+er=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6868=
+336102&u=3D3436297208&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campai=
+gn=3Dweekly_digest&seg=3D403" style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Aria=
+l,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-=
+rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#fa=
+f9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentatio=
+n" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td =
+style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;fo=
+nt-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px=
+;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"=
+https://click.example-news.com/r/?id=3D3598862507&u=3D8211516617&utm_source=
+=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D404" st=
+yle=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font=
+-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;b=
+order:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span><=
+/td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9370133343&u=3D6892752604&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D405" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4277422858&u=3D3464975279=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D406" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7568980185&u=3D7004510516&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D407" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8084809436&u=
+=3D1487258103&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D408" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4159699467&u=3D3412365931&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D409" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+916728422&u=3D3109688769&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D410" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1526723719&u=3D4662861038&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D411=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2941508568&u=3D9868845806&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D412" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7623575561&u=3D912320=
+7735&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D413" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4656572173&u=3D3738900744&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D414" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8703867299=
+&u=3D3185089287&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D415" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1596471620&u=3D8689593739&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D416" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5407856339&u=3D6879428703&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D417" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3369305560&u=3D1370292681=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D418" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6623360831&u=3D8382488970&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D419" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7552812957&u=
+=3D8598503901&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D420" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D1316756902&u=3D9471306442&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D421" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+758823240&u=3D7227593033&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D422" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2479679716&u=3D5150074940&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D423=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5952163720&u=3D1707196784&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D424" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4046558332&u=3D913864=
+4862&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D425" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4633257620&u=3D2076341629&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D426" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7660813178=
+&u=3D3291270703&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D427" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1662259333&u=3D7894019119&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D428" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3420721027&u=3D1121863227&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D429" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7772180882&u=3D3796581976=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D430" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D3744446292&u=3D9403748506&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D431" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3074232200&u=
+=3D8236980551&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D432" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6572436051&u=3D9903351330&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D433" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+257324536&u=3D7183058541&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D434" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D7374810067&u=3D6171239466&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D435=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3605585995&u=3D8380312396&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D436" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8991977937&u=3D948416=
+7278&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D437" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3412273600&u=3D2370592316&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D438" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3003484425=
+&u=3D6443749394&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D439" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2064803502&u=3D1415802902&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D440" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7937993287&u=3D2343100352&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D441" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4277581356&u=3D7505693643=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D442" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6620138568&u=3D1099541460&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D443" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9354711271&u=
+=3D7465834732&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D444" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5151887478&u=3D2515672889&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D445" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5=
+512036684&u=3D7316122432&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D446" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3305069227&u=3D4638577630&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D447=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2850820685&u=3D9085085822&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D448" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8419590655&u=3D857570=
+7116&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D449" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2571688961&u=3D2720484983&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D450" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6131005449=
+&u=3D7671041685&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D451" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5610783750&u=3D7460728316&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D452" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D1510289448&u=3D5187948804&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D453" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6986770879&u=3D9327720702=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D454" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4242550727&u=3D7481631841&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D455" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3147818256&u=
+=3D1194576436&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D456" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2962750929&u=3D3214080278&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D457" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+928074841&u=3D5992908271&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D458" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D7581349462&u=3D6582557981&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D459=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4503614567&u=3D6877052039&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D460" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3893976444&u=3D950359=
+7301&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D461" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7801948900&u=3D9704383251&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D462" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7333316743=
+&u=3D3480920839&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D463" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4098389895&u=3D7801180691&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D464" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8907752604&u=3D3923699745&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D465" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9725528903&u=3D1471997674=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D466" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D5376302686&u=3D6642266247&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D467" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5945359606&u=
+=3D3965676060&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D468" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9248574674&u=3D9857430687&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D469" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+139209752&u=3D7551874474&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D470" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6038780151&u=3D8272725281&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D471=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7915226263&u=3D6353758928&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D472" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7691931213&u=3D832286=
+8827&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D473" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6656646925&u=3D6469458472&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D474" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9504724761=
+&u=3D8809871735&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D475" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4455798713&u=3D2247484671&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D476" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4067213499&u=3D3057629778&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D477" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7608141858&u=3D8285000265=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D478" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1589582865&u=3D3520417815&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D479" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2041349374&u=
+=3D3280805846&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D480" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3739951076&u=3D1225447588&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D481" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+070083150&u=3D8375996697&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D482" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4310415016&u=3D4990452762&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D483=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9067664957&u=3D9434946584&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D484" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6674372082&u=3D377411=
+0439&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D485" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D9974165440&u=3D3465883999&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D486" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5022964382=
+&u=3D6046864799&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D487" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4949801453&u=3D3127657643&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D488" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9272277508&u=3D4765583254&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D489" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5334769475&u=3D9516893896=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D490" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6517150278&u=3D5031086659&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D491" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7305101214&u=
+=3D5778781449&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D492" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D1799718923&u=3D8458717057&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D493" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+691288568&u=3D4252504650&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D494" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9147736635&u=3D8846861559&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D495=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7508080884&u=3D5667503195&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D496" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3874432021&u=3D589889=
+0707&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D497" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2065354117&u=3D6415031531&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D498" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6306523372=
+&u=3D8532327465&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D499" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D9392515666&u=3D5344083406&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D500" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8102515984&u=3D3975418439&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D501" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9856756553&u=3D5802739154=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D502" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2317723211&u=3D6562144159&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D503" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3639796200&u=
+=3D5868640848&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D504" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5952894290&u=3D7896596272&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D505" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+941564880&u=3D8317619798&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D506" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3423086220&u=3D3171050399&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D507=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D1643611097&u=3D7529817193&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D508" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7799567490&u=3D748701=
+2742&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D509" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4473306055&u=3D2947476917&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D510" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7499349987=
+&u=3D9837912162&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D511" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8760642358&u=3D4106464319&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D512" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6995554056&u=3D4506639908&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D513" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4203205881&u=3D3483827971=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D514" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D5489485517&u=3D9863781331&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D515" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5269728610&u=
+=3D9305502799&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D516" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5431267548&u=3D2756070122&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D517" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4=
+302709858&u=3D7100408092&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D518" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6937704752&u=3D9189503254&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D519=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2613385303&u=3D3316277000&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D520" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D2493660313&u=3D760247=
+4923&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D521" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3271361431&u=3D6576426590&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D522" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7633342225=
+&u=3D7579604766&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D523" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4536306171&u=3D6358023411&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D524" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2486744752&u=3D2183906581&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D525" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1484664056&u=3D1067198189=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D526" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1885113834&u=3D5439176290&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D527" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1209063208&u=
+=3D4180599722&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D528" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7022683808&u=3D1242425303&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D529" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+242377075&u=3D2377246195&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D530" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6244338653&u=3D6585609060&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D531=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9851745648&u=3D4915196257&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D532" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3128675098&u=3D947092=
+2075&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D533" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D8178361487&u=3D7083067988&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D534" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5935852056=
+&u=3D2616884203&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D535" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3033747850&u=3D4647891535&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D536" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4039019230&u=3D8755749566&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D537" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4928783441&u=3D7710396573=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D538" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9451577335&u=3D5870891270&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D539" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6338036681&u=
+=3D6168291913&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D540" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3777580509&u=3D9255898264&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D541" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+933377472&u=3D9987064419&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D542" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1818112342&u=3D6448001026&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D543=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3589530484&u=3D4752171298&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D544" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D3400244542&u=3D305898=
+2440&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D545" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6725038117&u=3D1065857791&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D546" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5025070544=
+&u=3D6173344564&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D547" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4930438209&u=3D7666129822&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D548" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8625774078&u=3D6929897032&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D549" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6837975356&u=3D6418365941=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D550" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7430757004&u=3D8901585274&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D551" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4927019611&u=
+=3D6887132821&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D552" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D2777816561&u=3D1626733282&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D553" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7=
+088451458&u=3D1654602021&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D554" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2416760621&u=3D4579265601&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D555=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8236361108&u=3D8823677798&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D556" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7402059279&u=3D870936=
+1138&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D557" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1726990714&u=3D3097302637&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D558" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9842186844=
+&u=3D4636537575&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D559" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3869963931&u=3D4282810353&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D560" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2771211118&u=3D1993998848&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D561" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4037270171&u=3D1039262289=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D562" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7467073633&u=3D2602884797&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D563" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3095318649&u=
+=3D9618334441&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D564" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7664258343&u=3D1050899550&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D565" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+493209128&u=3D9663561486&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D566" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8189916797&u=3D4907446848&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D567=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D1639509845&u=3D7556078550&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D568" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8796286443&u=3D270465=
+7157&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D569" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7038841740&u=3D3426665919&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D570" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6265016831=
+&u=3D4641561499&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D571" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4262396395&u=3D5696548897&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D572" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6923893872&u=3D7668801906&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D573" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9830946410&u=3D9630522755=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D574" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1736086849&u=3D8663837890&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D575" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1182758417&u=
+=3D7337225482&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D576" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9909257076&u=3D9270323795&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D577" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+141312095&u=3D2350701477&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D578" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5129478722&u=3D3521300895&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D579=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5625411308&u=3D6719736115&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D580" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4110258855&u=3D947965=
+4136&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D581" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1230624431&u=3D2877279755&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D582" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4602080228=
+&u=3D8617360361&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D583" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D9717175839&u=3D9558091177&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D584" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3107125807&u=3D9337145038&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D585" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2854772804&u=3D8132531532=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D586" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7951902330&u=3D4427620889&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D587" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4062777850&u=
+=3D5647317872&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D588" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5957341287&u=3D3722583581&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D589" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+471762590&u=3D6655089949&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D590" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1457632732&u=3D6618965944&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D591=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2158638062&u=3D1569113257&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D592" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6099808894&u=3D275253=
+6389&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D593" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1112794026&u=3D9989642546&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D594" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2654584280=
+&u=3D6548442140&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D595" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D9953716239&u=3D5201221330&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D596" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2635231601&u=3D5891280823&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D597" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6588316233&u=3D3117951204=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D598" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1271730355&u=3D7161887665&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D599" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7103588071&u=
+=3D5625342041&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D600" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7979466538&u=3D6134840512&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D601" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+459442845&u=3D2308496151&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D602" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9370133032&u=3D7958672456&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D603=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6710338189&u=3D6732648420&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D604" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D5879617459&u=3D615761=
+7867&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D605" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2349406919&u=3D9437783771&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D606" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9455610447=
+&u=3D6336171726&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D607" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D6910112521&u=3D6982610835&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D608" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3421719519&u=3D3343459102&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D609" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3362657890&u=3D4042413312=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D610" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D3975704877&u=3D3144490990&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D611" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8015124886&u=
+=3D6334440295&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D612" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3828935922&u=3D8366884200&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D613" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+684026200&u=3D5612645121&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D614" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8265834251&u=3D3334938378&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D615=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D1364994639&u=3D4302632494&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D616" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D2524751277&u=3D978018=
+7424&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D617" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D8527715219&u=3D2848792488&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D618" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1045302356=
+&u=3D2111272861&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D619" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3470617247&u=3D7209571615&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D620" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6974875750&u=3D3149484176&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D621" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5400463094&u=3D5744003377=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D622" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D5130589741&u=3D5903457537&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D623" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6634526139&u=
+=3D7369118672&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D624" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3045102506&u=3D8287542751&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D625" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+369705770&u=3D2289624427&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D626" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1494287462&u=3D8942167666&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D627=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3783009621&u=3D5982744929&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D628" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7699500243&u=3D941153=
+2909&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D629" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1792214339&u=3D7150970643&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D630" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9715314442=
+&u=3D6142469284&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D631" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7838460497&u=3D2670036982&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D632" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4026816435&u=3D6178804925&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D633" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9858643842&u=3D6097953682=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D634" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2400094541&u=3D2965164102&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D635" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8999963054&u=
+=3D8039917766&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D636" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7858937483&u=3D7920516981&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D637" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+521166052&u=3D6789292252&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D638" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8926438617&u=3D3651552513&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D639=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D9953941533&u=3D5870268582&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D640" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1506211965&u=3D231159=
+7141&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D641" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6081137534&u=3D3978287288&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D642" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7488943393=
+&u=3D6942989052&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D643" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D6092773357&u=3D5294535887&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D644" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D3383331379&u=3D7397963801&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D645" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1602569046&u=3D5336127859=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D646" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1586412136&u=3D8796293088&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D647" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7420846622&u=
+=3D8235717104&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D648" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D8902275119&u=3D3098948446&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D649" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+945002229&u=3D4268713302&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D650" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2254516608&u=3D2180484299&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D651=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7603978731&u=3D8584566722&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D652" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D5785481124&u=3D838296=
+3909&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D653" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3346569443&u=3D9546021691&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D654" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4227004325=
+&u=3D5292015249&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D655" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7226553010&u=3D4507822591&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D656" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5269015757&u=3D2017675569&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D657" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8012696455&u=3D9844874547=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D658" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D3313993297&u=3D8318855178&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D659" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1408988968&u=
+=3D8669484644&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D660" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4946081594&u=3D9557663181&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D661" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4=
+719780110&u=3D2072355594&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D662" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8350384902&u=3D4558302256&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D663=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8199372599&u=3D3102209245&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D664" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7074050517&u=3D294128=
+9685&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D665" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5694806361&u=3D6880115912&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D666" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9376277483=
+&u=3D4147025728&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D667" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7590302909&u=3D6204862411&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D668" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6448324230&u=3D8852676046&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D669" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3482206102&u=3D1207916194=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D670" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2973888646&u=3D4683585586&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D671" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7190276026&u=
+=3D9409682410&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D672" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D8086684009&u=3D2176904638&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D673" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+106401208&u=3D2075413763&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D674" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1710924824&u=3D6300607425&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D675=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3815287619&u=3D4022360089&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D676" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1004665657&u=3D304786=
+9247&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D677" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D8215470878&u=3D1039887139&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D678" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8282534126=
+&u=3D4509456565&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D679" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5862655247&u=3D1304205279&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D680" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2645272822&u=3D1439921366&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D681" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6640801643&u=3D9078786223=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D682" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D5883933127&u=3D1613549255&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D683" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9626333315&u=
+=3D3791815554&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D684" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7185179917&u=3D4102821948&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D685" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+243746556&u=3D4693510920&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D686" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1431494396&u=3D4231729466&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D687=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6944371787&u=3D9432088993&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D688" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1600566083&u=3D136184=
+5490&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D689" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D7904559790&u=3D3965572185&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D690" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2295574037=
+&u=3D3188382776&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D691" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8506931282&u=3D5100282913&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D692" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7420493866&u=3D1484230338&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D693" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D3550908958&u=3D5199176431=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D694" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9533595495&u=3D9306142066&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D695" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5861829469&u=
+=3D7736142481&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D696" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3933213766&u=3D8570850267&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D697" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4=
+308701294&u=3D9661615016&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D698" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1290050198&u=3D2126077199&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D699=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8684942020&u=3D7470843264&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D700" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7079234115&u=3D830922=
+1034&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D701" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D9943959352&u=3D3645901955&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D702" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2191714875=
+&u=3D2331039957&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D703" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4470591645&u=3D7598745558&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D704" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5578929439&u=3D8295757364&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D705" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4635552887&u=3D1248704157=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D706" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2866092821&u=3D3614915281&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D707" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4181102664&u=
+=3D1513003815&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D708" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4040409964&u=3D4012917912&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D709" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5=
+998623100&u=3D9388140708&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D710" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8390631634&u=3D6012067717&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D711=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D4807122420&u=3D5421051452&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D712" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8761469117&u=3D556929=
+5400&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D713" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5625980561&u=3D2546720356&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D714" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3434757387=
+&u=3D2579206999&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D715" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4104309491&u=3D3185386258&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D716" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D4706249669&u=3D2050340486&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D717" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7321180787&u=3D1644608746=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D718" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4682870880&u=3D2801177461&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D719" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2382129132&u=
+=3D8388580360&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D720" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9924456994&u=3D2601198885&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D721" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4=
+873807154&u=3D1770278136&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D722" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D5215140451&u=3D9392707144&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D723=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8923555411&u=3D2405746777&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D724" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D7670476743&u=3D532919=
+4647&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D725" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6156843353&u=3D3674551397&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D726" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7287517250=
+&u=3D2052811909&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D727" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2761091683&u=3D4767539382&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D728" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D9379439373&u=3D8118065825&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D729" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D8418332121&u=3D1446457642=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D730" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6317889312&u=3D5281907480&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D731" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8351491401&u=
+=3D1399546384&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D732" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D4956843441&u=3D7527316141&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D733" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+894808149&u=3D9954587710&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D734" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8816681105&u=3D9911329062&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D735=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D3438771483&u=3D5141285960&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D736" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6311894154&u=3D873444=
+9371&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D737" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D8453283834&u=3D6661014794&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D738" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2168041588=
+&u=3D1870644102&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D739" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3511301900&u=3D1667483244&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D740" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6000952470&u=3D7296658772&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D741" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2745958114&u=3D7596745715=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D742" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D6186758088&u=3D6619138852&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D743" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1515024824&u=
+=3D8241550421&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D744" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D1173215225&u=3D2407863065&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D745" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+981691030&u=3D6822870815&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D746" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3205292512&u=3D8203447752&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D747=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5254923696&u=3D2073108894&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D748" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D2984460654&u=3D160040=
+6558&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D749" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1051354601&u=3D5220094152&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D750" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1561417687=
+&u=3D8832617672&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D751" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3768901084&u=3D4490722186&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D752" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D1276905285&u=3D1553155490&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D753" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2423995953&u=3D2979958124=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D754" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7759781156&u=3D6991473746&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D755" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5421592782&u=
+=3D8229344434&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D756" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6037168610&u=3D6098775210&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D757" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+496933442&u=3D4794276323&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D758" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D9738752801&u=3D6562434335&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D759=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7660157097&u=3D1261903104&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D760" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6496596008&u=3D588439=
+1502&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D761" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3258354191&u=3D4413838650&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D762" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9544423456=
+&u=3D6837342064&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D763" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7376649850&u=3D7452729913&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D764" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6963052185&u=3D1772303297&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D765" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1940684569&u=3D8638763775=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D766" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9553561889&u=3D7568861677&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D767" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5293274004&u=
+=3D5183211669&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D768" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D1430073711&u=3D3821211202&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D769" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8=
+719734235&u=3D4630196130&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D770" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1756345332&u=3D7839819230&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D771=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8291250562&u=3D9711080868&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D772" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D8303853049&u=3D342067=
+1425&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D773" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2327372855&u=3D3106408413&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D774" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1387652480=
+&u=3D1939777262&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D775" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7556046460&u=3D5297902885&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D776" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D5855415646&u=3D4079223686&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D777" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2389803385&u=3D1094115188=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D778" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4939447721&u=3D4325878813&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D779" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8991514523&u=
+=3D5125568431&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D780" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5728897164&u=3D6591038760&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D781" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+369574998&u=3D9420979586&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D782" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D8083175325&u=3D8675071314&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D783=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6048096802&u=3D8252045593&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D784" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D1546957087&u=3D413030=
+5126&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D785" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1139082827&u=3D7882206934&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D786" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3429019820=
+&u=3D9318010743&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D787" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5899025962&u=3D4201225242&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D788" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6317152031&u=3D9514255777&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D789" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D9103115140&u=3D2918260963=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D790" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D2139078760&u=3D5586143660&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D791" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1005502537&u=
+=3D6952554500&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D792" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D8441393731&u=3D5162260671&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D793" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+094089209&u=3D6921525436&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D794" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D7640122370&u=3D3951331472&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D795=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D5993571693&u=3D4632522232&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D796" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D2266622851&u=3D666384=
+6005&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D797" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5087357728&u=3D5613655595&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D798" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2612579345=
+&u=3D4143852021&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D799" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D5694848867&u=3D5428082088&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D800" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">Weekly digest re=
+adable item THREE about rollout timing</a><span style=3D"font-family:'Segoe=
+ UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18=
+px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;b=
+ackground-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table =
+role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" widt=
+h=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-ser=
+if;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exact=
+ly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSS=
+LEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9116428507&u=3D16=
+74755608&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_d=
+igest&seg=3D801" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif=
+;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly=
+;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLE=
+AKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;=
+color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;=
+padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEA=
+KZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellpaddin=
+g=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font=
+-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;=
+line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px s=
+olid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click=
+.example-news.com/r/?id=3D5729866281&u=3D6110943464&utm_source=3Dnewsletter=
+&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D802" style=3D"font-f=
+amily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;li=
+ne-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px sol=
+id #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-fa=
+mily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;lin=
+e-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px soli=
+d #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></ta=
+ble><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=
+=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Ari=
+al,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height=
+-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#f=
+af9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D650409=
+9682&u=3D2020262123&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=
+=3Dweekly_digest&seg=3D803" style=3D"font-family:'Segoe UI',Helvetica,Arial=
+,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-r=
+ule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf=
+9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,=
+sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-ru=
+le:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9=
+f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation"=
+ cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td st=
+yle=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font=
+-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;b=
+order:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"ht=
+tps://click.example-news.com/r/?id=3D5508149905&u=3D8902114913&utm_source=
+=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D804" st=
+yle=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font=
+-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;b=
+order:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span sty=
+le=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-=
+size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bo=
+rder:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span><=
+/td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D1659663750&u=3D2549748436&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D805" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D2836553621&u=3D7872873371=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D806" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1857596764&u=3D1110533960&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D807" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5646880148&u=
+=3D4623960580&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D808" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7002076563&u=3D8134112721&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D809" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9=
+981364488&u=3D7631970791&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D810" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6089026099&u=3D9098129449&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D811=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2586568081&u=3D2914590233&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D812" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6425814872&u=3D729237=
+6027&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D813" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1264739091&u=3D3866755218&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D814" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9958044697=
+&u=3D7620473079&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D815" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3532855799&u=3D3377702111&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D816" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D8906163641&u=3D4786674545&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D817" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7340498236&u=3D5634076661=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D818" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D4067919621&u=3D3664052763&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D819" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8547068234&u=
+=3D5227828349&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D820" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D5175416378&u=3D4472312361&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D821" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1=
+541964762&u=3D2818381356&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D822" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D2869999754&u=3D3693916084&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D823=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6402580787&u=3D1287814151&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D824" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4751509023&u=3D280214=
+1793&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D825" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D2780016559&u=3D5035765954&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D826" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4972536230=
+&u=3D7059726570&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D827" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D7910439839&u=3D1160913827&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D828" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6477862024&u=3D8274219704&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D829" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D5461537013&u=3D2020395327=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D830" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8497938394&u=3D9249923427&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D831" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9147687657&u=
+=3D5381866906&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D832" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6596578419&u=3D4731897202&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D833" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5=
+872148707&u=3D8841851495&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D834" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3772636814&u=3D6102144947&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D835=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8833889083&u=3D8477300991&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D836" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D9019515562&u=3D452624=
+2854&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D837" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D1682781467&u=3D7471636437&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D838" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1124331395=
+&u=3D4577406847&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D839" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D4594787485&u=3D2071552532&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D840" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2960432117&u=3D9237880732&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D841" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D4026379752&u=3D6471691689=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D842" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8831899893&u=3D7464468567&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D843" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D1131267917&u=
+=3D6894699853&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D844" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D7846365089&u=3D9033653743&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D845" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6=
+797174636&u=3D9136780852&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D846" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D3958590550&u=3D2224363672&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D847=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D2660286914&u=3D5144289583&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D848" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4681264539&u=3D378047=
+5472&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D849" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D3910678913&u=3D5333183840&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D850" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D4914929023=
+&u=3D3780439666&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D851" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D1036351450&u=3D8055515912&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D852" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D6792661894&u=3D2082326234&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D853" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D7299420031&u=3D1439427140=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D854" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D7910817577&u=3D5759272717&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D855" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D5569145346&u=
+=3D9539945315&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D856" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D8046300793&u=3D8995045543&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D857" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+283298067&u=3D4287687478&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D858" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4864126433&u=3D7872090713&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D859=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D8131923452&u=3D3923823693&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D860" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4097887746&u=3D810989=
+1300&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D861" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D9579064478&u=3D7092693247&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D862" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9741628563=
+&u=3D6110646714&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D863" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D8666074487&u=3D8180620422&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D864" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D7473868020&u=3D4631048029&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D865" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D6072939882&u=3D5714169271=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D866" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D1383539822&u=3D2525930586&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D867" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D6613888489&u=
+=3D6717963562&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D868" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D6557907251&u=3D4655935832&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D869" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+020939193&u=3D5600836559&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D870" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D4820055862&u=3D3149533961&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D871=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6576395496&u=3D4668931881&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D872" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D6155234610&u=3D296525=
+4350&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D873" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D4073772623&u=3D4345526911&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D874" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D7389111087=
+&u=3D6054421752&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D875" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D3725152347&u=3D5315211627&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D876" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D2174793230&u=3D4283432667&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D877" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1378134712&u=3D7934137693=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D878" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D8015775567&u=3D7027529118&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D879" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9441018790&u=
+=3D2646331504&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D880" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D9751963589&u=3D1818520766&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D881" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3=
+906611156&u=3D2068687175&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D882" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D6773938304&u=3D1553753599&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D883=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D7823288650&u=3D1717346250&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D884" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D4538382315&u=3D654406=
+3167&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D885" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D6745958212&u=3D5275521470&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D886" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D9166381136=
+&u=3D1809283659&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D887" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cel=
+lpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https=
+://click.example-news.com/r/?id=3D2732553940&u=3D1981049082&utm_source=3Dne=
+wsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D888" style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=
+=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-si=
+ze:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;bord=
+er:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></t=
+d></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=
+=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',=
+Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;ms=
+o-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgr=
+ound-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r=
+/?id=3D1563524533&u=3D4152835101&utm_source=3Dnewsletter&utm_medium=3Demail=
+&utm_campaign=3Dweekly_digest&seg=3D889" style=3D"font-family:'Segoe UI',He=
+lvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-=
+line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgrou=
+nd-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Hel=
+vetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-l=
+ine-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backgroun=
+d-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"=
+presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100=
+%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color=
+:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;paddi=
+ng:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">=
+<a href=3D"https://click.example-news.com/r/?id=3D1725783958&u=3D5455441991=
+&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&se=
+g=3D890" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#=
+323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding=
+:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></=
+a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#3=
+23130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:=
+8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nb=
+sp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D"0" =
+cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:=
+'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-hei=
+ght:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #ed=
+ebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example=
+-news.com/r/?id=3D9798613995&u=3D5272119095&utm_source=3Dnewsletter&utm_med=
+ium=3Demail&utm_campaign=3Dweekly_digest&seg=3D891" style=3D"font-family:'S=
+egoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-heigh=
+t:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edeb=
+e9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Se=
+goe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height=
+:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe=
+9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><tab=
+le role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" w=
+idth=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D3843139149&u=
+=3D1084790270&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dwee=
+kly_digest&seg=3D892" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-=
+serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:ex=
+actly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZ=
+CSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-s=
+erif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exa=
+ctly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZC=
+SSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presentation" cellp=
+adding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D=
+"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:=
+13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:=
+1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://=
+click.example-news.com/r/?id=3D3962452613&u=3D7085004726&utm_source=3Dnewsl=
+etter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D893" style=3D"f=
+ont-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13=
+px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1p=
+x solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"fo=
+nt-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13p=
+x;line-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px=
+ solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr=
+></table><table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" b=
+order=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetic=
+a,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-h=
+eight-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-col=
+or:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D2=
+633177480&u=3D7645527239&utm_source=3Dnewsletter&utm_medium=3Demail&utm_cam=
+paign=3Dweekly_digest&seg=3D894" style=3D"font-family:'Segoe UI',Helvetica,=
+Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-hei=
+ght-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color=
+:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,A=
+rial,sans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-heig=
+ht-rule:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:=
+#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=3D"presenta=
+tion" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><=
+td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130=
+;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 1=
+2px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=
+=3D"https://click.example-news.com/r/?id=3D1657675888&u=3D3707166618&utm_so=
+urce=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D895=
+" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;=
+font-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12=
+px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span=
+ style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;f=
+ont-size:13px;line-height:18px;mso-line-height-rule:exactly;padding:8px 12p=
+x;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</sp=
+an></td></tr></table><table role=3D"presentation" cellpadding=3D"0" cellspa=
+cing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-family:'Segoe =
+UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18p=
+x;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;ba=
+ckground-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.c=
+om/r/?id=3D6588252632&u=3D3841827734&utm_source=3Dnewsletter&utm_medium=3De=
+mail&utm_campaign=3Dweekly_digest&seg=3D896" style=3D"font-family:'Segoe UI=
+',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;=
+mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;back=
+ground-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI'=
+,Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-height:18px;m=
+so-line-height-rule:exactly;padding:8px 12px;border:1px solid #edebe9;backg=
+round-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table><table role=
+=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"0" width=3D=
+"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;c=
+olor:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;p=
+adding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAK=
+ZZ"><a href=3D"https://click.example-news.com/r/?id=3D5884080139&u=3D580063=
+3419&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dweekly_diges=
+t&seg=3D897" style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;col=
+or:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;pad=
+ding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ=
+"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans-serif;colo=
+r:#323130;font-size:13px;line-height:18px;mso-line-height-rule:exactly;padd=
+ing:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"=
+>&nbsp;</span></td></tr></table><table role=3D"presentation" cellpadding=3D=
+"0" cellspacing=3D"0" border=3D"0" width=3D"100%"><tr><td style=3D"font-fam=
+ily:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line=
+-height:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid=
+ #edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"><a href=3D"https://click.exa=
+mple-news.com/r/?id=3D5751366455&u=3D6161147047&utm_source=3Dnewsletter&utm=
+_medium=3Demail&utm_campaign=3Dweekly_digest&seg=3D898" style=3D"font-famil=
+y:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-h=
+eight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #=
+edebe9;background-color:#faf9f8;ZZCSSLEAKZZ"></a><span style=3D"font-family=
+:'Segoe UI',Helvetica,Arial,sans-serif;color:#323130;font-size:13px;line-he=
+ight:18px;mso-line-height-rule:exactly;padding:8px 12px;border:1px solid #e=
+debe9;background-color:#faf9f8;ZZCSSLEAKZZ">&nbsp;</span></td></tr></table>=
+<table role=3D"presentation" cellpadding=3D"0" cellspacing=3D"0" border=3D"=
+0" width=3D"100%"><tr><td style=3D"font-family:'Segoe UI',Helvetica,Arial,s=
+ans-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rul=
+e:exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f=
+8;ZZCSSLEAKZZ"><a href=3D"https://click.example-news.com/r/?id=3D8316205130=
+&u=3D2268523764&utm_source=3Dnewsletter&utm_medium=3Demail&utm_campaign=3Dw=
+eekly_digest&seg=3D899" style=3D"font-family:'Segoe UI',Helvetica,Arial,san=
+s-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:=
+exactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;=
+ZZCSSLEAKZZ"></a><span style=3D"font-family:'Segoe UI',Helvetica,Arial,sans=
+-serif;color:#323130;font-size:13px;line-height:18px;mso-line-height-rule:e=
+xactly;padding:8px 12px;border:1px solid #edebe9;background-color:#faf9f8;Z=
+ZCSSLEAKZZ">&nbsp;</span></td></tr></table></body></html>
+--=-SyntheticBoundary42==--


### PR DESCRIPTION
Force message/rfc822 for .eml regardless of provided type, coerce multipart/* in parse_file, and strip <style>/<script> from HTML email parts before extraction. A 968KB styled newsletter drops 628k -> ~3.9k tokens.