### PR TITLE
Extract host-agnostic auth seam from MsalNaaProvider

### DIFF
--- a/frontend/src/auth/apiRequestAuth.ts
+++ b/frontend/src/auth/apiRequestAuth.ts
@@ -19,6 +19,13 @@ export function mergeApiAuthHeaders(
     return definedHeaders;
   }
 
+  // The web app leaves this null (cookie auth). The Office add-in populates it,
+  // but for the add-in this Bearer is INCIDENTAL, not the auth source of truth:
+  // requests are authenticated by the oauth2-proxy session cookie minted at
+  // /oauth2/redeem-external-token. The add-in's MSAL token is a separate app
+  // registration from oauth2-proxy's, and there is no `oidc_extra_audiences`, so
+  // the proxy does not accept this Bearer — it falls through to the cookie. Kept
+  // as a harmless best-effort header; do not treat its freshness as load-bearing.
   const idToken = getIdToken();
   if (!idToken) {
     return definedHeaders;

--- a/office-addin/src/auth/AuthSource.ts
+++ b/office-addin/src/auth/AuthSource.ts
@@ -1,0 +1,97 @@
+import type { AccountInfo } from "@azure/msal-browser";
+
+/**
+ * The auth strategy in effect for the current host/environment. Step 0 only
+ * produces a working source for `entra-msal`; the other two are honest
+ * "not supported yet" states (see {@link "./UnsupportedAuthSource"}).
+ */
+export type AuthMode = "entra-msal" | "exchange-callback" | "unsupported";
+
+/**
+ * Layer-1 bootstrap token plus the identity it was minted for. This is the
+ * input to oauth2-proxy session redemption (Layer-2) and the ONLY thing the
+ * host-agnostic SessionAuth core receives from an {@link AuthSource}.
+ */
+export interface BootstrapToken {
+  /** Redeemed at `/oauth2/redeem-external-token` as `id_token`. */
+  idToken: string;
+  /** Redeemed as `access_token` when present. EXO has it; on-prem won't. */
+  accessToken?: string;
+  /** MSAL account when MSAL-backed; null otherwise. The core never reads it. */
+  account: AccountInfo | null;
+}
+
+export interface AcquireBootstrapOptions {
+  /**
+   * Re-mint even if a silent/cached token exists. Drives `recoverAuth` in a
+   * later step; unused on the Step-0 happy path.
+   */
+  forceRefresh?: boolean;
+  /**
+   * When true the source MAY open interactive UI (popup) if a silent acquire
+   * fails. Maps to the old `allowPopup`: init/timed-refresh pass false, the
+   * user-driven retry passes true. Background timers/focus must pass false.
+   */
+  allowInteraction?: boolean;
+}
+
+/**
+ * Host-agnostic Layer-1 token source — one instance per auth mode. The
+ * SessionAuth core depends ONLY on this interface, never on Office, the
+ * mailbox, MSAL, or Microsoft Graph.
+ */
+export interface AuthSource {
+  readonly mode: AuthMode;
+
+  /**
+   * Prepare the source (MSAL: create the nestable PCA + resolve the login
+   * hint). MUST be re-runnable after a failure so the retry flow can re-init.
+   * Throws on hard init failure; the core catches it and surfaces it via
+   * `error`.
+   */
+  initialize(): Promise<void>;
+
+  /**
+   * Acquire/re-acquire the Layer-1 bootstrap token. Silent unless
+   * `allowInteraction` is set. Throws {@link InteractionRequiredError} when
+   * interaction is required but not allowed — the core maps that to the
+   * sign-in-required state.
+   */
+  acquireBootstrapToken(
+    options?: AcquireBootstrapOptions,
+  ): Promise<BootstrapToken>;
+}
+
+/**
+ * Resolves an optional login hint for the bootstrap acquire. Injected per host:
+ * the Outlook wrapper adds a mailbox fallback; Excel/Word supply a mailbox-less
+ * resolver (or none). Keeping this injected is what stops the mailbox from
+ * leaking into the Entra source.
+ */
+export type LoginHintResolver = () => Promise<string | undefined>;
+
+/**
+ * Outlook-only capability bolted onto the Entra source: acquires a Microsoft
+ * Graph access token for arbitrary scopes (`Mail.Read`, …) reusing the SAME
+ * initialized PCA + login hint. Returns the full bootstrap so the caller can
+ * re-redeem the proxy session from the token it ALREADY holds — no second MSAL
+ * acquisition. Excel/Word never reference this.
+ */
+export interface GraphCapableSource {
+  acquireGraphToken(scopes: string[]): Promise<{
+    accessToken: string;
+    bootstrap: BootstrapToken;
+  }>;
+}
+
+/**
+ * Host-agnostic "interaction required" signal. The Entra source translates
+ * MSAL's `InteractionRequiredAuthError` into this so the SessionAuth core can
+ * recognise "sign-in required" without importing `@azure/msal-browser`.
+ */
+export class InteractionRequiredError extends Error {
+  constructor(message = "Interaction required", options?: { cause?: unknown }) {
+    super(message, options?.cause === undefined ? undefined : options);
+    this.name = "InteractionRequiredError";
+  }
+}

--- a/office-addin/src/auth/EntraNaaAuthSource.ts
+++ b/office-addin/src/auth/EntraNaaAuthSource.ts
@@ -1,0 +1,171 @@
+import {
+  InteractionRequiredAuthError,
+  createNestablePublicClientApplication,
+  type AuthenticationResult,
+  type IPublicClientApplication,
+} from "@azure/msal-browser";
+import { env, setIdToken } from "@erato/frontend/library";
+import { t } from "@lingui/core/macro";
+
+import {
+  InteractionRequiredError,
+  type AcquireBootstrapOptions,
+  type AuthSource,
+  type BootstrapToken,
+  type GraphCapableSource,
+  type LoginHintResolver,
+} from "./AuthSource";
+
+/** Scopes for the Layer-1 bootstrap token that gets redeemed for the session. */
+const OAUTH2_PROXY_SESSION_SCOPES = ["User.Read"];
+
+interface EntraNaaAuthSourceOptions {
+  /** Host-injected: Outlook adds a mailbox fallback, Excel/Word does not. */
+  resolveLoginHint: LoginHintResolver;
+}
+
+/**
+ * The Entra/MSAL-NAA {@link AuthSource} (EXO / Microsoft 365). All MSAL and NAA
+ * coupling lives here, behind the host-agnostic `AuthSource` interface, so the
+ * SessionAuth core and other hosts never import `@azure/msal-browser`.
+ *
+ * Also implements {@link GraphCapableSource} — the Outlook-only Graph token
+ * path — because it reuses the same initialized PCA + login hint. Non-Outlook
+ * hosts simply never call `acquireGraphToken`.
+ */
+export function createEntraNaaAuthSource(
+  options: EntraNaaAuthSourceOptions,
+): AuthSource & GraphCapableSource {
+  let pca: IPublicClientApplication | null = null;
+  let loginHint: string | undefined;
+
+  async function acquireMsalResult(
+    instance: IPublicClientApplication,
+    scopes: string[],
+    allowInteraction: boolean,
+    forceRefresh: boolean,
+  ): Promise<AuthenticationResult> {
+    try {
+      return await instance.acquireTokenSilent({
+        scopes,
+        ...(loginHint ? { loginHint } : {}),
+        ...(forceRefresh ? { forceRefresh: true } : {}),
+      });
+    } catch (silentError) {
+      if (silentError instanceof InteractionRequiredAuthError) {
+        if (allowInteraction) {
+          const result = await instance.acquireTokenPopup({
+            scopes,
+            prompt: "select_account",
+          });
+          if (result.account) {
+            instance.setActiveAccount(result.account);
+          }
+          return result;
+        }
+        // Translate to a host-agnostic signal so the core stays MSAL-free.
+        throw new InteractionRequiredError("MSAL interaction required", {
+          cause: silentError,
+        });
+      }
+      throw silentError;
+    }
+  }
+
+  function applyResult(
+    instance: IPublicClientApplication,
+    result: AuthenticationResult,
+  ): void {
+    if (result.account) {
+      instance.setActiveAccount(result.account);
+    }
+    setIdToken(result.idToken);
+  }
+
+  function requirePca(): IPublicClientApplication {
+    if (!pca) {
+      throw new Error(
+        t({
+          id: "officeAddin.auth.msalNotInitialized",
+          message: "MSAL not initialized",
+        }),
+      );
+    }
+    return pca;
+  }
+
+  return {
+    mode: "entra-msal",
+
+    async initialize(): Promise<void> {
+      const clientId =
+        import.meta.env.VITE_MSAL_CLIENT_ID ?? env().msalClientId;
+      if (!clientId) {
+        throw new Error(
+          t({
+            id: "officeAddin.auth.msalClientIdMissing",
+            message: "MSAL client ID is not configured",
+          }),
+        );
+      }
+
+      const authority =
+        import.meta.env.VITE_MSAL_AUTHORITY ??
+        env().msalAuthority ??
+        "https://login.microsoftonline.com/common";
+
+      // Assigned to a variable (not passed as a literal) so TS's excess-property
+      // check doesn't reject `supportsNestedAppAuth`, which the NAA-capable
+      // runtime reads but isn't in the published BrowserAuthOptions type.
+      const msalConfig = {
+        auth: {
+          clientId,
+          authority,
+          supportsNestedAppAuth: true,
+        },
+        cache: {
+          cacheLocation: "localStorage" as const,
+        },
+      };
+      pca = await createNestablePublicClientApplication(msalConfig);
+      loginHint = await options.resolveLoginHint();
+    },
+
+    async acquireBootstrapToken(
+      opts: AcquireBootstrapOptions = {},
+    ): Promise<BootstrapToken> {
+      const instance = requirePca();
+      const result = await acquireMsalResult(
+        instance,
+        OAUTH2_PROXY_SESSION_SCOPES,
+        opts.allowInteraction ?? false,
+        opts.forceRefresh ?? false,
+      );
+      applyResult(instance, result);
+      return {
+        idToken: result.idToken,
+        accessToken: result.accessToken,
+        account: result.account,
+      };
+    },
+
+    async acquireGraphToken(scopes: string[]): Promise<{
+      accessToken: string;
+      bootstrap: BootstrapToken;
+    }> {
+      const instance = requirePca();
+      // Graph acquisition is user-initiated (an email action), so interaction
+      // is allowed — matching the old `acquireToken(scopes)` (allowPopup=true).
+      const result = await acquireMsalResult(instance, scopes, true, false);
+      applyResult(instance, result);
+      return {
+        accessToken: result.accessToken,
+        bootstrap: {
+          idToken: result.idToken,
+          accessToken: result.accessToken,
+          account: result.account,
+        },
+      };
+    },
+  };
+}

--- a/office-addin/src/auth/UnsupportedAuthSource.ts
+++ b/office-addin/src/auth/UnsupportedAuthSource.ts
@@ -1,0 +1,54 @@
+import { t } from "@lingui/core/macro";
+
+import type { AuthMode, AuthSource, BootstrapToken } from "./AuthSource";
+
+/** The modes Step 0 recognises but can't authenticate yet — every `AuthMode`
+ * except the one working source. Derived from {@link AuthMode} so a new mode
+ * can't silently fall out of sync. */
+type UnsupportedReason = Exclude<AuthMode, "entra-msal">;
+
+/** The localized "can't sign in here yet" error for an unsupported mode. */
+function unsupportedReasonError(mode: UnsupportedReason): Error {
+  if (mode === "exchange-callback") {
+    return new Error(
+      t({
+        id: "officeAddin.auth.onPremNotSupported",
+        message: "On-prem (legacy Exchange) sign-in isn't supported yet.",
+      }),
+    );
+  }
+  return new Error(
+    t({
+      id: "officeAddin.auth.naaUnsupported",
+      message: "Nested App Authentication is not supported in this environment",
+    }),
+  );
+}
+
+/**
+ * An {@link AuthSource} for environments Step 0 can't authenticate yet. Its
+ * `initialize()` throws a typed, localized message that the SessionAuth core
+ * surfaces through the existing error + "Try again" UI — no new component.
+ *
+ * - `exchange-callback`: on-prem Exchange (callback-token path) — recognised but
+ *   not implemented yet (a future step wires the Exchange callback token).
+ * - `unsupported`: genuinely unsupported host (no NAA, no mailbox) — preserves
+ *   the previous "Nested App Authentication is not supported" behaviour.
+ */
+export class UnsupportedAuthSource implements AuthSource {
+  readonly mode: UnsupportedReason;
+
+  constructor(reason: UnsupportedReason) {
+    this.mode = reason;
+  }
+
+  initialize(): Promise<void> {
+    return Promise.reject(unsupportedReasonError(this.mode));
+  }
+
+  acquireBootstrapToken(): Promise<BootstrapToken> {
+    // Unreachable on the happy path — the core never advances to bootstrap once
+    // initialize() rejects — but the AuthSource contract requires it.
+    return Promise.reject(unsupportedReasonError(this.mode));
+  }
+}

--- a/office-addin/src/auth/detectAuthMode.ts
+++ b/office-addin/src/auth/detectAuthMode.ts
@@ -1,0 +1,20 @@
+/**
+ * Host-agnostic auth-mode probe. Reasons ONLY about Nested App Auth support —
+ * it deliberately knows nothing about the mailbox, Exchange, or Graph so the
+ * seam stays reusable across Office hosts (Outlook today, Excel/Word later).
+ *
+ * The host-specific decision "no NAA but this is a mailbox ⇒ legacy on-prem
+ * Exchange" lives in the Outlook wrapper, which is allowed to read Outlook
+ * surfaces. Here we return only the host-agnostic verdict.
+ */
+export function detectAuthMode(): "entra-msal" | "unsupported" {
+  try {
+    const naaSupported =
+      typeof Office !== "undefined" &&
+      !!Office.context?.requirements?.isSetSupported("NestedAppAuth", "1.1");
+    return naaSupported ? "entra-msal" : "unsupported";
+  } catch {
+    // Office absent (outside an add-in host) — nothing to authenticate against.
+    return "unsupported";
+  }
+}

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -41,7 +41,7 @@ import { AddinSettingsDialog } from "./AddinSettingsDialog";
 import { useEmailDedupSet } from "../hooks/useEmailDedupSet";
 import { useOfficeDragAndDrop } from "../hooks/useOfficeDragAndDrop";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
-import { useMsalNaa } from "../providers/MsalNaaProvider";
+import { useGraphToken } from "../providers/EntraGraphTokenProvider";
 import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { fetchOutlookMessageBytesViaGraph } from "../utils/fetchOutlookMessageGraph";
@@ -140,7 +140,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     chatInputControlsRef.current?.addUploadedFiles(uploaded);
   }, []);
 
