### PR TITLE
Extract host-agnostic auth seam from MsalNaaProvider

### DIFF
--- a/frontend/src/auth/__tests__/authRecovery.test.ts
+++ b/frontend/src/auth/__tests__/authRecovery.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { setAuthRecoveryHandler, tryRecoverAuth } from "../authRecovery";
+
+describe("authRecovery", () => {
+  afterEach(() => {
+    setAuthRecoveryHandler(null);
+  });
+
+  it("is a no-op returning false when no handler is registered (web app)", async () => {
+    await expect(tryRecoverAuth("rest-401")).resolves.toBe(false);
+  });
+
+  it("runs the registered handler with the reason and returns its result", async () => {
+    const handler = vi.fn().mockResolvedValue(true);
+    setAuthRecoveryHandler(handler);
+
+    await expect(tryRecoverAuth("sse-401")).resolves.toBe(true);
+    expect(handler).toHaveBeenCalledWith("sse-401");
+  });
+
+  it("treats a throwing handler as a failed recovery", async () => {
+    setAuthRecoveryHandler(vi.fn().mockRejectedValue(new Error("boom")));
+
+    await expect(tryRecoverAuth("rest-401")).resolves.toBe(false);
+  });
+
+  it("stops invoking the handler once cleared with null", async () => {
+    const handler = vi.fn().mockResolvedValue(true);
+    setAuthRecoveryHandler(handler);
+    setAuthRecoveryHandler(null);
+
+    await expect(tryRecoverAuth("rest-401")).resolves.toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/auth/apiRequestAuth.ts
+++ b/frontend/src/auth/apiRequestAuth.ts
@@ -19,13 +19,14 @@ export function mergeApiAuthHeaders(
     return definedHeaders;
   }
 
-  // The web app leaves this null (cookie auth). The Office add-in populates it,
-  // but for the add-in this Bearer is INCIDENTAL, not the auth source of truth:
-  // requests are authenticated by the oauth2-proxy session cookie minted at
-  // /oauth2/redeem-external-token. The add-in's MSAL token is a separate app
-  // registration from oauth2-proxy's, and there is no `oidc_extra_audiences`, so
-  // the proxy does not accept this Bearer — it falls through to the cookie. Kept
-  // as a harmless best-effort header; do not treat its freshness as load-bearing.
+  // Optional Bearer for shells that opt into header auth. Both the web app and
+  // the Office add-in currently leave this null and authenticate via the
+  // oauth2-proxy session cookie (the add-in redeems its MSAL id token for that
+  // cookie at /oauth2/redeem-external-token rather than sending it per request),
+  // so this branch is inert today. NOTE: do not assume the proxy would reject
+  // such a Bearer — with `skip_jwt_bearer_tokens` and a matching audience it can
+  // accept it; the store is left unused on purpose to keep the cookie the single
+  // source of truth.
   const idToken = getIdToken();
   if (!idToken) {
     return definedHeaders;

--- a/frontend/src/auth/authRecovery.ts
+++ b/frontend/src/auth/authRecovery.ts
@@ -1,0 +1,42 @@
+/**
+ * Optional, injectable auth-recovery hook.
+ *
+ * The normal web app uses cookie auth with no client-side refresh, so it
+ * registers NOTHING here and every export is a no-op for it. Alternate shells —
+ * the Office add-in — register a handler that, on a 401, re-acquires a fresh
+ * bootstrap token and re-redeems the oauth2-proxy session so the caller can
+ * replay the failed request once. Mirrors the {@link "./tokenStore"} injection
+ * pattern.
+ */
+
+/**
+ * Attempts to recover authentication after a 401. Resolves `true` when the
+ * session was refreshed (the caller may replay the request once) and `false`
+ * when recovery is unavailable or failed (the caller keeps its existing
+ * behaviour).
+ */
+export type AuthRecoveryHandler = (reason: string) => Promise<boolean>;
+
+let handler: AuthRecoveryHandler | null = null;
+
+/** Register (or clear, with `null`) the recovery handler. Add-in shell only. */
+export function setAuthRecoveryHandler(next: AuthRecoveryHandler | null) {
+  handler = next;
+}
+
+/**
+ * Runs the registered recovery handler, if any. Returns `false` immediately
+ * when none is registered (the web app), which makes every 401 call site a
+ * no-op there. Swallows handler errors as a failed recovery. The handler is
+ * expected to dedupe concurrent recoveries itself.
+ */
+export async function tryRecoverAuth(reason: string): Promise<boolean> {
+  if (!handler) {
+    return false;
+  }
+  try {
+    return await handler(reason);
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -691,6 +691,122 @@ describe("useChatMessaging", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("should attempt resumestream on unexpected close during an edit stream", async () => {
+    const { result, sendSSEEvent, simulateConnectionClose } =
+      setupChatMessagingTest();
+
+    await act(async () => {
+      await result.current.editMessage("msg1", "Edited content");
+    });
+
+    await sendSSEEvent({
+      message_type: "assistant_message_started",
+      message_id: "assistant-edit-close",
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    mockCreateSSEConnection.mockClear();
+
+    await simulateConnectionClose();
+
+    expect(mockCreateSSEConnection).toHaveBeenCalledWith(
+      "/api/v1beta/me/messages/resumestream",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ chat_id: "chat1" }),
+      }),
+    );
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should attempt resumestream on SSE error during an edit stream", async () => {
+    const { result, sendSSEEvent, simulateConnectionError } =
+      setupChatMessagingTest();
+
+    await act(async () => {
+      await result.current.editMessage("msg1", "Edited content");
+    });
+
+    await sendSSEEvent({
+      message_type: "assistant_message_started",
+      message_id: "assistant-edit-error",
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    mockCreateSSEConnection.mockClear();
+
+    await simulateConnectionError();
+
+    expect(mockCreateSSEConnection).toHaveBeenCalledWith(
+      "/api/v1beta/me/messages/resumestream",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ chat_id: "chat1" }),
+      }),
+    );
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should attempt resumestream on unexpected close during a regenerate stream", async () => {
+    const { result, sendSSEEvent, simulateConnectionClose } =
+      setupChatMessagingTest();
+
+    await act(async () => {
+      await result.current.regenerateMessage("msg2");
+    });
+
+    await sendSSEEvent({
+      message_type: "assistant_message_started",
+      message_id: "assistant-regen-close",
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    mockCreateSSEConnection.mockClear();
+
+    await simulateConnectionClose();
+
+    expect(mockCreateSSEConnection).toHaveBeenCalledWith(
+      "/api/v1beta/me/messages/resumestream",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ chat_id: "chat1" }),
+      }),
+    );
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("should attempt resumestream on SSE error during a regenerate stream", async () => {
+    const { result, sendSSEEvent, simulateConnectionError } =
+      setupChatMessagingTest();
+
+    await act(async () => {
+      await result.current.regenerateMessage("msg2");
+    });
+
+    await sendSSEEvent({
+      message_type: "assistant_message_started",
+      message_id: "assistant-regen-error",
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    mockCreateSSEConnection.mockClear();
+
+    await simulateConnectionError();
+
+    expect(mockCreateSSEConnection).toHaveBeenCalledWith(
+      "/api/v1beta/me/messages/resumestream",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ chat_id: "chat1" }),
+      }),
+    );
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
   it("should keep completed assistant placeholder visible when refetch has not persisted it yet", async () => {
     mockUseChatMessages.mockReturnValue({
       data: undefined,

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1711,10 +1711,28 @@ export function useChatMessaging(
               "[DEBUG_STREAMING] SSE error in editMessage:",
               connectionError,
             );
+            const activeStreamKey = connectionStreamKeyRef.current;
+            // Mid-stream drop/expiry: reconnect via resumestream (replays from
+            // the backend's event history and re-runs connect-time auth
+            // recovery), matching submitstream.
+            if (
+              useMessagingStore.getState().getStreaming(activeStreamKey)
+                .isStreaming
+            ) {
+              setSSECleanupForKey(activeStreamKey, null);
+              setSSEAbortCallback(null, activeStreamKey);
+              const resumed = attemptResumeStream({
+                reason: "editstream-onError",
+                streamKeyHint: activeStreamKey,
+              });
+              if (resumed) {
+                return;
+              }
+            }
             setError(connectionError);
-            resetStreaming(streamKey);
+            resetStreaming(activeStreamKey);
             void handleRefetchAndClear({ logContext: "SSE error (edit)" });
-            setSubmittingForKey(streamKey, false);
+            setSubmittingForKey(activeStreamKey, false);
           },
           onOpen: () => {
             // no-op
@@ -1728,11 +1746,20 @@ export function useChatMessaging(
                 logContext: "Edit SSE closed normally",
               });
             } else {
+              setSSECleanupForKey(activeStreamKey, null);
+              setSSEAbortCallback(null, activeStreamKey);
+              const resumed = attemptResumeStream({
+                reason: "editstream-onClose-unexpected",
+                streamKeyHint: activeStreamKey,
+              });
+              if (resumed) {
+                return;
+              }
               logger.warn(
                 "[DEBUG_STREAMING] Edit SSE connection closed unexpectedly while streaming was still active.",
               );
               setError(new Error("SSE connection closed unexpectedly (edit)"));
-              resetStreaming(streamKey);
+              resetStreaming(activeStreamKey);
               void handleRefetchAndClear({
                 logContext: "Edit SSE closed unexpectedly",
               });
@@ -1827,12 +1854,30 @@ export function useChatMessaging(
               "[DEBUG_STREAMING] SSE error in regenerateMessage:",
               connectionError,
             );
+            const activeStreamKey = connectionStreamKeyRef.current;
+            // Mid-stream drop/expiry: reconnect via resumestream (replays from
+            // the backend's event history and re-runs connect-time auth
+            // recovery), matching submitstream.
+            if (
+              useMessagingStore.getState().getStreaming(activeStreamKey)
+                .isStreaming
+            ) {
+              setSSECleanupForKey(activeStreamKey, null);
+              setSSEAbortCallback(null, activeStreamKey);
+              const resumed = attemptResumeStream({
+                reason: "regeneratestream-onError",
+                streamKeyHint: activeStreamKey,
+              });
+              if (resumed) {
+                return;
+              }
+            }
             setError(connectionError);
-            resetStreaming(streamKey);
+            resetStreaming(activeStreamKey);
             void handleRefetchAndClear({
               logContext: "SSE error (regenerate)",
             });
-            setSubmittingForKey(streamKey, false);
+            setSubmittingForKey(activeStreamKey, false);
           },
           onOpen: () => {
             // no-op
@@ -1846,13 +1891,22 @@ export function useChatMessaging(
                 logContext: "Regenerate SSE closed normally",
               });
             } else {
+              setSSECleanupForKey(activeStreamKey, null);
+              setSSEAbortCallback(null, activeStreamKey);
+              const resumed = attemptResumeStream({
+                reason: "regeneratestream-onClose-unexpected",
+                streamKeyHint: activeStreamKey,
+              });
+              if (resumed) {
+                return;
+              }
               logger.warn(
                 "[DEBUG_STREAMING] Regenerate SSE connection closed unexpectedly while streaming was still active.",
               );
               setError(
                 new Error("SSE connection closed unexpectedly (regenerate)"),
               );
-              resetStreaming(streamKey);
+              resetStreaming(activeStreamKey);
               void handleRefetchAndClear({
                 logContext: "Regenerate SSE closed unexpectedly",
               });

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiFetcher.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiFetcher.ts
@@ -1,4 +1,5 @@
 import { V1betaApiContext } from "./v1betaApiContext";
+import { tryRecoverAuth } from "../../../auth/authRecovery";
 import { mergeApiAuthHeaders } from "../../../auth/apiRequestAuth";
 
 const baseUrl = ""; // TODO add your baseUrl
@@ -30,20 +31,15 @@ export async function v1betaApiFetch<
   THeaders extends {},
   TQueryParams extends {},
   TPathParams extends {},
->({
-  url,
-  method,
-  body,
-  headers,
-  pathParams,
-  queryParams,
-  signal,
-}: V1betaApiFetcherOptions<
-  TBody,
-  THeaders,
-  TQueryParams,
-  TPathParams
->): Promise<TData> {
+>(
+  options: V1betaApiFetcherOptions<TBody, THeaders, TQueryParams, TPathParams>,
+  // Add-in only: allow a single auth-recovery retry on 401. The recursive
+  // replay below sets this false so it can't loop. No-op for the web app, which
+  // registers no recovery handler (see ../../../auth/authRecovery).
+  allowAuthRetry = true,
+): Promise<TData> {
+  const { url, method, body, headers, pathParams, queryParams, signal } =
+    options;
   let error: ErrorWrapper<TError>;
   try {
     const isFormDataBody = body instanceof FormData;
@@ -79,6 +75,23 @@ export async function v1betaApiFetch<
       },
     );
     if (!response.ok) {
+      // On a 401, ask the (optionally) registered recovery handler to refresh
+      // the session, then replay the request exactly once. Falls straight
+      // through for the web app (tryRecoverAuth returns false with no handler).
+      if (
+        response.status === 401 &&
+        allowAuthRetry &&
+        (await tryRecoverAuth("rest-401"))
+      ) {
+        return v1betaApiFetch<
+          TData,
+          TError,
+          TBody,
+          THeaders,
+          TQueryParams,
+          TPathParams
+        >(options, false);
+      }
       try {
         error = await response.json();
       } catch (e) {

--- a/frontend/src/lib/v1betaApiFetcher.test.ts
+++ b/frontend/src/lib/v1betaApiFetcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { setAuthRecoveryHandler } from "@/auth/authRecovery";
 import { setIdToken } from "@/auth/tokenStore";
 
 import { v1betaApiFetch } from "./generated/v1betaApi/v1betaApiFetcher";
@@ -112,5 +113,72 @@ describe("v1betaApiFetch auth injection", () => {
     expect(fetchMock.mock.calls[0][1]?.headers).toEqual({
       Authorization: "Bearer caller-token",
     });
+  });
+});
+
+// Guards the hand-added 401-recovery seam in the (codegen-generated) fetcher: if
+// a regenerate ever clobbers it back to the stock template, these fail in CI
+// rather than silently shipping a fetcher that can't recover.
+describe("v1betaApiFetch 401 auth recovery", () => {
+  afterEach(() => {
+    setAuthRecoveryHandler(null);
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  const okJson = () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    json: vi.fn().mockResolvedValue({ recovered: true }),
+  });
+  const unauthorized = () => ({
+    ok: false,
+    status: 401,
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue({ detail: "unauthorized" }),
+  });
+
+  it("recovers on a 401 and replays the request exactly once", async () => {
+    const handler = vi.fn().mockResolvedValue(true);
+    setAuthRecoveryHandler(handler);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(unauthorized())
+      .mockResolvedValueOnce(okJson());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await v1betaApiFetch({
+      url: "/api/v1beta/me/budget",
+      method: "get",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith("rest-401");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ recovered: true });
+  });
+
+  it("does not replay when no recovery handler is registered (web app)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      v1betaApiFetch({ url: "/api/v1beta/me/budget", method: "get" }),
+    ).rejects.toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replay when recovery fails", async () => {
+    const handler = vi.fn().mockResolvedValue(false);
+    setAuthRecoveryHandler(handler);
+    const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      v1betaApiFetch({ url: "/api/v1beta/me/budget", method: "get" }),
+    ).rejects.toBeDefined();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -187,6 +187,10 @@ export {
   type UiChatMessage,
 } from "@/utils/adapters/messageAdapter";
 export { getIdToken, setIdToken } from "@/auth/tokenStore";
+export {
+  setAuthRecoveryHandler,
+  type AuthRecoveryHandler,
+} from "@/auth/authRecovery";
 
 export type { Message } from "@/types/chat";
 export type {

--- a/frontend/src/utils/sse/sseClient.ts
+++ b/frontend/src/utils/sse/sseClient.ts
@@ -10,6 +10,7 @@
  */
 
 import { mergeApiAuthHeaders } from "@/auth/apiRequestAuth";
+import { tryRecoverAuth } from "@/auth/authRecovery";
 
 import { createLogger } from "../debugLogger";
 
@@ -242,7 +243,9 @@ export function createSSEConnection(url: string, options: SSEOptions = {}) {
         return;
       }
 
-      const response = await fetch(url, {
+      // Built fresh per attempt so an auth-recovery retry picks up the
+      // refreshed session cookie / Authorization header.
+      const buildInit = (): RequestInit => ({
         method,
         headers: mergeApiAuthHeaders({
           ...(method === "POST" && { "Content-Type": "application/json" }),
@@ -254,6 +257,15 @@ export function createSSEConnection(url: string, options: SSEOptions = {}) {
         cache: "no-store",
         credentials: "same-origin",
       });
+
+      let response = await fetch(url, buildInit());
+      // Connect-time 401 (the proxy rejected the request before it reached the
+      // backend/stream): recover the session and reopen ONCE. Safe to replay —
+      // a pre-stream 401 means nothing was processed. No-op for the web app,
+      // which registers no recovery handler (see @/auth/authRecovery).
+      if (response.status === 401 && (await tryRecoverAuth("sse-401"))) {
+        response = await fetch(url, buildInit());
+      }
 
       if (!response.ok) {
         // Read the body so the caller can surface the validation reason

--- a/office-addin/src/App.tsx
+++ b/office-addin/src/App.tsx
@@ -39,8 +39,8 @@ function AuthGate({ children }: { children: React.ReactNode }) {
         <p className="office-status office-status--error" role="alert">
           {error ??
             t({
-              id: "officeAddin.auth.signInRequired",
-              message: "Sign-in required",
+              id: "officeAddin.auth.signInToContinue",
+              message: "Sign in to continue",
             })}
         </p>
         <button
@@ -51,8 +51,8 @@ function AuthGate({ children }: { children: React.ReactNode }) {
           }}
         >
           {t({
-            id: "officeAddin.auth.tryAgain",
-            message: "Try again",
+            id: "officeAddin.auth.signIn",
+            message: "Sign in",
           })}
         </button>
       </div>

--- a/office-addin/src/auth/AuthSource.ts
+++ b/office-addin/src/auth/AuthSource.ts
@@ -78,7 +78,10 @@ export type LoginHintResolver = () => Promise<string | undefined>;
  * acquisition. Excel/Word never reference this.
  */
 export interface GraphCapableSource {
-  acquireGraphToken(scopes: string[]): Promise<{
+  acquireGraphToken(
+    scopes: string[],
+    options?: { forceRefresh?: boolean; allowInteraction?: boolean },
+  ): Promise<{
     accessToken: string;
     bootstrap: BootstrapToken;
   }>;

--- a/office-addin/src/auth/EntraNaaAuthSource.ts
+++ b/office-addin/src/auth/EntraNaaAuthSource.ts
@@ -4,7 +4,7 @@ import {
   type AuthenticationResult,
   type IPublicClientApplication,
 } from "@azure/msal-browser";
-import { env, setIdToken } from "@erato/frontend/library";
+import { env } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 
 import {
@@ -72,6 +72,11 @@ export function createEntraNaaAuthSource(
     }
   }
 
+  // Sets the MSAL active account so subsequent silent acquisitions resolve it.
+  // Deliberately does NOT push the id token into the shared token store: the
+  // add-in authenticates via the oauth2-proxy session cookie (the id token is
+  // redeemed for that cookie, not sent as a per-request Bearer), matching the
+  // cookie-only on-prem Exchange SE path.
   function applyResult(
     instance: IPublicClientApplication,
     result: AuthenticationResult,
@@ -79,7 +84,6 @@ export function createEntraNaaAuthSource(
     if (result.account) {
       instance.setActiveAccount(result.account);
     }
-    setIdToken(result.idToken);
   }
 
   function requirePca(): IPublicClientApplication {
@@ -149,14 +153,24 @@ export function createEntraNaaAuthSource(
       };
     },
 
-    async acquireGraphToken(scopes: string[]): Promise<{
+    async acquireGraphToken(
+      scopes: string[],
+      options: { forceRefresh?: boolean; allowInteraction?: boolean } = {},
+    ): Promise<{
       accessToken: string;
       bootstrap: BootstrapToken;
     }> {
       const instance = requirePca();
-      // Graph acquisition is user-initiated (an email action), so interaction
-      // is allowed — matching the old `acquireToken(scopes)` (allowPopup=true).
-      const result = await acquireMsalResult(instance, scopes, true, false);
+      // Silent by default: a failed silent acquire surfaces as
+      // InteractionRequiredError so the caller can show an inline "Sign in"
+      // prompt instead of auto-popping a window mid email-drop. A popup happens
+      // only when the user explicitly opts in via `allowInteraction`.
+      const result = await acquireMsalResult(
+        instance,
+        scopes,
+        options.allowInteraction ?? false,
+        options.forceRefresh ?? false,
+      );
       applyResult(instance, result);
       return {
         accessToken: result.accessToken,

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -142,7 +142,8 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
 
   const { acquireToken } = useGraphToken();
   const acquireGraphToken = useCallback(
-    () => acquireToken(GRAPH_MAIL_SCOPES),
+    (options?: { forceRefresh?: boolean }) =>
+      acquireToken(GRAPH_MAIL_SCOPES, options),
     [acquireToken],
   );
 

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -68,14 +68,25 @@ msgstr "Die Anmeldung bei lokalem Exchange (Legacy) wird noch nicht unterstützt
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/SessionAuthProvider.tsx
-msgid "officeAddin.auth.signInRequired"
-msgstr "Anmeldung erforderlich"
+msgid "officeAddin.auth.signIn"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-msgid "officeAddin.auth.tryAgain"
-msgstr "Erneut versuchen"
+#: src/providers/SessionAuthProvider.tsx
+#~ msgid "officeAddin.auth.signInRequired"
+#~ msgstr "Anmeldung erforderlich"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#: src/providers/SessionAuthProvider.tsx
+msgid "officeAddin.auth.signInToContinue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#~ msgid "officeAddin.auth.tryAgain"
+#~ msgstr "Erneut versuchen"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
@@ -181,6 +192,26 @@ msgstr "Unbekannter Absender"
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Datei überschreitet das Serverlimit von {globalMaxFormatted}"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signedIn.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.action"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -68,14 +68,25 @@ msgstr "On-prem (legacy Exchange) sign-in isn't supported yet."
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/SessionAuthProvider.tsx
-msgid "officeAddin.auth.signInRequired"
-msgstr "Sign-in required"
+msgid "officeAddin.auth.signIn"
+msgstr "Sign in"
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-msgid "officeAddin.auth.tryAgain"
-msgstr "Try again"
+#: src/providers/SessionAuthProvider.tsx
+#~ msgid "officeAddin.auth.signInRequired"
+#~ msgstr "Sign-in required"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#: src/providers/SessionAuthProvider.tsx
+msgid "officeAddin.auth.signInToContinue"
+msgstr "Sign in to continue"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#~ msgid "officeAddin.auth.tryAgain"
+#~ msgstr "Try again"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
@@ -181,6 +192,26 @@ msgstr "Unknown sender"
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "File exceeds the server limit of {globalMaxFormatted}"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signedIn.title"
+msgstr "Signed in. Add the email again to attach it."
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.action"
+msgstr "Sign in"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.description"
+msgstr "This email wasn't attached because reading it needs a quick sign-in."
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.title"
+msgstr "Sign in to load email"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -68,14 +68,25 @@ msgstr "El inicio de sesión en Exchange local (heredado) aún no es compatible.
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/SessionAuthProvider.tsx
-msgid "officeAddin.auth.signInRequired"
-msgstr "Se requiere iniciar sesión"
+msgid "officeAddin.auth.signIn"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-msgid "officeAddin.auth.tryAgain"
-msgstr "Intentar de nuevo"
+#: src/providers/SessionAuthProvider.tsx
+#~ msgid "officeAddin.auth.signInRequired"
+#~ msgstr "Se requiere iniciar sesión"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#: src/providers/SessionAuthProvider.tsx
+msgid "officeAddin.auth.signInToContinue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#~ msgid "officeAddin.auth.tryAgain"
+#~ msgstr "Intentar de nuevo"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
@@ -181,6 +192,26 @@ msgstr "Remitente desconocido"
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "El archivo supera el límite del servidor de {globalMaxFormatted}"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signedIn.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.action"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -68,14 +68,25 @@ msgstr "La connexion à Exchange local (hérité) n’est pas encore prise en ch
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/SessionAuthProvider.tsx
-msgid "officeAddin.auth.signInRequired"
-msgstr "Connexion requise"
+msgid "officeAddin.auth.signIn"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-msgid "officeAddin.auth.tryAgain"
-msgstr "Réessayer"
+#: src/providers/SessionAuthProvider.tsx
+#~ msgid "officeAddin.auth.signInRequired"
+#~ msgstr "Connexion requise"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#: src/providers/SessionAuthProvider.tsx
+msgid "officeAddin.auth.signInToContinue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#~ msgid "officeAddin.auth.tryAgain"
+#~ msgstr "Réessayer"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
@@ -181,6 +192,26 @@ msgstr "Expéditeur inconnu"
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Le fichier dépasse la limite du serveur de {globalMaxFormatted}"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signedIn.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.action"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -68,14 +68,25 @@ msgstr "Logowanie do lokalnego Exchange (starsza wersja) nie jest jeszcze obsłu
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-#: src/providers/SessionAuthProvider.tsx
-msgid "officeAddin.auth.signInRequired"
-msgstr "Wymagane logowanie"
+msgid "officeAddin.auth.signIn"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/App.tsx
-msgid "officeAddin.auth.tryAgain"
-msgstr "Spróbuj ponownie"
+#: src/providers/SessionAuthProvider.tsx
+#~ msgid "officeAddin.auth.signInRequired"
+#~ msgstr "Wymagane logowanie"
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#: src/providers/SessionAuthProvider.tsx
+msgid "officeAddin.auth.signInToContinue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/App.tsx
+#~ msgid "officeAddin.auth.tryAgain"
+#~ msgstr "Spróbuj ponownie"
 
 #. js-lingui-explicit-id
 #: src/components/AddinChat.tsx
@@ -181,6 +192,26 @@ msgstr "Nieznany nadawca"
 #: src/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Plik przekracza limit serwera wynoszący {globalMaxFormatted}"
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signedIn.title"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.action"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/providers/EntraGraphTokenProvider.tsx
+msgid "officeAddin.email.signInToLoad.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/providers/EntraGraphTokenProvider.tsx
+++ b/office-addin/src/providers/EntraGraphTokenProvider.tsx
@@ -1,13 +1,29 @@
+import { toast } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { createContext, useCallback, useContext, useMemo } from "react";
 
 import { useSessionRedeem } from "./SessionAuthProvider";
-import { type AuthSource, type GraphCapableSource } from "../auth/AuthSource";
+import {
+  InteractionRequiredError,
+  type AuthSource,
+  type GraphCapableSource,
+} from "../auth/AuthSource";
 import { shouldRefreshOauth2ProxySession } from "../auth/oauth2ProxySession";
 
+/** Dedupe key so repeated failed email drops replace (not stack) the prompt. */
+const GRAPH_SIGNIN_TOAST_KEY = "graph-email-signin";
+
 export interface GraphTokenContextValue {
-  /** Microsoft Graph access token for the given scopes (e.g. `["Mail.Read"]`). */
-  acquireToken: (scopes: string[]) => Promise<string>;
+  /**
+   * Microsoft Graph access token for the given scopes (e.g. `["Mail.Read"]`).
+   * Silent by default (never auto-popups). `{ forceRefresh: true }` bypasses the
+   * MSAL cache (Graph 401-retry); `{ allowInteraction: true }` permits a popup
+   * and is used only by the user-initiated "Sign in" action.
+   */
+  acquireToken: (
+    scopes: string[],
+    options?: { forceRefresh?: boolean; allowInteraction?: boolean },
+  ) => Promise<string>;
 }
 
 const GraphTokenContext = createContext<GraphTokenContextValue | null>(null);
@@ -56,17 +72,80 @@ export function EntraGraphTokenProvider({
 }) {
   const { redeemSessionForToken, lastRedeemedAtRef } = useSessionRedeem();
 
-  const acquireToken = useCallback(
-    async (scopes: string[]): Promise<string> => {
-      const { accessToken, bootstrap } = await source.acquireGraphToken(scopes);
-      // Opportunistically warm the proxy session from the token we just got,
-      // but only if it's gone stale — reusing the core's dedup + staleness ref.
-      if (shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)) {
-        await redeemSessionForToken(bootstrap, "refreshing");
-      }
-      return accessToken;
+  // Explicit, user-initiated interactive sign-in for Graph (Mail.Read). Fired
+  // ONLY from the toast's "Sign in" action (a real click), never automatically.
+  const signInForGraph = useCallback(
+    async (scopes: string[]): Promise<void> => {
+      await source.acquireGraphToken(scopes, { allowInteraction: true });
+      toast.success({
+        dedupeKey: GRAPH_SIGNIN_TOAST_KEY,
+        title: t({
+          id: "officeAddin.email.signedIn.title",
+          message: "Signed in. Add the email again to attach it.",
+        }),
+      });
     },
-    [lastRedeemedAtRef, redeemSessionForToken, source],
+    [source],
+  );
+
+  const acquireToken = useCallback(
+    async (
+      scopes: string[],
+      options?: { forceRefresh?: boolean; allowInteraction?: boolean },
+    ): Promise<string> => {
+      try {
+        const { accessToken, bootstrap } = await source.acquireGraphToken(
+          scopes,
+          options,
+        );
+        // Opportunistically warm the proxy session from the token we just got,
+        // but only if it's gone stale — reusing the core's dedup + staleness ref.
+        if (shouldRefreshOauth2ProxySession(lastRedeemedAtRef.current)) {
+          await redeemSessionForToken(bootstrap, "refreshing");
+        }
+        return accessToken;
+      } catch (error) {
+        // Silent Graph acquire needs the user to sign in (first-run consent or a
+        // Conditional-Access policy on the Graph resource). Do NOT auto-popup
+        // mid-drop — surface a deduped, email-scoped "Sign in" prompt and let the
+        // email fetch fail gracefully (it just doesn't attach). The chat session
+        // is unaffected.
+        if (
+          error instanceof InteractionRequiredError &&
+          !options?.allowInteraction
+        ) {
+          toast.warning({
+            dedupeKey: GRAPH_SIGNIN_TOAST_KEY,
+            title: t({
+              id: "officeAddin.email.signInToLoad.title",
+              message: "Sign in to load email",
+            }),
+            description: t({
+              id: "officeAddin.email.signInToLoad.description",
+              message:
+                "This email wasn't attached because reading it needs a quick sign-in.",
+            }),
+            actions: [
+              {
+                id: "graph-signin",
+                label: t({
+                  id: "officeAddin.email.signInToLoad.action",
+                  message: "Sign in",
+                }),
+                variant: "primary",
+                onClick: () => {
+                  void signInForGraph(scopes).catch(() => {
+                    // Popup cancelled/blocked — leave the prompt in place.
+                  });
+                },
+              },
+            ],
+          });
+        }
+        throw error;
+      }
+    },
+    [lastRedeemedAtRef, redeemSessionForToken, signInForGraph, source],
   );
 
   const value = useMemo<GraphTokenContextValue>(

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -211,7 +211,8 @@ export function OutlookEmailSourceProvider({
   const [droppedEmails, setDroppedEmails] = useState<DroppedEmailEntry[]>([]);
 
   const acquireGraphToken = useCallback(
-    () => acquireToken(GRAPH_MAIL_SCOPES),
+    (options?: { forceRefresh?: boolean }) =>
+      acquireToken(GRAPH_MAIL_SCOPES, options),
     [acquireToken],
   );
 

--- a/office-addin/src/providers/SessionAuthProvider.tsx
+++ b/office-addin/src/providers/SessionAuthProvider.tsx
@@ -185,9 +185,26 @@ export function SessionAuthProvider({
     async (
       token: BootstrapToken,
       status: Extract<Oauth2ProxySessionStatus, "establishing" | "refreshing">,
+      // A `forced` redeem carries a freshly force-refreshed token (recoverAuth).
+      // It must NOT silently coalesce onto a non-forced redeem in flight, which
+      // may be re-POSTing the very token that's stale/revoked.
+      forced = false,
     ): Promise<number> => {
-      if (redeemInFlightRef.current) {
-        return redeemInFlightRef.current;
+      const inFlight = redeemInFlightRef.current;
+      if (inFlight) {
+        if (!forced) {
+          // Non-forced callers (timed / focus / Graph-warm) coalesce.
+          return inFlight;
+        }
+        // Forced recovery: let the in-flight redeem finish first. If it
+        // establishes a session we're done; only if it FAILS do we redeem with
+        // our fresh force-refreshed token below (sequentially — no concurrent
+        // redeems, so no error-clobbers-success race).
+        try {
+          return await inFlight;
+        } catch {
+          // fall through to a fresh redeem with the forced token
+        }
       }
 
       const redeemPromise = (async () => {
@@ -221,12 +238,18 @@ export function SessionAuthProvider({
           }));
           setError(message);
           throw redeemError;
-        } finally {
-          redeemInFlightRef.current = null;
         }
       })();
 
       redeemInFlightRef.current = redeemPromise;
+      // Clear the in-flight ref once this redeem settles — but only if a later
+      // (forced) recovery hasn't already superseded it mid-flight.
+      const clearIfCurrent = () => {
+        if (redeemInFlightRef.current === redeemPromise) {
+          redeemInFlightRef.current = null;
+        }
+      };
+      void redeemPromise.then(clearIfCurrent, clearIfCurrent);
       return redeemPromise;
     },
     [],
@@ -335,7 +358,7 @@ export function SessionAuthProvider({
             allowInteraction: false,
           });
           setIsBootstrapAcquired(true);
-          await redeemSessionForToken(token, "refreshing");
+          await redeemSessionForToken(token, "refreshing", true);
           return true;
         } catch (recoverError) {
           const message = formatAuthenticationError(recoverError);
@@ -345,6 +368,9 @@ export function SessionAuthProvider({
             error: message,
           }));
           setError(message);
+          // Contribute to the shared backoff curve so a recovery failure (not
+          // just a timed-refresh failure) advances the retry interval.
+          setRefreshFailureCount((count) => count + 1);
           // Only a genuine interaction-required failure escalates to the full
           // sign-in screen; transient failures keep the chat visible and are
           // retried by the request's caller / the backoff timer.

--- a/office-addin/src/providers/SessionAuthProvider.tsx
+++ b/office-addin/src/providers/SessionAuthProvider.tsx
@@ -1,3 +1,4 @@
+import { setAuthRecoveryHandler } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import {
   createContext,
@@ -113,8 +114,8 @@ function formatAuthenticationError(error: unknown): string {
 
   if (error instanceof InteractionRequiredError) {
     return t({
-      id: "officeAddin.auth.signInRequired",
-      message: "Sign-in required",
+      id: "officeAddin.auth.signInToContinue",
+      message: "Sign in to continue",
     });
   }
 
@@ -158,6 +159,11 @@ export function SessionAuthProvider({
   // Replaces the old `!!account` check. Must be state and must appear in the
   // refresh effects' dependency arrays, or the refresh timer never arms.
   const [isBootstrapAcquired, setIsBootstrapAcquired] = useState(false);
+  // True ONLY when an interactive sign-in is required (interaction-required).
+  // Transient / background-refresh failures do NOT set this, so a working chat
+  // stays visible while recovery retries silently; only a genuine sign-in
+  // escalation (or a never-established session) gates the chat.
+  const [signInRequired, setSignInRequired] = useState(false);
   const [oauth2ProxySession, setOauth2ProxySession] =
     useState<Oauth2ProxySessionState>(createInitialOauth2ProxySessionState);
   // Bumped to re-run the init effect when retrying after an init failure (which
@@ -167,6 +173,9 @@ export function SessionAuthProvider({
   const [refreshFailureCount, setRefreshFailureCount] = useState(0);
   const lastRedeemedAtRef = useRef(oauth2ProxySession.lastRedeemedAt);
   const redeemInFlightRef = useRef<Promise<number> | null>(null);
+  // Dedupes the whole acquire+redeem recovery unit so N concurrent 401s trigger
+  // a single recovery (the redeem half is additionally deduped by the ref above).
+  const recoverInFlightRef = useRef<Promise<boolean> | null>(null);
 
   useEffect(() => {
     lastRedeemedAtRef.current = oauth2ProxySession.lastRedeemedAt;
@@ -201,6 +210,7 @@ export function SessionAuthProvider({
           });
           setError(null);
           setRefreshFailureCount(0);
+          setSignInRequired(false);
           return redeemedAt;
         } catch (redeemError) {
           const message = formatAuthenticationError(redeemError);
@@ -251,9 +261,10 @@ export function SessionAuthProvider({
             return;
           }
           if (authenticationError instanceof InteractionRequiredError) {
-            // Silent acquire needs interaction we didn't allow — not an error,
-            // the gate renders "Sign-in required" with a Try-again button.
+            // Silent establish needs interaction we didn't allow — surface the
+            // sign-in screen (this is a genuine sign-in-required, not transient).
             setError(null);
+            setSignInRequired(true);
           } else if (
             authenticationError instanceof Oauth2ProxySessionRedeemError
           ) {
@@ -303,6 +314,67 @@ export function SessionAuthProvider({
     },
     [authSource, redeemSessionForToken],
   );
+
+  /**
+   * 401-recovery primitive: force-refresh a fresh bootstrap token and re-redeem
+   * the proxy session, deduped across concurrent callers. Silent (never opens a
+   * popup). Resolves `true` when the session was refreshed (the caller may
+   * replay its request once) and `false` on failure — surfacing the error so the
+   * AuthGate "Try again" path is reachable. Registered with the shared API/SSE
+   * layer below so a 401 anywhere drives a single recovery.
+   */
+  const recoverAuth = useCallback(
+    async (reason: string): Promise<boolean> => {
+      if (recoverInFlightRef.current) {
+        return recoverInFlightRef.current;
+      }
+      const recoverPromise = (async () => {
+        try {
+          const token = await authSource.acquireBootstrapToken({
+            forceRefresh: true,
+            allowInteraction: false,
+          });
+          setIsBootstrapAcquired(true);
+          await redeemSessionForToken(token, "refreshing");
+          return true;
+        } catch (recoverError) {
+          const message = formatAuthenticationError(recoverError);
+          setOauth2ProxySession((previous) => ({
+            status: "error",
+            lastRedeemedAt: previous.lastRedeemedAt,
+            error: message,
+          }));
+          setError(message);
+          // Only a genuine interaction-required failure escalates to the full
+          // sign-in screen; transient failures keep the chat visible and are
+          // retried by the request's caller / the backoff timer.
+          if (recoverError instanceof InteractionRequiredError) {
+            setSignInRequired(true);
+          }
+          console.warn(
+            `OAuth2 proxy session recovery failed (${reason})`,
+            recoverError,
+          );
+          return false;
+        } finally {
+          recoverInFlightRef.current = null;
+        }
+      })();
+      recoverInFlightRef.current = recoverPromise;
+      return recoverPromise;
+    },
+    [authSource, redeemSessionForToken],
+  );
+
+  useEffect(() => {
+    // Register recovery with the shared @erato/frontend API + SSE layer so a 401
+    // on any request triggers a single silent re-acquire + re-redeem, then a
+    // one-shot replay. The web app registers nothing, so those sites no-op there.
+    setAuthRecoveryHandler(recoverAuth);
+    return () => {
+      setAuthRecoveryHandler(null);
+    };
+  }, [recoverAuth]);
 
   useEffect(() => {
     // Only schedule once we hold a session to refresh. An initial establish that
@@ -430,8 +502,15 @@ export function SessionAuthProvider({
     oauth2ProxySession.lastRedeemedAt !== null &&
     oauth2ProxySession.status !== "error";
   const authError = error ?? oauth2ProxySession.error;
+  // The chat stays mounted as long as we hold an established session and no
+  // interactive sign-in is required. A transient background-refresh failure
+  // (status "error") no longer blanks the UI — the backoff timer retries it
+  // silently; only a never-established session or a sign-in-required escalation
+  // gates the chat.
   const isAuthenticated =
-    isBootstrapAcquired && isOauth2ProxySessionReady && authError === null;
+    isBootstrapAcquired &&
+    oauth2ProxySession.lastRedeemedAt !== null &&
+    !signInRequired;
 
   return (
     <SessionAuthContext.Provider

--- a/office-addin/src/providers/__tests__/MsalNaaProvider.test.tsx
+++ b/office-addin/src/providers/__tests__/MsalNaaProvider.test.tsx
@@ -1,5 +1,5 @@
 import { createNestablePublicClientApplication } from "@azure/msal-browser";
-import { setIdToken } from "@erato/frontend/library";
+import { setAuthRecoveryHandler } from "@erato/frontend/library";
 import { i18n } from "@lingui/core";
 import {
   act,
@@ -9,7 +9,15 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 
 import { OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS } from "../../auth/oauth2ProxySession";
 import { MsalNaaProvider, useMsalNaa } from "../MsalNaaProvider";
@@ -35,6 +43,13 @@ vi.mock("@erato/frontend/library", () => ({
     msalAuthority: "https://login.microsoftonline.com/tenant",
   }),
   setIdToken: vi.fn(),
+  setAuthRecoveryHandler: vi.fn(),
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 const account = {
@@ -183,7 +198,6 @@ describe("MsalNaaProvider", () => {
 
     expect(screen.getByTestId("cookie")).toHaveTextContent("true");
     expect(screen.getByTestId("status")).toHaveTextContent("ready");
-    expect(setIdToken).toHaveBeenCalledWith("id-token");
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(fetcher).toHaveBeenCalledWith(
       "/oauth2/redeem-external-token",
@@ -263,7 +277,10 @@ describe("MsalNaaProvider", () => {
       await advance(OAUTH2_PROXY_SESSION_REFRESH_AFTER_MS + 1_000);
       expect(fetcher).toHaveBeenCalledTimes(2);
       expect(screen.getByTestId("status")).toHaveTextContent("error");
-      expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+      // A transient background-refresh failure must NOT blank the chat: the
+      // session is still established, so the user stays authenticated while the
+      // backoff timer retries silently.
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
 
       // The backoff timer re-arms and the next attempt restores the session.
       // Advancing past the max backoff guarantees the retry fires.
@@ -324,5 +341,50 @@ describe("MsalNaaProvider", () => {
       expect(screen.getByTestId("authenticated")).toHaveTextContent("true"),
     );
     expect(screen.getByTestId("status")).toHaveTextContent("ready");
+  });
+
+  it("registers a recovery handler that force-refreshes and re-redeems on a 401", async () => {
+    const fetcher = stubFetch(new Response("{}", { status: 202 }));
+    const pca = createPcaMock();
+    vi.mocked(createNestablePublicClientApplication).mockResolvedValue(pca);
+
+    render(
+      <MsalNaaProvider>
+        <AuthProbe />
+      </MsalNaaProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true"),
+    );
+
+    // The provider registered its recoverAuth with the shared API/SSE layer.
+    const handler = vi
+      .mocked(setAuthRecoveryHandler)
+      .mock.calls.map((call) => call[0])
+      .find(
+        (arg): arg is (reason: string) => Promise<boolean> =>
+          typeof arg === "function",
+      );
+    expect(handler).toBeDefined();
+
+    fetcher.mockClear();
+    (pca.acquireTokenSilent as Mock).mockClear();
+
+    let recovered: boolean | undefined;
+    await act(async () => {
+      recovered = await handler!("rest-401");
+    });
+
+    expect(recovered).toBe(true);
+    // Forced a fresh MSAL token (not the cached one that just 401'd)…
+    expect(pca.acquireTokenSilent).toHaveBeenCalledWith(
+      expect.objectContaining({ forceRefresh: true }),
+    );
+    // …and re-redeemed the proxy session cookie.
+    expect(fetcher).toHaveBeenCalledWith(
+      "/oauth2/redeem-external-token",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
   });
 });

--- a/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
+++ b/office-addin/src/utils/__tests__/fetchOutlookMessageGraph.test.ts
@@ -109,6 +109,46 @@ describe("fetchOutlookMessageFilesViaGraph", () => {
     expect(valueHeaders.Authorization).toBe("Bearer graph-token-xyz");
   });
 
+  it("force-refreshes the Graph token and retries once on a 401", async () => {
+    const acquireToken = vi.fn(async (options?: { forceRefresh?: boolean }) =>
+      options?.forceRefresh ? "fresh-token" : "stale-token",
+    );
+    const fetchMock = installFetchMock((url, init) => {
+      const auth = (init?.headers as Record<string, string> | undefined)
+        ?.Authorization;
+      // The first attempt carries the stale cached token and is rejected.
+      if (auth === "Bearer stale-token") {
+        return { ok: false, status: 401, statusText: "Unauthorized" };
+      }
+      if (url.endsWith("/$value")) {
+        return { ok: true, bytes: bytesFrom("raw-mime") };
+      }
+      return {
+        ok: true,
+        jsonValue: { subject: "Recovered", internetMessageId: "<abc@host>" },
+      };
+    });
+
+    const { subject } = await fetchOutlookMessageFilesViaGraph(
+      EWS_ID,
+      acquireToken,
+    );
+
+    expect(subject).toBe("Recovered");
+    expect(acquireToken).toHaveBeenCalledWith({ forceRefresh: true });
+    // metadata(stale → 401) → metadata(fresh) → $value(fresh, reuses cache).
+    const authorizations = fetchMock.mock.calls.map(
+      (call) =>
+        ((call[1] as RequestInit).headers as Record<string, string>)
+          .Authorization,
+    );
+    expect(authorizations).toEqual([
+      "Bearer stale-token",
+      "Bearer fresh-token",
+      "Bearer fresh-token",
+    ]);
+  });
+
   it("returns a single .eml File wrapping the RFC822 stream, named after the subject", async () => {
     const acquireToken = vi.fn().mockResolvedValue("tok");
     installFetchMock((url) => {

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -597,17 +597,39 @@ interface GraphTokenSource {
 function makeGraphTokenSource(
   acquireToken: AcquireGraphToken,
 ): GraphTokenSource {
+  // The current in-flight/resolved token promise, and the in-flight FORCED
+  // acquire (if any). A forced acquire is tracked separately so a burst of
+  // concurrent 401-driven refresh() calls (e.g. the bounded itemAttachment
+  // enrichment fan-out) coalesces onto ONE force-refresh instead of firing N.
   let cached: Promise<string> | null = null;
+  let pendingForce: Promise<string> | null = null;
+
+  const run = (force: boolean): Promise<string> => {
+    const promise = acquireToken(force ? { forceRefresh: true } : undefined);
+    cached = promise;
+    if (force) {
+      pendingForce = promise;
+    }
+    void promise.then(
+      () => {
+        if (pendingForce === promise) pendingForce = null;
+      },
+      () => {
+        // Never cache a rejected promise — clear so the next caller re-attempts
+        // instead of being served the poisoned failure forever.
+        if (cached === promise) cached = null;
+        if (pendingForce === promise) pendingForce = null;
+      },
+    );
+    return promise;
+  };
+
   return {
     get() {
-      if (!cached) {
-        cached = acquireToken();
-      }
-      return cached;
+      return cached ?? run(false);
     },
     refresh() {
-      cached = acquireToken({ forceRefresh: true });
-      return cached;
+      return pendingForce ?? run(true);
     },
   };
 }
@@ -635,6 +657,11 @@ async function graphFetch(
   const response = await request(await tokenSource.get());
   if (response.status !== 401) {
     return response;
+  }
+  // Don't waste a force-refresh + replay if the caller already aborted in the
+  // window between the 401 and the retry (matches the abort checks elsewhere).
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException("Aborted", "AbortError");
   }
   return request(await tokenSource.refresh());
 }

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -33,7 +33,9 @@ export interface FetchOutlookMessageBytesResult {
   internetMessageId: string | null;
 }
 
-export type AcquireGraphToken = () => Promise<string>;
+export type AcquireGraphToken = (options?: {
+  forceRefresh?: boolean;
+}) => Promise<string>;
 
 export interface GraphRequestOptions {
   signal?: AbortSignal;
@@ -64,9 +66,9 @@ export async function fetchOutlookMessageBytesViaGraph(
   options: GraphRequestOptions = {},
 ): Promise<FetchOutlookMessageBytesResult> {
   const restId = convertEwsIdToGraphId(ewsItemId);
-  const token = await acquireToken();
-  const metadata = await fetchMessageMetadataById(restId, token, options);
-  const bytes = await fetchMessageRawMimeById(restId, token, options);
+  const tokenSource = makeGraphTokenSource(acquireToken);
+  const metadata = await fetchMessageMetadataById(restId, tokenSource, options);
+  const bytes = await fetchMessageRawMimeById(restId, tokenSource, options);
   return {
     bytes,
     subject: metadata.subject ?? "",
@@ -101,7 +103,7 @@ export async function fetchParentMessageInConversationViaGraph(
   options: GraphRequestOptions = {},
 ): Promise<ParentMessageMetadata | null> {
   try {
-    const token = await acquireToken();
+    const tokenSource = makeGraphTokenSource(acquireToken);
     // Single-clause filter on an indexed property + no `$orderby`. Adding
     // `and isDraft eq false` plus `$orderby=receivedDateTime desc` trips
     // Graph's `InefficientFilter` constraint: properties in `$orderby` must
@@ -112,13 +114,12 @@ export async function fetchParentMessageInConversationViaGraph(
     // the latest non-draft client-side.
     const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
     const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=20&$select=id,subject,from,receivedDateTime,isDraft`;
-    const response = await fetch(url, {
-      signal: options.signal,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/json",
-      },
-    });
+    const response = await graphFetch(
+      url,
+      tokenSource,
+      "application/json",
+      options.signal,
+    );
     if (!response.ok) {
       console.warn(
         "[fetchParentMessageInConversationViaGraph] non-OK status:",
@@ -264,16 +265,7 @@ export async function fetchConversationMessagesViaGraph(
   options: FetchConversationOptions = {},
 ): Promise<FetchConversationResult> {
   const transport = options.transport ?? globalThis.fetch.bind(globalThis);
-  let token: string;
-  try {
-    token = await acquireToken();
-  } catch (error) {
-    console.warn(
-      "[fetchConversationMessagesViaGraph] token acquire failed:",
-      error,
-    );
-    return { messages: [], state: "error" };
-  }
+  const tokenSource = makeGraphTokenSource(acquireToken);
 
   const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
   const select = [
@@ -321,13 +313,13 @@ export async function fetchConversationMessagesViaGraph(
   while (nextUrl && pages < MAX_CONVERSATION_PAGES) {
     let response: Response;
     try {
-      response = await transport(nextUrl, {
-        signal: options.signal,
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/json",
-        },
-      });
+      response = await graphFetch(
+        nextUrl,
+        tokenSource,
+        "application/json",
+        options.signal,
+        transport,
+      );
     } catch (error) {
       if (options.signal?.aborted) {
         throw options.signal.reason ?? error;
@@ -372,7 +364,12 @@ export async function fetchConversationMessagesViaGraph(
   // so its content reaches the LLM. Failures degrade to a disclosure marker
   // downstream (parsedThread.transformAttachment), never a silent drop.
   if (messages.length > 0) {
-    await enrichItemAttachments(messages, token, transport, options.signal);
+    await enrichItemAttachments(
+      messages,
+      tokenSource,
+      transport,
+      options.signal,
+    );
   }
 
   return { messages, state };
@@ -388,7 +385,7 @@ export async function fetchConversationMessagesViaGraph(
  */
 async function enrichItemAttachments(
   messages: GraphConversationMessage[],
-  token: string,
+  tokenSource: GraphTokenSource,
   transport: GraphTransport,
   signal: AbortSignal | undefined,
 ): Promise<void> {
@@ -405,7 +402,7 @@ async function enrichItemAttachments(
           messageId,
           attachmentId,
           attachment,
-          token,
+          tokenSource,
           transport,
           signal,
         ),
@@ -421,23 +418,31 @@ async function enrichOneItemAttachment(
   messageId: string,
   attachmentId: string,
   attachment: GraphAttachment,
-  token: string,
+  tokenSource: GraphTokenSource,
   transport: GraphTransport,
   signal: AbortSignal | undefined,
 ): Promise<void> {
   const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}/$value`;
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/octet-stream",
-  };
   try {
-    let response = await transport(url, { headers, signal });
+    let response = await graphFetch(
+      url,
+      tokenSource,
+      "application/octet-stream",
+      signal,
+      transport,
+    );
     // Honor a single Retry-After on throttle before giving up to a marker.
     if (response.status === 429) {
       const retryMs = retryAfterMs(response);
       if (retryMs !== null) {
         await sleep(retryMs, signal);
-        response = await transport(url, { headers, signal });
+        response = await graphFetch(
+          url,
+          tokenSource,
+          "application/octet-stream",
+          signal,
+          transport,
+        );
       }
     }
     if (!response.ok) return;
@@ -554,16 +559,16 @@ export async function fetchOutlookMessageBytesByInternetMessageIdViaGraph(
   acquireToken: AcquireGraphToken,
   options: GraphRequestOptions = {},
 ): Promise<FetchOutlookMessageBytesResult | null> {
-  const token = await acquireToken();
+  const tokenSource = makeGraphTokenSource(acquireToken);
   const match = await findMessageByInternetMessageId(
     internetMessageId,
-    token,
+    tokenSource,
     options,
   );
   if (!match?.id) {
     return null;
   }
-  const bytes = await fetchMessageRawMimeById(match.id, token, options);
+  const bytes = await fetchMessageRawMimeById(match.id, tokenSource, options);
   return {
     bytes,
     subject: match.subject ?? "",
@@ -579,19 +584,73 @@ function convertEwsIdToGraphId(ewsItemId: string): string {
   );
 }
 
+/**
+ * Caches one Mail.Read token across all requests of a single operation (so a
+ * multi-request fetch still acquires only once) while allowing a forced refresh
+ * when a request comes back 401.
+ */
+interface GraphTokenSource {
+  get(): Promise<string>;
+  refresh(): Promise<string>;
+}
+
+function makeGraphTokenSource(
+  acquireToken: AcquireGraphToken,
+): GraphTokenSource {
+  let cached: Promise<string> | null = null;
+  return {
+    get() {
+      if (!cached) {
+        cached = acquireToken();
+      }
+      return cached;
+    },
+    refresh() {
+      cached = acquireToken({ forceRefresh: true });
+      return cached;
+    },
+  };
+}
+
+/**
+ * Issues a Graph request with the operation's cached Mail.Read token and, on a
+ * 401 (token revoked / CAE-invalidated even though MSAL returned it from cache),
+ * force-refreshes the token and retries exactly once. The add-in-side analogue
+ * of the session `recoverAuth`, scoped to the Graph token — a separate cache
+ * from the proxy-session bootstrap token, hence handled here rather than via the
+ * shared recovery handler.
+ */
+async function graphFetch(
+  url: string,
+  tokenSource: GraphTokenSource,
+  accept: string,
+  signal: AbortSignal | undefined,
+  transport: GraphTransport = globalThis.fetch.bind(globalThis),
+): Promise<Response> {
+  const request = (token: string) =>
+    transport(url, {
+      signal,
+      headers: { Authorization: `Bearer ${token}`, Accept: accept },
+    });
+  const response = await request(await tokenSource.get());
+  if (response.status !== 401) {
+    return response;
+  }
+  return request(await tokenSource.refresh());
+}
+
 async function fetchMessageMetadataById(
   messageId: string,
-  token: string,
+  tokenSource: GraphTokenSource,
   options: GraphRequestOptions = {},
 ): Promise<GraphMessageMetadata> {
   const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}?$select=subject,internetMessageId`;
-  const response = await fetch(url, {
-    signal: options.signal,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
+  const response = await graphFetch(
+    url,
+    tokenSource,
+    "application/json",
+    options.signal,
+  );
   if (!response.ok) {
     throw new Error(
       `Graph fetch failed: ${response.status} ${response.statusText}`,
@@ -602,17 +661,16 @@ async function fetchMessageMetadataById(
 
 async function fetchMessageRawMimeById(
   messageId: string,
-  token: string,
+  tokenSource: GraphTokenSource,
   options: GraphRequestOptions = {},
 ): Promise<ArrayBuffer> {
   const url = `${GRAPH_BASE}/me/messages/${encodeURIComponent(messageId)}/$value`;
-  const response = await fetch(url, {
-    signal: options.signal,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/octet-stream",
-    },
-  });
+  const response = await graphFetch(
+    url,
+    tokenSource,
+    "application/octet-stream",
+    options.signal,
+  );
   if (!response.ok) {
     throw new Error(
       `Graph MIME fetch failed: ${response.status} ${response.statusText}`,
@@ -623,18 +681,17 @@ async function fetchMessageRawMimeById(
 
 async function findMessageByInternetMessageId(
   internetMessageId: string,
-  token: string,
+  tokenSource: GraphTokenSource,
   options: GraphRequestOptions = {},
 ): Promise<GraphMessageMetadata | null> {
   const filter = `internetMessageId eq '${escapeODataString(internetMessageId)}'`;
   const url = `${GRAPH_BASE}/me/messages?$filter=${encodeURIComponent(filter)}&$top=1&$select=id,subject,internetMessageId`;
-  const response = await fetch(url, {
-    signal: options.signal,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
+  const response = await graphFetch(
+    url,
+    tokenSource,
+    "application/json",
+    options.signal,
+  );
   if (!response.ok) {
     throw new Error(
       `Graph lookup failed: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
This pull request implements a robust authentication recovery mechanism for alternate shells (such as the Office add-in), allowing the client to recover from authentication failures (HTTP 401) by replaying failed requests after refreshing the session. It also improves the handling of streaming errors in chat messaging, clarifies authentication logic, and updates some Office add-in UI and localization strings.

The most important changes are:

**Authentication Recovery Mechanism:**

* Introduced a new injectable `authRecovery` hook (`setAuthRecoveryHandler`, `tryRecoverAuth`) to enable client-side recovery from 401 errors, primarily for the Office add-in shell. The web app remains unaffected, as it does not register a handler. Includes comprehensive tests for this mechanism. [[1]](diffhunk://#diff-233736dc842fe2401d0188cf9d1ea0d45ef049772ed5c1bc7489f9d3957df1ddR1-R42) [[2]](diffhunk://#diff-e17ffef16bcbcb014a99c24f6ee2af5b6f3113e8d1c336e2e4ddaaeefeb27ae8R1-R36) [[3]](diffhunk://#diff-9a44d328da4c4456a355a49f8b07809c38bf10cf93efd70b1180db9f01998ed2R3) [[4]](diffhunk://#diff-9a44d328da4c4456a355a49f8b07809c38bf10cf93efd70b1180db9f01998ed2R118-R184) [[5]](diffhunk://#diff-f8fdb79a8f0e05aeeb3042be3a5cce6ee0db9f5851ddebc49ab36ef22801ae73R190-R193)

* Integrated the auth recovery hook into the SSE client (`sseClient.ts`), so that on a connect-time 401, the client attempts recovery and retries the connection once. [[1]](diffhunk://#diff-fb22891673c0e761b13b448d3458db79959d95f600a7d4eee667d8b3301caa63R13) [[2]](diffhunk://#diff-fb22891673c0e761b13b448d3458db79959d95f600a7d4eee667d8b3301caa63L245-R248) [[3]](diffhunk://#diff-fb22891673c0e761b13b448d3458db79959d95f600a7d4eee667d8b3301caa63R261-R269)

**Streaming Error Handling:**

* Enhanced chat streaming error handling in `useChatMessaging.ts` to attempt stream resumption (with auth recovery) on mid-stream errors or unexpected closures, ensuring a more resilient user experience. [[1]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1714-R1735) [[2]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1749-R1762) [[3]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1857-R1880) [[4]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1894-R1909)

**Office Add-in Authentication and UI:**

* Updated Office add-in authentication logic to clarify that the id token is not pushed into the shared token store, and improved the `acquireGraphToken` method to support silent acquisition and optional interaction/refresh. [[1]](diffhunk://#diff-0a08c2c050349ccc5f0deefafa819c3ab89777ea586c4bc71bdf4d9183a53804L7-R7) [[2]](diffhunk://#diff-0a08c2c050349ccc5f0deefafa819c3ab89777ea586c4bc71bdf4d9183a53804R75-L82) [[3]](diffhunk://#diff-0a08c2c050349ccc5f0deefafa819c3ab89777ea586c4bc71bdf4d9183a53804L152-R173) [[4]](diffhunk://#diff-21937a8fd0f867ff6a195eeb2f69bfed704c790e9d914dadb4235a0a964c48d8L81-R84) [[5]](diffhunk://#diff-8c1dcaa7553fe15f2c8177622f19dbf118e2f6c4d1e6228ca043b815dba88023L145-R146)

* Refined Office add-in UI strings for sign-in prompts and updated corresponding localization files. [[1]](diffhunk://#diff-5e5d2952245e4ff12f457c64c0ee8bca78ba7f3b0151b4297de78098d0b2c324L42-R43) [[2]](diffhunk://#diff-5e5d2952245e4ff12f457c64c0ee8bca78ba7f3b0151b4297de78098d0b2c324L54-R55) [[3]](diffhunk://#diff-290f116db4b11b05e1cf7ee6a0c331eeb4996466878c424a4188231f711cb6ceR69-R89)

**Authentication Header Logic:**

* Clarified comments in `mergeApiAuthHeaders` to explain the current and future use of the Bearer token, emphasizing that the session cookie remains the single source of truth for authentication.