### PR TITLE
feat: add copy button to markdown code snippets (ERMAIN-340)

### DIFF
--- a/frontend/src/components/ui/Controls/Button.tsx
+++ b/frontend/src/components/ui/Controls/Button.tsx
@@ -108,12 +108,23 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ) => {
     const [isPressed, setIsPressed] = React.useState(false);
     const [showConfirmDialog, setShowConfirmDialog] = React.useState(false);
+    const pressTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    );
+
+    React.useEffect(() => {
+      return () => {
+        if (pressTimerRef.current !== null) {
+          clearTimeout(pressTimerRef.current);
+        }
+      };
+    }, []);
 
     // Memoize the click handler
     const handleClick = useCallback(
       (e: React.MouseEvent<HTMLButtonElement>) => {
         setIsPressed(true);
-        setTimeout(() => setIsPressed(false), 200);
+        pressTimerRef.current = setTimeout(() => setIsPressed(false), 200);
 
         if (confirmAction) {
           e.stopPropagation();

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -601,10 +601,13 @@ describe("MessageContent", () => {
     );
 
     // No facet → stays an ordinary code block, no insert/replace UI.
+    // The code block does have its own copy button, but NOT the email artifact UI.
     expect(
       container.querySelector("pre.message-content-code-block"),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Copy/ })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Copy code/ }),
+    ).toBeInTheDocument();
   });
 
   it("renders a drifted email fence as HTML when the facet body_format is html", () => {

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -11,6 +11,7 @@ import {
   durationFromTracePartsOrLegacyMessageTimestamps,
   groupIntoTraceClusters,
 } from "@/components/ui/Trace";
+import { CheckIcon, CopyIcon } from "@/components/ui/icons";
 import {
   DEFAULT_DARK_CODE_HIGHLIGHT_PRESET,
   DEFAULT_LIGHT_CODE_HIGHLIGHT_PRESET,
@@ -142,6 +143,30 @@ function MarkdownPre({
   ...props
 }: MarkdownPreProps) {
   const artifact = React.useContext(OutlookArtifactContext);
+  const [copied, setCopied] = React.useState(false);
+
+  // Extract the raw code text from the child <code> element so the copy button
+  // can access it without needing a separate context or ref strategy.
+  let codeContent = "";
+  try {
+    const child = React.Children.only(children) as React.ReactElement<{
+      children?: React.ReactNode;
+    }>;
+    codeContent = String(child.props.children ?? "").replace(/\n$/, "");
+  } catch {
+    // Non-standard children structure — leave codeContent empty.
+  }
+
+  const handleCopy = React.useCallback(() => {
+    void navigator.clipboard
+      .writeText(codeContent)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  }, [codeContent]);
+
   // erato-email blocks render a custom component, not a code block —
   // use a plain <div> to avoid inheriting <pre> monospace font and
   // horizontal scroll from message-content-code-block styling.
@@ -160,16 +185,31 @@ function MarkdownPre({
   }
 
   return (
-    <pre
-      className={["message-content-code-block", className]
-        .filter(Boolean)
-        .join(" ")}
-      {...props}
-    >
-      <BlockCodeContext.Provider value={true}>
-        {children}
-      </BlockCodeContext.Provider>
-    </pre>
+    <div className="group relative my-4">
+      <pre
+        className={["message-content-code-block", className]
+          .filter(Boolean)
+          .join(" ")}
+        {...props}
+      >
+        <BlockCodeContext.Provider value={true}>
+          {children}
+        </BlockCodeContext.Provider>
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? t`Copied` : t`Copy code`}
+        title={copied ? t`Copied` : t`Copy code`}
+        className="absolute right-2 top-2 z-10 flex items-center justify-center rounded border border-theme-border bg-theme-bg-secondary p-1 text-theme-fg-muted opacity-0 transition-opacity hover:bg-theme-bg-tertiary hover:text-theme-fg-primary focus:opacity-100 group-hover:opacity-100"
+      >
+        {copied ? (
+          <CheckIcon className="size-3.5 text-theme-success-fg" />
+        ) : (
+          <CopyIcon className="size-3.5" />
+        )}
+      </button>
+    </div>
   );
 }
 

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1996,12 +1996,20 @@ msgstr "Die Kontextnutzung überschreitet die Modellkapazität. Der Assistent ka
 msgid "Conversational"
 msgstr ""
 
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copied"
+msgstr ""
+
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copied!"
 msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copy"
+msgstr ""
+
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copy code"
 msgstr ""
 
 #: src/hooks/audio/useAudioDictationRecorder.ts

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1996,6 +1996,10 @@ msgstr "Context usage exceeds model capacity. The assistant can't be created lik
 msgid "Conversational"
 msgstr "Conversational"
 
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copied"
+msgstr "Copied"
+
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copied!"
 msgstr "Copied!"
@@ -2003,6 +2007,10 @@ msgstr "Copied!"
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copy"
 msgstr "Copy"
+
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copy code"
+msgstr "Copy code"
 
 #: src/hooks/audio/useAudioDictationRecorder.ts
 #~ msgid "Could not complete audio dictation."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1996,12 +1996,20 @@ msgstr "El uso de contexto supera la capacidad del modelo. El asistente no se pu
 msgid "Conversational"
 msgstr ""
 
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copied"
+msgstr ""
+
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copied!"
 msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copy"
+msgstr ""
+
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copy code"
 msgstr ""
 
 #: src/hooks/audio/useAudioDictationRecorder.ts

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1996,12 +1996,20 @@ msgstr "L'utilisation du contexte dépasse la capacité du modèle. L'assistant 
 msgid "Conversational"
 msgstr ""
 
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copied"
+msgstr ""
+
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copied!"
 msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copy"
+msgstr ""
+
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copy code"
 msgstr ""
 
 #: src/hooks/audio/useAudioDictationRecorder.ts

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1996,12 +1996,20 @@ msgstr "Wykorzystanie kontekstu przekracza pojemność modelu. Asystent nie moż
 msgid "Conversational"
 msgstr ""
 
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copied"
+msgstr ""
+
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copied!"
 msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "Copy"
+msgstr ""
+
+#: src/components/ui/Message/MessageContent.tsx
+msgid "Copy code"
 msgstr ""
 
 #: src/hooks/audio/useAudioDictationRecorder.ts

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -572,7 +572,6 @@ body {
   }
 
   pre.message-content-code-block {
-    margin-block: 1rem;
     overflow-x: auto;
     padding: 0;
     border: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves ERMAIN-340. Adds a copy-to-clipboard button at the top-right of every fenced code block in chat messages.

## Changes

### `frontend/src/components/ui/Message/MessageContent.tsx`
- `MarkdownPre` now wraps the `<pre>` in a `relative`-positioned `div` with a Tailwind `group` class, enabling hover-triggered opacity transitions
- An absolutely-positioned copy button is placed **outside** the scrolling `<pre>`, so it stays anchored at the top-right even when code content overflows horizontally
- Code content is extracted directly from the child `<code>` element's props — no new context or ref needed
- Uses `CopyIcon` → `CheckIcon` toggle on click, with the check icon tinted success-green, reverting after 2 s — consistent with existing copy UX patterns elsewhere (e.g. `DefaultMessageControls`, `ChatShareDialog`)
- Keyboard-accessible: hidden by default (`opacity-0`), but visible on `focus:opacity-100` so tabbing reaches it
- `erato-email` blocks return early from `MarkdownPre` unchanged — artifact blocks already have their own copy UI

### `frontend/src/styles/globals.css`
- Removed `margin-block: 1rem` from `pre.message-content-code-block`; spacing is now handled by Tailwind `my-4` on the new wrapper `div`

### `frontend/src/components/ui/Message/MessageContent.test.tsx`
- Updated the one test that previously asserted no copy button on a regular code block — it now correctly expects the new code-block copy button

## Behaviour

- Button is hidden by default and fades in on hover (or keyboard focus)
- Click copies the code, button label switches to "Copied" with a check icon for 2 s
- Does not appear on `erato-email` artifact blocks (those keep their existing copy UI)
- Does not scroll with horizontally-overflowing code (fixed at top-right of the visible block)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-340](https://linear.app/erato-labs/issue/ERMAIN-340/add-copy-copy-button-to-markdown-code-snippets)

<div><a href="https://cursor.com/agents/bc-7ac2ab66-fe64-428c-ab8a-69d914f39df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ac2ab66-fe64-428c-ab8a-69d914f39df1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