-  const { acquireToken } = useMsalNaa();
+  const { acquireToken } = useGraphToken();
   const acquireGraphToken = useCallback(
     () => acquireToken(GRAPH_MAIL_SCOPES),
     [acquireToken],

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -22,12 +22,17 @@ msgid "officeAddin.auth.authenticating"
 msgstr "Authentifizierung..."
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.authenticationFailed"
 msgstr "Authentifizierung fehlgeschlagen"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.auth.graphUnavailable"
+msgstr "Graph-Authentifizierung ist auf diesem Host nicht verfügbar"
+
+#. js-lingui-explicit-id
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalClientIdMissing"
 msgstr "Die MSAL-Client-ID ist nicht konfiguriert"
 
@@ -37,28 +42,33 @@ msgstr "Die MSAL-Client-ID ist nicht konfiguriert"
 #~ msgstr "MSAL konnte nicht initialisiert werden"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalNotInitialized"
 msgstr "MSAL ist nicht initialisiert"
 
 #. js-lingui-explicit-id
 #: src/providers/MsalNaaProvider.tsx
-msgid "officeAddin.auth.msalProviderNotMounted"
-msgstr "MsalNaaProvider ist nicht eingebunden"
+#~ msgid "officeAddin.auth.msalProviderNotMounted"
+#~ msgstr "MsalNaaProvider ist nicht eingebunden"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/UnsupportedAuthSource.ts
 msgid "officeAddin.auth.naaUnsupported"
 msgstr "Verschachtelte App-Authentifizierung wird in dieser Umgebung nicht unterstützt"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.oauth2ProxySessionFailed"
 msgstr "Es konnte keine sichere Erato-Sitzung hergestellt werden. Melde dich erneut an."
 
 #. js-lingui-explicit-id
+#: src/auth/UnsupportedAuthSource.ts
+msgid "officeAddin.auth.onPremNotSupported"
+msgstr "Die Anmeldung bei lokalem Exchange (Legacy) wird noch nicht unterstützt."
+
+#. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.signInRequired"
 msgstr "Anmeldung erforderlich"
 

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -22,12 +22,17 @@ msgid "officeAddin.auth.authenticating"
 msgstr "Authenticating..."
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.authenticationFailed"
 msgstr "Authentication failed"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.auth.graphUnavailable"
+msgstr "Graph auth is not available on this host"
+
+#. js-lingui-explicit-id
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalClientIdMissing"
 msgstr "MSAL client ID is not configured"
 
@@ -37,28 +42,33 @@ msgstr "MSAL client ID is not configured"
 #~ msgstr "Failed to initialize MSAL"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalNotInitialized"
 msgstr "MSAL not initialized"
 
 #. js-lingui-explicit-id
 #: src/providers/MsalNaaProvider.tsx
-msgid "officeAddin.auth.msalProviderNotMounted"
-msgstr "MsalNaaProvider not mounted"
+#~ msgid "officeAddin.auth.msalProviderNotMounted"
+#~ msgstr "MsalNaaProvider not mounted"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/UnsupportedAuthSource.ts
 msgid "officeAddin.auth.naaUnsupported"
 msgstr "Nested App Authentication is not supported in this environment"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.oauth2ProxySessionFailed"
 msgstr "Could not establish a secure Erato session. Try signing in again."
 
 #. js-lingui-explicit-id
+#: src/auth/UnsupportedAuthSource.ts
+msgid "officeAddin.auth.onPremNotSupported"
+msgstr "On-prem (legacy Exchange) sign-in isn't supported yet."
+
+#. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.signInRequired"
 msgstr "Sign-in required"
 

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -22,12 +22,17 @@ msgid "officeAddin.auth.authenticating"
 msgstr "Autenticando..."
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.authenticationFailed"
 msgstr "Error de autenticación"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.auth.graphUnavailable"
+msgstr "La autenticación de Graph no está disponible en este host"
+
+#. js-lingui-explicit-id
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalClientIdMissing"
 msgstr "El ID de cliente de MSAL no está configurado"
 
@@ -37,28 +42,33 @@ msgstr "El ID de cliente de MSAL no está configurado"
 #~ msgstr "No se pudo inicializar MSAL"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalNotInitialized"
 msgstr "MSAL no está inicializado"
 
 #. js-lingui-explicit-id
 #: src/providers/MsalNaaProvider.tsx
-msgid "officeAddin.auth.msalProviderNotMounted"
-msgstr "MsalNaaProvider no está montado"
+#~ msgid "officeAddin.auth.msalProviderNotMounted"
+#~ msgstr "MsalNaaProvider no está montado"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/UnsupportedAuthSource.ts
 msgid "officeAddin.auth.naaUnsupported"
 msgstr "La autenticación de aplicación anidada no es compatible con este entorno"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.oauth2ProxySessionFailed"
 msgstr "No se pudo establecer una sesión segura de Erato. Inicia sesión de nuevo."
 
 #. js-lingui-explicit-id
+#: src/auth/UnsupportedAuthSource.ts
+msgid "officeAddin.auth.onPremNotSupported"
+msgstr "El inicio de sesión en Exchange local (heredado) aún no es compatible."
+
+#. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.signInRequired"
 msgstr "Se requiere iniciar sesión"
 

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -22,12 +22,17 @@ msgid "officeAddin.auth.authenticating"
 msgstr "Authentification..."
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.authenticationFailed"
 msgstr "Échec de l’authentification"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.auth.graphUnavailable"
+msgstr "L’authentification Graph n’est pas disponible sur cet hôte"
+
+#. js-lingui-explicit-id
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalClientIdMissing"
 msgstr "L’identifiant client MSAL n’est pas configuré"
 
@@ -37,28 +42,33 @@ msgstr "L’identifiant client MSAL n’est pas configuré"
 #~ msgstr "Échec de l’initialisation de MSAL"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalNotInitialized"
 msgstr "MSAL n’est pas initialisé"
 
 #. js-lingui-explicit-id
 #: src/providers/MsalNaaProvider.tsx
-msgid "officeAddin.auth.msalProviderNotMounted"
-msgstr "MsalNaaProvider n’est pas monté"
+#~ msgid "officeAddin.auth.msalProviderNotMounted"
+#~ msgstr "MsalNaaProvider n’est pas monté"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/UnsupportedAuthSource.ts
 msgid "officeAddin.auth.naaUnsupported"
 msgstr "L’authentification d’application imbriquée n’est pas prise en charge dans cet environnement"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.oauth2ProxySessionFailed"
 msgstr "Impossible d’établir une session Erato sécurisée. Reconnectez-vous."
 
 #. js-lingui-explicit-id
+#: src/auth/UnsupportedAuthSource.ts
+msgid "officeAddin.auth.onPremNotSupported"
+msgstr "La connexion à Exchange local (hérité) n’est pas encore prise en charge."
+
+#. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.signInRequired"
 msgstr "Connexion requise"
 

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -22,12 +22,17 @@ msgid "officeAddin.auth.authenticating"
 msgstr "Uwierzytelnianie..."
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.authenticationFailed"
 msgstr "Uwierzytelnianie nie powiodło się"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.auth.graphUnavailable"
+msgstr "Uwierzytelnianie Graph nie jest dostępne na tym hoście"
+
+#. js-lingui-explicit-id
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalClientIdMissing"
 msgstr "Identyfikator klienta MSAL nie jest skonfigurowany"
 
@@ -37,28 +42,33 @@ msgstr "Identyfikator klienta MSAL nie jest skonfigurowany"
 #~ msgstr "Nie udało się zainicjować MSAL"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/EntraNaaAuthSource.ts
 msgid "officeAddin.auth.msalNotInitialized"
 msgstr "MSAL nie został zainicjowany"
 
 #. js-lingui-explicit-id
 #: src/providers/MsalNaaProvider.tsx
-msgid "officeAddin.auth.msalProviderNotMounted"
-msgstr "MsalNaaProvider nie jest zamontowany"
+#~ msgid "officeAddin.auth.msalProviderNotMounted"
+#~ msgstr "MsalNaaProvider nie jest zamontowany"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/auth/UnsupportedAuthSource.ts
 msgid "officeAddin.auth.naaUnsupported"
 msgstr "Uwierzytelnianie zagnieżdżonej aplikacji nie jest obsługiwane w tym środowisku"
 
 #. js-lingui-explicit-id
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.oauth2ProxySessionFailed"
 msgstr "Nie udało się ustanowić bezpiecznej sesji Erato. Zaloguj się ponownie."
 
 #. js-lingui-explicit-id
+#: src/auth/UnsupportedAuthSource.ts
+msgid "officeAddin.auth.onPremNotSupported"
+msgstr "Logowanie do lokalnego Exchange (starsza wersja) nie jest jeszcze obsługiwane."
+
+#. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/MsalNaaProvider.tsx
+#: src/providers/SessionAuthProvider.tsx
 msgid "officeAddin.auth.signInRequired"
 msgstr "Wymagane logowanie"
 

--- a/office-addin/src/providers/EntraGraphTokenProvider.tsx
+++ b/office-addin/src/providers/EntraGraphTokenProvider.tsx
@@ -1,0 +1,82 @@
+import { t } from "@lingui/core/macro";
+import { createContext, useCallback, useContext, useMemo } from "react";
+
+import { useSessionRedeem } from "./SessionAuthProvider";
+import { type AuthSource, type GraphCapableSource } from "../auth/AuthSource";
+import { shouldRefreshOauth2ProxySession } from "../auth/oauth2ProxySession";
+
+export interface GraphTokenContextValue {
+  /** Microsoft Graph access token for the given scopes (e.g. `["Mail.Read"]`). */
+  acquireToken: (scopes: string[]) => Promise<string>;
+}
+
+const GraphTokenContext = createContext<GraphTokenContextValue | null>(null);
+
+/** The error raised when Graph auth is requested on a host without it (no
+ * EntraGraphTokenProvider mounted). Shared so the throwing `useGraphToken` and
+ * the back-compat `useMsalNaa` shim surface an identical message. */
+export function graphUnavailableError(): Error {
+  return new Error(
+    t({
+      id: "officeAddin.auth.graphUnavailable",
+      message: "Graph auth is not available on this host",
+    }),
+  );
+}
+
+export function useGraphToken(): GraphTokenContextValue {
+  const value = useContext(GraphTokenContext);
+  if (!value) {
+    throw graphUnavailableError();
+  }
+  return value;
+}
+
+/**
+ * Non-throwing variant for callers that may run outside the Graph provider
+ * (e.g. the back-compat `useMsalNaa()` shim in unsupported/non-Outlook modes).
+ */
+export function useGraphTokenOptional(): GraphTokenContextValue | null {
+  return useContext(GraphTokenContext);
+}
+
+/**
+ * Outlook-only provider for Microsoft Graph access tokens. Mounted ONLY in the
+ * Outlook subtree; Excel/Word never reference it. Lives inside
+ * {@link SessionAuthProvider} so it can opportunistically refresh the proxy
+ * session through the shared redeem seam from the token it already holds — no
+ * second MSAL acquisition.
+ */
+export function EntraGraphTokenProvider({
+  source,
+  children,
+}: {
+  source: AuthSource & GraphCapableSource;
+  children: React.ReactNode;
+}) {
+  const { redeemSessionForToken, lastRedeemedAtRef } = useSessionRedeem();
+
+  const acquireToken = useCallback(
+    async (scopes: string[]): Promise<string> => {
+      const { accessToken, bootstrap } = await source.acquireGraphToken(scopes);
+      // Opportunistically warm the proxy session from the token we just got,
+      // but only if it's gone stale — reusing the core's dedup + staleness ref.
+      if (shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)) {
+        await redeemSessionForToken(bootstrap, "refreshing");
+      }
+      return accessToken;
+    },
+    [lastRedeemedAtRef, redeemSessionForToken, source],
+  );
+
+  const value = useMemo<GraphTokenContextValue>(
+    () => ({ acquireToken }),
+    [acquireToken],
+  );
+
+  return (
+    <GraphTokenContext.Provider value={value}>
+      {children}
+    </GraphTokenContext.Provider>
+  );
+}

