### PR TITLE
Adjust Helm chart to run erato-backend container as non-root users

### DIFF
--- a/infrastructure/charts/erato/README.md
+++ b/infrastructure/charts/erato/README.md
@@ -178,6 +178,7 @@ ingress:
 | backend.configFile.inlineContent | string | `""` | Inline content for erato.toml (alternative to secret/configMap) |
 | backend.configFile.secretKey | string | `""` | Key in the secret that contains the erato.toml content |
 | backend.configFile.secretName | string | `""` | Name of the secret containing the erato.toml file |
+| backend.containerSecurityContext | object | `{"runAsNonRoot":true}` | Security context for the backend container |
 | backend.deploymentAnnotations | object | `{}` | Annotations to add to the backend deployment |
 | backend.deploymentStrategy | object | `{}` | Optional deployment strategy for backend rollout (e.g., RollingUpdate/Recreate). Example: deploymentStrategy:   type: RollingUpdate   rollingUpdate:     maxUnavailable: 25%     maxSurge: 25% |
 | backend.deploymentVersion | string | `""` | Optional deployment version for cache headers on static files (falls back to image tag if not set) |

--- a/infrastructure/charts/erato/templates/backend-deployment.yaml
+++ b/infrastructure/charts/erato/templates/backend-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         - name: erato-backend
           image: {{ include "common.images.image" ( dict "imageRoot" .Values.backend.image "global" .Values.global "chart" .Chart ) }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          {{- with .Values.backend.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3130

--- a/infrastructure/charts/erato/tests/backend-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/backend-deployment_test.yaml
@@ -32,6 +32,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3130
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
 
   - it: should honor namespaceOverride
     set:
@@ -66,6 +69,15 @@ tests:
       - equal:
           path: spec.strategy.rollingUpdate.maxSurge
           value: 1
+
+  - it: should set backend container security context when configured
+    set:
+      backend.containerSecurityContext:
+        runAsNonRoot: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: false
 
   - it: should use custom image repository and tag
     set:

--- a/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
@@ -29,7 +29,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: harbor.imassage.me/erato/oauth2-proxy:v7.15.2-erato.3
-
   - it: should not render when oauth2Proxy is disabled
     set:
       oauth2Proxy.enabled: false

--- a/infrastructure/charts/erato/tests/oauth2-proxy-redis-statefulset_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-redis-statefulset_test.yaml
@@ -17,7 +17,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: redis:8.8.0-alpine3.23@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
-
   - it: should not render when oauth2Proxy is disabled
     set:
       oauth2Proxy.enabled: false

--- a/infrastructure/charts/erato/values.yaml
+++ b/infrastructure/charts/erato/values.yaml
@@ -209,6 +209,9 @@ backend:
   deploymentStrategy: {}
   # -- Annotations to add to the backend pod
   podAnnotations: {}
+  # -- Security context for the backend container
+  containerSecurityContext:
+    runAsNonRoot: true
   networkPolicy:
     # -- Enable NetworkPolicy for backend pods
     enabled: true


### PR DESCRIPTION
Addresses Kubescape control C-0013

Related to #717 