--- a/office-addin/src/providers/MsalNaaProvider.tsx
+++ b/office-addin/src/providers/MsalNaaProvider.tsx
@@ -1,546 +1,122 @@
-import {
-  type AuthenticationResult,
-  InteractionRequiredAuthError,
-  createNestablePublicClientApplication,
-  type AccountInfo,
-  type IPublicClientApplication,
-} from "@azure/msal-browser";
-import { env, setIdToken } from "@erato/frontend/library";
-import { t } from "@lingui/core/macro";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import {
+  EntraGraphTokenProvider,
+  graphUnavailableError,
+  useGraphTokenOptional,
+} from "./EntraGraphTokenProvider";
 import { useOffice } from "./OfficeProvider";
-import {
-  OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS,
-  Oauth2ProxySessionRedeemError,
-  readStoredOauth2ProxySessionRedeemedAt,
-  redeemOauth2ProxySession,
-  shouldRefreshOauth2ProxySession,
-} from "../auth/oauth2ProxySession";
+import { SessionAuthProvider, useSessionAuth } from "./SessionAuthProvider";
+import { createEntraNaaAuthSource } from "../auth/EntraNaaAuthSource";
+import { UnsupportedAuthSource } from "../auth/UnsupportedAuthSource";
+import { detectAuthMode } from "../auth/detectAuthMode";
 
-const OAUTH2_PROXY_SESSION_SCOPES = ["User.Read"];
+import type {
+  AuthSource,
+  GraphCapableSource,
+  LoginHintResolver,
+} from "../auth/AuthSource";
 
-// When a timed refresh fails we keep the (now stale) session and retry on a
-// capped exponential backoff so a transient outage doesn't permanently stop the
-// refresh loop until the user interacts.
-const OAUTH2_PROXY_REFRESH_RETRY_BASE_MS = 30_000;
-const OAUTH2_PROXY_REFRESH_RETRY_MAX_MS = 5 * 60_000;
-
-type Oauth2ProxySessionStatus =
-  | "idle"
-  | "establishing"
-  | "ready"
-  | "refreshing"
-  | "error";
-
-interface Oauth2ProxySessionState {
-  status: Oauth2ProxySessionStatus;
-  lastRedeemedAt: number | null;
-  error: string | null;
-}
-
-interface MsalNaaContextValue {
-  isInitialized: boolean;
-  isAuthenticated: boolean;
-  isOauth2ProxySessionReady: boolean;
-  oauth2ProxySessionStatus: Oauth2ProxySessionStatus;
-  account: AccountInfo | null;
-  acquireToken: (scopes: string[]) => Promise<string>;
-  retryAuthentication: () => Promise<void>;
-  error: string | null;
-}
-
-const MsalNaaContext = createContext<MsalNaaContextValue>({
-  isInitialized: false,
-  isAuthenticated: false,
-  isOauth2ProxySessionReady: false,
-  oauth2ProxySessionStatus: "idle",
-  account: null,
-  acquireToken: () =>
-    Promise.reject(
-      new Error(
-        t({
-          id: "officeAddin.auth.msalProviderNotMounted",
-          message: "MsalNaaProvider not mounted",
-        }),
-      ),
-    ),
-  retryAuthentication: () => Promise.resolve(),
-  error: null,
-});
-
+/**
+ * Back-compat hook: merges the host-agnostic session contract with the
+ * Outlook-only Graph token. New code should prefer `useSessionAuth()` (session)
+ * and `useGraphToken()` (Graph) directly; this keeps existing callers and tests
+ * working unchanged while the seam lands.
+ */
 export function useMsalNaa() {
-  return useContext(MsalNaaContext);
-}
+  const session = useSessionAuth();
+  const graph = useGraphTokenOptional();
 
-function createInitialOauth2ProxySessionState(): Oauth2ProxySessionState {
-  const lastRedeemedAt = readStoredOauth2ProxySessionRedeemedAt();
+  const acquireToken = useCallback(
+    (scopes: string[]): Promise<string> => {
+      if (graph) {
+        return graph.acquireToken(scopes);
+      }
+      return Promise.reject(graphUnavailableError());
+    },
+    [graph],
+  );
+
   return {
-    status: lastRedeemedAt === null ? "idle" : "ready",
-    lastRedeemedAt,
-    error: null,
+    ...session,
+    acquireToken,
   };
 }
 
-function applyAuthenticationResult(
-  instance: IPublicClientApplication,
-  result: AuthenticationResult,
-  setAccount: React.Dispatch<React.SetStateAction<AccountInfo | null>>,
-) {
-  if (result.account) {
-    instance.setActiveAccount(result.account);
-  }
-  setAccount(result.account);
-  setIdToken(result.idToken);
-}
-
-async function acquireMsalResult(
-  instance: IPublicClientApplication,
-  scopes: string[],
-  loginHint: string | undefined,
-  allowPopup: boolean,
-): Promise<AuthenticationResult> {
-  try {
-    return await instance.acquireTokenSilent({
-      scopes,
-      ...(loginHint ? { loginHint } : {}),
-    });
-  } catch (silentError) {
-    if (silentError instanceof InteractionRequiredAuthError && allowPopup) {
-      const result = await instance.acquireTokenPopup({
-        scopes,
-        prompt: "select_account",
-      });
-      if (result.account) {
-        instance.setActiveAccount(result.account);
-      }
-      return result;
-    }
-
-    throw silentError;
-  }
-}
-
-function formatAuthenticationError(error: unknown): string {
-  if (error instanceof Oauth2ProxySessionRedeemError) {
-    return t({
-      id: "officeAddin.auth.oauth2ProxySessionFailed",
-      message:
-        "Could not establish a secure Erato session. Try signing in again.",
-    });
-  }
-
-  if (error instanceof InteractionRequiredAuthError) {
-    return t({
-      id: "officeAddin.auth.signInRequired",
-      message: "Sign-in required",
-    });
-  }
-
-  return error instanceof Error
-    ? error.message
-    : t({
-        id: "officeAddin.auth.authenticationFailed",
-        message: "Authentication failed",
-      });
-}
-
+/**
+ * Compatibility shim. The real work now lives in the host-agnostic
+ * {@link SessionAuthProvider} (session lifecycle) + the Outlook-only
+ * {@link EntraGraphTokenProvider} (Graph tokens). This wrapper is the single
+ * place Outlook globals are read for auth: it builds the mailbox-aware login
+ * hint and picks the {@link AuthSource} for the detected mode, then composes the
+ * two providers. Excel/Word will eventually mount `SessionAuthProvider`
+ * directly with a mailbox-less source and skip the Graph provider entirely.
+ */
 export function MsalNaaProvider({ children }: { children: React.ReactNode }) {
   const { mailboxUser } = useOffice();
-  const [pca, setPca] = useState<IPublicClientApplication | null>(null);
-  const [account, setAccount] = useState<AccountInfo | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isInitialized, setIsInitialized] = useState(false);
-  const [loginHint, setLoginHint] = useState<string | undefined>();
-  const [oauth2ProxySession, setOauth2ProxySession] =
-    useState<Oauth2ProxySessionState>(createInitialOauth2ProxySessionState);
-  // Bumped to re-run the MSAL initialization effect when retrying after an init
-  // failure (which leaves `pca` null and cannot be recovered by a refresh).
-  const [initNonce, setInitNonce] = useState(0);
-  // Number of consecutive failed timed refreshes; drives the backoff delay.
-  const [refreshFailureCount, setRefreshFailureCount] = useState(0);
-  const lastRedeemedAtRef = useRef(oauth2ProxySession.lastRedeemedAt);
-  const redeemInFlightRef = useRef<Promise<number> | null>(null);
+  // Bumped on a retry-after-init-failure so the `source` memo re-runs
+  // `detectAuthMode()` — without it the mode is frozen at first render and a
+  // stale "unsupported" verdict could never recover.
+  const [rebuildNonce, setRebuildNonce] = useState(0);
 
-  useEffect(() => {
-    lastRedeemedAtRef.current = oauth2ProxySession.lastRedeemedAt;
-  }, [oauth2ProxySession.lastRedeemedAt]);
-
-  const redeemSessionForResult = useCallback(
-    async (
-      result: AuthenticationResult,
-      status: Extract<Oauth2ProxySessionStatus, "establishing" | "refreshing">,
-    ): Promise<number> => {
-      if (redeemInFlightRef.current) {
-        return redeemInFlightRef.current;
-      }
-
-      const redeemPromise = (async () => {
-        setOauth2ProxySession((previous) => ({
-          status,
-          lastRedeemedAt: previous.lastRedeemedAt,
-          error: null,
-        }));
-
-        try {
-          const { redeemedAt } = await redeemOauth2ProxySession({
-            idToken: result.idToken,
-            accessToken: result.accessToken,
-          });
-          lastRedeemedAtRef.current = redeemedAt;
-          setOauth2ProxySession({
-            status: "ready",
-            lastRedeemedAt: redeemedAt,
-            error: null,
-          });
-          setError(null);
-          setRefreshFailureCount(0);
-          return redeemedAt;
-        } catch (redeemError) {
-          const message = formatAuthenticationError(redeemError);
-          setOauth2ProxySession((previous) => ({
-            status: "error",
-            lastRedeemedAt: previous.lastRedeemedAt,
-            error: message,
-          }));
-          setError(message);
-          throw redeemError;
-        } finally {
-          redeemInFlightRef.current = null;
-        }
-      })();
-
-      redeemInFlightRef.current = redeemPromise;
-      return redeemPromise;
-    },
-    [],
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    const clientId = import.meta.env.VITE_MSAL_CLIENT_ID ?? env().msalClientId;
-    if (!clientId) {
-      setError(
-        t({
-          id: "officeAddin.auth.msalClientIdMissing",
-          message: "MSAL client ID is not configured",
-        }),
-      );
-      setIsInitialized(true);
-      return;
-    }
-
-    setIsInitialized(false);
-    setError(null);
-
-    let naaSupported = false;
+  const resolveLoginHint = useCallback<LoginHintResolver>(async () => {
     try {
-      if (typeof Office !== "undefined" && Office.context?.requirements) {
-        naaSupported = Office.context.requirements.isSetSupported(
-          "NestedAppAuth",
-          "1.1",
-        );
+      if (typeof Office !== "undefined" && Office.auth?.getAuthContext) {
+        const authContext = await Office.auth.getAuthContext();
+        if (authContext?.userPrincipalName) {
+          return authContext.userPrincipalName;
+        }
       }
     } catch {
-      // Office not available outside add-in host.
+      // Fall back to the mailbox profile below.
     }
+    return mailboxUser?.emailAddress;
+  }, [mailboxUser]);
 
-    if (!naaSupported) {
-      setError(
-        t({
-          id: "officeAddin.auth.naaUnsupported",
-          message:
-            "Nested App Authentication is not supported in this environment",
-        }),
-      );
-      setIsInitialized(true);
-      return;
+  const source = useMemo<AuthSource>(() => {
+    if (detectAuthMode() === "entra-msal") {
+      return createEntraNaaAuthSource({ resolveLoginHint });
     }
-
-    const authority =
-      import.meta.env.VITE_MSAL_AUTHORITY ??
-      env().msalAuthority ??
-      "https://login.microsoftonline.com/common";
-
-    const msalConfig = {
-      auth: {
-        clientId,
-        authority,
-        supportsNestedAppAuth: true,
-      },
-      cache: {
-        cacheLocation: "localStorage" as const,
-      },
-    };
-
-    async function resolveLoginHint(): Promise<string | undefined> {
+    // No NAA. Host-aware heuristic: an Outlook mailbox surface means this is the
+    // legacy on-prem / Exchange-callback case (not implemented yet); anything
+    // else is a genuinely unsupported environment (keeps the existing NAA
+    // message).
+    //
+    // TODO(exchange-se): this is NAA-presence + mailbox-presence only, NOT a
+    // true cloud-vs-on-prem probe. In Step 0 both Unsupported reasons are
+    // dead-end "not supported yet" states, so the label only changes the error
+    // string — harmless. Replace with a real mailbox-environment probe (e.g.
+    // accountType / ewsUrl host) when Exchange SE auth is actually wired, so a
+    // NAA-less cloud host isn't mislabelled on-prem and vice versa.
+    const isOutlookMailbox = (() => {
       try {
-        if (typeof Office !== "undefined" && Office.auth?.getAuthContext) {
-          const authContext = await Office.auth.getAuthContext();
-          if (authContext?.userPrincipalName) {
-            return authContext.userPrincipalName;
-          }
-        }
+        return typeof Office !== "undefined" && !!Office.context?.mailbox;
       } catch {
-        // Fallback below.
+        return false;
       }
-
-      return mailboxUser?.emailAddress;
-    }
-
-    createNestablePublicClientApplication(msalConfig)
-      .then(async (instance) => {
-        if (cancelled) {
-          return;
-        }
-        setPca(instance);
-
-        const hint = await resolveLoginHint();
-        if (cancelled) {
-          return;
-        }
-        setLoginHint(hint);
-
-        try {
-          const result = await acquireMsalResult(
-            instance,
-            OAUTH2_PROXY_SESSION_SCOPES,
-            hint,
-            false,
-          );
-          if (cancelled) {
-            return;
-          }
-          applyAuthenticationResult(instance, result, setAccount);
-          await redeemSessionForResult(result, "establishing");
-        } catch (authenticationError) {
-          if (cancelled) {
-            return;
-          }
-          if (authenticationError instanceof InteractionRequiredAuthError) {
-            setError(null);
-          } else if (
-            authenticationError instanceof Oauth2ProxySessionRedeemError
-          ) {
-            // The redeem helper already set the user-facing error state.
-          } else {
-            console.warn("MSAL silent auth error", authenticationError);
-            setError(formatAuthenticationError(authenticationError));
-          }
-        } finally {
-          if (!cancelled) {
-            setIsInitialized(true);
-          }
-        }
-      })
-      .catch((initializationError) => {
-        if (cancelled) {
-          return;
-        }
-        console.error("MSAL initialization failed", initializationError);
-        setError(formatAuthenticationError(initializationError));
-        setIsInitialized(true);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [mailboxUser, redeemSessionForResult, initNonce]);
-
-  const refreshOauth2ProxySession = useCallback(
-    async (allowPopup: boolean): Promise<void> => {
-      try {
-        if (!pca) {
-          throw new Error(
-            t({
-              id: "officeAddin.auth.msalNotInitialized",
-              message: "MSAL not initialized",
-            }),
-          );
-        }
-
-        const result = await acquireMsalResult(
-          pca,
-          OAUTH2_PROXY_SESSION_SCOPES,
-          loginHint,
-          allowPopup,
-        );
-        applyAuthenticationResult(pca, result, setAccount);
-        await redeemSessionForResult(result, "refreshing");
-      } catch (refreshError) {
-        const message = formatAuthenticationError(refreshError);
-        setOauth2ProxySession((previous) => ({
-          status: "error",
-          lastRedeemedAt: previous.lastRedeemedAt,
-          error: message,
-        }));
-        setError(message);
-        throw refreshError;
-      }
-    },
-    [loginHint, pca, redeemSessionForResult],
-  );
-
-  useEffect(() => {
-    // Only schedule once we hold a session to refresh. An initial establish that
-    // never produced a session (lastRedeemedAt null) is recovered via the retry
-    // button instead of an automatic timer.
-    if (!pca || !account || oauth2ProxySession.lastRedeemedAt === null) {
-      return;
-    }
-
-    let refreshDelayMs: number;
-    if (oauth2ProxySession.status === "error") {
-      // A previous refresh failed but the session may still be valid. Retry on a
-      // capped exponential backoff rather than going terminal — otherwise a
-      // single transient failure would silently disconnect the add-in until the
-      // user reloads or hits "Try again".
-      const attempt = Math.max(0, refreshFailureCount - 1);
-      refreshDelayMs = Math.min(
-        OAUTH2_PROXY_REFRESH_RETRY_BASE_MS * 2 ** attempt,
-        OAUTH2_PROXY_REFRESH_RETRY_MAX_MS,
-      );
-    } else {
-      const sessionAgeMs = Date.now() - oauth2ProxySession.lastRedeemedAt;
-      refreshDelayMs = Math.max(
-        1_000,
-        OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS - sessionAgeMs,
-      );
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      void refreshOauth2ProxySession(false).catch((refreshError) => {
-        // A successful redeem resets the counter; bump it here so the next
-        // scheduled retry backs off further.
-        setRefreshFailureCount((count) => count + 1);
-        console.warn("OAuth2 proxy session refresh failed", refreshError);
-      });
-    }, refreshDelayMs);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [
-    account,
-    oauth2ProxySession.lastRedeemedAt,
-    oauth2ProxySession.status,
-    pca,
-    refreshFailureCount,
-    refreshOauth2ProxySession,
-  ]);
-
-  useEffect(() => {
-    function refreshIfStale() {
-      // Intentionally retries even from the "error" status: regaining focus is a
-      // natural recovery point, and the backoff timer may not have fired yet.
-      if (
-        !pca ||
-        !account ||
-        !shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)
-      ) {
-        return;
-      }
-
-      void refreshOauth2ProxySession(false).catch((refreshError) => {
-        console.warn(
-          "OAuth2 proxy session refresh after resume failed",
-          refreshError,
-        );
-      });
-    }
-
-    function handleVisibilityChange() {
-      if (document.visibilityState === "visible") {
-        refreshIfStale();
-      }
-    }
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("focus", refreshIfStale);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("focus", refreshIfStale);
-    };
-  }, [account, oauth2ProxySession.status, pca, refreshOauth2ProxySession]);
-
-  const acquireToken = useCallback(
-    async (scopes: string[]): Promise<string> => {
-      if (!pca) {
-        throw new Error(
-          t({
-            id: "officeAddin.auth.msalNotInitialized",
-            message: "MSAL not initialized",
-          }),
-        );
-      }
-
-      try {
-        const result = await acquireMsalResult(pca, scopes, loginHint, true);
-        applyAuthenticationResult(pca, result, setAccount);
-        if (shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)) {
-          await redeemSessionForResult(result, "refreshing");
-        }
-        return result.accessToken;
-      } catch (authenticationError) {
-        setError(formatAuthenticationError(authenticationError));
-        throw authenticationError;
-      }
-    },
-    [loginHint, pca, redeemSessionForResult],
-  );
-
-  const retryAuthentication = useCallback(async (): Promise<void> => {
-    setError(null);
-    setRefreshFailureCount(0);
-
-    // If MSAL never initialized (init failure, NAA not yet ready) there is no
-    // client to refresh against — re-run the initialization effect instead of
-    // throwing "MSAL not initialized". The effect flips isInitialized back on.
-    if (!pca) {
-      setIsInitialized(false);
-      setInitNonce((nonce) => nonce + 1);
-      return;
-    }
-
-    setIsInitialized(false);
-    try {
-      await refreshOauth2ProxySession(true);
-    } catch (authenticationError) {
-      setError(formatAuthenticationError(authenticationError));
-    } finally {
-      setIsInitialized(true);
-    }
-  }, [pca, refreshOauth2ProxySession]);
-
-  const isOauth2ProxySessionReady =
-    oauth2ProxySession.lastRedeemedAt !== null &&
-    oauth2ProxySession.status !== "error";
-  const authError = error ?? oauth2ProxySession.error;
-  const isAuthenticated =
-    account !== null && isOauth2ProxySessionReady && authError === null;
+    })();
+    return new UnsupportedAuthSource(
+      isOutlookMailbox ? "exchange-callback" : "unsupported",
+    );
+    // rebuildNonce is intentionally a dep: a retry-after-init-failure bumps it
+    // to force re-detection of the mode.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rebuildNonce is a recompute trigger, not read in the body
+  }, [resolveLoginHint, rebuildNonce]);
 
   return (
-    <MsalNaaContext.Provider
-      value={{
-        isInitialized,
-        isAuthenticated,
-        isOauth2ProxySessionReady,
-        oauth2ProxySessionStatus: oauth2ProxySession.status,
-        account,
-        acquireToken,
-        retryAuthentication,
-        error: authError,
-      }}
+    <SessionAuthProvider
+      authSource={source}
+      onReinitialize={() => setRebuildNonce((nonce) => nonce + 1)}
     >
-      {children}
-    </MsalNaaContext.Provider>
+      {source.mode === "entra-msal" ? (
+        <EntraGraphTokenProvider
+          source={source as AuthSource & GraphCapableSource}
+        >
+          {children}
+        </EntraGraphTokenProvider>
+      ) : (
+        children
+      )}
+    </SessionAuthProvider>
   );
 }

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 
-import { useMsalNaa } from "./MsalNaaProvider";
+import { useGraphToken } from "./EntraGraphTokenProvider";
 import { useOutlookMailItem } from "./OutlookMailItemProvider";
 import { useCurrentThread } from "../hooks/useCurrentThread";
 import { buildThreadEmlFile } from "../utils/buildThreadEmlFile";
@@ -198,7 +198,7 @@ export function OutlookEmailSourceProvider({
     isLoadingAttachments,
     getAttachmentFile,
   } = useOutlookMailItem();
-  const { acquireToken } = useMsalNaa();
+  const { acquireToken } = useGraphToken();
   const [dismissedAttachmentIds, setDismissedAttachmentIds] = useState<
     string[]
   >([]);

--- a/office-addin/src/providers/SessionAuthProvider.tsx
+++ b/office-addin/src/providers/SessionAuthProvider.tsx
@@ -1,0 +1,454 @@
+import { t } from "@lingui/core/macro";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  InteractionRequiredError,
+  type AuthSource,
+  type BootstrapToken,
+} from "../auth/AuthSource";
+import {
+  OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS,
+  Oauth2ProxySessionRedeemError,
+  readStoredOauth2ProxySessionRedeemedAt,
+  redeemOauth2ProxySession,
+  shouldRefreshOauth2ProxySession,
+} from "../auth/oauth2ProxySession";
+
+// When a timed refresh fails we keep the (now stale) session and retry on a
+// capped exponential backoff so a transient outage doesn't permanently stop the
+// refresh loop until the user interacts.
+const OAUTH2_PROXY_REFRESH_RETRY_BASE_MS = 30_000;
+const OAUTH2_PROXY_REFRESH_RETRY_MAX_MS = 5 * 60_000;
+
+type Oauth2ProxySessionStatus =
+  | "idle"
+  | "establishing"
+  | "ready"
+  | "refreshing"
+  | "error";
+
+interface Oauth2ProxySessionState {
+  status: Oauth2ProxySessionStatus;
+  lastRedeemedAt: number | null;
+  error: string | null;
+}
+
+/** The host-agnostic contract AuthGate consumes — the four fields it reads. */
+export interface SessionAuthCore {
+  isInitialized: boolean;
+  isAuthenticated: boolean;
+  retryAuthentication: () => Promise<void>;
+  error: string | null;
+}
+
+interface SessionAuthContextValue extends SessionAuthCore {
+  isOauth2ProxySessionReady: boolean;
+  oauth2ProxySessionStatus: Oauth2ProxySessionStatus;
+}
+
+const SessionAuthContext = createContext<SessionAuthContextValue>({
+  isInitialized: false,
+  isAuthenticated: false,
+  isOauth2ProxySessionReady: false,
+  oauth2ProxySessionStatus: "idle",
+  retryAuthentication: () => Promise.resolve(),
+  error: null,
+});
+
+export function useSessionAuth(): SessionAuthContextValue {
+  return useContext(SessionAuthContext);
+}
+
+/**
+ * Internal re-redeem seam. NOT exported from the package barrel — consumed only
+ * by the co-located Outlook {@link "./EntraGraphTokenProvider"} so a Graph token
+ * acquisition can opportunistically refresh the proxy session through the SAME
+ * `redeemInFlightRef` dedup and the SAME live `lastRedeemedAtRef` gate the
+ * timed/focus refreshes use (never re-derived from localStorage).
+ */
+interface SessionRedeemContextValue {
+  redeemSessionForToken: (
+    token: BootstrapToken,
+    status: "refreshing",
+  ) => Promise<number>;
+  lastRedeemedAtRef: React.MutableRefObject<number | null>;
+}
+
+const SessionRedeemContext = createContext<SessionRedeemContextValue | null>(
+  null,
+);
+
+export function useSessionRedeem(): SessionRedeemContextValue {
+  const value = useContext(SessionRedeemContext);
+  if (!value) {
+    throw new Error("useSessionRedeem must be used within SessionAuthProvider");
+  }
+  return value;
+}
+
+function createInitialOauth2ProxySessionState(): Oauth2ProxySessionState {
+  const lastRedeemedAt = readStoredOauth2ProxySessionRedeemedAt();
+  return {
+    status: lastRedeemedAt === null ? "idle" : "ready",
+    lastRedeemedAt,
+    error: null,
+  };
+}
+
+function formatAuthenticationError(error: unknown): string {
+  if (error instanceof Oauth2ProxySessionRedeemError) {
+    return t({
+      id: "officeAddin.auth.oauth2ProxySessionFailed",
+      message:
+        "Could not establish a secure Erato session. Try signing in again.",
+    });
+  }
+
+  if (error instanceof InteractionRequiredError) {
+    return t({
+      id: "officeAddin.auth.signInRequired",
+      message: "Sign-in required",
+    });
+  }
+
+  return error instanceof Error
+    ? error.message
+    : t({
+        id: "officeAddin.auth.authenticationFailed",
+        message: "Authentication failed",
+      });
+}
+
+/**
+ * Host-agnostic auth core. Owns Layer-2: it redeems a {@link BootstrapToken}
+ * (produced by the injected {@link AuthSource}) for an oauth2-proxy session
+ * cookie and runs the whole session lifecycle — redeem dedup, the 20-minute
+ * timed refresh, focus/visibility recovery, capped backoff, and retry. It
+ * imports nothing from Office, the mailbox, MSAL, or Graph, so Excel/Word reuse
+ * it verbatim by passing a different `AuthSource`.
+ */
+export function SessionAuthProvider({
+  authSource,
+  onReinitialize,
+  children,
+}: {
+  authSource: AuthSource;
+  /**
+   * Optional: asks the owner to rebuild the {@link AuthSource} (re-running mode
+   * detection) when the user retries after an init failure. The Outlook wrapper
+   * supplies this so a stale "unsupported" verdict can recover; standalone
+   * hosts omit it and fall back to re-initializing the same source via
+   * `initNonce`.
+   */
+  onReinitialize?: () => void;
+  children: React.ReactNode;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+  // Replaces the old `!!pca` check. Must be state (not a ref) so the retry
+  // branch and effects re-run when the source finishes (re-)initializing.
+  const [isSourceInitialized, setIsSourceInitialized] = useState(false);
+  // Replaces the old `!!account` check. Must be state and must appear in the
+  // refresh effects' dependency arrays, or the refresh timer never arms.
+  const [isBootstrapAcquired, setIsBootstrapAcquired] = useState(false);
+  const [oauth2ProxySession, setOauth2ProxySession] =
+    useState<Oauth2ProxySessionState>(createInitialOauth2ProxySessionState);
+  // Bumped to re-run the init effect when retrying after an init failure (which
+  // leaves the source uninitialized and unrecoverable by a plain refresh).
+  const [initNonce, setInitNonce] = useState(0);
+  // Number of consecutive failed timed refreshes; drives the backoff delay.
+  const [refreshFailureCount, setRefreshFailureCount] = useState(0);
+  const lastRedeemedAtRef = useRef(oauth2ProxySession.lastRedeemedAt);
+  const redeemInFlightRef = useRef<Promise<number> | null>(null);
+
+  useEffect(() => {
+    lastRedeemedAtRef.current = oauth2ProxySession.lastRedeemedAt;
+  }, [oauth2ProxySession.lastRedeemedAt]);
+
+  const redeemSessionForToken = useCallback(
+    async (
+      token: BootstrapToken,
+      status: Extract<Oauth2ProxySessionStatus, "establishing" | "refreshing">,
+    ): Promise<number> => {
+      if (redeemInFlightRef.current) {
+        return redeemInFlightRef.current;
+      }
+
+      const redeemPromise = (async () => {
+        setOauth2ProxySession((previous) => ({
+          status,
+          lastRedeemedAt: previous.lastRedeemedAt,
+          error: null,
+        }));
+
+        try {
+          const { redeemedAt } = await redeemOauth2ProxySession({
+            idToken: token.idToken,
+            accessToken: token.accessToken,
+          });
+          lastRedeemedAtRef.current = redeemedAt;
+          setOauth2ProxySession({
+            status: "ready",
+            lastRedeemedAt: redeemedAt,
+            error: null,
+          });
+          setError(null);
+          setRefreshFailureCount(0);
+          return redeemedAt;
+        } catch (redeemError) {
+          const message = formatAuthenticationError(redeemError);
+          setOauth2ProxySession((previous) => ({
+            status: "error",
+            lastRedeemedAt: previous.lastRedeemedAt,
+            error: message,
+          }));
+          setError(message);
+          throw redeemError;
+        } finally {
+          redeemInFlightRef.current = null;
+        }
+      })();
+
+      redeemInFlightRef.current = redeemPromise;
+      return redeemPromise;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setIsInitialized(false);
+    setIsSourceInitialized(false);
+    setError(null);
+
+    authSource
+      .initialize()
+      .then(async () => {
+        if (cancelled) {
+          return;
+        }
+        setIsSourceInitialized(true);
+
+        try {
+          const token = await authSource.acquireBootstrapToken({
+            allowInteraction: false,
+          });
+          if (cancelled) {
+            return;
+          }
+          setIsBootstrapAcquired(true);
+          await redeemSessionForToken(token, "establishing");
+        } catch (authenticationError) {
+          if (cancelled) {
+            return;
+          }
+          if (authenticationError instanceof InteractionRequiredError) {
+            // Silent acquire needs interaction we didn't allow — not an error,
+            // the gate renders "Sign-in required" with a Try-again button.
+            setError(null);
+          } else if (
+            authenticationError instanceof Oauth2ProxySessionRedeemError
+          ) {
+            // The redeem helper already set the user-facing error state.
+          } else {
+            console.warn("Bootstrap auth error", authenticationError);
+            setError(formatAuthenticationError(authenticationError));
+          }
+        } finally {
+          if (!cancelled) {
+            setIsInitialized(true);
+          }
+        }
+      })
+      .catch((initializationError) => {
+        if (cancelled) {
+          return;
+        }
+        console.error("Auth source initialization failed", initializationError);
+        setError(formatAuthenticationError(initializationError));
+        setIsInitialized(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authSource, redeemSessionForToken, initNonce]);
+
+  const refreshSession = useCallback(
+    async (allowInteraction: boolean): Promise<void> => {
+      try {
+        const token = await authSource.acquireBootstrapToken({
+          allowInteraction,
+        });
+        setIsBootstrapAcquired(true);
+        await redeemSessionForToken(token, "refreshing");
+      } catch (refreshError) {
+        const message = formatAuthenticationError(refreshError);
+        setOauth2ProxySession((previous) => ({
+          status: "error",
+          lastRedeemedAt: previous.lastRedeemedAt,
+          error: message,
+        }));
+        setError(message);
+        throw refreshError;
+      }
+    },
+    [authSource, redeemSessionForToken],
+  );
+
+  useEffect(() => {
+    // Only schedule once we hold a session to refresh. An initial establish that
+    // never produced a session (lastRedeemedAt null) is recovered via the retry
+    // button instead of an automatic timer.
+    if (
+      !isSourceInitialized ||
+      !isBootstrapAcquired ||
+      oauth2ProxySession.lastRedeemedAt === null
+    ) {
+      return;
+    }
+
+    let refreshDelayMs: number;
+    if (oauth2ProxySession.status === "error") {
+      // A previous refresh failed but the session may still be valid. Retry on a
+      // capped exponential backoff rather than going terminal — otherwise a
+      // single transient failure would silently disconnect the add-in until the
+      // user reloads or hits "Try again".
+      const attempt = Math.max(0, refreshFailureCount - 1);
+      refreshDelayMs = Math.min(
+        OAUTH2_PROXY_REFRESH_RETRY_BASE_MS * 2 ** attempt,
+        OAUTH2_PROXY_REFRESH_RETRY_MAX_MS,
+      );
+    } else {
+      const sessionAgeMs = Date.now() - oauth2ProxySession.lastRedeemedAt;
+      refreshDelayMs = Math.max(
+        1_000,
+        OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS - sessionAgeMs,
+      );
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void refreshSession(false).catch((refreshError) => {
+        // A successful redeem resets the counter; bump it here so the next
+        // scheduled retry backs off further.
+        setRefreshFailureCount((count) => count + 1);
+        console.warn("OAuth2 proxy session refresh failed", refreshError);
+      });
+    }, refreshDelayMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [
+    isBootstrapAcquired,
+    isSourceInitialized,
+    oauth2ProxySession.lastRedeemedAt,
+    oauth2ProxySession.status,
+    refreshFailureCount,
+    refreshSession,
+  ]);
+
+  useEffect(() => {
+    function refreshIfStale() {
+      // Intentionally retries even from the "error" status: regaining focus is a
+      // natural recovery point, and the backoff timer may not have fired yet.
+      if (
+        !isSourceInitialized ||
+        !isBootstrapAcquired ||
+        !shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)
+      ) {
+        return;
+      }
+
+      void refreshSession(false).catch((refreshError) => {
+        console.warn(
+          "OAuth2 proxy session refresh after resume failed",
+          refreshError,
+        );
+      });
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        refreshIfStale();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", refreshIfStale);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", refreshIfStale);
+    };
+  }, [
+    isBootstrapAcquired,
+    isSourceInitialized,
+    oauth2ProxySession.status,
+    refreshSession,
+  ]);
+
+  const retryAuthentication = useCallback(async (): Promise<void> => {
+    setError(null);
+    setRefreshFailureCount(0);
+
+    // If the source never initialized (init failure) there is nothing to
+    // refresh against — re-run the init effect instead of throwing. The effect
+    // flips isInitialized back on. Prefer rebuilding the source (re-detects the
+    // mode, so a stale "unsupported" verdict can recover); the new source
+    // identity re-triggers the init effect. Fall back to a plain re-init of the
+    // same source when no rebuild hook is wired.
+    if (!isSourceInitialized) {
+      setIsInitialized(false);
+      if (onReinitialize) {
+        onReinitialize();
+      } else {
+        setInitNonce((nonce) => nonce + 1);
+      }
+      return;
+    }
+
+    setIsInitialized(false);
+    try {
+      await refreshSession(true);
+    } catch (authenticationError) {
+      setError(formatAuthenticationError(authenticationError));
+    } finally {
+      setIsInitialized(true);
+    }
+  }, [isSourceInitialized, onReinitialize, refreshSession]);
+
+  const isOauth2ProxySessionReady =
+    oauth2ProxySession.lastRedeemedAt !== null &&
+    oauth2ProxySession.status !== "error";
+  const authError = error ?? oauth2ProxySession.error;
+  const isAuthenticated =
+    isBootstrapAcquired && isOauth2ProxySessionReady && authError === null;
+
+  return (
+    <SessionAuthContext.Provider
+      value={{
+        isInitialized,
+        isAuthenticated,
+        isOauth2ProxySessionReady,
+        oauth2ProxySessionStatus: oauth2ProxySession.status,
+        retryAuthentication,
+        error: authError,
+      }}
+    >
+      <SessionRedeemContext.Provider
+        value={{ redeemSessionForToken, lastRedeemedAtRef }}
+      >
+        {children}
+      </SessionRedeemContext.Provider>
+    </SessionAuthContext.Provider>
+  );
+}

--- a/office-addin/src/providers/__tests__/OutlookEmailSourceProvider.test.tsx
+++ b/office-addin/src/providers/__tests__/OutlookEmailSourceProvider.test.tsx
@@ -14,8 +14,8 @@ import type { ParsedThread, ThreadMessage } from "../../utils/parsedThread";
 const mockUseCurrentThread = vi.fn();
 const mockUseOutlookMailItem = vi.fn();
 
-vi.mock("../MsalNaaProvider", () => ({
-  useMsalNaa: () => ({ acquireToken: vi.fn() }),
+vi.mock("../EntraGraphTokenProvider", () => ({
+  useGraphToken: () => ({ acquireToken: vi.fn() }),
 }));
 
 vi.mock("../OutlookMailItemProvider", () => ({


### PR DESCRIPTION
This pull request introduces a new, host-agnostic authentication layer for the Office add-in, abstracting MSAL and Nested App Authentication (NAA) details behind a consistent interface. It adds robust support for both supported and unsupported authentication modes, improves error handling and localization, and prepares the codebase for future support of additional Office hosts (e.g., Excel, Word) and on-premises Exchange. Several provider and token acquisition hooks are updated to use the new abstractions.

**Key changes:**

### New Authentication Abstractions

* Introduced a host-agnostic `AuthSource` interface and related types (`AuthMode`, `BootstrapToken`, etc.) in `AuthSource.ts`, defining a consistent contract for authentication regardless of the Office host or backend. This includes a custom `InteractionRequiredError` for signaling interactive auth requirements.
* Added `EntraNaaAuthSource.ts`, implementing the `AuthSource` interface for Microsoft 365 (Entra/MSAL-NAA) environments, encapsulating all MSAL logic and providing both session and Microsoft Graph token acquisition.
* Added `UnsupportedAuthSource.ts`, which implements `AuthSource` for environments that are not yet supported (e.g., on-prem Exchange or hosts without NAA), surfacing clear, localized error messages.
* Added `detectAuthMode.ts`, providing a host-agnostic function to determine if NAA is supported in the current environment, enabling future extensibility.

### Integration and Refactoring

* Updated component and provider imports to use the new `EntraGraphTokenProvider` instead of the old `MsalNaaProvider`, and refactored token acquisition hooks accordingly in `AddinChat.tsx`. [[1]](diffhunk://#diff-8c1dcaa7553fe15f2c8177622f19dbf118e2f6c4d1e6228ca043b815dba88023L44-R44) [[2]](diffhunk://#diff-8c1dcaa7553fe15f2c8177622f19dbf118e2f6c4d1e6228ca043b815dba88023L143-R143)

### Localization and Error Handling

* Added and updated localized strings for new error cases and refactored existing messages to reference new provider locations, ensuring clear user feedback for supported and unsupported authentication scenarios across all supported languages. [[1]](diffhunk://#diff-290f116db4b11b05e1cf7ee6a0c331eeb4996466878c424a4188231f711cb6ceL25-R36) [[2]](diffhunk://#diff-290f116db4b11b05e1cf7ee6a0c331eeb4996466878c424a4188231f711cb6ceL40-R72) [[3]](diffhunk://#diff-4a032116cff86004ecc9a4c8dfb43a7c0ec7de42c7697c16a5cd9275970595d1L25-R36) [[4]](diffhunk://#diff-4a032116cff86004ecc9a4c8dfb43a7c0ec7de42c7697c16a5cd9275970595d1L40-R72) [[5]](diffhunk://#diff-10e6c3d96dfed1288655dab7abe35ed687e3a6843a5b2447f47ac4625bda5e17L25-R36) [[6]](diffhunk://#diff-10e6c3d96dfed1288655dab7abe35ed687e3a6843a5b2447f47ac4625bda5e17L40-R72) [[7]](diffhunk://#diff-963763776cf9d7386b6ecaa9d41f1981e9b798b116e3bb6bcdf9dff45f98350dL25-R36) [[8]](diffhunk://#diff-963763776cf9d7386b6ecaa9d41f1981e9b798b116e3bb6bcdf9dff45f98350dL40-R72)

### Documentation and Comments

* Added extensive documentation and comments throughout the new files, clarifying the reasoning behind the abstractions, error handling, and future extensibility. [[1]](diffhunk://#diff-21937a8fd0f867ff6a195eeb2f69bfed704c790e9d914dadb4235a0a964c48d8R1-R97) [[2]](diffhunk://#diff-0a08c2c050349ccc5f0deefafa819c3ab89777ea586c4bc71bdf4d9183a53804R1-R171) [[3]](diffhunk://#diff-ff6ed62b0d898d13356a671b4df8c2d1d0fdf383f57ac9482fb62837a742fcdeR1-R54) [[4]](diffhunk://#diff-c03d5d63445fda7a1eee118dd9cf98430e9898aee2dfa7fadd56560739471d2dR1-R20)

### Minor Improvements

* Clarified the handling of the Bearer token in `mergeApiAuthHeaders` to avoid confusion about its role in authentication, improving maintainability.Add SessionAuthProvider (session/redeem core) behind an injected AuthSource; move Graph tokens into an Outlook-only EntraGraphTokenProvider; MsalNaaProvider becomes a back-compat shim. EXO behaviour preserved; on-prem/SE deferred.