### PR TITLE
Outlook read-mode reply via client-action proposals

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -310,6 +310,31 @@ chat_provider_ids = ["test-token-limit"]
 # For general feedback (tone, completeness, structure), use plain text. Output exactly one suggestion unless the user explicitly asks for alternatives. On follow-up messages without a new draft, respond normally in plain text.
 # """
 # allowed_args = ["full_body", "body_format"]
+#
+# Client-action proposals: an action facet may additionally declare a fixed
+# set of client-side action identifiers via `client_actions`. While such a
+# facet is active, the model is offered a `propose_client_action` tool whose
+# input is restricted to exactly these values. The tool is never executed
+# server-side: the resulting tool_use content part is consumed by the client
+# application, which validates the proposal against this list and performs
+# the action only after user confirmation. The identifiers must match actions
+# implemented by the client - the Outlook add-in currently implements
+# "outlook.reply" and "outlook.reply_all" (read mode, opens a pre-filled
+# reply form; sending always remains a manual user step in Outlook).
+#
+# Per-turn templates must start with "FOR THIS MESSAGE ONLY:" so they are
+# stripped when the conversation history is replayed on later turns.
+#
+# [action_facets.facets.outlook_reply_from_read]
+# display_name = "Outlook Reply from Read Mode"
+# platform = "outlook"
+# client_actions = ["outlook.reply", "outlook.reply_all"]
+# allowed_args = ["body_format"]
+# template = """
+# FOR THIS MESSAGE ONLY: <your reply-drafting instructions; have the model emit
+# the reply body in an erato-email / erato-email-html fenced block and call the
+# propose_client_action tool exactly once with the recommended action>
+# """
 
 # Experimental facets feature configuration
 # [experimental_facets]

--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -334,6 +334,10 @@ chat_provider_ids = ["test-token-limit"]
 # # proposed action immediately after a fresh assistant completion, subject
 # # to the user's local approval preferences in the add-in settings).
 # presentation = "render_buttons"
+# # Subset of client_actions the deployment ENFORCES a per-use confirmation
+# # for: the client always asks and never offers a persistent "always allow"
+# # (greyed out with a reason in the client settings). Users can still deny.
+# client_actions_always_ask = ["outlook.reply_all"]
 # allowed_args = ["body_format"]
 # template = """
 # FOR THIS MESSAGE ONLY: <your reply-drafting instructions; have the model emit

--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -322,8 +322,12 @@ chat_provider_ids = ["test-token-limit"]
 # "outlook.reply" and "outlook.reply_all" (read mode, opens a pre-filled
 # reply form; sending always remains a manual user step in Outlook).
 #
-# Per-turn templates must start with "FOR THIS MESSAGE ONLY:" so they are
-# stripped when the conversation history is replayed on later turns.
+# Per-turn directives are persisted as metadata markers and dropped from
+# prior-turn history when it is replayed on later turns, so stripping does
+# not depend on the template text. The built-in templates still start with
+# "FOR THIS MESSAGE ONLY:" by convention: it makes the request-scoped intent
+# explicit to the model, and rows persisted before the marker format are
+# recognized (and stripped) by exactly this text prefix.
 #
 # [action_facets.facets.outlook_reply_from_read]
 # display_name = "Outlook Reply from Read Mode"

--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -329,6 +329,11 @@ chat_provider_ids = ["test-token-limit"]
 # display_name = "Outlook Reply from Read Mode"
 # platform = "outlook"
 # client_actions = ["outlook.reply", "outlook.reply_all"]
+# # How the client surfaces a proposal: "render_buttons" (default - show
+# # buttons, the user clicks) or "auto_prompt" (the client may surface the
+# # proposed action immediately after a fresh assistant completion, subject
+# # to the user's local approval preferences in the add-in settings).
+# presentation = "render_buttons"
 # allowed_args = ["body_format"]
 # template = """
 # FOR THIS MESSAGE ONLY: <your reply-drafting instructions; have the model emit

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -790,6 +790,14 @@ impl AppConfig {
                     );
                 }
             }
+            for enforced in &action_facet.client_actions_always_ask {
+                if !action_facet.client_actions.contains(enforced) {
+                    panic!(
+                        "Action facet '{}' lists '{}' in client_actions_always_ask but not in client_actions.",
+                        id, enforced
+                    );
+                }
+            }
         }
 
         validate_audio_feature_config(&config, "audio_transcription", &config.audio_transcription);
@@ -2307,6 +2315,7 @@ impl ActionFacetsConfig {
                 ],
                 client_actions: vec![],
                 presentation: None,
+                client_actions_always_ask: vec![],
             });
 
         self.facets
@@ -2318,6 +2327,7 @@ impl ActionFacetsConfig {
                 allowed_args: vec!["full_body".to_string(), "body_format".to_string()],
                 client_actions: vec![],
                 presentation: None,
+                client_actions_always_ask: vec![],
             });
     }
 }
@@ -2382,6 +2392,13 @@ pub struct ActionFacetConfig {
     //   approval preferences.
     // Only meaningful when `client_actions` is non-empty.
     pub presentation: Option<String>,
+
+    // Subset of `client_actions` for which the deployment ENFORCES a
+    // per-use confirmation: the client must always ask and must not offer
+    // (or honor) a persistent "always allow" for these actions. Users may
+    // still deny them entirely.
+    #[serde(default)]
+    pub client_actions_always_ask: Vec<String>,
 }
 
 /// Valid values for `ActionFacetConfig::presentation`.

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -774,6 +774,22 @@ impl AppConfig {
                     id
                 );
             }
+            if let Some(presentation) = &action_facet.presentation {
+                if !ACTION_FACET_PRESENTATIONS.contains(&presentation.as_str()) {
+                    panic!(
+                        "Action facet '{}' has an invalid presentation '{}'. Must be one of: {}",
+                        id,
+                        presentation,
+                        ACTION_FACET_PRESENTATIONS.join(", ")
+                    );
+                }
+                if action_facet.client_actions.is_empty() {
+                    panic!(
+                        "Action facet '{}' sets presentation but declares no client_actions.",
+                        id
+                    );
+                }
+            }
         }
 
         validate_audio_feature_config(&config, "audio_transcription", &config.audio_transcription);
@@ -2290,6 +2306,7 @@ impl ActionFacetsConfig {
                     "body_format".to_string(),
                 ],
                 client_actions: vec![],
+                presentation: None,
             });
 
         self.facets
@@ -2300,6 +2317,7 @@ impl ActionFacetsConfig {
                 template: BUILTIN_OUTLOOK_REVIEW_DRAFT_TEMPLATE.trim().to_string(),
                 allowed_args: vec!["full_body".to_string(), "body_format".to_string()],
                 client_actions: vec![],
+                presentation: None,
             });
     }
 }
@@ -2356,7 +2374,18 @@ pub struct ActionFacetConfig {
     // the action only after user confirmation.
     #[serde(default)]
     pub client_actions: Vec<String>,
+
+    // How the client should surface a proposed client action:
+    // - "render_buttons" (default): show action buttons; the user clicks.
+    // - "auto_prompt": the client may immediately surface the proposed action
+    //   after a fresh assistant completion, subject to the user's local
+    //   approval preferences.
+    // Only meaningful when `client_actions` is non-empty.
+    pub presentation: Option<String>,
 }
+
+/// Valid values for `ActionFacetConfig::presentation`.
+pub const ACTION_FACET_PRESENTATIONS: [&str; 2] = ["render_buttons", "auto_prompt"];
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Facet)]
 pub struct CachesConfig {

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -764,6 +764,16 @@ impl AppConfig {
                     id
                 );
             }
+            if action_facet
+                .client_actions
+                .iter()
+                .any(|action| action.trim().is_empty())
+            {
+                panic!(
+                    "Action facet '{}' has an empty client action identifier in client_actions.",
+                    id
+                );
+            }
         }
 
         validate_audio_feature_config(&config, "audio_transcription", &config.audio_transcription);
@@ -2279,6 +2289,7 @@ impl ActionFacetsConfig {
                     "source_property".to_string(),
                     "body_format".to_string(),
                 ],
+                client_actions: vec![],
             });
 
         self.facets
@@ -2288,6 +2299,7 @@ impl ActionFacetsConfig {
                 platform: Some("outlook".to_string()),
                 template: BUILTIN_OUTLOOK_REVIEW_DRAFT_TEMPLATE.trim().to_string(),
                 allowed_args: vec!["full_body".to_string(), "body_format".to_string()],
+                client_actions: vec![],
             });
     }
 }
@@ -2337,6 +2349,13 @@ pub struct ActionFacetConfig {
     // List of allowed argument names for the template.
     #[serde(default)]
     pub allowed_args: Vec<String>,
+
+    // Fixed identifiers of client-side actions (e.g. "outlook.reply") the
+    // model may propose via the `propose_client_action` tool when this facet
+    // is active. The client application validates the proposal and performs
+    // the action only after user confirmation.
+    #[serde(default)]
+    pub client_actions: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Facet)]

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -774,6 +774,29 @@ impl AppConfig {
                     id
                 );
             }
+            for (list_name, actions) in [
+                ("client_actions", &action_facet.client_actions),
+                (
+                    "client_actions_always_ask",
+                    &action_facet.client_actions_always_ask,
+                ),
+            ] {
+                if let Some(untrimmed) = actions.iter().find(|action| *action != action.trim()) {
+                    panic!(
+                        "Action facet '{}' has a client action identifier '{}' with leading or trailing whitespace in {}.",
+                        id, untrimmed, list_name
+                    );
+                }
+                let mut seen = std::collections::HashSet::new();
+                for action in actions {
+                    if !seen.insert(action) {
+                        panic!(
+                            "Action facet '{}' has a duplicate client action identifier '{}' in {}.",
+                            id, action, list_name
+                        );
+                    }
+                }
+            }
             if let Some(presentation) = &action_facet.presentation {
                 if !ACTION_FACET_PRESENTATIONS.contains(&presentation.as_str()) {
                     panic!(

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -615,6 +615,31 @@ pub fn get_generation_chat_provider_id_from_message(
     Ok(None)
 }
 
+/// An action facet (id + args) as stored in generation parameters.
+pub type StoredActionFacet = (String, std::collections::HashMap<String, String>);
+
+/// The action facet (id + args) stored in a message's generation parameters,
+/// if any. Used by regenerate to re-apply the facet the original generation
+/// ran under when the request doesn't re-send one.
+pub fn get_generation_action_facet_from_message(
+    message: &messages::Model,
+) -> Result<Option<StoredActionFacet>, Report> {
+    if let Some(generation_params_json) = &message.generation_parameters {
+        let generation_params: GenerationParameters =
+            serde_json::from_value(generation_params_json.clone()).map_err(|e| {
+                eyre!(
+                    "Failed to parse generation parameters for message {}: {}",
+                    message.id,
+                    e
+                )
+            })?;
+        return Ok(generation_params
+            .action_facet_id
+            .map(|id| (id, generation_params.action_facet_args.unwrap_or_default())));
+    }
+    Ok(None)
+}
+
 /// Resolve a provider for a user message branch by checking the assistant response that follows
 /// the user message. Prefer the active-thread assistant sibling; fall back to newest sibling.
 pub async fn get_generation_chat_provider_id_for_replaced_user_message(

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1885,9 +1885,9 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         && let Some(facet_config) = app_state.config.action_facets.facets.get(&action_facet.id)
         && !facet_config.client_actions.is_empty()
     {
-        let name_taken_by_mcp_tool = generation_mcp_tools.iter().any(|tool| {
-            tool.tool.name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
-        });
+        let name_taken_by_mcp_tool = generation_mcp_tools
+            .iter()
+            .any(|tool| tool.tool.name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME);
         if name_taken_by_mcp_tool {
             tracing::warn!(
                 "Not offering the client-action tool for action facet '{}': an MCP tool already uses the name '{}'",
@@ -6228,6 +6228,38 @@ pub async fn regenerate_message_sse(
             } else {
                 None
             };
+            // Mirror the chat-provider fallback for the action facet: a
+            // regenerate without an explicit facet re-applies the one the
+            // original generation ran under ("same input, new sample"),
+            // including any client-action tool it implied. Re-validated
+            // against the CURRENT config — a facet that was removed or
+            // changed since is dropped (regenerate proceeds without it)
+            // rather than failing the request.
+            let fallback_action_facet = if request.action_facet.is_none() {
+                crate::models::message::get_generation_action_facet_from_message(&current_message)
+                    .ok()
+                    .flatten()
+                    .map(|(id, args)| ActionFacetRequest { id, args })
+                    .filter(|af| {
+                        let platform = generation_request_context
+                            .platform
+                            .as_deref()
+                            .unwrap_or(DEFAULT_ERATO_PLATFORM);
+                        match validate_action_facet(&app_state.config, Some(af), platform) {
+                            Ok(()) => true,
+                            Err((_, reason)) => {
+                                tracing::warn!(
+                                    "Dropping stored action facet '{}' on regenerate: {}",
+                                    af.id,
+                                    reason
+                                );
+                                false
+                            }
+                        }
+                    })
+            } else {
+                None
+            };
 
             let me_profile_input = MeProfileChatRequestInput::from_me_profile(&me_user);
             let user_input = crate::services::prompt_composition::PromptCompositionUserInput {
@@ -6238,12 +6270,16 @@ pub async fn regenerate_message_sse(
                     .or(fallback_chat_provider_id),
                 new_input_file_ids: input_files_for_previous_message,
                 selected_facet_ids: request.selected_facet_ids.clone(),
-                action_facet: request.action_facet.as_ref().map(|af| {
-                    crate::services::prompt_composition::types::ActionFacetUserInput {
-                        id: af.id.clone(),
-                        args: af.args.clone(),
-                    }
-                }),
+                action_facet: request
+                    .action_facet
+                    .as_ref()
+                    .or(fallback_action_facet.as_ref())
+                    .map(
+                        |af| crate::services::prompt_composition::types::ActionFacetUserInput {
+                            id: af.id.clone(),
+                            args: af.args.clone(),
+                        },
+                    ),
             };
             let prepare_chat_request_res = prepare_chat_request(
                 &app_state,

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1872,10 +1872,35 @@ pub(crate) async fn prepare_chat_request_with_adapters(
     if did_prior_assistant_chat_provider_change {
         strip_persisted_reasoning_messages(&mut chat_request);
     }
-    let chat_request_tools = convert_mcp_tools_to_genai_tools(
+    let mut chat_request_tools = convert_mcp_tools_to_genai_tools(
         generation_mcp_tools.clone(),
         effective_model_settings.compat_omit_strict,
     );
+    // Offer the synthetic client-action tool only when the current request's
+    // action facet declares client actions. The tool is handled in the tool
+    // call loop instead of being dispatched to an MCP server. If an MCP tool
+    // already claims the same name, it wins — adding a duplicate tool name
+    // would be rejected by providers and ambiguous to dispatch.
+    if let Some(action_facet) = user_input.action_facet.as_ref()
+        && let Some(facet_config) = app_state.config.action_facets.facets.get(&action_facet.id)
+        && !facet_config.client_actions.is_empty()
+    {
+        let name_taken_by_mcp_tool = generation_mcp_tools.iter().any(|tool| {
+            tool.tool.name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+        });
+        if name_taken_by_mcp_tool {
+            tracing::warn!(
+                "Not offering the client-action tool for action facet '{}': an MCP tool already uses the name '{}'",
+                action_facet.id,
+                crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+            );
+        } else {
+            chat_request_tools.push(crate::services::client_actions::build_client_action_tool(
+                &facet_config.client_actions,
+                effective_model_settings.compat_omit_strict,
+            ));
+        }
+    }
     if !chat_request_tools.is_empty() {
         chat_request.tools = Some(chat_request_tools);
     } else {
@@ -2260,6 +2285,90 @@ async fn stream_generate_chat_completion<
                     )))
                     .await;
                 return Err(());
+            }
+
+            // Client-action proposals are never executed server-side: validate
+            // the input against the enum offered on this request, record the
+            // ToolUse part for the client to consume after user confirmation,
+            // and answer the model so the turn can continue. An MCP tool that
+            // happens to use the same name takes precedence (the synthetic
+            // tool is never offered in that case — see prepare).
+            if unfinished_tool_call.fn_name
+                == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+                && !available_mcp_tools_by_name
+                    .contains_key(crate::services::client_actions::CLIENT_ACTION_TOOL_NAME)
+            {
+                let allowed_actions =
+                    crate::services::client_actions::allowed_client_actions_from_tools(
+                        current_turn_chat_request.tools.as_ref(),
+                    );
+                let tool_call_started = tool_call_started_at
+                    .remove(&unfinished_tool_call.call_id)
+                    .unwrap_or_else(now_timestamp);
+                tool_call_parent_observation_ids.remove(&unfinished_tool_call.call_id);
+                let (status, bg_status, message_status, output_value, response_text) =
+                    match crate::services::client_actions::validate_client_action_input(
+                        &unfinished_tool_call.fn_arguments,
+                        &allowed_actions,
+                    ) {
+                        Ok(action) => (
+                            ToolCallStatus::Success,
+                            BgToolCallStatus::Success,
+                            MessageToolCallStatus::Success,
+                            json!({ "status": "proposed", "action": action }),
+                            format!(
+                                "Proposed client action '{action}' to the user. The user's application will ask for confirmation and perform it. Do not call this tool again for this request and do not claim the action has been executed."
+                            ),
+                        ),
+                        Err(error) => (
+                            ToolCallStatus::Error,
+                            BgToolCallStatus::Error,
+                            MessageToolCallStatus::Error,
+                            json!({ "status": "rejected", "error": error }),
+                            format!("Invalid client action proposal: {error}"),
+                        ),
+                    };
+                let update_event = MessageSubmitStreamingResponseToolCallUpdate {
+                    message_id: assistant_message_id,
+                    content_index: current_message_content.len(),
+                    tool_call_id: unfinished_tool_call.call_id.clone(),
+                    tool_name: unfinished_tool_call.fn_name.clone(),
+                    input: Some(unfinished_tool_call.fn_arguments.clone()),
+                    status,
+                    progress_message: None,
+                    output: Some(output_value.clone()),
+                };
+                if let Some(task) = streaming_task {
+                    let _ = task
+                        .send_event(StreamingEvent::ToolCallUpdate {
+                            message_id: assistant_message_id,
+                            content_index: current_message_content.len(),
+                            tool_call_id: unfinished_tool_call.call_id.clone(),
+                            tool_name: unfinished_tool_call.fn_name.clone(),
+                            input: Some(unfinished_tool_call.fn_arguments.clone()),
+                            status: bg_status,
+                            progress_message: None,
+                            output: Some(output_value.clone()),
+                        })
+                        .await;
+                }
+                let message: MSG = update_event.into();
+                message.send_event(tx.clone()).await?;
+                current_message_content.push(ContentPart::ToolUse(ToolUse {
+                    tool_call_id: unfinished_tool_call.call_id.clone(),
+                    status: message_status,
+                    tool_name: unfinished_tool_call.fn_name.clone(),
+                    input: Some(unfinished_tool_call.fn_arguments.clone()),
+                    progress_message: None,
+                    output: Some(output_value),
+                    started_at: Some(tool_call_started),
+                    ended_at: Some(now_timestamp()),
+                }));
+                current_turn_tool_responses.push(genai::chat::ToolResponse {
+                    call_id: unfinished_tool_call.call_id.clone(),
+                    content: response_text,
+                });
+                continue;
             }
 
             let managed_tool = match available_mcp_tools_by_name
@@ -4315,6 +4424,7 @@ mod tests {
                     platform: None,
                     template: "Summarize this".to_string(),
                     allowed_args: vec![],
+                    client_actions: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4334,6 +4444,7 @@ mod tests {
                     platform: Some("teams".to_string()),
                     template: "Reply".to_string(),
                     allowed_args: vec![],
+                    client_actions: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4354,6 +4465,7 @@ mod tests {
                     platform: Some("teams".to_string()),
                     template: "Reply".to_string(),
                     allowed_args: vec![],
+                    client_actions: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4372,6 +4484,7 @@ mod tests {
                     platform: None,
                     template: "Write about {{topic}}".to_string(),
                     allowed_args: vec!["topic".to_string()],
+                    client_actions: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4392,6 +4505,7 @@ mod tests {
                     platform: None,
                     template: "Write about {{topic}}".to_string(),
                     allowed_args: vec!["topic".to_string()],
+                    client_actions: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4410,6 +4524,7 @@ mod tests {
                     platform: None,
                     template: "{{content}}".to_string(),
                     allowed_args: vec!["content".to_string()],
+                    client_actions: vec![],
                 },
             );
             let oversized = "x".repeat(ACTION_FACET_ARG_MAX_SIZE + 1);
@@ -4431,6 +4546,7 @@ mod tests {
                     platform: None,
                     template: "{{content}}".to_string(),
                     allowed_args: vec!["content".to_string()],
+                    client_actions: vec![],
                 },
             );
             let at_limit = "x".repeat(ACTION_FACET_ARG_MAX_SIZE);
@@ -4455,6 +4571,7 @@ mod tests {
                     platform: Some("outlook".to_string()),
                     template: "Rewrite {{text}}".to_string(),
                     allowed_args: vec!["text".to_string()],
+                    client_actions: vec![],
                 },
             );
             config
@@ -4509,6 +4626,7 @@ mod tests {
                     platform: None,
                     template: "Do something".to_string(),
                     allowed_args: vec![],
+                    client_actions: vec![],
                 },
             );
             assert!(is_known_platform(&config, "web"));

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -2105,6 +2105,10 @@ async fn stream_generate_chat_completion<
     let mut unfinished_tool_calls: Vec<genai::chat::ToolCall> = vec![];
     let mut current_turn = 0;
     let mut current_tool_call_count = 0;
+    // At most one successful client-action proposal per generation: the
+    // client needs a single authoritative proposal, so duplicate or
+    // conflicting calls after the first are answered with an error.
+    let mut client_action_already_proposed = false;
 
     let mut current_message_content: Vec<ContentPart> = vec![];
     let mut current_turn_chat_request = chat_request.clone();
@@ -2306,20 +2310,34 @@ async fn stream_generate_chat_completion<
                     .remove(&unfinished_tool_call.call_id)
                     .unwrap_or_else(now_timestamp);
                 tool_call_parent_observation_ids.remove(&unfinished_tool_call.call_id);
+                let validated = crate::services::client_actions::validate_client_action_input(
+                    &unfinished_tool_call.fn_arguments,
+                    &allowed_actions,
+                )
+                .and_then(|action| {
+                    if client_action_already_proposed {
+                        Err(
+                            "a client action was already proposed for this message; only one proposal is allowed and it cannot be changed"
+                                .to_string(),
+                        )
+                    } else {
+                        Ok(action)
+                    }
+                });
                 let (status, bg_status, message_status, output_value, response_text) =
-                    match crate::services::client_actions::validate_client_action_input(
-                        &unfinished_tool_call.fn_arguments,
-                        &allowed_actions,
-                    ) {
-                        Ok(action) => (
-                            ToolCallStatus::Success,
-                            BgToolCallStatus::Success,
-                            MessageToolCallStatus::Success,
-                            json!({ "status": "proposed", "action": action }),
-                            format!(
-                                "Proposed client action '{action}' to the user. The user's application will ask for confirmation and perform it. Do not call this tool again for this request and do not claim the action has been executed."
-                            ),
-                        ),
+                    match validated {
+                        Ok(action) => {
+                            client_action_already_proposed = true;
+                            (
+                                ToolCallStatus::Success,
+                                BgToolCallStatus::Success,
+                                MessageToolCallStatus::Success,
+                                json!({ "status": "proposed", "action": action }),
+                                format!(
+                                    "Proposed client action '{action}' to the user. The user's application will ask for confirmation and perform it. Do not call this tool again for this request and do not claim the action has been executed."
+                                ),
+                            )
+                        }
                         Err(error) => (
                             ToolCallStatus::Error,
                             BgToolCallStatus::Error,

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -4444,6 +4444,7 @@ mod tests {
                     allowed_args: vec![],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4465,6 +4466,7 @@ mod tests {
                     allowed_args: vec![],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4487,6 +4489,7 @@ mod tests {
                     allowed_args: vec![],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4507,6 +4510,7 @@ mod tests {
                     allowed_args: vec!["topic".to_string()],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4529,6 +4533,7 @@ mod tests {
                     allowed_args: vec!["topic".to_string()],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let af = ActionFacetRequest {
@@ -4549,6 +4554,7 @@ mod tests {
                     allowed_args: vec!["content".to_string()],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let oversized = "x".repeat(ACTION_FACET_ARG_MAX_SIZE + 1);
@@ -4572,6 +4578,7 @@ mod tests {
                     allowed_args: vec!["content".to_string()],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             let at_limit = "x".repeat(ACTION_FACET_ARG_MAX_SIZE);
@@ -4598,6 +4605,7 @@ mod tests {
                     allowed_args: vec!["text".to_string()],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             config
@@ -4654,6 +4662,7 @@ mod tests {
                     allowed_args: vec![],
                     client_actions: vec![],
                     presentation: None,
+                    client_actions_always_ask: vec![],
                 },
             );
             assert!(is_known_platform(&config, "web"));

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -2102,7 +2102,8 @@ async fn stream_generate_chat_completion<
         .as_ref()
         .map(|client| client.trace_id().to_string());
     let max_tool_call_iterations = 15;
-    let mut unfinished_tool_calls: Vec<genai::chat::ToolCall> = vec![];
+    let mut unfinished_tool_calls: std::collections::VecDeque<genai::chat::ToolCall> =
+        std::collections::VecDeque::new();
     let mut current_turn = 0;
     let mut current_tool_call_count = 0;
     // At most one successful client-action proposal per generation: the
@@ -2226,9 +2227,11 @@ async fn stream_generate_chat_completion<
                 "Trying to progress chat completion after first iteration without open tool calls. Will likely result in error."
             )
         }
-        // First work off open tool calls
+        // First work off open tool calls, in the order the model emitted them
+        // — for a parallel batch of client-action proposals the FIRST one
+        // must be the one that wins.
         let mut current_turn_tool_responses = vec![];
-        while let Some(unfinished_tool_call) = unfinished_tool_calls.pop() {
+        while let Some(unfinished_tool_call) = unfinished_tool_calls.pop_front() {
             if streaming_task.is_some_and(|task| task.is_abort_requested()) {
                 let generation_metadata = build_generation_metadata(
                     total_prompt_tokens,

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -4425,6 +4425,7 @@ mod tests {
                     template: "Summarize this".to_string(),
                     allowed_args: vec![],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let af = ActionFacetRequest {
@@ -4445,6 +4446,7 @@ mod tests {
                     template: "Reply".to_string(),
                     allowed_args: vec![],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let af = ActionFacetRequest {
@@ -4466,6 +4468,7 @@ mod tests {
                     template: "Reply".to_string(),
                     allowed_args: vec![],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let af = ActionFacetRequest {
@@ -4485,6 +4488,7 @@ mod tests {
                     template: "Write about {{topic}}".to_string(),
                     allowed_args: vec!["topic".to_string()],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let af = ActionFacetRequest {
@@ -4506,6 +4510,7 @@ mod tests {
                     template: "Write about {{topic}}".to_string(),
                     allowed_args: vec!["topic".to_string()],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let af = ActionFacetRequest {
@@ -4525,6 +4530,7 @@ mod tests {
                     template: "{{content}}".to_string(),
                     allowed_args: vec!["content".to_string()],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let oversized = "x".repeat(ACTION_FACET_ARG_MAX_SIZE + 1);
@@ -4547,6 +4553,7 @@ mod tests {
                     template: "{{content}}".to_string(),
                     allowed_args: vec!["content".to_string()],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             let at_limit = "x".repeat(ACTION_FACET_ARG_MAX_SIZE);
@@ -4572,6 +4579,7 @@ mod tests {
                     template: "Rewrite {{text}}".to_string(),
                     allowed_args: vec!["text".to_string()],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             config
@@ -4627,6 +4635,7 @@ mod tests {
                     template: "Do something".to_string(),
                     allowed_args: vec![],
                     client_actions: vec![],
+                    presentation: None,
                 },
             );
             assert!(is_known_platform(&config, "web"));

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -536,6 +536,14 @@ pub struct ActionFacetInfo {
     /// must only execute actions from this list, after user confirmation.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     client_actions: Vec<String>,
+    /// How the client should surface a proposed client action:
+    /// `render_buttons` (show buttons, user clicks) or `auto_prompt` (the
+    /// client may surface the proposal immediately after a fresh assistant
+    /// completion, subject to the user's local approval preferences). Present
+    /// only when `client_actions` is non-empty; defaults to `render_buttons`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    presentation: Option<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -640,6 +648,11 @@ pub async fn facets(
             id: id.clone(),
             platform: af.platform.clone(),
             client_actions: af.client_actions.clone(),
+            presentation: (!af.client_actions.is_empty()).then(|| {
+                af.presentation
+                    .clone()
+                    .unwrap_or_else(|| "render_buttons".to_string())
+            }),
         })
         .collect();
     action_facets.sort_by(|a, b| a.id.cmp(&b.id));

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -531,6 +531,11 @@ pub struct ActionFacetInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     platform: Option<String>,
+    /// Fixed identifiers of client-side actions the model may propose via the
+    /// `propose_client_action` tool when this facet is active. The client
+    /// must only execute actions from this list, after user confirmation.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    client_actions: Vec<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -634,6 +639,7 @@ pub async fn facets(
         .map(|(id, af)| ActionFacetInfo {
             id: id.clone(),
             platform: af.platform.clone(),
+            client_actions: af.client_actions.clone(),
         })
         .collect();
     action_facets.sort_by(|a, b| a.id.cmp(&b.id));

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -528,6 +528,8 @@ pub struct GlobalFacetSettings {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ActionFacetInfo {
     id: String,
+    /// Human readable name for the facet, e.g. for client settings UIs.
+    display_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     platform: Option<String>,
@@ -544,6 +546,12 @@ pub struct ActionFacetInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     presentation: Option<String>,
+    /// Subset of `client_actions` the deployment enforces a per-use
+    /// confirmation for: the client must always ask and must not offer or
+    /// honor a persistent "always allow" for these actions. Users may still
+    /// deny them entirely.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    client_actions_always_ask: Vec<String>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -646,6 +654,7 @@ pub async fn facets(
         .iter()
         .map(|(id, af)| ActionFacetInfo {
             id: id.clone(),
+            display_name: af.display_name.clone(),
             platform: af.platform.clone(),
             client_actions: af.client_actions.clone(),
             presentation: (!af.client_actions.is_empty()).then(|| {
@@ -653,6 +662,7 @@ pub async fn facets(
                     .clone()
                     .unwrap_or_else(|| "render_buttons".to_string())
             }),
+            client_actions_always_ask: af.client_actions_always_ask.clone(),
         })
         .collect();
     action_facets.sort_by(|a, b| a.id.cmp(&b.id));

--- a/backend/erato/src/services/client_actions.rs
+++ b/backend/erato/src/services/client_actions.rs
@@ -1,0 +1,129 @@
+//! Client-action proposal tool for action facets.
+//!
+//! Action facets may declare a fixed set of `client_actions`. When such a
+//! facet is active on a request, the model is offered a single synthetic tool
+//! through which it can propose exactly one of those actions. The tool is
+//! never executed server-side: the resulting `ToolUse` content part is
+//! consumed by the client application, which validates the proposal and only
+//! performs the action after user confirmation.
+
+use genai::chat::Tool as GenaiTool;
+use genai::chat::ToolName as GenaiToolName;
+use serde_json::{Value, json};
+
+/// Name of the synthetic tool offered to the model when the active action
+/// facet declares `client_actions`.
+pub const CLIENT_ACTION_TOOL_NAME: &str = "propose_client_action";
+
+/// Build the synthetic client-action tool with an enum-constrained input
+/// schema, so the model can only select one of the configured actions.
+pub fn build_client_action_tool(client_actions: &[String], omit_tool_strict: bool) -> GenaiTool {
+    GenaiTool {
+        name: GenaiToolName::Custom(CLIENT_ACTION_TOOL_NAME.to_string()),
+        description: Some(
+            "Propose a single client-side action for the user to confirm in their application. \
+             The action is NOT executed by calling this tool: the user's application validates \
+             the proposal and performs the action only after the user confirms it. Call this \
+             tool at most once per response and only with one of the allowed actions."
+                .to_string(),
+        ),
+        schema: Some(json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": client_actions,
+                    "description": "The client-side action to propose to the user.",
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false,
+        })),
+        strict: if omit_tool_strict { None } else { Some(false) },
+        config: None,
+    }
+}
+
+/// Extract the allowed actions back out of the prepared request's tool set.
+/// The tool schema is the single source of truth for what was offered to the
+/// model on this request.
+pub fn allowed_client_actions_from_tools(tools: Option<&Vec<GenaiTool>>) -> Vec<String> {
+    tools
+        .into_iter()
+        .flatten()
+        .find(|tool| tool.name.to_string() == CLIENT_ACTION_TOOL_NAME)
+        .and_then(|tool| tool.schema.as_ref())
+        .and_then(|schema| schema.pointer("/properties/action/enum"))
+        .and_then(|actions| actions.as_array())
+        .map(|actions| {
+            actions
+                .iter()
+                .filter_map(|action| action.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Validate the model-provided tool input against the allowed actions.
+/// Returns the selected action on success, or a model-facing error message.
+pub fn validate_client_action_input(input: &Value, allowed: &[String]) -> Result<String, String> {
+    let action = input
+        .get("action")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "missing required string field 'action'".to_string())?;
+    if allowed.iter().any(|allowed_action| allowed_action == action) {
+        Ok(action.to_string())
+    } else {
+        Err(format!(
+            "action '{}' is not allowed; allowed actions: {}",
+            action,
+            allowed.join(", ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actions() -> Vec<String> {
+        vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()]
+    }
+
+    #[test]
+    fn builds_tool_with_enum_schema_and_roundtrips_allowed_actions() {
+        let tool = build_client_action_tool(&actions(), false);
+        assert_eq!(tool.name.to_string(), CLIENT_ACTION_TOOL_NAME);
+        let tools = vec![tool];
+        assert_eq!(allowed_client_actions_from_tools(Some(&tools)), actions());
+    }
+
+    #[test]
+    fn allowed_actions_empty_when_tool_absent() {
+        assert!(allowed_client_actions_from_tools(None).is_empty());
+        assert!(allowed_client_actions_from_tools(Some(&vec![])).is_empty());
+    }
+
+    #[test]
+    fn validates_allowed_action() {
+        let input = json!({"action": "outlook.reply_all"});
+        assert_eq!(
+            validate_client_action_input(&input, &actions()).unwrap(),
+            "outlook.reply_all"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_action() {
+        let input = json!({"action": "outlook.delete_mailbox"});
+        let err = validate_client_action_input(&input, &actions()).unwrap_err();
+        assert!(err.contains("not allowed"));
+    }
+
+    #[test]
+    fn rejects_missing_or_non_string_action() {
+        assert!(validate_client_action_input(&json!({}), &actions()).is_err());
+        assert!(validate_client_action_input(&json!({"action": 42}), &actions()).is_err());
+        assert!(validate_client_action_input(&json!("reply"), &actions()).is_err());
+    }
+}

--- a/backend/erato/src/services/client_actions.rs
+++ b/backend/erato/src/services/client_actions.rs
@@ -71,7 +71,10 @@ pub fn validate_client_action_input(input: &Value, allowed: &[String]) -> Result
         .get("action")
         .and_then(Value::as_str)
         .ok_or_else(|| "missing required string field 'action'".to_string())?;
-    if allowed.iter().any(|allowed_action| allowed_action == action) {
+    if allowed
+        .iter()
+        .any(|allowed_action| allowed_action == action)
+    {
         Ok(action.to_string())
     } else {
         Err(format!(

--- a/backend/erato/src/services/mod.rs
+++ b/backend/erato/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod background_tasks;
+pub mod client_actions;
 pub mod file_parsing;
 pub mod file_processing_cached;
 pub mod file_processor;

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -1914,8 +1914,7 @@ mod test_cases {
                 ContentPart::ToolUse(ToolUse {
                     tool_call_id: "call_client_action".to_string(),
                     status: ToolCallStatus::Success,
-                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
-                        .to_string(),
+                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
                     progress_message: None,
                     input: Some(serde_json::json!({ "action": "outlook.reply" })),
                     output: Some(

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2119,6 +2119,7 @@ mod test_cases {
                 platform: None,
                 template: "You are composing an email. Context: {{context}}".to_string(),
                 allowed_args: vec!["context".to_string()],
+                client_actions: vec![],
             },
         )]);
 
@@ -2250,6 +2251,7 @@ mod test_cases {
                 platform: None,
                 template: "Compose a reply with tone: {{tone}}".to_string(),
                 allowed_args: vec!["tone".to_string()],
+                client_actions: vec![],
             },
         )]);
 

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2120,6 +2120,7 @@ mod test_cases {
                 template: "You are composing an email. Context: {{context}}".to_string(),
                 allowed_args: vec!["context".to_string()],
                 client_actions: vec![],
+                presentation: None,
             },
         )]);
 
@@ -2252,6 +2253,7 @@ mod test_cases {
                 template: "Compose a reply with tone: {{tone}}".to_string(),
                 allowed_args: vec!["tone".to_string()],
                 client_actions: vec![],
+                presentation: None,
             },
         )]);
 

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2198,6 +2198,7 @@ mod test_cases {
                 allowed_args: vec!["context".to_string()],
                 client_actions: vec![],
                 presentation: None,
+                client_actions_always_ask: vec![],
             },
         )]);
 
@@ -2331,6 +2332,7 @@ mod test_cases {
                 allowed_args: vec!["tone".to_string()],
                 client_actions: vec![],
                 presentation: None,
+                client_actions_always_ask: vec![],
             },
         )]);
 

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -1887,6 +1887,84 @@ mod test_cases {
     }
 
     #[tokio::test]
+    async fn test_client_action_tool_use_is_stripped_from_replay() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_test_chat();
+        let config = create_test_chat_provider_config();
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
+
+        // Assistant turn produced under a client-action facet: draft text plus
+        // a propose_client_action ToolUse. The synthetic tool is only offered
+        // while the facet is active, so the call/response pair must NOT replay
+        // on later requests (providers reject tool messages for unknown tools).
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message_with_content(
+            msg2_id,
+            Some(msg1_id),
+            MessageRole::Assistant,
+            vec![
+                ContentPart::Text(ContentPartText {
+                    text: "Here is a draft reply.".to_string(),
+                }),
+                ContentPart::ToolUse(ToolUse {
+                    tool_call_id: "call_client_action".to_string(),
+                    status: ToolCallStatus::Success,
+                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+                        .to_string(),
+                    progress_message: None,
+                    input: Some(serde_json::json!({ "action": "outlook.reply" })),
+                    output: Some(
+                        serde_json::json!({ "status": "proposed", "action": "outlook.reply" }),
+                    ),
+                    ..Default::default()
+                }),
+            ],
+        );
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Make it shorter");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        assert!(
+            !resolved.messages.iter().any(|msg| matches!(
+                &msg.content,
+                ContentPart::ToolUse(ToolUse { tool_name, .. })
+                    if tool_name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+            )),
+            "propose_client_action ToolUse parts must not replay into later requests",
+        );
+        assert!(
+            resolved.messages.iter().any(|msg| matches!(
+                &msg.content,
+                ContentPart::Text(text) if text.text == "Here is a draft reply."
+            )),
+            "The assistant draft text must still replay",
+        );
+    }
+
+    #[tokio::test]
     async fn test_history_replays_single_tool_call_as_valid_openai_sequence() {
         let generation_input = GenerationInputMessages {
             messages: vec![

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -5,7 +5,9 @@ mod test_cases {
         build_abstract_sequence, build_abstract_sequence_with_facet_tool_expansions,
         resolve_sequence,
     };
-    use super::super::types::{AbstractChatSequencePart, ActionFacetUserInput, PromptSpec};
+    use super::super::types::{
+        AbstractChatSequencePart, ActionFacetUserInput, PromptSpec, ResolvedChatSequence,
+    };
     use crate::config::{ChatProviderConfig, ExperimentalFacetsConfig, PromptSourceSpecification};
     use crate::db::entity::{chats, messages};
     use crate::models::assistant::{AssistantWithFiles, FileInfo};
@@ -1899,9 +1901,9 @@ mod test_cases {
         message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
 
         // Assistant turn produced under a client-action facet: draft text plus
-        // a propose_client_action ToolUse. The synthetic tool is only offered
-        // while the facet is active, so the call/response pair must NOT replay
-        // on later requests (providers reject tool messages for unknown tools).
+        // a propose_client_action ToolUse with the synthetic interception's
+        // success output. Proposals are request-scoped UI hints, so the
+        // call/response pair must NOT replay on later requests.
         let msg2_id = Uuid::new_v4();
         message_repo.add_message_with_content(
             msg2_id,
@@ -1960,6 +1962,351 @@ mod test_cases {
                 ContentPart::Text(text) if text.text == "Here is a draft reply."
             )),
             "The assistant draft text must still replay",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rejected_client_action_tool_use_is_stripped_from_replay() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_test_chat();
+        let config = create_test_chat_provider_config();
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
+
+        // Synthetic interception error output: stripped just like a success —
+        // the rejected call also references the request-scoped tool.
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message_with_content(
+            msg2_id,
+            Some(msg1_id),
+            MessageRole::Assistant,
+            vec![
+                ContentPart::Text(ContentPartText {
+                    text: "I could not propose that action.".to_string(),
+                }),
+                ContentPart::ToolUse(ToolUse {
+                    tool_call_id: "call_client_action".to_string(),
+                    status: ToolCallStatus::Error,
+                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
+                    progress_message: None,
+                    input: Some(serde_json::json!({ "action": "outlook.forward" })),
+                    output: Some(serde_json::json!({
+                        "status": "rejected",
+                        "error": "action 'outlook.forward' is not allowed"
+                    })),
+                    ..Default::default()
+                }),
+            ],
+        );
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Try again");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        assert!(
+            !resolved.messages.iter().any(|msg| matches!(
+                &msg.content,
+                ContentPart::ToolUse(ToolUse { tool_name, .. })
+                    if tool_name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+            )),
+            "Rejected synthetic proposals must not replay into later requests",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_same_named_mcp_tool_use_is_preserved_in_replay() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_test_chat();
+        let config = create_test_chat_provider_config();
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
+
+        // An MCP tool that claims the synthetic tool's name takes precedence
+        // at prepare time, so this ToolUse is a real MCP round-trip — its
+        // output does not carry the interception's status shape and it must
+        // replay normally.
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message_with_content(
+            msg2_id,
+            Some(msg1_id),
+            MessageRole::Assistant,
+            vec![ContentPart::ToolUse(ToolUse {
+                tool_call_id: "call_mcp_tool".to_string(),
+                status: ToolCallStatus::Success,
+                tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
+                progress_message: None,
+                input: Some(serde_json::json!({ "action": "outlook.reply" })),
+                output: Some(serde_json::json!({ "result": "reply form opened" })),
+                ..Default::default()
+            })],
+        );
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Make it shorter");
+
+        let assert_round_trip_preserved = |resolved: &ResolvedChatSequence, path: &str| {
+            let assistant_call = resolved.messages.iter().any(|msg| {
+                msg.role == MessageRole::Assistant
+                    && matches!(
+                        &msg.content,
+                        ContentPart::ToolUse(ToolUse { tool_call_id, .. })
+                            if tool_call_id == "call_mcp_tool"
+                    )
+            });
+            let tool_response = resolved.messages.iter().any(|msg| {
+                msg.role == MessageRole::Tool
+                    && matches!(
+                        &msg.content,
+                        ContentPart::ToolUse(ToolUse { tool_call_id, .. })
+                            if tool_call_id == "call_mcp_tool"
+                    )
+            });
+            assert!(
+                assistant_call && tool_response,
+                "A same-named MCP tool round-trip must replay as call + response ({path})",
+            );
+        };
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, unresolved) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+        assert_round_trip_preserved(&resolved, "previous assistant message");
+
+        // One turn later the round-trip replays again, this time out of the
+        // persisted generation_input_messages of the next assistant message.
+        let msg4_id = Uuid::new_v4();
+        message_repo.add_message(msg4_id, Some(msg3_id), MessageRole::Assistant, "Shorter.");
+        message_repo.update_generation_input_messages(msg4_id, &unresolved);
+
+        let msg5_id = Uuid::new_v4();
+        message_repo.add_message(msg5_id, Some(msg4_id), MessageRole::User, "Even shorter");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg5_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+        assert_round_trip_preserved(&resolved, "historic generation input");
+    }
+
+    #[tokio::test]
+    async fn test_same_named_mcp_tool_with_non_string_status_values_is_preserved_in_replay() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_test_chat();
+        let config = create_test_chat_provider_config();
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
+
+        // A same-named MCP tool may emit output that coincidentally carries
+        // the interception's `status`/`action` (or `status`/`error`) keys but
+        // with non-string values. The interception always writes string
+        // values, so these parts are real MCP round-trips and must replay.
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message_with_content(
+            msg2_id,
+            Some(msg1_id),
+            MessageRole::Assistant,
+            vec![
+                ContentPart::ToolUse(ToolUse {
+                    tool_call_id: "call_non_string_action".to_string(),
+                    status: ToolCallStatus::Success,
+                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
+                    progress_message: None,
+                    input: Some(serde_json::json!({ "action": "outlook.reply" })),
+                    output: Some(serde_json::json!({
+                        "status": "proposed",
+                        "action": { "id": "outlook.reply" }
+                    })),
+                    ..Default::default()
+                }),
+                ContentPart::ToolUse(ToolUse {
+                    tool_call_id: "call_non_string_error".to_string(),
+                    status: ToolCallStatus::Error,
+                    tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
+                    progress_message: None,
+                    input: Some(serde_json::json!({ "action": "outlook.forward" })),
+                    output: Some(serde_json::json!({ "status": "rejected", "error": 42 })),
+                    ..Default::default()
+                }),
+            ],
+        );
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Make it shorter");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        for tool_call_id in ["call_non_string_action", "call_non_string_error"] {
+            let assistant_call = resolved.messages.iter().any(|msg| {
+                msg.role == MessageRole::Assistant
+                    && matches!(
+                        &msg.content,
+                        ContentPart::ToolUse(ToolUse { tool_call_id: id, .. })
+                            if id == tool_call_id
+                    )
+            });
+            let tool_response = resolved.messages.iter().any(|msg| {
+                msg.role == MessageRole::Tool
+                    && matches!(
+                        &msg.content,
+                        ContentPart::ToolUse(ToolUse { tool_call_id: id, .. })
+                            if id == tool_call_id
+                    )
+            });
+            assert!(
+                assistant_call && tool_response,
+                "A same-named MCP round-trip with non-string status values must replay ({tool_call_id})",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_synthetic_client_action_in_historic_generation_input_is_stripped() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_test_chat();
+        let config = create_test_chat_provider_config();
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "Draft a reply");
+
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message(msg2_id, Some(msg1_id), MessageRole::Assistant, "Done.");
+        // Simulate a legacy persisted generation input that still contains a
+        // synthetic proposal round-trip (rows written before the proposal was
+        // stripped at generation time).
+        let synthetic_tool_use = ToolUse {
+            tool_call_id: "call_client_action".to_string(),
+            status: ToolCallStatus::Success,
+            tool_name: crate::services::client_actions::CLIENT_ACTION_TOOL_NAME.to_string(),
+            progress_message: None,
+            input: Some(serde_json::json!({ "action": "outlook.reply" })),
+            output: Some(serde_json::json!({ "status": "proposed", "action": "outlook.reply" })),
+            ..Default::default()
+        };
+        message_repo.update_generation_input_messages(
+            msg2_id,
+            &GenerationInputMessages {
+                messages: vec![
+                    InputMessage {
+                        role: MessageRole::User,
+                        content: ContentPart::Text(ContentPartText {
+                            text: "Draft a reply".to_string(),
+                        }),
+                    },
+                    InputMessage {
+                        role: MessageRole::Assistant,
+                        content: ContentPart::ToolUse(synthetic_tool_use.clone()),
+                    },
+                    InputMessage {
+                        role: MessageRole::Tool,
+                        content: ContentPart::ToolUse(synthetic_tool_use),
+                    },
+                ],
+            },
+        );
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Make it shorter");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        assert!(
+            !resolved.messages.iter().any(|msg| matches!(
+                &msg.content,
+                ContentPart::ToolUse(ToolUse { tool_name, .. })
+                    if tool_name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+            )),
+            "Synthetic proposals in historic generation input must not replay",
         );
     }
 

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -526,11 +526,9 @@ pub async fn resolve_sequence(
                 for content_part in parsed.content {
                     match content_part {
                         ContentPart::ToolUse(tool_use) => {
-                            // Client-action proposals never replay — see
-                            // is_client_action_tool_use_message.
-                            if tool_use.tool_name
-                                == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
-                            {
+                            // Synthetic client-action proposals never replay
+                            // — see is_client_action_tool_use_message.
+                            if is_synthetic_client_action_tool_use(&tool_use) {
                                 continue;
                             }
                             input_messages.push(InputMessage {
@@ -624,19 +622,43 @@ fn is_prior_turn_action_facet_message(input_msg: &InputMessage) -> bool {
     }
 }
 
-/// True when an `InputMessage` carries a `propose_client_action` ToolUse.
-/// Client-action proposals are request-scoped UI hints, not real tool
-/// round-trips: the synthetic tool is only offered while the producing
-/// action facet is active, so replaying the call/response pair on later
-/// requests would reference a tool absent from the request's tool set —
-/// which some providers reject outright. Stripped like prior-turn
-/// action-facet directives.
+/// True when an `InputMessage` carries a ToolUse produced by the synthetic
+/// `propose_client_action` tool. Such proposals are request-scoped UI hints,
+/// not real tool round-trips, so they are stripped like prior-turn
+/// action-facet directives. The tool name alone is not enough to decide: an
+/// MCP tool may legitimately claim the same name (in which case the synthetic
+/// tool is never offered and the call dispatches to MCP — see prepare), and
+/// those round-trips must replay normally.
 fn is_client_action_tool_use_message(input_msg: &InputMessage) -> bool {
     matches!(
         &input_msg.content,
-        ContentPart::ToolUse(tool_use)
-            if tool_use.tool_name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+        ContentPart::ToolUse(tool_use) if is_synthetic_client_action_tool_use(tool_use)
     )
+}
+
+/// True when a `ToolUse` part was produced by the synthetic client-action
+/// interception rather than a same-named MCP tool. Identified by the output
+/// shape the interception writes (`{"status": "proposed", "action": <string>}`
+/// on success, `{"status": "rejected", "error": <string>}` on error — the
+/// `action`/`error` values are always strings); parts with absent or
+/// differently shaped output carry real MCP tool output.
+fn is_synthetic_client_action_tool_use(tool_use: &crate::models::message::ToolUse) -> bool {
+    if tool_use.tool_name != crate::services::client_actions::CLIENT_ACTION_TOOL_NAME {
+        return false;
+    }
+    tool_use.output.as_ref().is_some_and(|output| {
+        match output.get("status").and_then(serde_json::Value::as_str) {
+            Some("proposed") => output
+                .get("action")
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            Some("rejected") => output
+                .get("error")
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            _ => false,
+        }
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -491,7 +491,9 @@ pub async fn resolve_sequence(
                                 //   • legacy rendered text (pre-marker rows
                                 //     in the DB) → System message whose text
                                 //     starts with "FOR THIS MESSAGE ONLY:"
-                                if is_prior_turn_action_facet_message(&input_msg) {
+                                if is_prior_turn_action_facet_message(&input_msg)
+                                    || is_client_action_tool_use_message(&input_msg)
+                                {
                                     continue;
                                 }
                                 let input_msg = normalize_historical_input_message(input_msg);
@@ -524,6 +526,13 @@ pub async fn resolve_sequence(
                 for content_part in parsed.content {
                     match content_part {
                         ContentPart::ToolUse(tool_use) => {
+                            // Client-action proposals never replay — see
+                            // is_client_action_tool_use_message.
+                            if tool_use.tool_name
+                                == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+                            {
+                                continue;
+                            }
                             input_messages.push(InputMessage {
                                 role: MessageRole::Assistant,
                                 content: ContentPart::ToolUse(tool_use.clone()),
@@ -613,6 +622,21 @@ fn is_prior_turn_action_facet_message(input_msg: &InputMessage) -> bool {
         }
         _ => false,
     }
+}
+
+/// True when an `InputMessage` carries a `propose_client_action` ToolUse.
+/// Client-action proposals are request-scoped UI hints, not real tool
+/// round-trips: the synthetic tool is only offered while the producing
+/// action facet is active, so replaying the call/response pair on later
+/// requests would reference a tool absent from the request's tool set —
+/// which some providers reject outright. Stripped like prior-turn
+/// action-facet directives.
+fn is_client_action_tool_use_message(input_msg: &InputMessage) -> bool {
+    matches!(
+        &input_msg.content,
+        ContentPart::ToolUse(tool_use)
+            if tool_use.tool_name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/backend/erato/tests/integration_tests/api/facets.rs
+++ b/backend/erato/tests/integration_tests/api/facets.rs
@@ -132,6 +132,7 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
                 "outlook.reply".to_string(),
                 "outlook.reply_all".to_string(),
             ],
+            presentation: None,
         },
     );
     app_config.action_facets.facets.insert(
@@ -142,6 +143,7 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
             template: "FOR THIS MESSAGE ONLY: x".to_string(),
             allowed_args: vec![],
             client_actions: vec![],
+            presentation: None,
         },
     );
 
@@ -178,8 +180,64 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
         action_facets[0]["client_actions"],
         serde_json::json!(["outlook.reply", "outlook.reply_all"])
     );
+    // Presentation defaults to render_buttons when client actions exist...
+    assert_eq!(action_facets[0]["presentation"], "render_buttons");
     assert_eq!(action_facets[1]["id"], "plain_facet");
     assert!(action_facets[1].get("client_actions").is_none());
+    // ...and is omitted entirely for facets without client actions.
+    assert!(action_facets[1].get("presentation").is_none());
+}
+
+/// A configured `presentation = "auto_prompt"` is passed through verbatim.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_facets_endpoint_exposes_auto_prompt_presentation(pool: Pool<Postgres>) {
+    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+
+    app_config.action_facets.facets.insert(
+        "outlook_reply_from_read".to_string(),
+        erato::config::ActionFacetConfig {
+            display_name: "Outlook Reply from Read Mode".to_string(),
+            platform: Some("outlook".to_string()),
+            template: "FOR THIS MESSAGE ONLY: draft a reply.".to_string(),
+            allowed_args: vec!["body_format".to_string()],
+            client_actions: vec![
+                "outlook.reply".to_string(),
+                "outlook.reply_all".to_string(),
+            ],
+            presentation: Some("auto_prompt".to_string()),
+        },
+    );
+
+    let app_state = test_app_state(app_config, pool).await;
+
+    let issuer = TEST_USER_ISSUER;
+    let subject = TEST_USER_SUBJECT;
+    let _user = erato::models::user::get_or_create_user(&app_state.db, issuer, subject, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let response = server
+        .get("/api/v1beta/me/facets")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    response.assert_status_ok();
+
+    let response_body: Value = response.json();
+    let action_facets = response_body
+        .get("action_facets")
+        .and_then(Value::as_array)
+        .expect("Missing action_facets list");
+    assert_eq!(action_facets[0]["presentation"], "auto_prompt");
 }
 
 #[sqlx::test(migrator = "crate::MIGRATOR")]

--- a/backend/erato/tests/integration_tests/api/facets.rs
+++ b/backend/erato/tests/integration_tests/api/facets.rs
@@ -110,6 +110,78 @@ async fn test_facets_endpoint(pool: Pool<Postgres>) {
     assert_eq!(facets[1]["default_enabled"], true);
 }
 
+/// Action facets expose their configured `client_actions` so the client can
+/// validate model proposals against them; facets without client actions omit
+/// the field entirely.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Postgres>) {
+    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+
+    app_config.action_facets.facets.insert(
+        "outlook_reply_from_read".to_string(),
+        erato::config::ActionFacetConfig {
+            display_name: "Outlook Reply from Read Mode".to_string(),
+            platform: Some("outlook".to_string()),
+            template: "FOR THIS MESSAGE ONLY: draft a reply.".to_string(),
+            allowed_args: vec!["body_format".to_string()],
+            client_actions: vec![
+                "outlook.reply".to_string(),
+                "outlook.reply_all".to_string(),
+            ],
+        },
+    );
+    app_config.action_facets.facets.insert(
+        "plain_facet".to_string(),
+        erato::config::ActionFacetConfig {
+            display_name: "Plain".to_string(),
+            platform: None,
+            template: "FOR THIS MESSAGE ONLY: x".to_string(),
+            allowed_args: vec![],
+            client_actions: vec![],
+        },
+    );
+
+    let app_state = test_app_state(app_config, pool).await;
+
+    let issuer = TEST_USER_ISSUER;
+    let subject = TEST_USER_SUBJECT;
+    let _user = erato::models::user::get_or_create_user(&app_state.db, issuer, subject, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let response = server
+        .get("/api/v1beta/me/facets")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    response.assert_status_ok();
+
+    let response_body: Value = response.json();
+    let action_facets = response_body
+        .get("action_facets")
+        .and_then(Value::as_array)
+        .expect("Missing action_facets list");
+    assert_eq!(action_facets.len(), 2);
+    // Sorted by id.
+    assert_eq!(action_facets[0]["id"], "outlook_reply_from_read");
+    assert_eq!(action_facets[0]["platform"], "outlook");
+    assert_eq!(
+        action_facets[0]["client_actions"],
+        serde_json::json!(["outlook.reply", "outlook.reply_all"])
+    );
+    assert_eq!(action_facets[1]["id"], "plain_facet");
+    assert!(action_facets[1].get("client_actions").is_none());
+}
+
 #[sqlx::test(migrator = "crate::MIGRATOR")]
 async fn test_facets_endpoint_filters_by_policy(pool: Pool<Postgres>) {
     let (mut app_config, _server) = setup_mock_llm_server(None).await;

--- a/backend/erato/tests/integration_tests/api/facets.rs
+++ b/backend/erato/tests/integration_tests/api/facets.rs
@@ -130,6 +130,7 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
             allowed_args: vec!["body_format".to_string()],
             client_actions: vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()],
             presentation: None,
+            client_actions_always_ask: vec![],
         },
     );
     app_config.action_facets.facets.insert(
@@ -141,6 +142,7 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
             allowed_args: vec![],
             client_actions: vec![],
             presentation: None,
+            client_actions_always_ask: vec![],
         },
     );
 
@@ -179,6 +181,12 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
     );
     // Presentation defaults to render_buttons when client actions exist...
     assert_eq!(action_facets[0]["presentation"], "render_buttons");
+    assert_eq!(
+        action_facets[0]["display_name"],
+        "Outlook Reply from Read Mode"
+    );
+    // No enforced confirmations configured → field omitted.
+    assert!(action_facets[0].get("client_actions_always_ask").is_none());
     assert_eq!(action_facets[1]["id"], "plain_facet");
     assert!(action_facets[1].get("client_actions").is_none());
     // ...and is omitted entirely for facets without client actions.
@@ -203,6 +211,7 @@ async fn test_facets_endpoint_exposes_auto_prompt_presentation(pool: Pool<Postgr
             allowed_args: vec!["body_format".to_string()],
             client_actions: vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()],
             presentation: Some("auto_prompt".to_string()),
+            client_actions_always_ask: vec!["outlook.reply_all".to_string()],
         },
     );
 
@@ -232,6 +241,12 @@ async fn test_facets_endpoint_exposes_auto_prompt_presentation(pool: Pool<Postgr
         .and_then(Value::as_array)
         .expect("Missing action_facets list");
     assert_eq!(action_facets[0]["presentation"], "auto_prompt");
+    // Deployment-enforced per-use confirmation is passed through so the
+    // client can grey out "always allow" with a reason.
+    assert_eq!(
+        action_facets[0]["client_actions_always_ask"],
+        serde_json::json!(["outlook.reply_all"])
+    );
 }
 
 #[sqlx::test(migrator = "crate::MIGRATOR")]

--- a/backend/erato/tests/integration_tests/api/facets.rs
+++ b/backend/erato/tests/integration_tests/api/facets.rs
@@ -128,10 +128,7 @@ async fn test_facets_endpoint_exposes_action_facet_client_actions(pool: Pool<Pos
             platform: Some("outlook".to_string()),
             template: "FOR THIS MESSAGE ONLY: draft a reply.".to_string(),
             allowed_args: vec!["body_format".to_string()],
-            client_actions: vec![
-                "outlook.reply".to_string(),
-                "outlook.reply_all".to_string(),
-            ],
+            client_actions: vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()],
             presentation: None,
         },
     );
@@ -204,10 +201,7 @@ async fn test_facets_endpoint_exposes_auto_prompt_presentation(pool: Pool<Postgr
             platform: Some("outlook".to_string()),
             template: "FOR THIS MESSAGE ONLY: draft a reply.".to_string(),
             allowed_args: vec!["body_format".to_string()],
-            client_actions: vec![
-                "outlook.reply".to_string(),
-                "outlook.reply_all".to_string(),
-            ],
+            client_actions: vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()],
             presentation: Some("auto_prompt".to_string()),
         },
     );

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2875,6 +2875,7 @@ fn add_action_facets(app_config: &mut erato::config::AppConfig) {
             template: "Rewrite the following in a {{tone}} tone:\n\n{{content}}".to_string(),
             allowed_args: vec!["tone".to_string(), "content".to_string()],
             client_actions: vec![],
+            presentation: None,
         },
     );
 }

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2966,6 +2966,7 @@ fn add_action_facets(app_config: &mut erato::config::AppConfig) {
             allowed_args: vec!["tone".to_string(), "content".to_string()],
             client_actions: vec![],
             presentation: None,
+            client_actions_always_ask: vec![],
         },
     );
 }

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2874,6 +2874,7 @@ fn add_action_facets(app_config: &mut erato::config::AppConfig) {
             platform: None,
             template: "Rewrite the following in a {{tone}} tone:\n\n{{content}}".to_string(),
             allowed_args: vec!["tone".to_string(), "content".to_string()],
+            client_actions: vec![],
         },
     );
 }

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -20,16 +20,33 @@ use sqlx::postgres::Postgres;
 use std::collections::HashMap;
 use std::env;
 
+use mocktail::MockSet;
+use mocktail::body::BodyAction;
+use mocktail::mock_builder::Then;
+
 use crate::test_app_state;
 use crate::test_utils::{
-    JwtTokenBuilder, TEST_JWT_TOKEN, TEST_USER_ISSUER, TEST_USER_SUBJECT, TestRequestAuthExt,
-    extract_chat_id, extract_full_text, parse_sse_events, read_integration_test_file_bytes,
-    setup_mock_llm_server,
+    BodyContainsMatcher, JwtTokenBuilder, RequestBodyRecorder, TEST_JWT_TOKEN, TEST_USER_ISSUER,
+    TEST_USER_SUBJECT, TestRequestAuthExt, build_openai_text_streaming_response,
+    build_openai_tool_calls_streaming_response, extract_chat_id, extract_full_text,
+    hermetic_app_config, parse_sse_events, read_integration_test_file_bytes, setup_mock_llm_server,
+    setup_mock_llm_server_with_mocks,
 };
 
 fn mock_mcp_base_url() -> String {
     env::var("TEST_MOCK_MCP_SERVER_BASE_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:44321".to_string())
+}
+
+/// Configures a mock-LLM `then` clause to stream the given SSE body actions.
+fn mock_llm_sse_response(then: Then, actions: Vec<BodyAction>) {
+    then.status(http::StatusCode::OK)
+        .headers([
+            ("Content-Type", "text/event-stream"),
+            ("Cache-Control", "no-cache"),
+            ("Connection", "keep-alive"),
+        ])
+        .bytes_stream_with_delays(actions);
 }
 
 fn mcp_server_config(
@@ -543,7 +560,18 @@ async fn test_platform_persisted_for_regenerate_and_edit_generation_requests(poo
 /// - `uses-mocked-llm`
 #[sqlx::test(migrator = "crate::MIGRATOR")]
 async fn test_regenerate_falls_back_to_stored_action_facet(pool: Pool<Postgres>) {
-    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+    // Capture the LLM request bodies so we can assert the rendered facet
+    // directive actually reached the model, not just the persisted params.
+    let llm_request_recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    {
+        let recorder = llm_request_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post().path("/v1/chat/completions").matcher(recorder);
+            mock_llm_sse_response(then, build_openai_text_streaming_response(&["Rewritten."]));
+        });
+    }
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
     add_action_facets(&mut app_config);
     let app_state = test_app_state(app_config, pool).await;
     let db = app_state.db.clone();
@@ -620,6 +648,132 @@ async fn test_regenerate_falls_back_to_stored_action_facet(pool: Pool<Postgres>)
             .map(String::as_str),
         Some("professional")
     );
+
+    // The rendered directive must have reached the LLM on both the original
+    // submit and the regenerate request, not merely the persisted parameters.
+    // The recorder also sees the chat-title summary request, which carries
+    // only the raw user message — so count the directive-carrying bodies.
+    let llm_request_bodies = llm_request_recorder.bodies();
+    let directive_body_count = llm_request_bodies
+        .iter()
+        .filter(|body| {
+            body.contains("Rewrite the following in a professional tone:")
+                && body.contains("yo whats up")
+        })
+        .count();
+    assert_eq!(
+        directive_body_count, 2,
+        "Expected the rendered facet directive in both generation request bodies: {llm_request_bodies:?}"
+    );
+}
+
+/// Regenerating after the stored action facet stopped validating against the
+/// current config drops the facet instead of failing the request.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_drops_stored_action_facet_that_no_longer_validates(pool: Pool<Postgres>) {
+    let (mut app_config, server) = setup_mock_llm_server(None).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool.clone()).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let test_server =
+        TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let submit_response = test_server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+
+    let submit_events = parse_sse_events(&submit_response);
+    let original_assistant_message_id = submit_events
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "assistant_message_completed"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected assistant_message_completed event with message_id");
+
+    // Replace the config with one that no longer knows the stored facet
+    // (same mock LLM, same database) and regenerate against the new app.
+    let replacement_config = hermetic_app_config(None, Some(server.url("/v1/").to_string()));
+    assert!(
+        !replacement_config
+            .action_facets
+            .facets
+            .contains_key("rewrite"),
+        "Replacement config must not declare the stored facet"
+    );
+    let replacement_app_state = test_app_state(replacement_config, pool).await;
+    let db = replacement_app_state.db.clone();
+    let replacement_app: Router = router(replacement_app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(replacement_app_state);
+    let replacement_server =
+        TestServer::new(replacement_app.into_make_service()).expect("Failed to create test server");
+
+    let regenerate_response = replacement_server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "current_message_id": original_assistant_message_id }))
+        .await;
+    regenerate_response.assert_status_ok();
+
+    // The stream returns 200 even when it carries a mid-stream error event,
+    // so assert the regenerate actually completed a generation.
+    let regenerate_events = parse_sse_events(&regenerate_response);
+    let regenerate_assistant_message_id = assistant_message_id_from_events(&regenerate_events);
+
+    let assistant_messages = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::GenerationParameters.is_not_null())
+        .order_by_asc(erato::db::entity::messages::Column::CreatedAt)
+        .all(&db)
+        .await
+        .expect("Failed to fetch assistant messages");
+    assert_eq!(assistant_messages.len(), 2);
+    assert_eq!(
+        assistant_messages[1].id.to_string(),
+        regenerate_assistant_message_id,
+        "The completed regenerate stream must correspond to the second assistant row",
+    );
+
+    let regenerate_params: GenerationParameters = serde_json::from_value(
+        assistant_messages[1]
+            .generation_parameters
+            .clone()
+            .expect("Missing regenerate generation_parameters"),
+    )
+    .expect("Failed to deserialize regenerate generation parameters");
+    assert_eq!(
+        regenerate_params.action_facet_id, None,
+        "A stored facet that no longer validates must be dropped on regenerate",
+    );
+    assert_eq!(regenerate_params.action_facet_args, None);
 }
 
 /// Test facet prompt injection behavior across a two-turn chat.
@@ -2969,6 +3123,20 @@ fn add_action_facets(app_config: &mut erato::config::AppConfig) {
             client_actions_always_ask: vec![],
         },
     );
+    app_config.action_facets.facets.insert(
+        "reply".to_string(),
+        ActionFacetConfig {
+            display_name: "Reply".to_string(),
+            platform: None,
+            template: "FOR THIS MESSAGE ONLY: Draft a reply ({{body_format}}) and propose \
+                       how to send it."
+                .to_string(),
+            allowed_args: vec!["body_format".to_string()],
+            client_actions: vec!["outlook.reply".to_string(), "outlook.reply_all".to_string()],
+            presentation: None,
+            client_actions_always_ask: vec![],
+        },
+    );
 }
 
 #[sqlx::test(migrator = "crate::MIGRATOR")]
@@ -3208,4 +3376,311 @@ async fn test_action_facet_template_literal_values_no_rerendering(pool: Pool<Pos
         marker["content"]["args"]["content"].as_str(),
         Some("actual content")
     );
+}
+
+// --- Client-action interception tests ---
+
+const CLIENT_ACTION_TOOL: &str = erato::services::client_actions::CLIENT_ACTION_TOOL_NAME;
+
+/// Distinctive fragments of the model-facing tool responses written by the
+/// client-action interception, used to route the mock LLM's turns.
+const PROPOSED_RESPONSE_FRAGMENT: &str = "Proposed client action";
+const INVALID_RESPONSE_FRAGMENT: &str = "Invalid client action proposal";
+
+/// Submits a message under the `reply` client-action facet and returns the
+/// parsed SSE events of the response.
+async fn submit_under_reply_facet(server: &TestServer) -> Vec<crate::test_utils::Event> {
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Reply to this email",
+            "action_facet": { "id": "reply", "args": { "body_format": "text" } }
+        }))
+        .await;
+    response.assert_status_ok();
+    parse_sse_events(&response)
+}
+
+/// Fetches the persisted assistant message's tool_use content parts.
+async fn fetch_assistant_tool_use_parts(
+    server: &TestServer,
+    chat_id: &str,
+    assistant_message_id: &str,
+) -> Vec<Value> {
+    let response = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    response.assert_status_ok();
+    let body: Value = response.json();
+    let assistant_message = body["messages"]
+        .as_array()
+        .and_then(|messages| {
+            messages
+                .iter()
+                .find(|message| message["id"] == assistant_message_id)
+        })
+        .expect("Expected assistant message in chat messages response")
+        .clone();
+    assistant_message["content"]
+        .as_array()
+        .expect("Expected content parts array")
+        .iter()
+        .filter(|part| part["content_type"] == "tool_use")
+        .cloned()
+        .collect()
+}
+
+fn tool_call_update_events(events: &[crate::test_utils::Event]) -> Vec<Value> {
+    events
+        .iter()
+        .filter_map(|event| serde_json::from_str::<Value>(&event.data).ok())
+        .filter(|json| json["message_type"] == "tool_call_update")
+        .collect()
+}
+
+fn assistant_message_id_from_events(events: &[crate::test_utils::Event]) -> String {
+    events
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "assistant_message_completed"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected assistant_message_completed event with message_id")
+}
+
+/// Two `propose_client_action` calls in one parallel batch: the FIRST one
+/// wins, the second is answered with the already-proposed error, and the
+/// model receives corrective tool responses before finishing the turn.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_client_action_parallel_proposals_first_wins(pool: Pool<Postgres>) {
+    let corrective_request_recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    // Turn 1: no tool responses in the request yet → propose both actions in
+    // one parallel batch.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[], &[PROPOSED_RESPONSE_FRAGMENT]));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[
+                (
+                    "call_first",
+                    CLIENT_ACTION_TOOL,
+                    json!({"action": "outlook.reply"}),
+                ),
+                (
+                    "call_second",
+                    CLIENT_ACTION_TOOL,
+                    json!({"action": "outlook.reply_all"}),
+                ),
+            ]),
+        );
+    });
+    // Turn 2: the corrective tool responses arrived → finish with text.
+    {
+        let recorder = corrective_request_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&[PROPOSED_RESPONSE_FRAGMENT], &[]))
+                .matcher(recorder);
+            mock_llm_sse_response(then, build_openai_text_streaming_response(&["Done."]));
+        });
+    }
+
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let events = submit_under_reply_facet(&server).await;
+
+    // SSE: both calls get a terminal update — success for the first emitted
+    // call, the already-proposed error for the second.
+    let updates = tool_call_update_events(&events);
+    assert_eq!(
+        updates.len(),
+        2,
+        "Expected one tool_call_update per proposal, got: {updates:?}"
+    );
+    assert_eq!(updates[0]["tool_call_id"], "call_first");
+    assert_eq!(updates[0]["status"], "success");
+    assert_eq!(updates[0]["output"]["status"], "proposed");
+    assert_eq!(updates[0]["output"]["action"], "outlook.reply");
+    assert_eq!(updates[1]["tool_call_id"], "call_second");
+    assert_eq!(updates[1]["status"], "error");
+    assert_eq!(updates[1]["output"]["status"], "rejected");
+    assert!(
+        updates[1]["output"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("already proposed")),
+        "Expected the already-proposed error, got: {}",
+        updates[1]["output"]
+    );
+
+    // Persisted message: exactly one successful proposal (the FIRST action)
+    // plus the error part for the superseded call.
+    let chat_id = extract_chat_id(&events).expect("Expected chat_id");
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let tool_use_parts =
+        fetch_assistant_tool_use_parts(&server, &chat_id, &assistant_message_id).await;
+    let proposed: Vec<&Value> = tool_use_parts
+        .iter()
+        .filter(|part| part["output"]["status"] == "proposed")
+        .collect();
+    assert_eq!(
+        proposed.len(),
+        1,
+        "Expected exactly one successful proposal part, got: {tool_use_parts:?}"
+    );
+    assert_eq!(proposed[0]["tool_call_id"], "call_first");
+    assert_eq!(proposed[0]["status"], "success");
+    assert_eq!(proposed[0]["output"]["action"], "outlook.reply");
+    let rejected: Vec<&Value> = tool_use_parts
+        .iter()
+        .filter(|part| part["output"]["status"] == "rejected")
+        .collect();
+    assert_eq!(
+        rejected.len(),
+        1,
+        "Expected exactly one rejected proposal part, got: {tool_use_parts:?}"
+    );
+    assert_eq!(rejected[0]["tool_call_id"], "call_second");
+    assert_eq!(rejected[0]["status"], "error");
+    assert_eq!(tool_use_parts.len(), 2);
+
+    // The model received both corrective tool responses on the next turn.
+    let corrective_bodies = corrective_request_recorder.bodies();
+    assert!(
+        corrective_bodies.iter().any(|body| {
+            body.contains("Proposed client action 'outlook.reply'")
+                && body.contains("only one proposal is allowed")
+        }),
+        "Expected corrective tool responses in the follow-up LLM request: {corrective_bodies:?}"
+    );
+}
+
+/// An out-of-enum action is answered with a corrective error WITHOUT
+/// consuming the one-proposal budget: a later valid call in the same
+/// generation still succeeds.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_client_action_invalid_proposal_then_valid_retry_succeeds(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    // Turn 1: propose an action outside the configured enum.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &[],
+                &[INVALID_RESPONSE_FRAGMENT, PROPOSED_RESPONSE_FRAGMENT],
+            ));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[(
+                "call_invalid",
+                CLIENT_ACTION_TOOL,
+                json!({"action": "outlook.forward"}),
+            )]),
+        );
+    });
+    // Turn 2: the corrective error arrived → retry with a valid action.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &[INVALID_RESPONSE_FRAGMENT],
+                &[PROPOSED_RESPONSE_FRAGMENT],
+            ));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[(
+                "call_valid",
+                CLIENT_ACTION_TOOL,
+                json!({"action": "outlook.reply_all"}),
+            )]),
+        );
+    });
+    // Turn 3: the retry was accepted → finish with text.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[PROPOSED_RESPONSE_FRAGMENT], &[]));
+        mock_llm_sse_response(then, build_openai_text_streaming_response(&["Done."]));
+    });
+
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let events = submit_under_reply_facet(&server).await;
+
+    let updates = tool_call_update_events(&events);
+    assert_eq!(
+        updates.len(),
+        2,
+        "Expected one tool_call_update per proposal, got: {updates:?}"
+    );
+    assert_eq!(updates[0]["tool_call_id"], "call_invalid");
+    assert_eq!(updates[0]["status"], "error");
+    assert_eq!(updates[0]["output"]["status"], "rejected");
+    assert!(
+        updates[0]["output"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("not allowed")),
+        "Expected the out-of-enum error, got: {}",
+        updates[0]["output"]
+    );
+    assert_eq!(updates[1]["tool_call_id"], "call_valid");
+    assert_eq!(updates[1]["status"], "success");
+    assert_eq!(updates[1]["output"]["status"], "proposed");
+    assert_eq!(updates[1]["output"]["action"], "outlook.reply_all");
+
+    let chat_id = extract_chat_id(&events).expect("Expected chat_id");
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let tool_use_parts =
+        fetch_assistant_tool_use_parts(&server, &chat_id, &assistant_message_id).await;
+    assert_eq!(tool_use_parts.len(), 2, "Got: {tool_use_parts:?}");
+    assert_eq!(tool_use_parts[0]["tool_call_id"], "call_invalid");
+    assert_eq!(tool_use_parts[0]["output"]["status"], "rejected");
+    assert_eq!(tool_use_parts[1]["tool_call_id"], "call_valid");
+    assert_eq!(tool_use_parts[1]["output"]["status"], "proposed");
+    assert_eq!(tool_use_parts[1]["output"]["action"], "outlook.reply_all");
 }

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -532,6 +532,96 @@ async fn test_platform_persisted_for_regenerate_and_edit_generation_requests(poo
     );
 }
 
+/// Regenerating a message generated under an action facet re-applies the
+/// stored facet when the request doesn't re-send one — mirroring the chat
+/// provider fallback ("same input, new sample").
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_falls_back_to_stored_action_facet(pool: Pool<Postgres>) {
+    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+    let db = app_state.db.clone();
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let submit_response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+
+    let submit_events = parse_sse_events(&submit_response);
+    let original_assistant_message_id = submit_events
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "assistant_message_completed"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected assistant_message_completed event with message_id");
+
+    // Regenerate WITHOUT re-sending the action facet.
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "current_message_id": original_assistant_message_id }))
+        .await;
+    regenerate_response.assert_status_ok();
+
+    let assistant_messages = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::GenerationParameters.is_not_null())
+        .order_by_asc(erato::db::entity::messages::Column::CreatedAt)
+        .all(&db)
+        .await
+        .expect("Failed to fetch assistant messages");
+    assert_eq!(assistant_messages.len(), 2);
+
+    let regenerate_params: GenerationParameters = serde_json::from_value(
+        assistant_messages[1]
+            .generation_parameters
+            .clone()
+            .expect("Missing regenerate generation_parameters"),
+    )
+    .expect("Failed to deserialize regenerate generation parameters");
+    assert_eq!(
+        regenerate_params.action_facet_id.as_deref(),
+        Some("rewrite"),
+        "Regenerate must re-apply the facet stored on the original generation",
+    );
+    assert_eq!(
+        regenerate_params
+            .action_facet_args
+            .as_ref()
+            .and_then(|args| args.get("tone"))
+            .map(String::as_str),
+        Some("professional")
+    );
+}
+
 /// Test facet prompt injection behavior across a two-turn chat.
 ///
 /// # Test Categories

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -2857,6 +2857,182 @@ allowed_args = []
 }
 
 #[test]
+#[should_panic(expected = "duplicate client action identifier 'outlook.reply' in client_actions.")]
+fn test_config_action_facet_duplicate_client_action_rejected() {
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[action_facets.facets.bad_facet]
+display_name = "Bad"
+template = "Do something with {{text}}"
+allowed_args = ["text"]
+client_actions = ["outlook.reply", "outlook.reply"]
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    let temp_path = temp_file.path().to_str().unwrap();
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    let _ = config.migrate(); // should panic
+}
+
+#[test]
+#[should_panic(
+    expected = "duplicate client action identifier 'outlook.reply_all' in client_actions_always_ask."
+)]
+fn test_config_action_facet_duplicate_client_action_always_ask_rejected() {
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[action_facets.facets.bad_facet]
+display_name = "Bad"
+template = "Do something with {{text}}"
+allowed_args = ["text"]
+client_actions = ["outlook.reply", "outlook.reply_all"]
+client_actions_always_ask = ["outlook.reply_all", "outlook.reply_all"]
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    let temp_path = temp_file.path().to_str().unwrap();
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    let _ = config.migrate(); // should panic
+}
+
+#[test]
+#[should_panic(expected = "with leading or trailing whitespace in client_actions.")]
+fn test_config_action_facet_untrimmed_client_action_rejected() {
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[action_facets.facets.bad_facet]
+display_name = "Bad"
+template = "Do something with {{text}}"
+allowed_args = ["text"]
+client_actions = ["outlook.reply ", "outlook.reply_all"]
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    let temp_path = temp_file.path().to_str().unwrap();
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    let _ = config.migrate(); // should panic
+}
+
+#[test]
+#[should_panic(expected = "with leading or trailing whitespace in client_actions_always_ask.")]
+fn test_config_action_facet_untrimmed_client_action_always_ask_rejected() {
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-3.5-turbo"
+
+[file_storage_providers.azblob_demo]
+provider_kind = "azblob"
+config = { endpoint = "https://xxx.blob.core.windows.net", container = "xxx", account_name = "xxx", account_key = "xxx" }
+
+[action_facets.facets.bad_facet]
+display_name = "Bad"
+template = "Do something with {{text}}"
+allowed_args = ["text"]
+client_actions = ["outlook.reply", "outlook.reply_all"]
+client_actions_always_ask = ["outlook.reply_all "]
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    let temp_path = temp_file.path().to_str().unwrap();
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    let _ = config.migrate(); // should panic
+}
+
+#[test]
 fn test_config_server_encryption_key_parses() {
     let mut temp_file = Builder::new()
         .suffix(".toml")

--- a/backend/erato/tests/integration_tests/test_utils.rs
+++ b/backend/erato/tests/integration_tests/test_utils.rs
@@ -16,6 +16,7 @@ use std::fs;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tempfile::{Builder, NamedTempFile};
 
@@ -749,4 +750,179 @@ pub fn hermetic_app_config(
         .unwrap();
 
     app_config.build().unwrap().try_deserialize().unwrap()
+}
+
+// ============================================================================
+// Multi-turn Mock LLM Helpers
+// ============================================================================
+
+/// Starts a mock LLM server with caller-provided mocks and returns an
+/// `AppConfig` pointing at it. Unlike [`setup_mock_llm_server`], the caller
+/// fully controls the mock set, which allows routing the individual turns of
+/// a tool-call loop to different responses (e.g. via [`BodyContainsMatcher`]).
+pub async fn setup_mock_llm_server_with_mocks(mocks: MockSet) -> (AppConfig, MockServer) {
+    let mockserver_config = MockServerConfig {
+        listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        ..Default::default()
+    };
+    let server = MockServer::new_http("llm-mock")
+        .with_config(mockserver_config)
+        .with_mocks(mocks);
+
+    server.start().await.expect("Failed to start mock server");
+
+    let mock_url_str = server.url("/v1/").to_string();
+    let app_config = hermetic_app_config(None, Some(mock_url_str));
+
+    (app_config, server)
+}
+
+/// Builds an OpenAI-compatible SSE stream for an assistant turn consisting of
+/// streamed tool calls (one delta chunk per call, all in one parallel batch).
+///
+/// Each tool call is given as `(call_id, tool_name, arguments)`.
+pub fn build_openai_tool_calls_streaming_response(
+    tool_calls: &[(&str, &str, Value)],
+) -> Vec<BodyAction> {
+    let mut actions = Vec::new();
+
+    let role_chunk = json!({
+        "id": "chatcmpl-mock-123",
+        "object": "chat.completion.chunk",
+        "created": 1234567890,
+        "model": "gpt-3.5-turbo",
+        "choices": [{
+            "index": 0,
+            "delta": { "role": "assistant", "content": null },
+            "finish_reason": null
+        }]
+    });
+    actions.push(BodyAction::Bytes(
+        format!("data: {}\n\n", role_chunk).into(),
+    ));
+
+    for (index, (call_id, tool_name, arguments)) in tool_calls.iter().enumerate() {
+        let tool_call_chunk = json!({
+            "id": "chatcmpl-mock-123",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-3.5-turbo",
+            "choices": [{
+                "index": 0,
+                "delta": {
+                    "tool_calls": [{
+                        "index": index,
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": tool_name,
+                            "arguments": arguments.to_string()
+                        }
+                    }]
+                },
+                "finish_reason": null
+            }]
+        });
+        actions.push(BodyAction::Bytes(
+            format!("data: {}\n\n", tool_call_chunk).into(),
+        ));
+    }
+
+    let finish_chunk = json!({
+        "id": "chatcmpl-mock-123",
+        "object": "chat.completion.chunk",
+        "created": 1234567890,
+        "model": "gpt-3.5-turbo",
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": "tool_calls"
+        }]
+    });
+    actions.push(BodyAction::Bytes(
+        format!("data: {}\n\n", finish_chunk).into(),
+    ));
+    actions.push(BodyAction::Bytes("data: [DONE]\n\n".into()));
+
+    actions
+}
+
+/// Builds an OpenAI-compatible SSE stream for a plain text assistant turn.
+pub fn build_openai_text_streaming_response(chunks: &[&str]) -> Vec<BodyAction> {
+    build_delayed_streaming_response(chunks.to_vec(), 0)
+}
+
+fn request_body_string(req: &Request) -> String {
+    String::from_utf8_lossy(&req.body().clone().as_bytes()).into_owned()
+}
+
+/// Matches when the request body contains all `contains` needles and none of
+/// the `excludes` needles. Used to route the turns of a multi-turn mock-LLM
+/// conversation (e.g. a tool-call loop) to different responses.
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct BodyContainsMatcher {
+    contains: Vec<String>,
+    excludes: Vec<String>,
+}
+
+impl BodyContainsMatcher {
+    pub fn new(contains: &[&str], excludes: &[&str]) -> Self {
+        Self {
+            contains: contains.iter().map(|s| s.to_string()).collect(),
+            excludes: excludes.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+}
+
+impl Matcher for BodyContainsMatcher {
+    fn name(&self) -> &str {
+        "body_contains"
+    }
+
+    fn matches(&self, req: &Request) -> bool {
+        let body = request_body_string(req);
+        self.contains.iter().all(|needle| body.contains(needle))
+            && self.excludes.iter().all(|needle| !body.contains(needle))
+    }
+}
+
+/// Always-matching matcher that records every request body it is evaluated
+/// against. Attach it last in a `when` chain so it only sees requests that
+/// passed the preceding matchers.
+#[derive(Debug, Clone, Default)]
+pub struct RequestBodyRecorder {
+    bodies: Arc<Mutex<Vec<String>>>,
+}
+
+impl RequestBodyRecorder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bodies(&self) -> Vec<String> {
+        self.bodies.lock().unwrap().clone()
+    }
+}
+
+impl PartialEq for RequestBodyRecorder {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.bodies, &other.bodies)
+    }
+}
+
+impl PartialOrd for RequestBodyRecorder {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.eq(other).then_some(std::cmp::Ordering::Equal)
+    }
+}
+
+impl Matcher for RequestBodyRecorder {
+    fn name(&self) -> &str {
+        "request_body_recorder"
+    }
+
+    fn matches(&self, req: &Request) -> bool {
+        self.bodies.lock().unwrap().push(request_body_string(req));
+        true
+    }
 }

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -1,6 +1,7 @@
 {
   "action_facets.enable_builtin_ms_office_addin": {},
   "action_facets.facets.<facet-id>.allowed_args.[]": {},
+  "action_facets.facets.<facet-id>.client_actions.[]": {},
   "action_facets.facets.<facet-id>.display_name": {},
   "action_facets.facets.<facet-id>.platform": {},
   "action_facets.facets.<facet-id>.template": {},

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -2,6 +2,7 @@
   "action_facets.enable_builtin_ms_office_addin": {},
   "action_facets.facets.<facet-id>.allowed_args.[]": {},
   "action_facets.facets.<facet-id>.client_actions.[]": {},
+  "action_facets.facets.<facet-id>.client_actions_always_ask.[]": {},
   "action_facets.facets.<facet-id>.display_name": {},
   "action_facets.facets.<facet-id>.platform": {},
   "action_facets.facets.<facet-id>.presentation": {},

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -4,6 +4,7 @@
   "action_facets.facets.<facet-id>.client_actions.[]": {},
   "action_facets.facets.<facet-id>.display_name": {},
   "action_facets.facets.<facet-id>.platform": {},
+  "action_facets.facets.<facet-id>.presentation": {},
   "action_facets.facets.<facet-id>.template": {},
   "additional_frontend_environment": {
     "hide_in_docs": true,

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2416,6 +2416,10 @@
           },
           "platform": {
             "type": "string"
+          },
+          "presentation": {
+            "type": "string",
+            "description": "How the client should surface a proposed client action:\n`render_buttons` (show buttons, user clicks) or `auto_prompt` (the\nclient may surface the proposal immediately after a fresh assistant\ncompletion, subject to the user's local approval preferences). Present\nonly when `client_actions` is non-empty; defaults to `render_buttons`."
           }
         }
       },

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2404,6 +2404,13 @@
           "id"
         ],
         "properties": {
+          "client_actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fixed identifiers of client-side actions the model may propose via the\n`propose_client_action` tool when this facet is active. The client\nmust only execute actions from this list, after user confirmation."
+          },
           "id": {
             "type": "string"
           },

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2401,7 +2401,8 @@
       "ActionFacetInfo": {
         "type": "object",
         "required": [
-          "id"
+          "id",
+          "display_name"
         ],
         "properties": {
           "client_actions": {
@@ -2410,6 +2411,17 @@
               "type": "string"
             },
             "description": "Fixed identifiers of client-side actions the model may propose via the\n`propose_client_action` tool when this facet is active. The client\nmust only execute actions from this list, after user confirmation."
+          },
+          "client_actions_always_ask": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Subset of `client_actions` the deployment enforces a per-use\nconfirmation for: the client must always ask and must not offer or\nhonor a persistent \"always allow\" for these actions. Users may still\ndeny them entirely."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human readable name for the facet, e.g. for client settings UIs."
           },
           "id": {
             "type": "string"

--- a/frontend/src/components/ui/Controls/RadioCard.tsx
+++ b/frontend/src/components/ui/Controls/RadioCard.tsx
@@ -27,6 +27,11 @@ interface RadioCardProps {
    *   selectable-card layout.
    */
   size?: "sm" | "md";
+  /**
+   * Renders the card greyed out and non-interactive (e.g. an option locked
+   * by deployment policy). Communicate the reason via `helper`.
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -48,6 +53,7 @@ export function RadioCard({
   trailing,
   children,
   size = "sm",
+  disabled = false,
 }: RadioCardProps) {
   const inputId = id ?? `radiocard-${name}-${value}`;
   const hideRadio = Boolean(icon);
@@ -60,10 +66,12 @@ export function RadioCard({
     checked
       ? "border-theme-border-focus bg-theme-bg-hover"
       : "border-theme-border bg-theme-bg-primary",
+    disabled && "opacity-60",
   );
 
   const rowClasses = clsx(
-    "relative flex cursor-pointer items-start gap-3 hover:bg-theme-bg-hover",
+    "relative flex items-start gap-3",
+    disabled ? "cursor-not-allowed" : "cursor-pointer hover:bg-theme-bg-hover",
     size === "md" ? "p-4" : "p-3",
   );
 
@@ -87,14 +95,15 @@ export function RadioCard({
           value={value}
           checked={checked}
           onChange={onChange}
+          disabled={disabled}
           className={
             hideRadio
               ? // Cover the whole label as a transparent overlay so click
                 // targeting (incl. Playwright's getByRole("radio").click())
                 // lands on the input rather than the label that would
                 // otherwise occlude an `sr-only` 1x1 input.
-                "absolute inset-0 cursor-pointer opacity-0"
-              : "mt-1 size-4 cursor-pointer accent-theme-bg-accent"
+                "absolute inset-0 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+              : "mt-1 size-4 cursor-pointer accent-theme-bg-accent disabled:cursor-not-allowed"
           }
         />
         {icon ? (

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
@@ -13,26 +13,62 @@ vi.mock("../Controls/Button", () => ({
 }));
 
 describe("ActionConfirmationCard", () => {
-  it("renders title, description, and both actions while pending", () => {
-    const onConfirm = vi.fn();
-    const onDismiss = vi.fn();
+  it("renders the generic frame with all three decisions", () => {
+    const onAllowOnce = vi.fn();
+    const onAlwaysAllow = vi.fn();
+    const onDeny = vi.fn();
     render(
       <ActionConfirmationCard
-        title="Reply to all recipients?"
-        description="Alice, Bob"
-        confirmLabel="Open Reply All"
-        dismissLabel="Not now"
-        onConfirm={onConfirm}
-        onDismiss={onDismiss}
+        description="Open a reply to all recipients: Alice, Bob"
+        onAllowOnce={onAllowOnce}
+        onAlwaysAllow={onAlwaysAllow}
+        onDeny={onDeny}
       />,
     );
 
-    expect(screen.getByText("Reply to all recipients?")).toBeInTheDocument();
-    expect(screen.getByText("Alice, Bob")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Open Reply All"));
-    expect(onConfirm).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByText("Not now"));
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Allow this action?")).toBeInTheDocument();
+    expect(
+      screen.getByText("Open a reply to all recipients: Alice, Bob"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Allow once"));
+    expect(onAllowOnce).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Always allow"));
+    expect(onAlwaysAllow).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Deny"));
+    expect(onDeny).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Always allow when no persistence callback is given", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Always allow")).not.toBeInTheDocument();
+  });
+
+  it("greys out Always allow with the deployment reason", () => {
+    const onAlwaysAllow = vi.fn();
+    render(
+      <ActionConfirmationCard
+        title="t"
+        onAllowOnce={vi.fn()}
+        onAlwaysAllow={onAlwaysAllow}
+        alwaysAllowDisabledReason="Your organization requires confirmation for this action."
+        onDeny={vi.fn()}
+      />,
+    );
+    const alwaysAllow = screen.getByText("Always allow");
+    expect(alwaysAllow).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Your organization requires confirmation for this action.",
+      ),
+    ).toBeInTheDocument();
+    fireEvent.click(alwaysAllow);
+    expect(onAlwaysAllow).not.toHaveBeenCalled();
   });
 
   it("renders rich description nodes as-is", () => {
@@ -40,60 +76,55 @@ describe("ActionConfirmationCard", () => {
       <ActionConfirmationCard
         title="t"
         description={<ul data-testid="recipients" />}
-        onConfirm={vi.fn()}
-        onDismiss={vi.fn()}
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
       />,
     );
     expect(screen.getByTestId("recipients")).toBeInTheDocument();
   });
 
-  it("disables both buttons while busy", () => {
+  it("disables all buttons while busy", () => {
     render(
       <ActionConfirmationCard
         title="t"
-        confirmLabel="Go"
-        dismissLabel="No"
-        onConfirm={vi.fn()}
-        onDismiss={vi.fn()}
+        onAllowOnce={vi.fn()}
+        onAlwaysAllow={vi.fn()}
+        onDeny={vi.fn()}
         isBusy
       />,
     );
-    expect(screen.getByText("Go")).toBeDisabled();
-    expect(screen.getByText("No")).toBeDisabled();
+    expect(screen.getByText("Allow once")).toBeDisabled();
+    expect(screen.getByText("Always allow")).toBeDisabled();
+    expect(screen.getByText("Deny")).toBeDisabled();
   });
 
   it("renders a compact resolved row instead of buttons once resolved", () => {
     render(
       <ActionConfirmationCard
         title="t"
-        confirmLabel="Go"
-        onConfirm={vi.fn()}
-        onDismiss={vi.fn()}
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
         status="confirmed"
         resolvedLabel="Reply opened"
       />,
     );
     expect(screen.getByText("Reply opened")).toBeInTheDocument();
-    expect(screen.queryByText("Go")).not.toBeInTheDocument();
+    expect(screen.queryByText("Allow once")).not.toBeInTheDocument();
   });
 
   it("scrolls into view on mount only when requested", () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
     const { unmount } = render(
-      <ActionConfirmationCard
-        title="t"
-        onConfirm={vi.fn()}
-        onDismiss={vi.fn()}
-      />,
+      <ActionConfirmationCard title="t" onAllowOnce={vi.fn()} onDeny={vi.fn()} />,
     );
     expect(scrollIntoView).not.toHaveBeenCalled();
     unmount();
     render(
       <ActionConfirmationCard
         title="t"
-        onConfirm={vi.fn()}
-        onDismiss={vi.fn()}
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
         scrollIntoViewOnMount
       />,
     );

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ActionConfirmationCard } from "./ActionConfirmationCard";
+
+vi.mock("../Controls/Button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+describe("ActionConfirmationCard", () => {
+  it("renders title, description, and both actions while pending", () => {
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <ActionConfirmationCard
+        title="Reply to all recipients?"
+        description="Alice, Bob"
+        confirmLabel="Open Reply All"
+        dismissLabel="Not now"
+        onConfirm={onConfirm}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText("Reply to all recipients?")).toBeInTheDocument();
+    expect(screen.getByText("Alice, Bob")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Open Reply All"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText("Not now"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders rich description nodes as-is", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        description={<ul data-testid="recipients" />}
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("recipients")).toBeInTheDocument();
+  });
+
+  it("disables both buttons while busy", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        confirmLabel="Go"
+        dismissLabel="No"
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+        isBusy
+      />,
+    );
+    expect(screen.getByText("Go")).toBeDisabled();
+    expect(screen.getByText("No")).toBeDisabled();
+  });
+
+  it("renders a compact resolved row instead of buttons once resolved", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        confirmLabel="Go"
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+        status="confirmed"
+        resolvedLabel="Reply opened"
+      />,
+    );
+    expect(screen.getByText("Reply opened")).toBeInTheDocument();
+    expect(screen.queryByText("Go")).not.toBeInTheDocument();
+  });
+
+  it("scrolls into view on mount only when requested", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const { unmount } = render(
+      <ActionConfirmationCard
+        title="t"
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    unmount();
+    render(
+      <ActionConfirmationCard
+        title="t"
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+        scrollIntoViewOnMount
+      />,
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.test.tsx
@@ -26,7 +26,9 @@ describe("ActionConfirmationCard", () => {
       />,
     );
 
-    expect(screen.getByText("Allow this action?")).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Allow this action?" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByText("Open a reply to all recipients: Alice, Bob"),
     ).toBeInTheDocument();
@@ -49,7 +51,7 @@ describe("ActionConfirmationCard", () => {
     expect(screen.queryByText("Always allow")).not.toBeInTheDocument();
   });
 
-  it("greys out Always allow with the deployment reason", () => {
+  it("greys out Always allow with the deployment reason but keeps it focusable", () => {
     const onAlwaysAllow = vi.fn();
     render(
       <ActionConfirmationCard
@@ -61,12 +63,15 @@ describe("ActionConfirmationCard", () => {
       />,
     );
     const alwaysAllow = screen.getByText("Always allow");
-    expect(alwaysAllow).toBeDisabled();
-    expect(
-      screen.getByText(
-        "Your organization requires confirmation for this action.",
-      ),
-    ).toBeInTheDocument();
+    // aria-disabled keeps the button in the tab order, unlike native
+    // disabled, so keyboard/SR users can discover the option and the reason.
+    expect(alwaysAllow).not.toBeDisabled();
+    expect(alwaysAllow).toHaveAttribute("aria-disabled", "true");
+    expect(alwaysAllow).toHaveAccessibleDescription(
+      "Your organization requires confirmation for this action.",
+    );
+    alwaysAllow.focus();
+    expect(alwaysAllow).toHaveFocus();
     fireEvent.click(alwaysAllow);
     expect(onAlwaysAllow).not.toHaveBeenCalled();
   });
@@ -106,17 +111,117 @@ describe("ActionConfirmationCard", () => {
         onDeny={vi.fn()}
         status="confirmed"
         resolvedLabel="Reply opened"
+        data-testid="card"
       />,
     );
-    expect(screen.getByText("Reply opened")).toBeInTheDocument();
+    expect(screen.getByTestId("card")).toHaveTextContent("Reply opened");
     expect(screen.queryByText("Allow once")).not.toBeInTheDocument();
+  });
+
+  it("moves focus to a pending card on mount", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
+        data-testid="card"
+      />,
+    );
+    expect(screen.getByTestId("card")).toHaveFocus();
+  });
+
+  it("does not grab focus when mounted already resolved", () => {
+    render(
+      <ActionConfirmationCard
+        title="t"
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
+        status="dismissed"
+        data-testid="card"
+      />,
+    );
+    expect(screen.getByTestId("card")).not.toHaveFocus();
+  });
+
+  it("keeps focus on the card when the pending buttons resolve away", () => {
+    const props = {
+      title: "t",
+      onAllowOnce: vi.fn(),
+      onDeny: vi.fn(),
+      "data-testid": "card",
+    };
+    const { rerender } = render(<ActionConfirmationCard {...props} />);
+    screen.getByText("Deny").focus();
+    rerender(<ActionConfirmationCard {...props} status="dismissed" />);
+    expect(screen.getByTestId("card")).toHaveFocus();
+  });
+
+  it("populates the polite announcement region after mount and on resolution", () => {
+    const props = { onAllowOnce: vi.fn(), onDeny: vi.fn() };
+    const { rerender } = render(<ActionConfirmationCard {...props} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Allow this action?");
+    rerender(
+      <ActionConfirmationCard
+        {...props}
+        status="confirmed"
+        resolvedLabel="Reply opened"
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Reply opened");
+  });
+
+  it("announces the pending→resolved transition exactly once", async () => {
+    const props = { onAllowOnce: vi.fn(), onDeny: vi.fn() };
+    const { rerender } = render(<ActionConfirmationCard {...props} />);
+    const region = screen.getByRole("status");
+    // Live regions announce on DOM mutation, so count mutations directly.
+    const mutations: string[] = [];
+    const observer = new MutationObserver((records) => {
+      mutations.push(...records.map(() => region.textContent ?? ""));
+    });
+    observer.observe(region, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    const resolvedProps = (
+      <ActionConfirmationCard
+        {...props}
+        status="confirmed"
+        resolvedLabel="Reply opened"
+      />
+    );
+    rerender(resolvedProps);
+    // A second render of the already-resolved card must not re-announce.
+    rerender(resolvedProps);
+    await Promise.resolve(); // flush the MutationObserver microtask
+    observer.disconnect();
+    expect(mutations).toEqual(["Reply opened"]);
+  });
+
+  it("does not announce a card that mounts already resolved", () => {
+    render(
+      <ActionConfirmationCard
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
+        status="confirmed"
+        resolvedLabel="Reply opened"
+      />,
+    );
+    // Reloaded transcripts mount resolved cards in bulk; an announcement
+    // here would queue one polite readout per historical card.
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
 
   it("scrolls into view on mount only when requested", () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
     const { unmount } = render(
-      <ActionConfirmationCard title="t" onAllowOnce={vi.fn()} onDeny={vi.fn()} />,
+      <ActionConfirmationCard
+        title="t"
+        onAllowOnce={vi.fn()}
+        onDeny={vi.fn()}
+      />,
     );
     expect(scrollIntoView).not.toHaveBeenCalled();
     unmount();

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
@@ -9,28 +9,45 @@ import type { ReactNode } from "react";
 export type ActionConfirmationStatus = "pending" | "confirmed" | "dismissed";
 
 interface ActionConfirmationCardProps {
-  /** Short question, e.g. "Reply to all recipients?" */
-  title: string;
   /**
-   * Explanatory body; string or rich node (e.g. a recipient list). Strings
-   * get default secondary-text styling, nodes render as-is.
+   * Title of the permission step. Defaults to a generic "Allow this action?"
+   * so every consumer presents the same recognizable frame; the
+   * action-specific information belongs in `description`.
+   */
+  title?: string;
+  /**
+   * What the assistant wants to do and its consequences (e.g. the action
+   * label and a recipient list). Strings get default secondary-text styling,
+   * nodes render as-is.
    */
   description?: ReactNode;
-  /** Label for the confirm button. */
-  confirmLabel?: string;
-  /** Label for the dismiss button. */
-  dismissLabel?: string;
-  onConfirm: () => void;
-  onDismiss: () => void;
+  /** Allow the action this one time; the card will ask again next time. */
+  onAllowOnce: () => void;
   /**
-   * Lifecycle state. `pending` renders the confirm/dismiss buttons;
+   * Persist the decision and allow the action. Omit to hide the button
+   * entirely (e.g. the consumer has no persistence).
+   */
+  onAlwaysAllow?: () => void;
+  /**
+   * When set, "Always allow" renders disabled with this reason below the
+   * buttons — used when a deployment enforces per-use confirmation. Only
+   * meaningful together with `onAlwaysAllow`.
+   */
+  alwaysAllowDisabledReason?: string;
+  /** Skip the action this one time; the card will ask again next time. */
+  onDeny: () => void;
+  allowOnceLabel?: string;
+  alwaysAllowLabel?: string;
+  denyLabel?: string;
+  /**
+   * Lifecycle state. `pending` renders the decision buttons;
    * `confirmed` / `dismissed` render a compact resolved row so the decision
    * stays visible in the transcript.
    */
   status?: ActionConfirmationStatus;
   /** Text for the resolved row (e.g. "Reply opened"). */
   resolvedLabel?: string;
-  /** Disables the buttons while the confirmed action is executing. */
+  /** Disables the buttons while the allowed action is executing. */
   isBusy?: boolean;
   /**
    * Scroll the card into view when it mounts. Used when the card is
@@ -45,22 +62,31 @@ interface ActionConfirmationCardProps {
 }
 
 /**
- * Inline, message-scoped confirmation step for an assistant-proposed action.
+ * Inline, message-scoped permission step for an assistant-proposed action.
+ *
+ * Presents the same three-way decision every time — allow once, always
+ * allow, deny — with browser-permission semantics: only "always allow"
+ * persists; "allow once" and "deny" apply to this proposal and the card asks
+ * again next time. A deployment can enforce per-use confirmation, in which
+ * case "always allow" renders greyed out with the reason.
  *
  * Unlike a modal, the card lives WITH the proposal in the conversation: it
  * never steals focus, multiple proposals can be pending independently, and a
  * resolved card stays visible as a record of the decision. The component is
- * deliberately execution-agnostic — `onConfirm` may run a client-side action
- * (e.g. the Outlook add-in opening a reply form) or call an approval endpoint
- * for server-gated tools; the card only renders the decision step.
+ * deliberately execution-agnostic — the callbacks may run a client-side
+ * action (e.g. the Outlook add-in opening a reply form) or call an approval
+ * endpoint for server-gated tools; the card only renders the decision step.
  */
 export const ActionConfirmationCard: React.FC<ActionConfirmationCardProps> = ({
   title,
   description,
-  confirmLabel,
-  dismissLabel,
-  onConfirm,
-  onDismiss,
+  onAllowOnce,
+  onAlwaysAllow,
+  alwaysAllowDisabledReason,
+  onDeny,
+  allowOnceLabel,
+  alwaysAllowLabel,
+  denyLabel,
   status = "pending",
   resolvedLabel,
   isBusy = false,
@@ -96,40 +122,71 @@ export const ActionConfirmationCard: React.FC<ActionConfirmationCardProps> = ({
     );
   }
 
+  const resolvedTitle =
+    title ??
+    t({
+      id: "actionConfirmation.title",
+      message: "Allow this action?",
+    });
+
   return (
     <div
       ref={cardRef}
       // Non-modal by design: announce politely instead of trapping focus.
       role="group"
       aria-live="polite"
-      aria-label={title}
+      aria-label={resolvedTitle}
       className={`mt-2 space-y-2 rounded-md border border-theme-border bg-theme-bg-primary p-3 ${className}`}
       data-testid={dataTestId}
     >
-      <p className="text-sm font-medium text-theme-fg-primary">{title}</p>
+      <p className="text-sm font-medium text-theme-fg-primary">
+        {resolvedTitle}
+      </p>
       {typeof description === "string" ? (
         <p className="text-sm text-theme-fg-secondary">{description}</p>
       ) : (
         description
       )}
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <Button
           variant="primary"
           size="sm"
-          onClick={onConfirm}
+          onClick={onAllowOnce}
           disabled={isBusy}
         >
-          {confirmLabel ?? t`Confirm`}
+          {allowOnceLabel ??
+            t({
+              id: "actionConfirmation.allowOnce",
+              message: "Allow once",
+            })}
         </Button>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={onDismiss}
-          disabled={isBusy}
-        >
-          {dismissLabel ?? t`Cancel`}
+        {onAlwaysAllow && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onAlwaysAllow}
+            disabled={isBusy || !!alwaysAllowDisabledReason}
+          >
+            {alwaysAllowLabel ??
+              t({
+                id: "actionConfirmation.alwaysAllow",
+                message: "Always allow",
+              })}
+          </Button>
+        )}
+        <Button variant="secondary" size="sm" onClick={onDeny} disabled={isBusy}>
+          {denyLabel ??
+            t({
+              id: "actionConfirmation.deny",
+              message: "Deny",
+            })}
         </Button>
       </div>
+      {alwaysAllowDisabledReason && (
+        <p className="text-xs text-theme-fg-muted">
+          {alwaysAllowDisabledReason}
+        </p>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
@@ -1,0 +1,138 @@
+import { t } from "@lingui/core/macro";
+import { useEffect, useRef } from "react";
+
+import { Button } from "../Controls/Button";
+
+import type React from "react";
+import type { ReactNode } from "react";
+
+export type ActionConfirmationStatus = "pending" | "confirmed" | "dismissed";
+
+interface ActionConfirmationCardProps {
+  /** Short question, e.g. "Reply to all recipients?" */
+  title: string;
+  /**
+   * Explanatory body; string or rich node (e.g. a recipient list). Strings
+   * get default secondary-text styling, nodes render as-is.
+   */
+  description?: ReactNode;
+  /** Label for the confirm button. */
+  confirmLabel?: string;
+  /** Label for the dismiss button. */
+  dismissLabel?: string;
+  onConfirm: () => void;
+  onDismiss: () => void;
+  /**
+   * Lifecycle state. `pending` renders the confirm/dismiss buttons;
+   * `confirmed` / `dismissed` render a compact resolved row so the decision
+   * stays visible in the transcript.
+   */
+  status?: ActionConfirmationStatus;
+  /** Text for the resolved row (e.g. "Reply opened"). */
+  resolvedLabel?: string;
+  /** Disables the buttons while the confirmed action is executing. */
+  isBusy?: boolean;
+  /**
+   * Scroll the card into view when it mounts. Used when the card is
+   * surfaced by the application (e.g. after a fresh assistant completion)
+   * rather than by a user click, so it can't appear off-screen unnoticed.
+   */
+  scrollIntoViewOnMount?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+  /** Test ID for e2e testing */
+  "data-testid"?: string;
+}
+
+/**
+ * Inline, message-scoped confirmation step for an assistant-proposed action.
+ *
+ * Unlike a modal, the card lives WITH the proposal in the conversation: it
+ * never steals focus, multiple proposals can be pending independently, and a
+ * resolved card stays visible as a record of the decision. The component is
+ * deliberately execution-agnostic — `onConfirm` may run a client-side action
+ * (e.g. the Outlook add-in opening a reply form) or call an approval endpoint
+ * for server-gated tools; the card only renders the decision step.
+ */
+export const ActionConfirmationCard: React.FC<ActionConfirmationCardProps> = ({
+  title,
+  description,
+  confirmLabel,
+  dismissLabel,
+  onConfirm,
+  onDismiss,
+  status = "pending",
+  resolvedLabel,
+  isBusy = false,
+  scrollIntoViewOnMount = false,
+  className = "",
+  "data-testid": dataTestId,
+}) => {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (scrollIntoViewOnMount) {
+      cardRef.current?.scrollIntoView({ block: "nearest" });
+    }
+    // Mount-only by design: re-scrolling on later prop changes would yank
+    // the viewport while the user reads or scrolls elsewhere.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (status !== "pending") {
+    return (
+      <div
+        ref={cardRef}
+        className={`mt-2 rounded-md border border-theme-border bg-theme-bg-primary px-3 py-2 text-xs text-theme-fg-muted ${className}`}
+        data-testid={dataTestId}
+      >
+        {resolvedLabel ??
+          (status === "confirmed"
+            ? t`Confirmed`
+            : t({
+                id: "actionConfirmation.dismissed",
+                message: "Dismissed",
+              }))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={cardRef}
+      // Non-modal by design: announce politely instead of trapping focus.
+      role="group"
+      aria-live="polite"
+      aria-label={title}
+      className={`mt-2 space-y-2 rounded-md border border-theme-border bg-theme-bg-primary p-3 ${className}`}
+      data-testid={dataTestId}
+    >
+      <p className="text-sm font-medium text-theme-fg-primary">{title}</p>
+      {typeof description === "string" ? (
+        <p className="text-sm text-theme-fg-secondary">{description}</p>
+      ) : (
+        description
+      )}
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={onConfirm}
+          disabled={isBusy}
+        >
+          {confirmLabel ?? t`Confirm`}
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onDismiss}
+          disabled={isBusy}
+        >
+          {dismissLabel ?? t`Cancel`}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+// eslint-disable-next-line lingui/no-unlocalized-strings
+ActionConfirmationCard.displayName = "ActionConfirmationCard";

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 
 import { Button } from "../Controls/Button";
 
@@ -62,6 +62,22 @@ interface ActionConfirmationCardProps {
 }
 
 /**
+ * Focus the card only when focus would otherwise be lost to <body> — the
+ * consumer disables its trigger while a card is pending, and the button row
+ * unmounts on resolution. Never steals focus from an unrelated element.
+ */
+const focusIfUnclaimed = (card: HTMLElement | null) => {
+  if (!card) {
+    return;
+  }
+  const active = document.activeElement;
+  if (active === null || active === document.body || card.contains(active)) {
+    // preventScroll keeps scrolling governed solely by scrollIntoViewOnMount.
+    card.focus({ preventScroll: true });
+  }
+};
+
+/**
  * Inline, message-scoped permission step for an assistant-proposed action.
  *
  * Presents the same three-way decision every time — allow once, always
@@ -95,32 +111,34 @@ export const ActionConfirmationCard: React.FC<ActionConfirmationCardProps> = ({
   "data-testid": dataTestId,
 }) => {
   const cardRef = useRef<HTMLDivElement | null>(null);
+  const alwaysAllowReasonId = useId();
+  const isPending = status === "pending";
+
   useEffect(() => {
     if (scrollIntoViewOnMount) {
       cardRef.current?.scrollIntoView({ block: "nearest" });
+    }
+    if (isPending) {
+      // A card mounted already-resolved (e.g. a reloaded transcript) must
+      // not grab focus.
+      focusIfUnclaimed(cardRef.current);
     }
     // Mount-only by design: re-scrolling on later prop changes would yank
     // the viewport while the user reads or scrolls elsewhere.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (status !== "pending") {
-    return (
-      <div
-        ref={cardRef}
-        className={`mt-2 rounded-md border border-theme-border bg-theme-bg-primary px-3 py-2 text-xs text-theme-fg-muted ${className}`}
-        data-testid={dataTestId}
-      >
-        {resolvedLabel ??
-          (status === "confirmed"
-            ? t`Confirmed`
-            : t({
-                id: "actionConfirmation.dismissed",
-                message: "Dismissed",
-              }))}
-      </div>
-    );
-  }
+  const previousStatusRef = useRef(status);
+  // Layout effect so focus moves before paint — with a passive effect, focus
+  // would sit on <body> for a frame after the button row unmounts before
+  // focusIfUnclaimed claims it.
+  useLayoutEffect(() => {
+    const previousStatus = previousStatusRef.current;
+    previousStatusRef.current = status;
+    if (previousStatus === "pending" && status !== "pending") {
+      focusIfUnclaimed(cardRef.current);
+    }
+  }, [status]);
 
   const resolvedTitle =
     title ??
@@ -129,64 +147,118 @@ export const ActionConfirmationCard: React.FC<ActionConfirmationCardProps> = ({
       message: "Allow this action?",
     });
 
+  const resolvedRowLabel =
+    resolvedLabel ??
+    (status === "confirmed"
+      ? t({
+          id: "actionConfirmation.confirmed",
+          message: "Confirmed",
+        })
+      : t({
+          id: "actionConfirmation.dismissed",
+          message: "Dismissed",
+        }));
+
+  // Live regions only announce mutations, so the region starts empty and is
+  // populated after paint — both the card's appearance and the
+  // pending→resolved transition then announce politely (non-modal by
+  // design: announce instead of trapping focus). A card mounted
+  // already-resolved (e.g. a reloaded transcript) stays silent, otherwise
+  // every historical card would queue an announcement.
+  const [announcement, setAnnouncement] = useState("");
+  const wasPendingAtMountRef = useRef(isPending);
+  const announcementText = isPending ? resolvedTitle : resolvedRowLabel;
+  useEffect(() => {
+    if (wasPendingAtMountRef.current) {
+      setAnnouncement(announcementText);
+    }
+  }, [announcementText]);
+
   return (
     <div
       ref={cardRef}
-      // Non-modal by design: announce politely instead of trapping focus.
-      role="group"
-      aria-live="polite"
-      aria-label={resolvedTitle}
-      className={`mt-2 space-y-2 rounded-md border border-theme-border bg-theme-bg-primary p-3 ${className}`}
+      // Programmatic focus target so keyboard focus never drops to <body>
+      // when the trigger disables on open or the button row unmounts.
+      tabIndex={-1}
+      role={isPending ? "group" : undefined}
+      aria-label={isPending ? resolvedTitle : undefined}
+      className={
+        isPending
+          ? `mt-2 space-y-2 rounded-md border border-theme-border bg-theme-bg-primary p-3 ${className}`
+          : `mt-2 rounded-md border border-theme-border bg-theme-bg-primary px-3 py-2 text-xs text-theme-fg-muted ${className}`
+      }
       data-testid={dataTestId}
     >
-      <p className="text-sm font-medium text-theme-fg-primary">
-        {resolvedTitle}
-      </p>
-      {typeof description === "string" ? (
-        <p className="text-sm text-theme-fg-secondary">{description}</p>
+      {isPending ? (
+        <>
+          <p className="text-sm font-medium text-theme-fg-primary">
+            {resolvedTitle}
+          </p>
+          {typeof description === "string" ? (
+            <p className="text-sm text-theme-fg-secondary">{description}</p>
+          ) : (
+            description
+          )}
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={onAllowOnce}
+              disabled={isBusy}
+            >
+              {allowOnceLabel ??
+                t({
+                  id: "actionConfirmation.allowOnce",
+                  message: "Allow once",
+                })}
+            </Button>
+            {onAlwaysAllow && (
+              <Button
+                variant="secondary"
+                size="sm"
+                // aria-disabled instead of disabled keeps the button in the
+                // tab order so keyboard/SR users can discover the option and
+                // the reason; the click guard makes it inert.
+                onClick={alwaysAllowDisabledReason ? undefined : onAlwaysAllow}
+                disabled={isBusy}
+                aria-disabled={alwaysAllowDisabledReason ? true : undefined}
+                aria-describedby={
+                  alwaysAllowDisabledReason ? alwaysAllowReasonId : undefined
+                }
+                className="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+              >
+                {alwaysAllowLabel ??
+                  t({
+                    id: "actionConfirmation.alwaysAllow",
+                    message: "Always allow",
+                  })}
+              </Button>
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={onDeny}
+              disabled={isBusy}
+            >
+              {denyLabel ??
+                t({
+                  id: "actionConfirmation.deny",
+                  message: "Deny",
+                })}
+            </Button>
+          </div>
+          {alwaysAllowDisabledReason && (
+            <p id={alwaysAllowReasonId} className="text-xs text-theme-fg-muted">
+              {alwaysAllowDisabledReason}
+            </p>
+          )}
+        </>
       ) : (
-        description
+        resolvedRowLabel
       )}
-      <div className="flex flex-wrap gap-2">
-        <Button
-          variant="primary"
-          size="sm"
-          onClick={onAllowOnce}
-          disabled={isBusy}
-        >
-          {allowOnceLabel ??
-            t({
-              id: "actionConfirmation.allowOnce",
-              message: "Allow once",
-            })}
-        </Button>
-        {onAlwaysAllow && (
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={onAlwaysAllow}
-            disabled={isBusy || !!alwaysAllowDisabledReason}
-          >
-            {alwaysAllowLabel ??
-              t({
-                id: "actionConfirmation.alwaysAllow",
-                message: "Always allow",
-              })}
-          </Button>
-        )}
-        <Button variant="secondary" size="sm" onClick={onDeny} disabled={isBusy}>
-          {denyLabel ??
-            t({
-              id: "actionConfirmation.deny",
-              message: "Deny",
-            })}
-        </Button>
-      </div>
-      {alwaysAllowDisabledReason && (
-        <p className="text-xs text-theme-fg-muted">
-          {alwaysAllowDisabledReason}
-        </p>
-      )}
+      <p role="status" className="sr-only">
+        {announcement}
+      </p>
     </div>
   );
 };

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -107,6 +107,16 @@ const OutlookArtifactContext = React.createContext<OutlookArtifact | null>(
   null,
 );
 
+/**
+ * The Outlook artifact hint for the message currently being rendered, or null
+ * outside an Outlook-facet message. Exposed so registry overrides (e.g. the
+ * add-in's erato-email renderer) can read facet metadata such as the allowed
+ * and proposed client actions without new props on every code block.
+ */
+export function useOutlookArtifact(): OutlookArtifact | null {
+  return React.useContext(OutlookArtifactContext);
+}
+
 const INLINE_CODE_CLASS_NAME =
   "rounded-md border border-theme-code-inline-border bg-theme-code-inline-bg px-1.5 py-0.5 font-mono text-sm text-theme-code-inline-fg";
 const BlockCodeContext = React.createContext(false);

--- a/frontend/src/components/ui/Message/index.ts
+++ b/frontend/src/components/ui/Message/index.ts
@@ -1,4 +1,5 @@
 export * from "../MessageList";
+export * from "./ActionConfirmationCard";
 export * from "./MessageContent";
 export * from "./MessageTimestamp";
 export * from "./DefaultMessageControls";

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -26,6 +26,14 @@ export type ActionFacetInfo = {
   client_actions?: string[];
   id: string;
   platform?: string;
+  /**
+   * How the client should surface a proposed client action:
+   * `render_buttons` (show buttons, user clicks) or `auto_prompt` (the
+   * client may surface the proposal immediately after a fresh assistant
+   * completion, subject to the user's local approval preferences). Present
+   * only when `client_actions` is non-empty; defaults to `render_buttons`.
+   */
+  presentation?: string;
 };
 
 /**

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -24,6 +24,17 @@ export type ActionFacetInfo = {
    * must only execute actions from this list, after user confirmation.
    */
   client_actions?: string[];
+  /**
+   * Subset of `client_actions` the deployment enforces a per-use
+   * confirmation for: the client must always ask and must not offer or
+   * honor a persistent "always allow" for these actions. Users may still
+   * deny them entirely.
+   */
+  client_actions_always_ask?: string[];
+  /**
+   * Human readable name for the facet, e.g. for client settings UIs.
+   */
+  display_name: string;
   id: string;
   platform?: string;
   /**

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -18,6 +18,12 @@ export type AbortStreamResponse = {
 };
 
 export type ActionFacetInfo = {
+  /**
+   * Fixed identifiers of client-side actions the model may propose via the
+   * `propose_client_action` tool when this facet is active. The client
+   * must only execute actions from this list, after user confirmation.
+   */
+  client_actions?: string[];
   id: string;
   platform?: string;
 };

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -25,7 +25,10 @@ export { MessageTimestamp } from "@/components/ui/Message/MessageTimestamp";
 export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
 export { FilePreviewModal } from "@/components/ui/Modal/FilePreviewModal";
 export { ModalBase } from "@/components/ui/Modal/ModalBase";
-export { ConfirmationDialog } from "@/components/ui/Modal/ConfirmationDialog";
+export {
+  ActionConfirmationCard,
+  type ActionConfirmationStatus,
+} from "@/components/ui/Message/ActionConfirmationCard";
 export { AppearanceTabContent } from "@/components/ui/Settings/AppearanceTabContent";
 export { AudioInputTabContent } from "@/components/ui/Settings/AudioInputTabContent";
 export { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -16,11 +16,16 @@ export {
   type ChatMessageProps,
 } from "@/components/ui/Chat/ChatMessage";
 export * from "@/components/ui/MessageList";
-export { MessageContent } from "@/components/ui/Message/MessageContent";
+export {
+  MessageContent,
+  useOutlookArtifact,
+} from "@/components/ui/Message/MessageContent";
+export type { OutlookArtifact } from "@/types/chat";
 export { MessageTimestamp } from "@/components/ui/Message/MessageTimestamp";
 export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
 export { FilePreviewModal } from "@/components/ui/Modal/FilePreviewModal";
 export { ModalBase } from "@/components/ui/Modal/ModalBase";
+export { ConfirmationDialog } from "@/components/ui/Modal/ConfirmationDialog";
 export { AppearanceTabContent } from "@/components/ui/Settings/AppearanceTabContent";
 export { AudioInputTabContent } from "@/components/ui/Settings/AudioInputTabContent";
 export { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -23,8 +23,28 @@ msgstr "Über uns"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.allowOnce"
+msgstr "Einmal erlauben"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.alwaysAllow"
+msgstr "Immer erlauben"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.deny"
+msgstr "Ablehnen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.dismissed"
 msgstr "Verworfen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.title"
+msgstr "Diese Aktion erlauben?"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
@@ -1866,7 +1886,6 @@ msgstr "Browsersprache:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -1969,7 +1988,6 @@ msgstr "Konfiguration"
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr "Konfigurieren Sie einen benutzerdefinierten Assistenten mit spezifischen Anweisungen und Fähigkeiten"
 
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Bestätigen"

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -33,6 +33,11 @@ msgstr "Immer erlauben"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.confirmed"
+msgstr "Bestätigt"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.deny"
 msgstr "Ablehnen"
 
@@ -2008,10 +2013,6 @@ msgstr "Archivierung bestätigen"
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Entfernung bestätigen"
-
-#: src/components/ui/Message/ActionConfirmationCard.tsx
-msgid "Confirmed"
-msgstr "Bestätigt"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -22,6 +22,11 @@ msgid "about.title"
 msgstr "Über uns"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.dismissed"
+msgstr "Verworfen"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "assistant.form.button.save"
 msgstr "Änderungen speichern"
@@ -1861,6 +1866,7 @@ msgstr "Browsersprache:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -1963,6 +1969,7 @@ msgstr "Konfiguration"
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr "Konfigurieren Sie einen benutzerdefinierten Assistenten mit spezifischen Anweisungen und Fähigkeiten"
 
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Bestätigen"
@@ -1983,6 +1990,10 @@ msgstr "Archivierung bestätigen"
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Entfernung bestätigen"
+
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "Confirmed"
+msgstr "Bestätigt"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -23,8 +23,28 @@ msgstr "About Page"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.allowOnce"
+msgstr "Allow once"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.alwaysAllow"
+msgstr "Always allow"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.deny"
+msgstr "Deny"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.dismissed"
 msgstr "Dismissed"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.title"
+msgstr "Allow this action?"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
@@ -1866,7 +1886,6 @@ msgstr "Browser Language:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -1969,7 +1988,6 @@ msgstr "Configuration"
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr "Configure a custom assistant with specific instructions and capabilities"
 
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirm"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -33,6 +33,11 @@ msgstr "Always allow"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.confirmed"
+msgstr "Confirmed"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.deny"
 msgstr "Deny"
 
@@ -2008,10 +2013,6 @@ msgstr "Confirm Archive"
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirm Removal"
-
-#: src/components/ui/Message/ActionConfirmationCard.tsx
-msgid "Confirmed"
-msgstr "Confirmed"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -22,6 +22,11 @@ msgid "about.title"
 msgstr "About Page"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.dismissed"
+msgstr "Dismissed"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "assistant.form.button.save"
 msgstr "Save Changes"
@@ -1861,6 +1866,7 @@ msgstr "Browser Language:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -1963,6 +1969,7 @@ msgstr "Configuration"
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr "Configure a custom assistant with specific instructions and capabilities"
 
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirm"
@@ -1983,6 +1990,10 @@ msgstr "Confirm Archive"
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirm Removal"
+
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "Confirmed"
+msgstr "Confirmed"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -22,6 +22,11 @@ msgid "about.title"
 msgstr "Acerca de"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.dismissed"
+msgstr "Descartado"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "assistant.form.button.save"
 msgstr "Guardar cambios"
@@ -1861,6 +1866,7 @@ msgstr "Idioma del navegador:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Cancelar"
@@ -1963,6 +1969,7 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirmar"
@@ -1983,6 +1990,10 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirmar eliminación"
+
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "Confirmed"
+msgstr "Confirmado"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -23,8 +23,28 @@ msgstr "Acerca de"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.allowOnce"
+msgstr "Permitir una vez"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.alwaysAllow"
+msgstr "Permitir siempre"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.deny"
+msgstr "Denegar"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.dismissed"
 msgstr "Descartado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.title"
+msgstr "¿Permitir esta acción?"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
@@ -1866,7 +1886,6 @@ msgstr "Idioma del navegador:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Cancelar"
@@ -1969,7 +1988,6 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirmar"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -33,6 +33,11 @@ msgstr "Permitir siempre"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.confirmed"
+msgstr "Confirmado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.deny"
 msgstr "Denegar"
 
@@ -2008,10 +2013,6 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirmar eliminación"
-
-#: src/components/ui/Message/ActionConfirmationCard.tsx
-msgid "Confirmed"
-msgstr "Confirmado"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -22,6 +22,11 @@ msgid "about.title"
 msgstr "À propos"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.dismissed"
+msgstr "Ignoré"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "assistant.form.button.save"
 msgstr "Enregistrer les modifications"
@@ -1861,6 +1866,7 @@ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Annuler"
@@ -1963,6 +1969,7 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirmer"
@@ -1983,6 +1990,10 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirmer la suppression"
+
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "Confirmed"
+msgstr "Confirmé"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -23,8 +23,28 @@ msgstr "À propos"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.allowOnce"
+msgstr "Autoriser une fois"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.alwaysAllow"
+msgstr "Toujours autoriser"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.deny"
+msgstr "Refuser"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.dismissed"
 msgstr "Ignoré"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.title"
+msgstr "Autoriser cette action ?"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
@@ -1866,7 +1886,6 @@ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Annuler"
@@ -1969,7 +1988,6 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Confirmer"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -33,6 +33,11 @@ msgstr "Toujours autoriser"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.confirmed"
+msgstr "Confirmé"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.deny"
 msgstr "Refuser"
 
@@ -2008,10 +2013,6 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Confirmer la suppression"
-
-#: src/components/ui/Message/ActionConfirmationCard.tsx
-msgid "Confirmed"
-msgstr "Confirmé"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -23,8 +23,28 @@ msgstr "O nas"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.allowOnce"
+msgstr "Zezwól raz"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.alwaysAllow"
+msgstr "Zawsze zezwalaj"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.deny"
+msgstr "Odmów"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.dismissed"
 msgstr "Odrzucono"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.title"
+msgstr "Zezwolić na tę akcję?"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
@@ -1866,7 +1886,6 @@ msgstr "Język przeglądarki:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Anuluj"
@@ -1969,7 +1988,6 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
-#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Potwierdź"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -22,6 +22,11 @@ msgid "about.title"
 msgstr "O nas"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.dismissed"
+msgstr "Odrzucono"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "assistant.form.button.save"
 msgstr "Zapisz zmiany"
@@ -1861,6 +1866,7 @@ msgstr "Język przeglądarki:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 #: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel"
 msgstr "Anuluj"
@@ -1963,6 +1969,7 @@ msgstr ""
 msgid "Configure a custom assistant with specific instructions and capabilities"
 msgstr ""
 
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Confirm"
 msgstr "Potwierdź"
@@ -1983,6 +1990,10 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Potwierdź usunięcie"
+
+#: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "Confirmed"
+msgstr "Potwierdzono"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -33,6 +33,11 @@ msgstr "Zawsze zezwalaj"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ActionConfirmationCard.tsx
+msgid "actionConfirmation.confirmed"
+msgstr "Potwierdzono"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/ActionConfirmationCard.tsx
 msgid "actionConfirmation.deny"
 msgstr "Odmów"
 
@@ -2008,10 +2013,6 @@ msgstr ""
 #: src/components/ui/Chat/ChatHistoryList.tsx
 msgid "Confirm Removal"
 msgstr "Potwierdź usunięcie"
-
-#: src/components/ui/Message/ActionConfirmationCard.tsx
-msgid "Confirmed"
-msgstr "Potwierdzono"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -67,10 +67,29 @@ export interface OutlookArtifact {
    * The client action the model proposed for this message via the
    * `propose_client_action` tool, already validated by the add-in against
    * {@link OutlookArtifact.allowedClientActions} and the tool-call status.
-   * Used as a render hint (e.g. which button is primary) — never executed
-   * without an explicit user click.
+   * Used as a render hint (e.g. which button is primary) — auto-surfaced
+   * only under `auto_prompt` presentation and the user's local approval
+   * preferences, never on history reloads.
    */
   proposedClientAction?: string;
+  /**
+   * The producing facet's `presentation` from `GET /me/facets`:
+   * `render_buttons` (default) or `auto_prompt`.
+   */
+  clientActionPresentation?: string;
+  /**
+   * Id of the assistant message this artifact was stamped from. Lets a
+   * fence renderer key once-per-message behavior (auto-prompt) stably
+   * across remounts.
+   */
+  messageId?: string;
+  /**
+   * True only when this assistant message finished streaming during the
+   * current session (a status transition to complete was observed). False
+   * for messages loaded from history — auto-prompt must never fire for
+   * those.
+   */
+  isFreshCompletion?: boolean;
 }
 
 export interface Message {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -90,6 +90,14 @@ export interface OutlookArtifact {
    * those.
    */
   isFreshCompletion?: boolean;
+  /**
+   * The Outlook item identity observed when this message completed (fresh
+   * completions only). Executors compare it against the CURRENT item before
+   * opening anything, so a draft never opens a reply on a different email
+   * than it was written for. Absent for history messages, where the
+   * generation-time item is unknown.
+   */
+  itemIdentity?: string;
 }
 
 export interface Message {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -56,6 +56,21 @@ export interface OutlookArtifact {
    *   unfenced prose is left as normal markdown — never treated as a drop-in body.
    */
   renderMode: "body" | "suggestions";
+  /**
+   * Client actions the backend allows for the producing facet (the facet's
+   * `client_actions` from `GET /me/facets`). The renderer must only offer
+   * actions from this list, further intersected with the actions the client
+   * actually implements.
+   */
+  allowedClientActions?: string[];
+  /**
+   * The client action the model proposed for this message via the
+   * `propose_client_action` tool, already validated by the add-in against
+   * {@link OutlookArtifact.allowedClientActions} and the tool-call status.
+   * Used as a render hint (e.g. which button is primary) — never executed
+   * without an explicit user click.
+   */
+  proposedClientAction?: string;
 }
 
 export interface Message {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -64,6 +64,12 @@ export interface OutlookArtifact {
    */
   allowedClientActions?: string[];
   /**
+   * Actions the deployment enforces a per-use confirmation for (the facet's
+   * `client_actions_always_ask`). The client must not offer or honor a
+   * persistent "always allow" for these.
+   */
+  alwaysAskClientActions?: string[];
+  /**
    * The client action the model proposed for this message via the
    * `propose_client_action` tool, already validated by the add-in against
    * {@link OutlookArtifact.allowedClientActions} and the tool-call status.

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -97,11 +97,19 @@ export interface OutlookArtifact {
    */
   isFreshCompletion?: boolean;
   /**
-   * The Outlook item identity observed when this message completed (fresh
-   * completions only). Executors compare it against the CURRENT item before
-   * opening anything, so a draft never opens a reply on a different email
-   * than it was written for. Absent for history messages, where the
-   * generation-time item is unknown.
+   * The Outlook item identity captured when the user SENT the message that
+   * triggered this completion (fresh completions only). Send time is the
+   * guard's baseline — the user can switch emails while the response
+   * streams, so the item open at completion time proves nothing. Executors
+   * compare it against the CURRENT item before opening anything, so a draft
+   * never opens a reply on a different email than it was requested for.
+   *
+   * A fresh completion ({@link OutlookArtifact.isFreshCompletion}) WITHOUT
+   * this field means no send-time identity was recorded (no open item at
+   * send, or the completion could not be matched to a send): executors must
+   * fail closed — never auto-prompt, and treat the draft as stale rather
+   * than as unguarded. Absent together with `isFreshCompletion` for history
+   * messages, where the generation-time item is unknown.
    */
   itemIdentity?: string;
 }

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -34,7 +34,7 @@ import {
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
 import { AddinSettingsDialog } from "./AddinSettingsDialog";
@@ -45,6 +45,7 @@ import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
 import { useOutlookMessageFetcher } from "../hooks/useOutlookMessageFetcher";
 import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
+import { FreshCompletionTracker } from "../utils/freshCompletionTracker";
 import {
   OUTLOOK_GRAPH_MESSAGE_TIMEOUT_MS,
   runWithGraphTimeout,
@@ -646,6 +647,21 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // response is an insertable email); only review/critique facets opt into
   // "suggestions" (fenced blocks render, unfenced prose stays markdown).
   const clientActionsByFacetId = useActionFacetClientActions();
+
+  // Track which assistant messages finished streaming during THIS session.
+  // Auto-prompt (presentation = "auto_prompt") may only fire for those —
+  // history loads, refetches, and chat switches never auto-open anything.
+  const freshTrackerRef = useRef(new FreshCompletionTracker());
+  const [freshMessageIds, setFreshMessageIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
+    if (newlyFresh.length > 0) {
+      setFreshMessageIds((previous) => new Set([...previous, ...newlyFresh]));
+    }
+  }, [messages, messageOrder]);
+
   const messagesWithArtifact = useMemo(() => {
     let next = messages;
     for (const id of messageOrder) {
@@ -672,7 +688,8 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       // set comes from the backend facet config, and the model's proposal is
       // only stamped after revalidation against that set + tool-call status —
       // never parsed out of message text.
-      const allowedClientActions = clientActionsByFacetId.get(facetId);
+      const clientActionInfo = clientActionsByFacetId.get(facetId);
+      const allowedClientActions = clientActionInfo?.clientActions;
       const proposedClientAction = allowedClientActions
         ? extractProposedClientAction(message.content, allowedClientActions)
         : undefined;
@@ -685,13 +702,18 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           facetId,
           bodyFormat: facetBodyFormat,
           renderMode,
+          messageId: id,
           ...(allowedClientActions ? { allowedClientActions } : {}),
           ...(proposedClientAction ? { proposedClientAction } : {}),
+          ...(clientActionInfo?.presentation
+            ? { clientActionPresentation: clientActionInfo.presentation }
+            : {}),
+          ...(freshMessageIds.has(id) ? { isFreshCompletion: true } : {}),
         },
       };
     }
     return next;
-  }, [messages, messageOrder, clientActionsByFacetId]);
+  }, [messages, messageOrder, clientActionsByFacetId, freshMessageIds]);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -149,7 +149,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // drops keep working since they parse without a backend.
   const { fetcher: messageFetcher } = useOutlookMessageFetcher();
 
-  const { mailItem } = useOutlookMailItem();
+  const { mailItem, itemIdentity } = useOutlookMailItem();
   const {
     hasSelectedEmailSource,
     isEmailBodyIncluded,
@@ -651,16 +651,23 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // Track which assistant messages finished streaming during THIS session.
   // Auto-prompt (presentation = "auto_prompt") may only fire for those —
   // history loads, refetches, and chat switches never auto-open anything.
+  // The Outlook item identity at completion time is recorded alongside, so
+  // executors can refuse to open a reply when the user has meanwhile
+  // switched to a different email.
   const freshTrackerRef = useRef(new FreshCompletionTracker());
+  const freshItemIdentityRef = useRef(new Map<string, string | null>());
   const [freshMessageIds, setFreshMessageIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   useEffect(() => {
     const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
     if (newlyFresh.length > 0) {
+      for (const id of newlyFresh) {
+        freshItemIdentityRef.current.set(id, itemIdentity ?? null);
+      }
       setFreshMessageIds((previous) => new Set([...previous, ...newlyFresh]));
     }
-  }, [messages, messageOrder]);
+  }, [messages, messageOrder, itemIdentity]);
 
   const messagesWithArtifact = useMemo(() => {
     let next = messages;
@@ -708,7 +715,14 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           ...(clientActionInfo?.presentation
             ? { clientActionPresentation: clientActionInfo.presentation }
             : {}),
-          ...(freshMessageIds.has(id) ? { isFreshCompletion: true } : {}),
+          ...(freshMessageIds.has(id)
+            ? {
+                isFreshCompletion: true,
+                ...(freshItemIdentityRef.current.get(id)
+                  ? { itemIdentity: freshItemIdentityRef.current.get(id)! }
+                  : {}),
+              }
+            : {}),
         },
       };
     }

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -38,6 +38,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInput } from "./AddinChatInput";
 import { AddinSettingsDialog } from "./AddinSettingsDialog";
+import { useActionFacetClientActions } from "../hooks/useAvailableActionFacets";
 import { useEmailDedupSet } from "../hooks/useEmailDedupSet";
 import { useOfficeDragAndDrop } from "../hooks/useOfficeDragAndDrop";
 import { useOutlookMailListDrag } from "../hooks/useOutlookMailListDrag";
@@ -48,6 +49,7 @@ import {
   OUTLOOK_GRAPH_MESSAGE_TIMEOUT_MS,
   runWithGraphTimeout,
 } from "../utils/graphRequestTimeout";
+import { extractProposedClientAction } from "../utils/outlookClientActions";
 import { parseDroppedFiles } from "../utils/parseDroppedFiles";
 import { parseEmlBytes } from "../utils/parsedEmail";
 
@@ -643,6 +645,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // renders here with no add-in change. `renderMode` defaults to "body" (whole
   // response is an insertable email); only review/critique facets opt into
   // "suggestions" (fenced blocks render, unfenced prose stays markdown).
+  const clientActionsByFacetId = useActionFacetClientActions();
   const messagesWithArtifact = useMemo(() => {
     let next = messages;
     for (const id of messageOrder) {
@@ -665,16 +668,30 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       }
       const renderMode =
         facetId === "outlook_review_draft" ? "suggestions" : "body";
+      // Client actions (e.g. reply / reply-all from read mode): the offerable
+      // set comes from the backend facet config, and the model's proposal is
+      // only stamped after revalidation against that set + tool-call status —
+      // never parsed out of message text.
+      const allowedClientActions = clientActionsByFacetId.get(facetId);
+      const proposedClientAction = allowedClientActions
+        ? extractProposedClientAction(message.content, allowedClientActions)
+        : undefined;
       if (next === messages) {
         next = { ...messages };
       }
       next[id] = {
         ...message,
-        outlookArtifact: { facetId, bodyFormat: facetBodyFormat, renderMode },
+        outlookArtifact: {
+          facetId,
+          bodyFormat: facetBodyFormat,
+          renderMode,
+          ...(allowedClientActions ? { allowedClientActions } : {}),
+          ...(proposedClientAction ? { proposedClientAction } : {}),
+        },
       };
     }
     return next;
-  }, [messages, messageOrder]);
+  }, [messages, messageOrder, clientActionsByFacetId]);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -656,10 +656,18 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // switched to a different email.
   const freshTrackerRef = useRef(new FreshCompletionTracker());
   const freshItemIdentityRef = useRef(new Map<string, string | null>());
+  const freshTrackerChatIdRef = useRef(currentChatId);
   const [freshMessageIds, setFreshMessageIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   useEffect(() => {
+    // A chat switch replaces the whole message list — discard the tracker so
+    // the next snapshot is treated as history and nothing in the switched-to
+    // chat can be considered "just completed".
+    if (freshTrackerChatIdRef.current !== currentChatId) {
+      freshTrackerChatIdRef.current = currentChatId;
+      freshTrackerRef.current = new FreshCompletionTracker();
+    }
     const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
     if (newlyFresh.length > 0) {
       for (const id of newlyFresh) {
@@ -667,7 +675,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       }
       setFreshMessageIds((previous) => new Set([...previous, ...newlyFresh]));
     }
-  }, [messages, messageOrder, itemIdentity]);
+  }, [messages, messageOrder, itemIdentity, currentChatId]);
 
   const messagesWithArtifact = useMemo(() => {
     let next = messages;

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -719,6 +719,9 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           renderMode,
           messageId: id,
           ...(allowedClientActions ? { allowedClientActions } : {}),
+          ...(clientActionInfo && clientActionInfo.alwaysAskActions.length > 0
+            ? { alwaysAskClientActions: clientActionInfo.alwaysAskActions }
+            : {}),
           ...(proposedClientAction ? { proposedClientAction } : {}),
           ...(clientActionInfo?.presentation
             ? { clientActionPresentation: clientActionInfo.presentation }

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -149,7 +149,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // drops keep working since they parse without a backend.
   const { fetcher: messageFetcher } = useOutlookMessageFetcher();
 
-  const { mailItem, itemIdentity } = useOutlookMailItem();
+  const { mailItem } = useOutlookMailItem();
   const {
     hasSelectedEmailSource,
     isEmailBodyIncluded,
@@ -482,6 +482,60 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     [isPreviewBodyIncluded, emailBodyFile],
   );
 
+  // Outlook item identity captured by AddinChatInput when the user pressed
+  // send, held until the completion of that exchange is observed (there is
+  // one in-flight generation per chat). Edits and regenerations replay the
+  // ORIGINAL email (it rides in the stored user message / facet args), so
+  // they re-seed this ref with the original exchange's send-time identity
+  // when this session still knows it; otherwise it stays null and the
+  // completion is not stamped fresh at all (degrading to a history-like
+  // draft — see the tracking effect below).
+  const pendingSendItemIdentityRef = useRef<string | null>(null);
+
+  // Track which assistant messages finished streaming during THIS session.
+  // Auto-prompt (presentation = "auto_prompt") may only fire for those —
+  // history loads, refetches, and chat switches never auto-open anything.
+  // The SEND-time Outlook item identity is recorded alongside (the user can
+  // switch emails mid-stream, so the item at completion time is the wrong
+  // baseline), so executors can refuse to open a reply on a different email
+  // than the draft was requested for.
+  const freshTrackerRef = useRef(new FreshCompletionTracker());
+  const freshItemIdentityRef = useRef(new Map<string, string>());
+  const freshTrackerChatIdRef = useRef(currentChatId);
+  const [freshMessageIds, setFreshMessageIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    // A chat switch replaces the whole message list — discard the tracker so
+    // the next snapshot is treated as history and nothing in the switched-to
+    // chat can be considered "just completed". The pending send identity
+    // belongs to the abandoned chat's in-flight exchange, so drop it too.
+    if (freshTrackerChatIdRef.current !== currentChatId) {
+      freshTrackerChatIdRef.current = currentChatId;
+      freshTrackerRef.current = new FreshCompletionTracker();
+      pendingSendItemIdentityRef.current = null;
+    }
+    const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
+    if (newlyFresh.length > 0) {
+      // Consume the send-time identity: one send maps to one completion
+      // (several ids completing at once would make the mapping ambiguous, so
+      // none of them gets the identity). A completion whose identity is
+      // unknown is NOT stamped fresh at all: it renders exactly like a
+      // history draft — buttons usable, re-guarded at confirmation time,
+      // auto-prompt impossible — instead of being bricked behind the
+      // stale-item error. Only a KNOWN identity that mismatches the open
+      // item may block a reply.
+      const sendItemIdentity =
+        newlyFresh.length === 1 ? pendingSendItemIdentityRef.current : null;
+      pendingSendItemIdentityRef.current = null;
+      if (sendItemIdentity) {
+        const completedId = newlyFresh[0];
+        freshItemIdentityRef.current.set(completedId, sendItemIdentity);
+        setFreshMessageIds((previous) => new Set([...previous, completedId]));
+      }
+    }
+  }, [messages, messageOrder, currentChatId]);
+
   const handleSendMessage = useCallback(
     (
       message: string,
@@ -489,7 +543,9 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       modelId?: string,
       selectedFacetIds?: string[],
       actionFacet?: ActionFacetRequest,
+      sendItemIdentity?: string | null,
     ) => {
+      pendingSendItemIdentityRef.current = sendItemIdentity ?? null;
       void sendMessage(
         message,
         inputFileIds,
@@ -511,6 +567,22 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       replaceInputFileIds?: string[],
       selectedFacetIds?: string[],
     ) => {
+      // The edited exchange replays the ORIGINAL email (it rides in the
+      // stored user message / facet args), so the wrong-item guard must
+      // anchor on the original exchange's send-time identity — never the
+      // item open right now, which may be a different email entirely. That
+      // identity is the one stamped as `outlookArtifact.itemIdentity` on
+      // the exchange's assistant message; when this session no longer knows
+      // it (e.g. after a reload — the map is in-memory only) the ref stays
+      // null and the new completion degrades to a history-like draft.
+      const exchangeAssistantId = messageOrder.find(
+        (id) =>
+          messages[id]?.role === "assistant" &&
+          messages[id]?.previous_message_id === messageId,
+      );
+      pendingSendItemIdentityRef.current = exchangeAssistantId
+        ? (freshItemIdentityRef.current.get(exchangeAssistantId) ?? null)
+        : null;
       void editMessage(
         messageId,
         newContent,
@@ -518,11 +590,18 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
         selectedFacetIds,
       ).finally(() => setEditState({ mode: "compose" }));
     },
-    [editMessage],
+    [editMessage, messages, messageOrder],
   );
 
   const handleRegenerate = useCallback(
     (assistantMessageId: string) => {
+      // Same anchor rule as handleEditSubmit: the regenerated exchange
+      // replays the original email, so reuse the regenerated message's own
+      // send-time identity when this session still knows it (null after a
+      // reload — the completion then degrades to a history-like draft
+      // instead of stale-bricking the reply buttons).
+      pendingSendItemIdentityRef.current =
+        freshItemIdentityRef.current.get(assistantMessageId) ?? null;
       void regenerateMessage(assistantMessageId, activeSelectedFacetIds);
     },
     [activeSelectedFacetIds, regenerateMessage],
@@ -648,35 +727,6 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
   // "suggestions" (fenced blocks render, unfenced prose stays markdown).
   const clientActionsByFacetId = useActionFacetClientActions();
 
-  // Track which assistant messages finished streaming during THIS session.
-  // Auto-prompt (presentation = "auto_prompt") may only fire for those —
-  // history loads, refetches, and chat switches never auto-open anything.
-  // The Outlook item identity at completion time is recorded alongside, so
-  // executors can refuse to open a reply when the user has meanwhile
-  // switched to a different email.
-  const freshTrackerRef = useRef(new FreshCompletionTracker());
-  const freshItemIdentityRef = useRef(new Map<string, string | null>());
-  const freshTrackerChatIdRef = useRef(currentChatId);
-  const [freshMessageIds, setFreshMessageIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
-  useEffect(() => {
-    // A chat switch replaces the whole message list — discard the tracker so
-    // the next snapshot is treated as history and nothing in the switched-to
-    // chat can be considered "just completed".
-    if (freshTrackerChatIdRef.current !== currentChatId) {
-      freshTrackerChatIdRef.current = currentChatId;
-      freshTrackerRef.current = new FreshCompletionTracker();
-    }
-    const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
-    if (newlyFresh.length > 0) {
-      for (const id of newlyFresh) {
-        freshItemIdentityRef.current.set(id, itemIdentity ?? null);
-      }
-      setFreshMessageIds((previous) => new Set([...previous, ...newlyFresh]));
-    }
-  }, [messages, messageOrder, itemIdentity, currentChatId]);
-
   const messagesWithArtifact = useMemo(() => {
     let next = messages;
     for (const id of messageOrder) {
@@ -726,12 +776,17 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           ...(clientActionInfo?.presentation
             ? { clientActionPresentation: clientActionInfo.presentation }
             : {}),
+          // `itemIdentity` is the SEND-time identity, and fresh implies it
+          // is known: completions whose identity is unknown (capture
+          // failed, edit/regenerate of an exchange this session no longer
+          // knows, ambiguous multi-id completion) were never added to
+          // `freshMessageIds`, so they render as history-like drafts. The
+          // renderer still fails closed on a fresh-but-identity-less
+          // artifact, but this component no longer produces that shape.
           ...(freshMessageIds.has(id)
             ? {
                 isFreshCompletion: true,
-                ...(freshItemIdentityRef.current.get(id)
-                  ? { itemIdentity: freshItemIdentityRef.current.get(id)! }
-                  : {}),
+                itemIdentity: freshItemIdentityRef.current.get(id)!,
               }
             : {}),
         },

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -60,6 +60,13 @@ interface AddinChatInputProps {
     modelId?: string,
     selectedFacetIds?: string[],
     actionFacet?: ActionFacetRequest,
+    /**
+     * Identity of the Outlook item open at the moment the user pressed send
+     * — the wrong-item guard's baseline for the resulting completion. `null`
+     * when no item identity was available; the owner then fails closed
+     * (the completion's artifact is treated as stale, never unguarded).
+     */
+    sendItemIdentity?: string | null,
   ) => void;
   onEditMessage?: (
     messageId: string,
@@ -611,6 +618,11 @@ export const AddinChatInput = forwardRef<
       modelId?: string,
       selectedFacetIds?: string[],
     ) => {
+      // Capture the item identity BEFORE any await: the uploads below can
+      // take long enough for the user to switch emails, and the wrong-item
+      // guard must be anchored to the item the user actually sent from.
+      const sendItemIdentity = itemIdentity;
+
       // Build the action facet (selection rewrite vs. draft review) via a pure
       // resolver so the selection-priority and draft de-dup rules stay testable.
       //
@@ -663,6 +675,7 @@ export const AddinChatInput = forwardRef<
           modelId,
           selectedFacetIds,
           actionFacet,
+          sendItemIdentity,
         );
         return;
       }
@@ -684,6 +697,7 @@ export const AddinChatInput = forwardRef<
             modelId,
             selectedFacetIds,
             actionFacet,
+            sendItemIdentity,
           );
           // No upload was attempted (e.g. only dismissed drops remain) and
           // nothing failed, so the staged drops are safe to clear.
@@ -723,6 +737,7 @@ export const AddinChatInput = forwardRef<
         modelId,
         selectedFacetIds,
         actionFacet,
+        sendItemIdentity,
       );
 
       // Clear the drops only when their files actually uploaded. On a failed
@@ -741,6 +756,7 @@ export const AddinChatInput = forwardRef<
       draftBodyText,
       hasActiveSelection,
       isDraftContextIncluded,
+      itemIdentity,
       mailItem,
       onEmailSourceDropsSent,
       replyFromReadAvailable,

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -23,6 +23,7 @@ import { useOffice } from "../providers/OfficeProvider";
 import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import { resolveOutlookActionFacet } from "../utils/outlookActionFacet";
+import { OUTLOOK_REPLY_FROM_READ_FACET_ID } from "../utils/outlookClientActions";
 import { getComposeBodyType } from "../utils/outlookComposeWrite";
 
 function validateAttachment(
@@ -138,6 +139,9 @@ export const AddinChatInput = forwardRef<
   const { host } = useOffice();
   const availableFacetIds = useAvailableActionFacetIds();
   const composeEmailAvailable = availableFacetIds.has("compose_email");
+  const replyFromReadAvailable = availableFacetIds.has(
+    OUTLOOK_REPLY_FROM_READ_FACET_ID,
+  );
   const [isUploadingEmail, setIsUploadingEmail] = useState(false);
   const composeSelection = useOutlookComposeSelection();
   const { mailItem, itemIdentity } = useOutlookMailItem();
@@ -628,6 +632,8 @@ export const AddinChatInput = forwardRef<
         bodyFormat,
         isComposeMode: !!mailItem?.isComposeMode,
         composeEmailAvailable,
+        isReadMode: !!mailItem && !mailItem.isComposeMode,
+        replyFromReadAvailable,
       });
       if (sentDraftBody !== null) {
         // Remember what we sent so an unchanged follow-up de-dupes (#4).
@@ -737,6 +743,7 @@ export const AddinChatInput = forwardRef<
       isDraftContextIncluded,
       mailItem,
       onEmailSourceDropsSent,
+      replyFromReadAvailable,
       resolveSelectedFilesForSend,
       shouldUseSuggestedEmailSource,
       stagedEmails,

--- a/office-addin/src/components/BehaviorTabContent.tsx
+++ b/office-addin/src/components/BehaviorTabContent.tsx
@@ -9,6 +9,14 @@ import {
   outlookSessionPreferencesPersistedOptions,
   type OutlookSessionPreferences,
 } from "../sessionPolicy";
+import {
+  CLIENT_ACTION_PREFERENCES_KEY,
+  DEFAULT_CLIENT_ACTION_PREFERENCES,
+  clientActionPreferencesPersistedOptions,
+  type ClientActionApprovalMode,
+  type ClientActionPreferences,
+} from "../utils/clientActionPolicy";
+import { type OutlookClientAction } from "../utils/outlookClientActions";
 
 interface BehaviorTabContentProps {
   emptyStateText: string;
@@ -26,6 +34,12 @@ export function BehaviorTabContent({
       OUTLOOK_SESSION_PREFERENCES_KEY,
       DEFAULT_OUTLOOK_SESSION_PREFERENCES,
       outlookSessionPreferencesPersistedOptions,
+    );
+  const [actionPreferences, setActionPreferences] =
+    usePersistedState<ClientActionPreferences>(
+      CLIENT_ACTION_PREFERENCES_KEY,
+      DEFAULT_CLIENT_ACTION_PREFERENCES,
+      clientActionPreferencesPersistedOptions,
     );
 
   if (!isOutlook) {
@@ -74,6 +88,69 @@ export function BehaviorTabContent({
         message:
           "Start a new chat each time when opening or switching to a different conversation.",
       }),
+    },
+  ];
+
+  // Per-action approval settings for assistant-proposed reply actions.
+  // Reply-all deliberately has no "don't ask": its confirmation doubles as
+  // the fresh-recipient check and local settings cannot downgrade it.
+  const approvalOptionLabels: Record<
+    ClientActionApprovalMode,
+    { label: string; helper: string }
+  > = {
+    dont_ask: {
+      label: t({
+        id: "officeAddin.settings.addin.replyActions.dontAsk.label",
+        message: "Open immediately",
+      }),
+      helper: t({
+        id: "officeAddin.settings.addin.replyActions.dontAsk.helper",
+        message:
+          "Opens the prefilled Outlook reply window without asking. Nothing is sent until you press Send.",
+      }),
+    },
+    always_ask: {
+      label: t({
+        id: "officeAddin.settings.addin.replyActions.alwaysAsk.label",
+        message: "Ask first",
+      }),
+      helper: t({
+        id: "officeAddin.settings.addin.replyActions.alwaysAsk.helper",
+        message: "Shows a confirmation before opening the reply window.",
+      }),
+    },
+    deny: {
+      label: t({
+        id: "officeAddin.settings.addin.replyActions.deny.label",
+        message: "Never",
+      }),
+      helper: t({
+        id: "officeAddin.settings.addin.replyActions.deny.helper",
+        message: "Hides this action and ignores the assistant's suggestion.",
+      }),
+    },
+  };
+
+  const actionGroups: ReadonlyArray<{
+    action: OutlookClientAction;
+    legend: string;
+    modes: readonly ClientActionApprovalMode[];
+  }> = [
+    {
+      action: "outlook.reply",
+      legend: t({
+        id: "officeAddin.settings.addin.replyActions.reply.legend",
+        message: "Reply to sender",
+      }),
+      modes: ["dont_ask", "always_ask", "deny"],
+    },
+    {
+      action: "outlook.reply_all",
+      legend: t({
+        id: "officeAddin.settings.addin.replyActions.replyAll.legend",
+        message: "Reply to all recipients",
+      }),
+      modes: ["always_ask", "deny"],
     },
   ];
 
@@ -146,6 +223,45 @@ export function BehaviorTabContent({
             );
           })}
         </div>
+      </fieldset>
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium text-theme-fg-primary">
+          {t({
+            id: "officeAddin.settings.addin.replyActions.legend",
+            message: "When the assistant suggests replying to an email",
+          })}
+        </legend>
+        <p className="text-xs text-theme-fg-secondary">
+          {t({
+            id: "officeAddin.settings.addin.replyActions.intro",
+            message:
+              "Applies to reading mode. Replies only open as a prefilled Outlook draft — sending always stays your manual step.",
+          })}
+        </p>
+        {actionGroups.map((group) => (
+          <div key={group.action} className="space-y-2">
+            <p className="text-xs font-medium text-theme-fg-primary">
+              {group.legend}
+            </p>
+            {group.modes.map((mode) => (
+              <RadioCard
+                key={mode}
+                size="sm"
+                name={`${radioGroupName}-${group.action}`}
+                value={mode}
+                checked={actionPreferences[group.action] === mode}
+                onChange={() =>
+                  setActionPreferences({
+                    ...actionPreferences,
+                    [group.action]: mode,
+                  })
+                }
+                label={approvalOptionLabels[mode].label}
+                helper={approvalOptionLabels[mode].helper}
+              />
+            ))}
+          </div>
+        ))}
       </fieldset>
     </div>
   );

--- a/office-addin/src/components/BehaviorTabContent.tsx
+++ b/office-addin/src/components/BehaviorTabContent.tsx
@@ -239,7 +239,12 @@ export function BehaviorTabContent({
           })}
         </p>
         {actionGroups.map((group) => (
-          <div key={group.action} className="space-y-2">
+          <div
+            key={group.action}
+            role="radiogroup"
+            aria-label={group.legend}
+            className="space-y-2"
+          >
             <p className="text-xs font-medium text-theme-fg-primary">
               {group.legend}
             </p>

--- a/office-addin/src/components/BehaviorTabContent.tsx
+++ b/office-addin/src/components/BehaviorTabContent.tsx
@@ -2,6 +2,7 @@ import { RadioCard, usePersistedState } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { useId } from "react";
 
+import { useActionFacetClientActions } from "../hooks/useAvailableActionFacets";
 import { useOffice } from "../providers/OfficeProvider";
 import {
   DEFAULT_OUTLOOK_SESSION_PREFERENCES,
@@ -10,13 +11,17 @@ import {
   type OutlookSessionPreferences,
 } from "../sessionPolicy";
 import {
-  CLIENT_ACTION_PREFERENCES_KEY,
-  DEFAULT_CLIENT_ACTION_PREFERENCES,
-  clientActionPreferencesPersistedOptions,
-  type ClientActionApprovalMode,
-  type ClientActionPreferences,
+  CLIENT_ACTION_DECISIONS_KEY,
+  DEFAULT_CLIENT_ACTION_DECISIONS,
+  clientActionDecisionsPersistedOptions,
+  decisionKey,
+  effectiveDecision,
+  type ClientActionDecision,
 } from "../utils/clientActionPolicy";
-import { type OutlookClientAction } from "../utils/outlookClientActions";
+import {
+  clientActionDisplayLabel,
+  offerableClientActions,
+} from "../utils/outlookClientActions";
 
 interface BehaviorTabContentProps {
   emptyStateText: string;
@@ -35,12 +40,15 @@ export function BehaviorTabContent({
       DEFAULT_OUTLOOK_SESSION_PREFERENCES,
       outlookSessionPreferencesPersistedOptions,
     );
-  const [actionPreferences, setActionPreferences] =
-    usePersistedState<ClientActionPreferences>(
-      CLIENT_ACTION_PREFERENCES_KEY,
-      DEFAULT_CLIENT_ACTION_PREFERENCES,
-      clientActionPreferencesPersistedOptions,
-    );
+  const [decisions, setDecisions] = usePersistedState(
+    CLIENT_ACTION_DECISIONS_KEY,
+    DEFAULT_CLIENT_ACTION_DECISIONS,
+    clientActionDecisionsPersistedOptions,
+  );
+  // The settings rows mirror what the backend actually advertises: one group
+  // per facet with client actions, one decision toggle per implemented
+  // action. No facets advertised → the whole section is hidden.
+  const clientActionFacets = useActionFacetClientActions();
 
   if (!isOutlook) {
     return (
@@ -91,68 +99,65 @@ export function BehaviorTabContent({
     },
   ];
 
-  // Per-action approval settings for assistant-proposed reply actions.
-  // Reply-all deliberately has no "don't ask": its confirmation doubles as
-  // the fresh-recipient check and local settings cannot downgrade it.
-  const approvalOptionLabels: Record<
-    ClientActionApprovalMode,
+  // Decision toggles mirror the stored per-facet+action decisions written by
+  // the inline permission card. Always the same three options; defaults to
+  // "ask" until the user decides otherwise.
+  const decisionOptionLabels: Record<
+    ClientActionDecision,
     { label: string; helper: string }
   > = {
-    dont_ask: {
+    ask: {
       label: t({
-        id: "officeAddin.settings.addin.replyActions.dontAsk.label",
-        message: "Open immediately",
+        id: "officeAddin.settings.addin.clientActions.ask.label",
+        message: "Ask every time",
       }),
       helper: t({
-        id: "officeAddin.settings.addin.replyActions.dontAsk.helper",
+        id: "officeAddin.settings.addin.clientActions.ask.helper",
         message:
-          "Opens the prefilled Outlook reply window without asking. Nothing is sent until you press Send.",
+          "Shows a confirmation step in the chat before opening anything.",
       }),
     },
-    always_ask: {
+    always: {
       label: t({
-        id: "officeAddin.settings.addin.replyActions.alwaysAsk.label",
-        message: "Ask first",
+        id: "officeAddin.settings.addin.clientActions.always.label",
+        message: "Always allow",
       }),
       helper: t({
-        id: "officeAddin.settings.addin.replyActions.alwaysAsk.helper",
-        message: "Shows a confirmation before opening the reply window.",
+        id: "officeAddin.settings.addin.clientActions.always.helper",
+        message:
+          "Performs the action without asking. Nothing is sent until you press Send in Outlook.",
       }),
     },
-    deny: {
+    never: {
       label: t({
-        id: "officeAddin.settings.addin.replyActions.deny.label",
+        id: "officeAddin.settings.addin.clientActions.never.label",
         message: "Never",
       }),
       helper: t({
-        id: "officeAddin.settings.addin.replyActions.deny.helper",
+        id: "officeAddin.settings.addin.clientActions.never.helper",
         message: "Hides this action and ignores the assistant's suggestion.",
       }),
     },
   };
-
-  const actionGroups: ReadonlyArray<{
-    action: OutlookClientAction;
-    legend: string;
-    modes: readonly ClientActionApprovalMode[];
-  }> = [
-    {
-      action: "outlook.reply",
-      legend: t({
-        id: "officeAddin.settings.addin.replyActions.reply.legend",
-        message: "Reply to sender",
-      }),
-      modes: ["dont_ask", "always_ask", "deny"],
-    },
-    {
-      action: "outlook.reply_all",
-      legend: t({
-        id: "officeAddin.settings.addin.replyActions.replyAll.legend",
-        message: "Reply to all recipients",
-      }),
-      modes: ["always_ask", "deny"],
-    },
+  const alwaysLockedHelper = t({
+    id: "officeAddin.settings.addin.clientActions.always.locked",
+    message:
+      "Locked: your organization requires confirmation for this action every time.",
+  });
+  const decisionOrder: readonly ClientActionDecision[] = [
+    "ask",
+    "always",
+    "never",
   ];
+
+  const clientActionGroups = [...clientActionFacets.entries()].flatMap(
+    ([facetId, info]) => {
+      const actions = offerableClientActions(info.clientActions);
+      return actions.length > 0
+        ? [{ facetId, displayName: info.displayName, actions, info }]
+        : [];
+    },
+  );
 
   const composeToggleLabel = t({
     id: "officeAddin.settings.addin.composeInherits.label",
@@ -224,50 +229,79 @@ export function BehaviorTabContent({
           })}
         </div>
       </fieldset>
-      <fieldset className="space-y-3">
-        <legend className="text-sm font-medium text-theme-fg-primary">
-          {t({
-            id: "officeAddin.settings.addin.replyActions.legend",
-            message: "When the assistant suggests replying to an email",
-          })}
-        </legend>
-        <p className="text-xs text-theme-fg-secondary">
-          {t({
-            id: "officeAddin.settings.addin.replyActions.intro",
-            message:
-              "Applies to reading mode. Replies only open as a prefilled Outlook draft — sending always stays your manual step.",
-          })}
-        </p>
-        {actionGroups.map((group) => (
-          <div
-            key={group.action}
-            role="radiogroup"
-            aria-label={group.legend}
-            className="space-y-2"
-          >
-            <p className="text-xs font-medium text-theme-fg-primary">
-              {group.legend}
-            </p>
-            {group.modes.map((mode) => (
-              <RadioCard
-                key={mode}
-                size="sm"
-                name={`${radioGroupName}-${group.action}`}
-                value={mode}
-                checked={actionPreferences[group.action] === mode}
-                onChange={() =>
-                  setActionPreferences({
-                    ...actionPreferences,
-                    [group.action]: mode,
-                  })
-                }
-                label={approvalOptionLabels[mode].label}
-                helper={approvalOptionLabels[mode].helper}
-              />
-            ))}
-          </div>
-        ))}
-      </fieldset>
+      {clientActionGroups.length > 0 && (
+        <fieldset className="space-y-3">
+          <legend className="text-sm font-medium text-theme-fg-primary">
+            {t({
+              id: "officeAddin.settings.addin.clientActions.legend",
+              message: "Assistant-suggested actions",
+            })}
+          </legend>
+          <p className="text-xs text-theme-fg-secondary">
+            {t({
+              id: "officeAddin.settings.addin.clientActions.intro",
+              message:
+                "Your decisions from the in-chat confirmation are stored here and can be changed any time. Nothing is sent until you press Send in Outlook.",
+            })}
+          </p>
+          {clientActionGroups.map((group) => (
+            <div key={group.facetId} className="space-y-3">
+              <p className="text-xs font-medium text-theme-fg-primary">
+                {group.displayName}
+              </p>
+              {group.actions.map((action) => {
+                const enforced = group.info.alwaysAskActions.includes(action);
+                const current = effectiveDecision({
+                  facetId: group.facetId,
+                  action,
+                  decisions,
+                  enforcedAskActions: group.info.alwaysAskActions,
+                });
+                return (
+                  <div
+                    key={action}
+                    role="radiogroup"
+                    aria-label={clientActionDisplayLabel(action)}
+                    className="space-y-2"
+                  >
+                    <p className="text-xs text-theme-fg-secondary">
+                      {clientActionDisplayLabel(action)}
+                    </p>
+                    {decisionOrder.map((decision) => {
+                      const lockedAlways = decision === "always" && enforced;
+                      return (
+                        <RadioCard
+                          key={decision}
+                          size="sm"
+                          name={`${radioGroupName}-${group.facetId}-${action}`}
+                          value={decision}
+                          checked={current === decision}
+                          disabled={lockedAlways}
+                          onChange={() => {
+                            if (lockedAlways) {
+                              return;
+                            }
+                            setDecisions({
+                              ...decisions,
+                              [decisionKey(group.facetId, action)]: decision,
+                            });
+                          }}
+                          label={decisionOptionLabels[decision].label}
+                          helper={
+                            lockedAlways
+                              ? alwaysLockedHelper
+                              : decisionOptionLabels[decision].helper
+                          }
+                        />
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </fieldset>
+      )}
     </div>
   );
 }

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -2,12 +2,21 @@ import {
   ConfirmationDialog,
   sanitizeHtmlPreview,
   useOutlookArtifact,
+  usePersistedState,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
+import {
+  CLIENT_ACTION_PREFERENCES_KEY,
+  DEFAULT_CLIENT_ACTION_PREFERENCES,
+  clientActionPreferencesPersistedOptions,
+  isActionDenied,
+  resolveAutoPromptBehavior,
+  resolveClickBehavior,
+} from "../utils/clientActionPolicy";
 import {
   offerableClientActions,
   type OutlookClientAction,
@@ -29,6 +38,13 @@ const PRIMARY_ACTION_BUTTON_CLASS =
   "rounded-md border border-theme-border bg-theme-bg-tertiary px-3 py-1 text-xs font-medium hover:bg-theme-bg-hover disabled:opacity-50";
 
 /**
+ * Auto-prompt fires at most once per assistant message, across remounts
+ * (virtualized lists unmount/remount renderers) and across multiple fences
+ * within one message. Module-level by design.
+ */
+const firedAutoPrompts = new Set<string>();
+
+/**
  * Office-aware renderer for erato-email code blocks.
  * Registered via componentRegistry in main.tsx so the shared MessageContent
  * delegates to this component when running inside the Outlook addin.
@@ -39,9 +55,13 @@ const PRIMARY_ACTION_BUTTON_CLASS =
  * Read mode: when the producing facet allows client actions (reply /
  * reply-all from `GET /me/facets`, intersected with the add-in's fixed
  * registry), buttons that open Outlook's native reply form prefilled with the
- * draft. The model's proposal only chooses which button is primary — nothing
- * runs without an explicit click, reply-all asks for confirmation against
- * freshly read recipients, and sending always stays a manual step in Outlook.
+ * draft. Per-action local approval preferences apply: "deny" hides an action,
+ * "always ask" confirms before opening (reply-all is floored here and shows
+ * freshly read recipients), "don't ask" opens directly. Under the facet's
+ * `auto_prompt` presentation the proposed action may surface immediately —
+ * but only after a FRESH assistant completion, never from history, and still
+ * subject to the same preferences. Sending always stays a manual user step
+ * in Outlook's own compose window.
  */
 export function OutlookEratoEmailRenderer({
   content,
@@ -52,13 +72,20 @@ export function OutlookEratoEmailRenderer({
   const { mailItem } = useOutlookMailItem();
   const artifact = useOutlookArtifact();
   const isReadMode = !!mailItem && !mailItem.isComposeMode;
+  const [actionPreferences] = usePersistedState(
+    CLIENT_ACTION_PREFERENCES_KEY,
+    DEFAULT_CLIENT_ACTION_PREFERENCES,
+    clientActionPreferencesPersistedOptions,
+  );
 
   const readActions = useMemo<OutlookClientAction[]>(
     () =>
       isReadMode && isReadReplySupported()
-        ? offerableClientActions(artifact?.allowedClientActions)
+        ? offerableClientActions(artifact?.allowedClientActions).filter(
+            (action) => !isActionDenied(action, actionPreferences),
+          )
         : [],
-    [isReadMode, artifact],
+    [isReadMode, artifact, actionPreferences],
   );
   const proposedAction =
     artifact?.proposedClientAction &&
@@ -72,7 +99,8 @@ export function OutlookEratoEmailRenderer({
   const [errorKind, setErrorKind] = useState<"insert" | "reply" | "tooLarge">(
     "insert",
   );
-  const [pendingReplyAll, setPendingReplyAll] = useState<{
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    action: OutlookClientAction;
     recipients: ReadModeRecipientSummary;
   } | null>(null);
   const isBusy = status === "inserting";
@@ -114,26 +142,73 @@ export function OutlookEratoEmailRenderer({
     [content, isHtml],
   );
 
+  // Open the confirmation dialog with recipients RE-READ from the current
+  // item — the user confirms against fresh data, not against whatever the
+  // chat message was generated from.
+  const requestConfirmation = useCallback(
+    (action: OutlookClientAction): boolean => {
+      const recipients = getReadModeRecipientSummary();
+      if (!recipients) {
+        return false;
+      }
+      setPendingConfirm({ action, recipients });
+      return true;
+    },
+    [],
+  );
+
   const handleReplyAction = useCallback(
     (action: OutlookClientAction) => {
-      if (action === "outlook.reply_all") {
-        // Re-read the recipients of the CURRENT item at click time so the
-        // confirmation reflects what reply-all will actually address — not
-        // what the chat message was generated from.
-        const recipients = getReadModeRecipientSummary();
-        if (!recipients) {
-          setErrorKind("reply");
-          setStatus("error");
-          setTimeout(() => setStatus("idle"), 4000);
-          return;
-        }
-        setPendingReplyAll({ recipients });
+      if (resolveClickBehavior(action, actionPreferences) === "execute") {
+        void executeReply(action);
         return;
       }
-      void executeReply(action);
+      if (!requestConfirmation(action)) {
+        setErrorKind("reply");
+        setStatus("error");
+        setTimeout(() => setStatus("idle"), 4000);
+      }
     },
-    [executeReply],
+    [actionPreferences, executeReply, requestConfirmation],
   );
+
+  // Auto-prompt: only under the facet's `auto_prompt` presentation, only for
+  // a validated proposal on a FRESH completion (stamped by AddinChat — never
+  // history reloads), at most once per message, and still through the user's
+  // approval preference ("don't ask" opens the form, "ask" opens the
+  // confirmation dialog). If the user meanwhile left read mode,
+  // requestConfirmation returns false and nothing happens — the buttons
+  // remain as fallback.
+  const autoPromptBehavior = resolveAutoPromptBehavior({
+    presentation: artifact?.clientActionPresentation,
+    proposedAction,
+    isFreshCompletion: !!artifact?.isFreshCompletion,
+    preferences: actionPreferences,
+  });
+  const autoPromptMessageId = artifact?.messageId;
+  useEffect(() => {
+    if (autoPromptBehavior === "none") {
+      return;
+    }
+    if (!autoPromptMessageId || !proposedAction) {
+      return;
+    }
+    if (firedAutoPrompts.has(autoPromptMessageId)) {
+      return;
+    }
+    firedAutoPrompts.add(autoPromptMessageId);
+    if (autoPromptBehavior === "execute") {
+      void executeReply(proposedAction);
+    } else {
+      requestConfirmation(proposedAction);
+    }
+  }, [
+    autoPromptBehavior,
+    autoPromptMessageId,
+    proposedAction,
+    executeReply,
+    requestConfirmation,
+  ]);
 
   const handleCopy = useCallback(() => {
     void navigator.clipboard
@@ -189,9 +264,10 @@ export function OutlookEratoEmailRenderer({
       ]
     : readActions;
 
-  const replyAllRecipientCount = pendingReplyAll
-    ? pendingReplyAll.recipients.recipients.length +
-      (pendingReplyAll.recipients.sender ? 1 : 0)
+  const isConfirmingReplyAll = pendingConfirm?.action === "outlook.reply_all";
+  const confirmRecipientCount = pendingConfirm
+    ? (isConfirmingReplyAll ? pendingConfirm.recipients.recipients.length : 0) +
+      (pendingConfirm.recipients.sender ? 1 : 0)
     : 0;
 
   return (
@@ -276,40 +352,65 @@ export function OutlookEratoEmailRenderer({
         </p>
       )}
       <ConfirmationDialog
-        isOpen={pendingReplyAll !== null}
-        onClose={() => setPendingReplyAll(null)}
+        isOpen={pendingConfirm !== null}
+        onClose={() => setPendingConfirm(null)}
         onConfirm={() => {
-          setPendingReplyAll(null);
-          void executeReply("outlook.reply_all");
+          const action = pendingConfirm?.action;
+          setPendingConfirm(null);
+          if (action) {
+            void executeReply(action);
+          }
         }}
-        title={t({
-          id: "officeAddin.emailRenderer.replyAllConfirmTitle",
-          message: "Reply to all recipients?",
-        })}
+        title={
+          isConfirmingReplyAll
+            ? t({
+                id: "officeAddin.emailRenderer.replyAllConfirmTitle",
+                message: "Reply to all recipients?",
+              })
+            : t({
+                id: "officeAddin.emailRenderer.replyConfirmTitle",
+                message: "Open this reply?",
+              })
+        }
         message={
           <div className="space-y-2 text-sm text-theme-fg-secondary">
             <p>
-              {t({
-                id: "officeAddin.emailRenderer.replyAllConfirmMessage",
-                message: `This opens a reply addressed to ${replyAllRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook.`,
-              })}
+              {isConfirmingReplyAll
+                ? t({
+                    id: "officeAddin.emailRenderer.replyAllConfirmMessage",
+                    message: `This opens a reply addressed to ${confirmRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook.`,
+                  })
+                : t({
+                    id: "officeAddin.emailRenderer.replyConfirmMessage",
+                    message:
+                      "This opens a prefilled reply to the sender of the email you are reading. Nothing is sent until you press Send in Outlook.",
+                  })}
             </p>
-            {pendingReplyAll && (
+            {pendingConfirm && (
               <p className="break-words text-xs">
                 {[
-                  ...(pendingReplyAll.recipients.sender
-                    ? [pendingReplyAll.recipients.sender]
+                  ...(pendingConfirm.recipients.sender
+                    ? [pendingConfirm.recipients.sender]
                     : []),
-                  ...pendingReplyAll.recipients.recipients,
+                  ...(isConfirmingReplyAll
+                    ? pendingConfirm.recipients.recipients
+                    : []),
                 ].join(", ")}
               </p>
             )}
           </div>
         }
-        confirmButtonText={t({
-          id: "officeAddin.emailRenderer.replyAllConfirm",
-          message: "Open Reply All",
-        })}
+        confirmButtonText={
+          isConfirmingReplyAll
+            ? t({
+                id: "officeAddin.emailRenderer.replyAllConfirm",
+                message: "Open Reply All",
+              })
+            : t({
+                id: "officeAddin.emailRenderer.replyConfirm",
+                message: "Open Reply",
+              })
+        }
       />
     </div>
   );

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -1,5 +1,5 @@
 import {
-  ConfirmationDialog,
+  ActionConfirmationCard,
   sanitizeHtmlPreview,
   useOutlookArtifact,
   usePersistedState,
@@ -113,6 +113,8 @@ export function OutlookEratoEmailRenderer({
   const [pendingConfirm, setPendingConfirm] = useState<{
     action: OutlookClientAction;
     recipients: ReadModeRecipientSummary;
+    /** Surfaced by auto-prompt (scrolls into view) rather than a click. */
+    autoTriggered: boolean;
   } | null>(null);
   const isBusy = status === "inserting";
   const previewHtml = useMemo(
@@ -185,16 +187,16 @@ export function OutlookEratoEmailRenderer({
     [content, isHtml, isStaleForCurrentItem, scheduleStatusReset, showError],
   );
 
-  // Open the confirmation dialog with recipients RE-READ from the current
-  // item — the user confirms against fresh data, not against whatever the
-  // chat message was generated from.
+  // Open the inline confirmation card with recipients RE-READ from the
+  // current item — the user confirms against fresh data, not against
+  // whatever the chat message was generated from.
   const requestConfirmation = useCallback(
-    (action: OutlookClientAction): boolean => {
+    (action: OutlookClientAction, autoTriggered = false): boolean => {
       const recipients = getReadModeRecipientSummary();
       if (!recipients) {
         return false;
       }
-      setPendingConfirm({ action, recipients });
+      setPendingConfirm({ action, recipients, autoTriggered });
       return true;
     },
     [],
@@ -228,8 +230,8 @@ export function OutlookEratoEmailRenderer({
   // Auto-prompt: only under the facet's `auto_prompt` presentation, only for
   // a validated proposal on a FRESH completion (stamped by AddinChat — never
   // history reloads), at most once per message, and still through the user's
-  // approval preference ("don't ask" opens the form, "ask" opens the
-  // confirmation dialog). If the user meanwhile left read mode,
+  // approval preference ("don't ask" opens the form, "ask" surfaces the
+  // inline confirmation card). If the user meanwhile left read mode,
   // requestConfirmation returns false and nothing happens — the buttons
   // remain as fallback.
   const autoPromptBehavior = resolveAutoPromptBehavior({
@@ -259,7 +261,7 @@ export function OutlookEratoEmailRenderer({
     if (autoPromptBehavior === "execute") {
       void executeReply(proposedAction);
     } else {
-      requestConfirmation(proposedAction);
+      requestConfirmation(proposedAction, true);
     }
   }, [
     autoPromptBehavior,
@@ -349,7 +351,7 @@ export function OutlookEratoEmailRenderer({
                 key={action}
                 type="button"
                 onClick={() => handleReplyAction(action)}
-                disabled={isBusy}
+                disabled={isBusy || pendingConfirm !== null}
                 className={
                   index === 0 && proposedAction
                     ? PRIMARY_ACTION_BUTTON_CLASS
@@ -417,46 +419,37 @@ export function OutlookEratoEmailRenderer({
                   })}
         </p>
       )}
-      <ConfirmationDialog
-        isOpen={pendingConfirm !== null}
-        onClose={() => setPendingConfirm(null)}
-        onConfirm={() => {
-          const action = pendingConfirm?.action;
-          setPendingConfirm(null);
-          if (action) {
-            void executeReply(action);
+      {pendingConfirm && (
+        <ActionConfirmationCard
+          title={
+            isConfirmingReplyAll
+              ? t({
+                  id: "officeAddin.emailRenderer.replyAllConfirmTitle",
+                  message: "Reply to all recipients?",
+                })
+              : t({
+                  id: "officeAddin.emailRenderer.replyConfirmTitle",
+                  message: "Open this reply?",
+                })
           }
-        }}
-        title={
-          isConfirmingReplyAll
-            ? t({
-                id: "officeAddin.emailRenderer.replyAllConfirmTitle",
-                message: "Reply to all recipients?",
-              })
-            : t({
-                id: "officeAddin.emailRenderer.replyConfirmTitle",
-                message: "Open this reply?",
-              })
-        }
-        message={
-          <div className="space-y-2 text-sm text-theme-fg-secondary">
-            <p>
-              {isConfirmingReplyAll
-                ? t({
-                    id: "officeAddin.emailRenderer.replyAllConfirmMessage",
-                    message: plural(confirmRecipientCount, {
-                      one: "This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.",
-                      other:
-                        "This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.",
-                    }),
-                  })
-                : t({
-                    id: "officeAddin.emailRenderer.replyConfirmMessage",
-                    message:
-                      "This opens a prefilled reply to the sender of the email you are reading. Nothing is sent until you press Send in Outlook.",
-                  })}
-            </p>
-            {pendingConfirm && (
+          description={
+            <div className="space-y-2 text-sm text-theme-fg-secondary">
+              <p>
+                {isConfirmingReplyAll
+                  ? t({
+                      id: "officeAddin.emailRenderer.replyAllConfirmMessage",
+                      message: plural(confirmRecipientCount, {
+                        one: "This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.",
+                        other:
+                          "This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.",
+                      }),
+                    })
+                  : t({
+                      id: "officeAddin.emailRenderer.replyConfirmMessage",
+                      message:
+                        "This opens a prefilled reply to the sender of the email you are reading. Nothing is sent until you press Send in Outlook.",
+                    })}
+              </p>
               <p className="break-words text-xs">
                 {[
                   ...(pendingConfirm.recipients.sender
@@ -467,21 +460,29 @@ export function OutlookEratoEmailRenderer({
                     : []),
                 ].join(", ")}
               </p>
-            )}
-          </div>
-        }
-        confirmButtonText={
-          isConfirmingReplyAll
-            ? t({
-                id: "officeAddin.emailRenderer.replyAllConfirm",
-                message: "Open Reply All",
-              })
-            : t({
-                id: "officeAddin.emailRenderer.replyConfirm",
-                message: "Open Reply",
-              })
-        }
-      />
+            </div>
+          }
+          confirmLabel={
+            isConfirmingReplyAll
+              ? t({
+                  id: "officeAddin.emailRenderer.replyAllConfirm",
+                  message: "Open Reply All",
+                })
+              : t({
+                  id: "officeAddin.emailRenderer.replyConfirm",
+                  message: "Open Reply",
+                })
+          }
+          onConfirm={() => {
+            const action = pendingConfirm.action;
+            setPendingConfirm(null);
+            void executeReply(action);
+          }}
+          onDismiss={() => setPendingConfirm(null)}
+          isBusy={isBusy}
+          scrollIntoViewOnMount={pendingConfirm.autoTriggered}
+        />
+      )}
     </div>
   );
 }

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -4,7 +4,7 @@ import {
   useOutlookArtifact,
   usePersistedState,
 } from "@erato/frontend/library";
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
@@ -444,7 +444,11 @@ export function OutlookEratoEmailRenderer({
               {isConfirmingReplyAll
                 ? t({
                     id: "officeAddin.emailRenderer.replyAllConfirmMessage",
-                    message: `This opens a reply addressed to ${confirmRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook.`,
+                    message: plural(confirmRecipientCount, {
+                      one: "This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.",
+                      other:
+                        "This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.",
+                    }),
                   })
                 : t({
                     id: "officeAddin.emailRenderer.replyConfirmMessage",

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -10,14 +10,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import {
-  CLIENT_ACTION_PREFERENCES_KEY,
-  DEFAULT_CLIENT_ACTION_PREFERENCES,
-  clientActionPreferencesPersistedOptions,
+  CLIENT_ACTION_DECISIONS_KEY,
+  DEFAULT_CLIENT_ACTION_DECISIONS,
+  clientActionDecisionsPersistedOptions,
+  decisionKey,
   isActionDenied,
   resolveAutoPromptBehavior,
   resolveClickBehavior,
 } from "../utils/clientActionPolicy";
 import {
+  clientActionDisplayLabel,
   offerableClientActions,
   type OutlookClientAction,
 } from "../utils/outlookClientActions";
@@ -80,20 +82,31 @@ export function OutlookEratoEmailRenderer({
   const expectedItemIdentity = artifact?.itemIdentity;
   const isStaleForCurrentItem =
     !!expectedItemIdentity && itemIdentity !== expectedItemIdentity;
-  const [actionPreferences] = usePersistedState(
-    CLIENT_ACTION_PREFERENCES_KEY,
-    DEFAULT_CLIENT_ACTION_PREFERENCES,
-    clientActionPreferencesPersistedOptions,
+  const [decisions, setDecisions] = usePersistedState(
+    CLIENT_ACTION_DECISIONS_KEY,
+    DEFAULT_CLIENT_ACTION_DECISIONS,
+    clientActionDecisionsPersistedOptions,
+  );
+  const facetId = artifact?.facetId ?? "";
+  const enforcedAskActions = useMemo(
+    () => artifact?.alwaysAskClientActions ?? [],
+    [artifact],
   );
 
   const readActions = useMemo<OutlookClientAction[]>(
     () =>
       isReadMode && isReadReplySupported()
         ? offerableClientActions(artifact?.allowedClientActions).filter(
-            (action) => !isActionDenied(action, actionPreferences),
+            (action) =>
+              !isActionDenied({
+                facetId,
+                action,
+                decisions,
+                enforcedAskActions,
+              }),
           )
         : [],
-    [isReadMode, artifact, actionPreferences],
+    [isReadMode, artifact, facetId, decisions, enforcedAskActions],
   );
   const proposedAction =
     artifact?.proposedClientAction &&
@@ -210,7 +223,14 @@ export function OutlookEratoEmailRenderer({
         showError("staleItem", 4000);
         return;
       }
-      if (resolveClickBehavior(action, actionPreferences) === "execute") {
+      if (
+        resolveClickBehavior({
+          facetId,
+          action,
+          decisions,
+          enforcedAskActions,
+        }) === "execute"
+      ) {
         void executeReply(action);
         return;
       }
@@ -219,8 +239,10 @@ export function OutlookEratoEmailRenderer({
       }
     },
     [
-      actionPreferences,
+      decisions,
+      enforcedAskActions,
       executeReply,
+      facetId,
       isStaleForCurrentItem,
       requestConfirmation,
       showError,
@@ -236,9 +258,11 @@ export function OutlookEratoEmailRenderer({
   // remain as fallback.
   const autoPromptBehavior = resolveAutoPromptBehavior({
     presentation: artifact?.clientActionPresentation,
+    facetId: artifact?.facetId,
     proposedAction,
     isFreshCompletion: !!artifact?.isFreshCompletion,
-    preferences: actionPreferences,
+    decisions,
+    enforcedAskActions,
   });
   const autoPromptMessageId = artifact?.messageId;
   useEffect(() => {
@@ -421,19 +445,11 @@ export function OutlookEratoEmailRenderer({
       )}
       {pendingConfirm && (
         <ActionConfirmationCard
-          title={
-            isConfirmingReplyAll
-              ? t({
-                  id: "officeAddin.emailRenderer.replyAllConfirmTitle",
-                  message: "Reply to all recipients?",
-                })
-              : t({
-                  id: "officeAddin.emailRenderer.replyConfirmTitle",
-                  message: "Open this reply?",
-                })
-          }
           description={
             <div className="space-y-2 text-sm text-theme-fg-secondary">
+              <p className="font-medium text-theme-fg-primary">
+                {clientActionDisplayLabel(pendingConfirm.action)}
+              </p>
               <p>
                 {isConfirmingReplyAll
                   ? t({
@@ -462,23 +478,32 @@ export function OutlookEratoEmailRenderer({
               </p>
             </div>
           }
-          confirmLabel={
-            isConfirmingReplyAll
-              ? t({
-                  id: "officeAddin.emailRenderer.replyAllConfirm",
-                  message: "Open Reply All",
-                })
-              : t({
-                  id: "officeAddin.emailRenderer.replyConfirm",
-                  message: "Open Reply",
-                })
-          }
-          onConfirm={() => {
+          onAllowOnce={() => {
             const action = pendingConfirm.action;
             setPendingConfirm(null);
             void executeReply(action);
           }}
-          onDismiss={() => setPendingConfirm(null)}
+          onAlwaysAllow={() => {
+            // Persist the grant for THIS facet + action, then execute. The
+            // store is the source the settings page mirrors and revises.
+            const action = pendingConfirm.action;
+            setDecisions({
+              ...decisions,
+              [decisionKey(facetId, action)]: "always",
+            });
+            setPendingConfirm(null);
+            void executeReply(action);
+          }}
+          alwaysAllowDisabledReason={
+            enforcedAskActions.includes(pendingConfirm.action)
+              ? t({
+                  id: "officeAddin.emailRenderer.alwaysAllowLocked",
+                  message:
+                    "Your organization requires confirmation for this action every time.",
+                })
+              : undefined
+          }
+          onDeny={() => setPendingConfirm(null)}
           isBusy={isBusy}
           scrollIntoViewOnMount={pendingConfirm.autoTriggered}
         />

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -1,21 +1,47 @@
-import { sanitizeHtmlPreview } from "@erato/frontend/library";
+import {
+  ConfirmationDialog,
+  sanitizeHtmlPreview,
+  useOutlookArtifact,
+} from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { useCallback, useMemo, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
+import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
+import {
+  offerableClientActions,
+  type OutlookClientAction,
+} from "../utils/outlookClientActions";
 import { replaceComposeSelection } from "../utils/outlookComposeWrite";
+import {
+  ReplyBodyTooLargeError,
+  getReadModeRecipientSummary,
+  isReadReplySupported,
+  openReplyForm,
+  type ReadModeRecipientSummary,
+} from "../utils/outlookReadReply";
 
 import type { EratoEmailCodeBlockProps } from "@erato/frontend/library";
+
+const ACTION_BUTTON_CLASS =
+  "rounded-md border border-theme-border bg-theme-bg-primary px-3 py-1 text-xs hover:bg-theme-bg-tertiary disabled:opacity-50";
+const PRIMARY_ACTION_BUTTON_CLASS =
+  "rounded-md border border-theme-border bg-theme-bg-tertiary px-3 py-1 text-xs font-medium hover:bg-theme-bg-hover disabled:opacity-50";
 
 /**
  * Office-aware renderer for erato-email code blocks.
  * Registered via componentRegistry in main.tsx so the shared MessageContent
  * delegates to this component when running inside the Outlook addin.
  *
- * Provides action buttons that write back into the Outlook compose body
- * via Office.js setSelectedDataAsync. Button labels adapt dynamically:
- * - "Replace Selection" when text is selected in the compose window
- * - "Insert at Cursor" when nothing is selected
+ * Compose mode: action buttons that write back into the Outlook compose body
+ * via Office.js setSelectedDataAsync ("Replace Selection" / "Insert at Cursor").
+ *
+ * Read mode: when the producing facet allows client actions (reply /
+ * reply-all from `GET /me/facets`, intersected with the add-in's fixed
+ * registry), buttons that open Outlook's native reply form prefilled with the
+ * draft. The model's proposal only chooses which button is primary — nothing
+ * runs without an explicit click, reply-all asks for confirmation against
+ * freshly read recipients, and sending always stays a manual step in Outlook.
  */
 export function OutlookEratoEmailRenderer({
   content,
@@ -23,10 +49,32 @@ export function OutlookEratoEmailRenderer({
 }: EratoEmailCodeBlockProps) {
   const composeSelection = useOutlookComposeSelection();
   const hasSelection = composeSelection.data.length > 0;
+  const { mailItem } = useOutlookMailItem();
+  const artifact = useOutlookArtifact();
+  const isReadMode = !!mailItem && !mailItem.isComposeMode;
+
+  const readActions = useMemo<OutlookClientAction[]>(
+    () =>
+      isReadMode && isReadReplySupported()
+        ? offerableClientActions(artifact?.allowedClientActions)
+        : [],
+    [isReadMode, artifact],
+  );
+  const proposedAction =
+    artifact?.proposedClientAction &&
+    (readActions as string[]).includes(artifact.proposedClientAction)
+      ? (artifact.proposedClientAction as OutlookClientAction)
+      : undefined;
 
   const [status, setStatus] = useState<
     "idle" | "inserting" | "done" | "copied" | "error"
   >("idle");
+  const [errorKind, setErrorKind] = useState<"insert" | "reply" | "tooLarge">(
+    "insert",
+  );
+  const [pendingReplyAll, setPendingReplyAll] = useState<{
+    recipients: ReadModeRecipientSummary;
+  } | null>(null);
   const isBusy = status === "inserting";
   const previewHtml = useMemo(
     () => (isHtml ? sanitizeHtmlPreview(content) : null),
@@ -41,10 +89,51 @@ export function OutlookEratoEmailRenderer({
       setTimeout(() => setStatus("idle"), 2000);
     } catch (err) {
       console.warn("Failed to insert into compose body:", err);
+      setErrorKind("insert");
       setStatus("error");
       setTimeout(() => setStatus("idle"), 2000);
     }
   }, [content, isHtml]);
+
+  const executeReply = useCallback(
+    async (action: OutlookClientAction) => {
+      setStatus("inserting");
+      try {
+        await openReplyForm(action, content, !!isHtml);
+        setStatus("done");
+        setTimeout(() => setStatus("idle"), 2000);
+      } catch (err) {
+        console.warn("Failed to open reply form:", err);
+        setErrorKind(
+          err instanceof ReplyBodyTooLargeError ? "tooLarge" : "reply",
+        );
+        setStatus("error");
+        setTimeout(() => setStatus("idle"), 4000);
+      }
+    },
+    [content, isHtml],
+  );
+
+  const handleReplyAction = useCallback(
+    (action: OutlookClientAction) => {
+      if (action === "outlook.reply_all") {
+        // Re-read the recipients of the CURRENT item at click time so the
+        // confirmation reflects what reply-all will actually address — not
+        // what the chat message was generated from.
+        const recipients = getReadModeRecipientSummary();
+        if (!recipients) {
+          setErrorKind("reply");
+          setStatus("error");
+          setTimeout(() => setStatus("idle"), 4000);
+          return;
+        }
+        setPendingReplyAll({ recipients });
+        return;
+      }
+      void executeReply(action);
+    },
+    [executeReply],
+  );
 
   const handleCopy = useCallback(() => {
     void navigator.clipboard
@@ -80,6 +169,31 @@ export function OutlookEratoEmailRenderer({
         });
   })();
 
+  const replyActionLabel = (action: OutlookClientAction) =>
+    action === "outlook.reply_all"
+      ? t({
+          id: "officeAddin.emailRenderer.replyAll",
+          message: "Reply All",
+        })
+      : t({
+          id: "officeAddin.emailRenderer.reply",
+          message: "Reply",
+        });
+
+  const showReadReplyActions = isReadMode && readActions.length > 0;
+  // Proposed action first (primary), then the remaining offerable actions.
+  const orderedReadActions = proposedAction
+    ? [
+        proposedAction,
+        ...readActions.filter((action) => action !== proposedAction),
+      ]
+    : readActions;
+
+  const replyAllRecipientCount = pendingReplyAll
+    ? pendingReplyAll.recipients.recipients.length +
+      (pendingReplyAll.recipients.sender ? 1 : 0)
+    : 0;
+
   return (
     <div className="my-2 rounded-lg border border-theme-border bg-theme-bg-secondary p-3">
       {isHtml ? (
@@ -93,19 +207,42 @@ export function OutlookEratoEmailRenderer({
         <div className="mb-2 whitespace-pre-wrap text-sm">{content}</div>
       )}
       <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={() => void handleInsert()}
-          disabled={isBusy}
-          className="rounded-md border border-theme-border bg-theme-bg-primary px-3 py-1 text-xs hover:bg-theme-bg-tertiary disabled:opacity-50"
-        >
-          {insertLabel}
-        </button>
+        {showReadReplyActions
+          ? orderedReadActions.map((action, index) => (
+              <button
+                key={action}
+                type="button"
+                onClick={() => handleReplyAction(action)}
+                disabled={isBusy}
+                className={
+                  index === 0 && proposedAction
+                    ? PRIMARY_ACTION_BUTTON_CLASS
+                    : ACTION_BUTTON_CLASS
+                }
+              >
+                {status === "inserting"
+                  ? t({
+                      id: "officeAddin.emailRenderer.opening",
+                      message: "Opening...",
+                    })
+                  : replyActionLabel(action)}
+              </button>
+            ))
+          : !isReadMode && (
+              <button
+                type="button"
+                onClick={() => void handleInsert()}
+                disabled={isBusy}
+                className={ACTION_BUTTON_CLASS}
+              >
+                {insertLabel}
+              </button>
+            )}
         <button
           type="button"
           onClick={handleCopy}
           disabled={isBusy}
-          className="rounded-md border border-theme-border bg-theme-bg-primary px-3 py-1 text-xs hover:bg-theme-bg-tertiary disabled:opacity-50"
+          className={ACTION_BUTTON_CLASS}
         >
           {status === "copied"
             ? t({
@@ -120,12 +257,60 @@ export function OutlookEratoEmailRenderer({
       </div>
       {status === "error" && (
         <p className="mt-1 text-xs text-red-500">
-          {t({
-            id: "officeAddin.emailRenderer.insertFailed",
-            message: "Failed to insert into compose body.",
-          })}
+          {errorKind === "tooLarge"
+            ? t({
+                id: "officeAddin.emailRenderer.replyTooLarge",
+                message:
+                  "Draft is too large to prefill a reply. Use Copy and paste it into a reply instead.",
+              })
+            : errorKind === "reply"
+              ? t({
+                  id: "officeAddin.emailRenderer.replyFailed",
+                  message:
+                    "Failed to open the reply form. Make sure the received email is still open, or use Copy.",
+                })
+              : t({
+                  id: "officeAddin.emailRenderer.insertFailed",
+                  message: "Failed to insert into compose body.",
+                })}
         </p>
       )}
+      <ConfirmationDialog
+        isOpen={pendingReplyAll !== null}
+        onClose={() => setPendingReplyAll(null)}
+        onConfirm={() => {
+          setPendingReplyAll(null);
+          void executeReply("outlook.reply_all");
+        }}
+        title={t({
+          id: "officeAddin.emailRenderer.replyAllConfirmTitle",
+          message: "Reply to all recipients?",
+        })}
+        message={
+          <div className="space-y-2 text-sm text-theme-fg-secondary">
+            <p>
+              {t({
+                id: "officeAddin.emailRenderer.replyAllConfirmMessage",
+                message: `This opens a reply addressed to ${replyAllRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook.`,
+              })}
+            </p>
+            {pendingReplyAll && (
+              <p className="break-words text-xs">
+                {[
+                  ...(pendingReplyAll.recipients.sender
+                    ? [pendingReplyAll.recipients.sender]
+                    : []),
+                  ...pendingReplyAll.recipients.recipients,
+                ].join(", ")}
+              </p>
+            )}
+          </div>
+        }
+        confirmButtonText={t({
+          id: "officeAddin.emailRenderer.replyAllConfirm",
+          message: "Open Reply All",
+        })}
+      />
     </div>
   );
 }

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -1,6 +1,7 @@
 import {
   ActionConfirmationCard,
   sanitizeHtmlPreview,
+  useChatContext,
   useOutlookArtifact,
   usePersistedState,
 } from "@erato/frontend/library";
@@ -48,6 +49,32 @@ const PRIMARY_ACTION_BUTTON_CLASS =
  */
 const firedAutoPrompts = new Set<string>();
 
+interface ConfirmCardState {
+  /**
+   * Monotonic per-request id: a new confirmation replaces a resolved card
+   * and remounts it (fresh scroll/focus), and an async resolution only
+   * lands on the card it was started from.
+   */
+  requestId: number;
+  action: OutlookClientAction;
+  recipients: ReadModeRecipientSummary;
+  /** Surfaced by auto-prompt (scrolls into view) rather than a click. */
+  autoTriggered: boolean;
+  /**
+   * Item identity when the card opened — the item the shown recipients
+   * were read from. Execution re-checks it so confirming a card opened on
+   * email A can never open a reply on email B, independent of whether the
+   * artifact carries an identity (history drafts don't).
+   */
+  itemIdentityAtOpen: string | null;
+  /**
+   * `pending` renders the decision buttons; afterwards the card stays
+   * mounted as a visible record of the outcome (allow → `opened` or
+   * `failed`, deny → `denied`).
+   */
+  resolution: "pending" | "opened" | "denied" | "failed";
+}
+
 /**
  * Office-aware renderer for erato-email code blocks.
  * Registered via componentRegistry in main.tsx so the shared MessageContent
@@ -76,12 +103,20 @@ export function OutlookEratoEmailRenderer({
   const { mailItem, itemIdentity } = useOutlookMailItem();
   const artifact = useOutlookArtifact();
   const isReadMode = !!mailItem && !mailItem.isComposeMode;
-  // Identity of the Outlook item this draft was generated for (fresh
-  // completions only). When it no longer matches the currently open item,
-  // the draft must not open a reply — the user switched emails since.
+  // Identity of the Outlook item open when the user SENT the request that
+  // produced this draft (stamped on fresh completions only). When it no
+  // longer matches the currently open item, the draft must not open a reply
+  // — the user switched emails since. AddinChat only marks a completion
+  // fresh when its send-time identity is KNOWN (identity-unknown
+  // completions degrade to history-like drafts instead); a fresh completion
+  // WITHOUT an identity would mean that invariant broke, so it still fails
+  // closed (stale), never unguarded. History(-like) drafts carry no
+  // identity and are guarded at confirmation time instead (see
+  // `ConfirmCardState.itemIdentityAtOpen`).
   const expectedItemIdentity = artifact?.itemIdentity;
-  const isStaleForCurrentItem =
-    !!expectedItemIdentity && itemIdentity !== expectedItemIdentity;
+  const isStaleForCurrentItem = artifact?.isFreshCompletion
+    ? !expectedItemIdentity || itemIdentity !== expectedItemIdentity
+    : !!expectedItemIdentity && itemIdentity !== expectedItemIdentity;
   const [decisions, setDecisions] = usePersistedState(
     CLIENT_ACTION_DECISIONS_KEY,
     DEFAULT_CLIENT_ACTION_DECISIONS,
@@ -123,13 +158,10 @@ export function OutlookEratoEmailRenderer({
   const [busyAction, setBusyAction] = useState<OutlookClientAction | null>(
     null,
   );
-  const [pendingConfirm, setPendingConfirm] = useState<{
-    action: OutlookClientAction;
-    recipients: ReadModeRecipientSummary;
-    /** Surfaced by auto-prompt (scrolls into view) rather than a click. */
-    autoTriggered: boolean;
-  } | null>(null);
+  const [confirmCard, setConfirmCard] = useState<ConfirmCardState | null>(null);
+  const confirmRequestIdRef = useRef(0);
   const isBusy = status === "inserting";
+  const isConfirmPending = confirmCard?.resolution === "pending";
   const previewHtml = useMemo(
     () => (isHtml ? sanitizeHtmlPreview(content) : null),
     [content, isHtml],
@@ -175,11 +207,28 @@ export function OutlookEratoEmailRenderer({
     }
   }, [content, isHtml, scheduleStatusReset, showError]);
 
+  /** Resolves `true` only when the reply form actually opened. */
   const executeReply = useCallback(
-    async (action: OutlookClientAction) => {
+    async (
+      action: OutlookClientAction,
+      /**
+       * Identity snapshotted when the confirmation card opened. `undefined`
+       * for direct (card-less) executions; when provided it must still match
+       * the live item — the user may have switched emails while the card
+       * was open.
+       */
+      confirmedItemIdentity?: string | null,
+    ): Promise<boolean> => {
       if (isStaleForCurrentItem) {
         showError("staleItem", 4000);
-        return;
+        return false;
+      }
+      if (
+        confirmedItemIdentity !== undefined &&
+        confirmedItemIdentity !== itemIdentity
+      ) {
+        showError("staleItem", 4000);
+        return false;
       }
       setBusyAction(action);
       setStatus("inserting");
@@ -187,32 +236,64 @@ export function OutlookEratoEmailRenderer({
         await openReplyForm(action, content, !!isHtml);
         setStatus("done");
         scheduleStatusReset(2000);
+        return true;
       } catch (err) {
         console.warn("Failed to open reply form:", err);
         showError(
           err instanceof ReplyBodyTooLargeError ? "tooLarge" : "reply",
           4000,
         );
+        return false;
       } finally {
         setBusyAction(null);
       }
     },
-    [content, isHtml, isStaleForCurrentItem, scheduleStatusReset, showError],
+    [
+      content,
+      isHtml,
+      isStaleForCurrentItem,
+      itemIdentity,
+      scheduleStatusReset,
+      showError,
+    ],
   );
 
   // Open the inline confirmation card with recipients RE-READ from the
   // current item — the user confirms against fresh data, not against
-  // whatever the chat message was generated from.
+  // whatever the chat message was generated from. Replaces a resolved card.
   const requestConfirmation = useCallback(
     (action: OutlookClientAction, autoTriggered = false): boolean => {
       const recipients = getReadModeRecipientSummary();
       if (!recipients) {
         return false;
       }
-      setPendingConfirm({ action, recipients, autoTriggered });
+      confirmRequestIdRef.current += 1;
+      setConfirmCard({
+        requestId: confirmRequestIdRef.current,
+        action,
+        recipients,
+        autoTriggered,
+        itemIdentityAtOpen: itemIdentity,
+        resolution: "pending",
+      });
       return true;
     },
-    [],
+    [itemIdentity],
+  );
+
+  // Allow paths: execute, then resolve THIS card into its record state — a
+  // newer confirmation may have replaced it while the form was opening.
+  const handleCardAllow = useCallback(
+    (card: ConfirmCardState) => {
+      void executeReply(card.action, card.itemIdentityAtOpen).then((opened) => {
+        setConfirmCard((current) =>
+          current?.requestId === card.requestId
+            ? { ...current, resolution: opened ? "opened" : "failed" }
+            : current,
+        );
+      });
+    },
+    [executeReply],
   );
 
   const handleReplyAction = useCallback(
@@ -251,35 +332,52 @@ export function OutlookEratoEmailRenderer({
 
   // Auto-prompt: only under the facet's `auto_prompt` presentation, only for
   // a validated proposal on a FRESH completion (stamped by AddinChat — never
-  // history reloads), at most once per message, and still through the user's
-  // approval preference ("don't ask" opens the form, "ask" surfaces the
-  // inline confirmation card). If the user meanwhile left read mode,
-  // requestConfirmation returns false and nothing happens — the buttons
-  // remain as fallback.
+  // history reloads) that is still the latest assistant message and whose
+  // send-time item is still the open one, at most once per message, and
+  // still through the user's approval preference ("don't ask" opens the
+  // form, "ask" surfaces the inline confirmation card). If the user
+  // meanwhile left read mode, requestConfirmation returns false and nothing
+  // happens — the buttons remain as fallback.
+  const { messages, messageOrder } = useChatContext();
+  const autoPromptMessageId = artifact?.messageId;
+  const isFreshCompletion = !!artifact?.isFreshCompletion;
+  const isLatestAssistantMessage = useMemo(() => {
+    if (!autoPromptMessageId) {
+      return false;
+    }
+    for (let index = messageOrder.length - 1; index >= 0; index -= 1) {
+      const id = messageOrder[index];
+      if (messages[id]?.role === "assistant") {
+        return id === autoPromptMessageId;
+      }
+    }
+    return false;
+  }, [autoPromptMessageId, messages, messageOrder]);
   const autoPromptBehavior = resolveAutoPromptBehavior({
     presentation: artifact?.clientActionPresentation,
     facetId: artifact?.facetId,
     proposedAction,
-    isFreshCompletion: !!artifact?.isFreshCompletion,
+    isFreshCompletion,
+    isLatestAssistantMessage,
+    expectedItemIdentity,
+    currentItemIdentity: itemIdentity,
     decisions,
     enforcedAskActions,
   });
-  const autoPromptMessageId = artifact?.messageId;
   useEffect(() => {
-    if (autoPromptBehavior === "none") {
-      return;
-    }
-    if (!autoPromptMessageId || !proposedAction) {
+    if (!autoPromptMessageId || !isFreshCompletion) {
       return;
     }
     if (firedAutoPrompts.has(autoPromptMessageId)) {
       return;
     }
+    // Consume the once-per-message slot on the FIRST evaluation for a fresh
+    // completion, regardless of the resolved behavior: a later settings flip
+    // (never → always allow) or a much later scroll-back mount must not
+    // resurrect the prompt. The failure direction is always a missed
+    // auto-open, never a late one — the buttons remain as fallback.
     firedAutoPrompts.add(autoPromptMessageId);
-    if (isStaleForCurrentItem) {
-      // The user switched emails before the auto-prompt could fire. The
-      // moment has passed: consume the fired flag silently (no surprise
-      // window later) and leave the buttons as fallback.
+    if (autoPromptBehavior === "none" || !proposedAction) {
       return;
     }
     if (autoPromptBehavior === "execute") {
@@ -290,9 +388,9 @@ export function OutlookEratoEmailRenderer({
   }, [
     autoPromptBehavior,
     autoPromptMessageId,
+    isFreshCompletion,
     proposedAction,
     executeReply,
-    isStaleForCurrentItem,
     requestConfirmation,
   ]);
 
@@ -350,11 +448,18 @@ export function OutlookEratoEmailRenderer({
       ]
     : readActions;
 
-  const isConfirmingReplyAll = pendingConfirm?.action === "outlook.reply_all";
-  const confirmRecipientCount = pendingConfirm
-    ? (isConfirmingReplyAll ? pendingConfirm.recipients.recipients.length : 0) +
-      (pendingConfirm.recipients.sender ? 1 : 0)
-    : 0;
+  const isConfirmingReplyAll = confirmCard?.action === "outlook.reply_all";
+  // The confirmation copy's count is BY CONSTRUCTION the number of entries
+  // the card lists — never a separately computed number that could drift.
+  const confirmListedEntries = confirmCard
+    ? [
+        ...(confirmCard.recipients.sender
+          ? [confirmCard.recipients.sender]
+          : []),
+        ...(isConfirmingReplyAll ? confirmCard.recipients.recipients : []),
+      ]
+    : [];
+  const confirmRecipientCount = confirmListedEntries.length;
 
   return (
     <div className="my-2 rounded-lg border border-theme-border bg-theme-bg-secondary p-3">
@@ -375,7 +480,7 @@ export function OutlookEratoEmailRenderer({
                 key={action}
                 type="button"
                 onClick={() => handleReplyAction(action)}
-                disabled={isBusy || pendingConfirm !== null}
+                disabled={isBusy || isConfirmPending}
                 className={
                   index === 0 && proposedAction
                     ? PRIMARY_ACTION_BUTTON_CLASS
@@ -443,12 +548,15 @@ export function OutlookEratoEmailRenderer({
                   })}
         </p>
       )}
-      {pendingConfirm && (
+      {confirmCard && (
         <ActionConfirmationCard
+          // Keyed per request: a replacement card remounts so the mount-only
+          // scroll/focus behavior applies to the new confirmation.
+          key={confirmCard.requestId}
           description={
             <div className="space-y-2 text-sm text-theme-fg-secondary">
               <p className="font-medium text-theme-fg-primary">
-                {clientActionDisplayLabel(pendingConfirm.action)}
+                {clientActionDisplayLabel(confirmCard.action)}
               </p>
               <p>
                 {isConfirmingReplyAll
@@ -467,35 +575,22 @@ export function OutlookEratoEmailRenderer({
                     })}
               </p>
               <p className="break-words text-xs">
-                {[
-                  ...(pendingConfirm.recipients.sender
-                    ? [pendingConfirm.recipients.sender]
-                    : []),
-                  ...(isConfirmingReplyAll
-                    ? pendingConfirm.recipients.recipients
-                    : []),
-                ].join(", ")}
+                {confirmListedEntries.join(", ")}
               </p>
             </div>
           }
-          onAllowOnce={() => {
-            const action = pendingConfirm.action;
-            setPendingConfirm(null);
-            void executeReply(action);
-          }}
+          onAllowOnce={() => handleCardAllow(confirmCard)}
           onAlwaysAllow={() => {
             // Persist the grant for THIS facet + action, then execute. The
             // store is the source the settings page mirrors and revises.
-            const action = pendingConfirm.action;
             setDecisions({
               ...decisions,
-              [decisionKey(facetId, action)]: "always",
+              [decisionKey(facetId, confirmCard.action)]: "always",
             });
-            setPendingConfirm(null);
-            void executeReply(action);
+            handleCardAllow(confirmCard);
           }}
           alwaysAllowDisabledReason={
-            enforcedAskActions.includes(pendingConfirm.action)
+            enforcedAskActions.includes(confirmCard.action)
               ? t({
                   id: "officeAddin.emailRenderer.alwaysAllowLocked",
                   message:
@@ -503,9 +598,40 @@ export function OutlookEratoEmailRenderer({
                 })
               : undefined
           }
-          onDeny={() => setPendingConfirm(null)}
+          onDeny={() =>
+            setConfirmCard((current) =>
+              current?.requestId === confirmCard.requestId
+                ? { ...current, resolution: "denied" }
+                : current,
+            )
+          }
+          status={
+            confirmCard.resolution === "pending"
+              ? "pending"
+              : confirmCard.resolution === "opened"
+                ? "confirmed"
+                : "dismissed"
+          }
+          resolvedLabel={
+            confirmCard.resolution === "opened"
+              ? confirmCard.action === "outlook.reply_all"
+                ? t({
+                    id: "officeAddin.emailRenderer.replyAllFormOpened",
+                    message: "Reply All form opened",
+                  })
+                : t({
+                    id: "officeAddin.emailRenderer.replyFormOpened",
+                    message: "Reply form opened",
+                  })
+              : confirmCard.resolution === "failed"
+                ? t({
+                    id: "officeAddin.emailRenderer.replyFormNotOpened",
+                    message: "Reply form could not be opened",
+                  })
+                : undefined
+          }
           isBusy={isBusy}
-          scrollIntoViewOnMount={pendingConfirm.autoTriggered}
+          scrollIntoViewOnMount={confirmCard.autoTriggered}
         />
       )}
     </div>

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -5,7 +5,7 @@ import {
   usePersistedState,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection";
 import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
@@ -34,8 +34,10 @@ import type { EratoEmailCodeBlockProps } from "@erato/frontend/library";
 
 const ACTION_BUTTON_CLASS =
   "rounded-md border border-theme-border bg-theme-bg-primary px-3 py-1 text-xs hover:bg-theme-bg-tertiary disabled:opacity-50";
+// Mirrors the library Button "primary" variant tokens (Button.tsx) at the
+// compact geometry of the sibling action buttons.
 const PRIMARY_ACTION_BUTTON_CLASS =
-  "rounded-md border border-theme-border bg-theme-bg-tertiary px-3 py-1 text-xs font-medium hover:bg-theme-bg-hover disabled:opacity-50";
+  "rounded-md px-3 py-1 text-xs font-medium bg-theme-action-primary-bg text-theme-action-primary-fg hover:bg-theme-action-primary-hover theme-transition disabled:opacity-50";
 
 /**
  * Auto-prompt fires at most once per assistant message, across remounts
@@ -69,9 +71,15 @@ export function OutlookEratoEmailRenderer({
 }: EratoEmailCodeBlockProps) {
   const composeSelection = useOutlookComposeSelection();
   const hasSelection = composeSelection.data.length > 0;
-  const { mailItem } = useOutlookMailItem();
+  const { mailItem, itemIdentity } = useOutlookMailItem();
   const artifact = useOutlookArtifact();
   const isReadMode = !!mailItem && !mailItem.isComposeMode;
+  // Identity of the Outlook item this draft was generated for (fresh
+  // completions only). When it no longer matches the currently open item,
+  // the draft must not open a reply — the user switched emails since.
+  const expectedItemIdentity = artifact?.itemIdentity;
+  const isStaleForCurrentItem =
+    !!expectedItemIdentity && itemIdentity !== expectedItemIdentity;
   const [actionPreferences] = usePersistedState(
     CLIENT_ACTION_PREFERENCES_KEY,
     DEFAULT_CLIENT_ACTION_PREFERENCES,
@@ -96,8 +104,11 @@ export function OutlookEratoEmailRenderer({
   const [status, setStatus] = useState<
     "idle" | "inserting" | "done" | "copied" | "error"
   >("idle");
-  const [errorKind, setErrorKind] = useState<"insert" | "reply" | "tooLarge">(
-    "insert",
+  const [errorKind, setErrorKind] = useState<
+    "insert" | "reply" | "tooLarge" | "staleItem"
+  >("insert");
+  const [busyAction, setBusyAction] = useState<OutlookClientAction | null>(
+    null,
   );
   const [pendingConfirm, setPendingConfirm] = useState<{
     action: OutlookClientAction;
@@ -109,37 +120,69 @@ export function OutlookEratoEmailRenderer({
     [content, isHtml],
   );
 
+  // Single pending status-reset timer: a new schedule cancels the previous
+  // one (a stale 2s success timer must not clear a newer 4s error early),
+  // and unmount cancels outright.
+  const statusResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleStatusReset = useCallback((delayMs: number) => {
+    if (statusResetRef.current) {
+      clearTimeout(statusResetRef.current);
+    }
+    statusResetRef.current = setTimeout(() => setStatus("idle"), delayMs);
+  }, []);
+  useEffect(
+    () => () => {
+      if (statusResetRef.current) {
+        clearTimeout(statusResetRef.current);
+      }
+    },
+    [],
+  );
+
+  const showError = useCallback(
+    (kind: "insert" | "reply" | "tooLarge" | "staleItem", delayMs: number) => {
+      setErrorKind(kind);
+      setStatus("error");
+      scheduleStatusReset(delayMs);
+    },
+    [scheduleStatusReset],
+  );
+
   const handleInsert = useCallback(async () => {
     setStatus("inserting");
     try {
       await replaceComposeSelection(content, isHtml);
       setStatus("done");
-      setTimeout(() => setStatus("idle"), 2000);
+      scheduleStatusReset(2000);
     } catch (err) {
       console.warn("Failed to insert into compose body:", err);
-      setErrorKind("insert");
-      setStatus("error");
-      setTimeout(() => setStatus("idle"), 2000);
+      showError("insert", 2000);
     }
-  }, [content, isHtml]);
+  }, [content, isHtml, scheduleStatusReset, showError]);
 
   const executeReply = useCallback(
     async (action: OutlookClientAction) => {
+      if (isStaleForCurrentItem) {
+        showError("staleItem", 4000);
+        return;
+      }
+      setBusyAction(action);
       setStatus("inserting");
       try {
         await openReplyForm(action, content, !!isHtml);
         setStatus("done");
-        setTimeout(() => setStatus("idle"), 2000);
+        scheduleStatusReset(2000);
       } catch (err) {
         console.warn("Failed to open reply form:", err);
-        setErrorKind(
+        showError(
           err instanceof ReplyBodyTooLargeError ? "tooLarge" : "reply",
+          4000,
         );
-        setStatus("error");
-        setTimeout(() => setStatus("idle"), 4000);
+      } finally {
+        setBusyAction(null);
       }
     },
-    [content, isHtml],
+    [content, isHtml, isStaleForCurrentItem, scheduleStatusReset, showError],
   );
 
   // Open the confirmation dialog with recipients RE-READ from the current
@@ -159,17 +202,27 @@ export function OutlookEratoEmailRenderer({
 
   const handleReplyAction = useCallback(
     (action: OutlookClientAction) => {
+      if (isStaleForCurrentItem) {
+        // Don't open a confirmation that would show the NEW email's
+        // recipients for a draft written against the old one.
+        showError("staleItem", 4000);
+        return;
+      }
       if (resolveClickBehavior(action, actionPreferences) === "execute") {
         void executeReply(action);
         return;
       }
       if (!requestConfirmation(action)) {
-        setErrorKind("reply");
-        setStatus("error");
-        setTimeout(() => setStatus("idle"), 4000);
+        showError("reply", 4000);
       }
     },
-    [actionPreferences, executeReply, requestConfirmation],
+    [
+      actionPreferences,
+      executeReply,
+      isStaleForCurrentItem,
+      requestConfirmation,
+      showError,
+    ],
   );
 
   // Auto-prompt: only under the facet's `auto_prompt` presentation, only for
@@ -197,6 +250,12 @@ export function OutlookEratoEmailRenderer({
       return;
     }
     firedAutoPrompts.add(autoPromptMessageId);
+    if (isStaleForCurrentItem) {
+      // The user switched emails before the auto-prompt could fire. The
+      // moment has passed: consume the fired flag silently (no surprise
+      // window later) and leave the buttons as fallback.
+      return;
+    }
     if (autoPromptBehavior === "execute") {
       void executeReply(proposedAction);
     } else {
@@ -207,6 +266,7 @@ export function OutlookEratoEmailRenderer({
     autoPromptMessageId,
     proposedAction,
     executeReply,
+    isStaleForCurrentItem,
     requestConfirmation,
   ]);
 
@@ -215,12 +275,12 @@ export function OutlookEratoEmailRenderer({
       .writeText(content)
       .then(() => {
         setStatus("copied");
-        setTimeout(() => setStatus("idle"), 2000);
+        scheduleStatusReset(2000);
       })
       .catch(() => {
         // ignore clipboard errors
       });
-  }, [content]);
+  }, [content, scheduleStatusReset]);
 
   const insertLabel = (() => {
     if (status === "done")
@@ -296,7 +356,7 @@ export function OutlookEratoEmailRenderer({
                     : ACTION_BUTTON_CLASS
                 }
               >
-                {status === "inserting"
+                {busyAction === action
                   ? t({
                       id: "officeAddin.emailRenderer.opening",
                       message: "Opening...",
@@ -332,23 +392,29 @@ export function OutlookEratoEmailRenderer({
         </button>
       </div>
       {status === "error" && (
-        <p className="mt-1 text-xs text-red-500">
+        <p role="alert" className="mt-1 text-xs text-theme-error-fg">
           {errorKind === "tooLarge"
             ? t({
                 id: "officeAddin.emailRenderer.replyTooLarge",
                 message:
                   "Draft is too large to prefill a reply. Use Copy and paste it into a reply instead.",
               })
-            : errorKind === "reply"
+            : errorKind === "staleItem"
               ? t({
-                  id: "officeAddin.emailRenderer.replyFailed",
+                  id: "officeAddin.emailRenderer.replyStaleItem",
                   message:
-                    "Failed to open the reply form. Make sure the received email is still open, or use Copy.",
+                    "This draft was written for a different email. Open that email again, or use Copy.",
                 })
-              : t({
-                  id: "officeAddin.emailRenderer.insertFailed",
-                  message: "Failed to insert into compose body.",
-                })}
+              : errorKind === "reply"
+                ? t({
+                    id: "officeAddin.emailRenderer.replyFailed",
+                    message:
+                      "Failed to open the reply form. Make sure the received email is still open, or use Copy.",
+                  })
+                : t({
+                    id: "officeAddin.emailRenderer.insertFailed",
+                    message: "Failed to insert into compose body.",
+                  })}
         </p>
       )}
       <ConfirmationDialog

--- a/office-addin/src/components/__tests__/AddinChat.test.tsx
+++ b/office-addin/src/components/__tests__/AddinChat.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@erato/frontend/library", () => ({
     openPreviewModal: vi.fn(),
     closePreviewModal: vi.fn(),
   }),
+  useFacets: () => ({ data: { action_facets: [] } }),
   useFileUploadWithTokenCheck: () => ({
     uploadFiles: vi.fn(async () => []),
     uploadError: null,

--- a/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
+++ b/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
@@ -1,0 +1,558 @@
+import { i18n } from "@lingui/core";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { OutlookEratoEmailRenderer } from "../OutlookEratoEmailRenderer";
+
+// The renderer's collaborators are mocked at the seams the tests steer:
+// the artifact + chat snapshot (what AddinChat stamps), the current Outlook
+// item identity, the persisted decisions, and the Office.js reply module —
+// the tests only assert WHETHER the reply form is reached, never how.
+const mockUseOutlookMailItem = vi.fn();
+const mockUseOutlookArtifact = vi.fn();
+const mockUseChatContext = vi.fn();
+const mockUsePersistedState = vi.fn();
+const mockOpenReplyForm = vi.fn();
+const mockGetReadModeRecipientSummary = vi.fn();
+
+vi.mock("@erato/frontend/library", () => ({
+  // Mirrors the real card's lifecycle contract: decision buttons only while
+  // pending, a resolved row afterwards.
+  ActionConfirmationCard: (props: {
+    onAllowOnce: () => void;
+    onAlwaysAllow: () => void;
+    onDeny: () => void;
+    status?: string;
+    resolvedLabel?: string;
+    isBusy?: boolean;
+  }) => (
+    <div
+      data-testid="confirmation-card"
+      data-status={props.status ?? "pending"}
+      data-busy={props.isBusy ? "true" : "false"}
+    >
+      {(props.status ?? "pending") === "pending" ? (
+        <>
+          <button
+            type="button"
+            disabled={props.isBusy}
+            onClick={props.onAllowOnce}
+          >
+            allow-once
+          </button>
+          <button
+            type="button"
+            disabled={props.isBusy}
+            onClick={props.onAlwaysAllow}
+          >
+            always-allow
+          </button>
+          <button type="button" disabled={props.isBusy} onClick={props.onDeny}>
+            deny
+          </button>
+        </>
+      ) : (
+        <span data-testid="resolved-label">{props.resolvedLabel}</span>
+      )}
+    </div>
+  ),
+  sanitizeHtmlPreview: (html: string) => html,
+  useChatContext: () => mockUseChatContext(),
+  useOutlookArtifact: () => mockUseOutlookArtifact(),
+  usePersistedState: () => mockUsePersistedState(),
+}));
+
+vi.mock("../../providers/OutlookMailItemProvider", () => ({
+  useOutlookMailItem: () => mockUseOutlookMailItem(),
+}));
+
+vi.mock("../../hooks/useOutlookComposeSelection", () => ({
+  useOutlookComposeSelection: () => ({ data: "", sourceProperty: "body" }),
+}));
+
+vi.mock("../../utils/outlookReadReply", () => ({
+  ReplyBodyTooLargeError: class ReplyBodyTooLargeError extends Error {},
+  isReadReplySupported: () => true,
+  getReadModeRecipientSummary: () => mockGetReadModeRecipientSummary(),
+  openReplyForm: (...args: unknown[]) => mockOpenReplyForm(...args),
+}));
+
+const FACET = "outlook_reply_from_read";
+const REPLY = "outlook.reply";
+
+interface TestArtifact {
+  facetId: string;
+  bodyFormat: "text" | "html";
+  renderMode: "body" | "suggestions";
+  messageId: string;
+  allowedClientActions: string[];
+  clientActionPresentation: string;
+  isFreshCompletion?: boolean;
+  itemIdentity?: string;
+  proposedClientAction?: string;
+}
+
+// Unique per test: the renderer's once-per-message auto-prompt slot is
+// module-level state that intentionally survives remounts (and thus tests).
+let nextMessageId = 0;
+
+function makeArtifact(overrides: Partial<TestArtifact> = {}): TestArtifact {
+  nextMessageId += 1;
+  return {
+    facetId: FACET,
+    bodyFormat: "text",
+    renderMode: "body",
+    messageId: `msg-${nextMessageId}`,
+    allowedClientActions: ["outlook.reply", "outlook.reply_all"],
+    clientActionPresentation: "render_buttons",
+    ...overrides,
+  };
+}
+
+function prime(options: {
+  artifact: TestArtifact;
+  currentItemIdentity: string | null;
+  decisions?: Record<string, string>;
+}) {
+  mockUseOutlookArtifact.mockReturnValue(options.artifact);
+  mockUseOutlookMailItem.mockReturnValue({
+    mailItem: { isComposeMode: false },
+    itemIdentity: options.currentItemIdentity,
+  });
+  mockUseChatContext.mockReturnValue({
+    messages: {
+      [options.artifact.messageId]: {
+        id: options.artifact.messageId,
+        role: "assistant",
+      },
+    },
+    messageOrder: [options.artifact.messageId],
+  });
+  mockUsePersistedState.mockReturnValue([options.decisions ?? {}, vi.fn()]);
+  mockGetReadModeRecipientSummary.mockReturnValue({
+    sender: "Alice Sender",
+    recipients: ["Bob", "Carol"],
+  });
+}
+
+beforeAll(() => {
+  i18n.load("en", {});
+  i18n.activate("en");
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("OutlookEratoEmailRenderer — wrong-item guard", () => {
+  it("blocks a reply click with the stale-item error when the draft was sent from a different email", () => {
+    prime({
+      artifact: makeArtifact({
+        isFreshCompletion: true,
+        itemIdentity: "item-a",
+      }),
+      currentItemIdentity: "item-b",
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "written for a different email",
+    );
+  });
+
+  it("keeps the guard active for a regenerated draft re-seeded with the ORIGINAL exchange's identity", () => {
+    // Regenerate/edit replays the ORIGINAL email (it rides in the stored
+    // user message), so AddinChat seeds the new completion with the original
+    // exchange's send-time identity — the artifact looks exactly like this.
+    // A user who switched to another email before regenerating must still be
+    // blocked: the draft was written for the original one.
+    prime({
+      artifact: makeArtifact({
+        isFreshCompletion: true,
+        itemIdentity: "item-original",
+      }),
+      currentItemIdentity: "item-b",
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "written for a different email",
+    );
+  });
+
+  it("still fails closed on a fresh completion without an identity (defense against a broken stamping invariant)", () => {
+    // AddinChat no longer produces this shape — an identity-unknown
+    // completion is not stamped fresh at all and degrades to a history-like
+    // draft (see the dedicated describe below). The renderer keeps the
+    // fail-closed rule for the OutlookArtifact contract regardless: fresh
+    // without identity must never behave as unguarded.
+    prime({
+      artifact: makeArtifact({ isFreshCompletion: true }),
+      currentItemIdentity: "item-a",
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "written for a different email",
+    );
+  });
+
+  it("opens the reply form when the send-time and current identities match", async () => {
+    prime({
+      artifact: makeArtifact({
+        isFreshCompletion: true,
+        itemIdentity: "item-a",
+      }),
+      currentItemIdentity: "item-a",
+      decisions: { [`${FACET}/${REPLY}`]: "always" },
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    });
+
+    expect(mockOpenReplyForm).toHaveBeenCalledWith(REPLY, "Draft body", false);
+  });
+});
+
+describe("OutlookEratoEmailRenderer — identity-unknown completions degrade to history-like drafts", () => {
+  // When no send-time identity is known for a regenerate/edit (e.g. after a
+  // reload — the identity map is in-memory only), AddinChat does NOT stamp
+  // the completion fresh. The artifact is then indistinguishable from a
+  // history draft: buttons stay usable, clicks are re-guarded by the
+  // confirmation card's item snapshot, the stale-item error never fires
+  // (it requires a KNOWN mismatching identity), and auto-prompt is
+  // impossible.
+
+  it("keeps the reply buttons usable with no stale-item error", () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByTestId("confirmation-card")).toBeInTheDocument();
+  });
+
+  it("executes a click directly under a granted action, like any history draft", async () => {
+    prime({
+      artifact: makeArtifact(),
+      currentItemIdentity: "item-a",
+      decisions: { [`${FACET}/${REPLY}`]: "always" },
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    });
+
+    expect(mockOpenReplyForm).toHaveBeenCalledWith(REPLY, "Draft body", false);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("never auto-prompts, even under auto_prompt with a granted proposal", () => {
+    prime({
+      artifact: makeArtifact({
+        clientActionPresentation: "auto_prompt",
+        proposedClientAction: REPLY,
+      }),
+      currentItemIdentity: "item-a",
+      decisions: { [`${FACET}/${REPLY}`]: "always" },
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirmation-card")).not.toBeInTheDocument();
+  });
+});
+
+describe("OutlookEratoEmailRenderer — confirmation-card item snapshot", () => {
+  it("aborts allow-once when the email changed while the card was open", async () => {
+    // History draft: no artifact identity, so only the card-open snapshot
+    // can catch the switch.
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    const view = render(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    expect(screen.getByTestId("confirmation-card")).toBeInTheDocument();
+
+    mockUseOutlookMailItem.mockReturnValue({
+      mailItem: { isComposeMode: false },
+      itemIdentity: "item-b",
+    });
+    view.rerender(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+    });
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "written for a different email",
+    );
+    // The card records the failed outcome instead of vanishing.
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "dismissed",
+    );
+  });
+
+  it("aborts always-allow the same way (the persisted grant must not bypass the snapshot)", async () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    const view = render(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    mockUseOutlookMailItem.mockReturnValue({
+      mailItem: { isComposeMode: false },
+      itemIdentity: "item-b",
+    });
+    view.rerender(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "always-allow" }));
+    });
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "written for a different email",
+    );
+  });
+
+  it("executes a confirmed action when the item is unchanged", async () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+    });
+
+    expect(mockOpenReplyForm).toHaveBeenCalledWith(REPLY, "Draft body", false);
+  });
+});
+
+describe("OutlookEratoEmailRenderer — auto-prompt one-shot", () => {
+  function makeAutoPromptArtifact(): TestArtifact {
+    return makeArtifact({
+      isFreshCompletion: true,
+      itemIdentity: "item-a",
+      clientActionPresentation: "auto_prompt",
+      proposedClientAction: REPLY,
+    });
+  }
+
+  it("auto-surfaces the confirmation card for a fresh matching proposal", () => {
+    prime({
+      artifact: makeAutoPromptArtifact(),
+      currentItemIdentity: "item-a",
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(screen.getByTestId("confirmation-card")).toBeInTheDocument();
+  });
+
+  it("does not resurrect the auto-prompt when a denied action is later granted", () => {
+    prime({
+      artifact: makeAutoPromptArtifact(),
+      currentItemIdentity: "item-a",
+      decisions: { [`${FACET}/${REPLY}`]: "never" },
+    });
+    const view = render(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+    expect(screen.queryByTestId("confirmation-card")).not.toBeInTheDocument();
+
+    // The user flips the setting AFTER the completion has passed. The
+    // once-per-message slot was consumed on the first fresh render, so the
+    // grant must not pop a reply form now.
+    mockUsePersistedState.mockReturnValue([
+      { [`${FACET}/${REPLY}`]: "always" },
+      vi.fn(),
+    ]);
+    view.rerender(
+      <OutlookEratoEmailRenderer content="Draft body" isHtml={false} />,
+    );
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirmation-card")).not.toBeInTheDocument();
+  });
+
+  it("does not auto-open for a message that is no longer the latest assistant message", () => {
+    const artifact = makeAutoPromptArtifact();
+    prime({
+      artifact,
+      currentItemIdentity: "item-a",
+      decisions: { [`${FACET}/${REPLY}`]: "always" },
+    });
+    mockUseChatContext.mockReturnValue({
+      messages: {
+        [artifact.messageId]: { id: artifact.messageId, role: "assistant" },
+        newer: { id: "newer", role: "assistant" },
+      },
+      messageOrder: [artifact.messageId, "newer"],
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirmation-card")).not.toBeInTheDocument();
+  });
+
+  it("does not auto-open when the user switched emails before the prompt could fire", () => {
+    prime({
+      artifact: makeAutoPromptArtifact(),
+      currentItemIdentity: "item-b",
+      decisions: { [`${FACET}/${REPLY}`]: "always" },
+    });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirmation-card")).not.toBeInTheDocument();
+  });
+});
+
+describe("OutlookEratoEmailRenderer — resolved confirmation card", () => {
+  it("keeps the card as a confirmed record after allow-once and re-enables the proposal buttons", async () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    expect(screen.getByRole("button", { name: "Reply" })).toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+    });
+
+    expect(mockOpenReplyForm).toHaveBeenCalledWith(REPLY, "Draft body", false);
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "confirmed",
+    );
+    expect(screen.getByTestId("resolved-label")).toHaveTextContent(
+      "Reply form opened",
+    );
+    expect(screen.getByRole("button", { name: "Reply" })).toBeEnabled();
+  });
+
+  it("labels a confirmed reply-all with its own outcome", async () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply All" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+    });
+
+    expect(screen.getByTestId("resolved-label")).toHaveTextContent(
+      "Reply All form opened",
+    );
+  });
+
+  it("records a deny as dismissed instead of unmounting the card", () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    fireEvent.click(screen.getByRole("button", { name: "deny" }));
+
+    expect(mockOpenReplyForm).not.toHaveBeenCalled();
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "dismissed",
+    );
+    expect(screen.getByRole("button", { name: "Reply" })).toBeEnabled();
+  });
+
+  it("resolves the card as not opened when the reply form fails", async () => {
+    mockOpenReplyForm.mockRejectedValueOnce(new Error("boom"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+    });
+
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "dismissed",
+    );
+    expect(screen.getByTestId("resolved-label")).toHaveTextContent(
+      "could not be opened",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Failed to open the reply form",
+    );
+    warn.mockRestore();
+  });
+
+  it("disables the card buttons while the reply form is opening", async () => {
+    let resolveOpen!: () => void;
+    mockOpenReplyForm.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOpen = resolve;
+        }),
+    );
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    fireEvent.click(screen.getByRole("button", { name: "allow-once" }));
+
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-busy",
+      "true",
+    );
+
+    await act(async () => {
+      resolveOpen();
+    });
+
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "confirmed",
+    );
+  });
+
+  it("replaces a resolved card with a fresh pending one on the next request", () => {
+    prime({ artifact: makeArtifact(), currentItemIdentity: "item-a" });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    fireEvent.click(screen.getByRole("button", { name: "deny" }));
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "dismissed",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
+    expect(screen.getByTestId("confirmation-card")).toHaveAttribute(
+      "data-status",
+      "pending",
+    );
+  });
+});

--- a/office-addin/src/hooks/useAvailableActionFacets.ts
+++ b/office-addin/src/hooks/useAvailableActionFacets.ts
@@ -20,21 +20,39 @@ export function useAvailableActionFacetIds(): Set<string> {
   );
 }
 
+export interface ActionFacetClientActionInfo {
+  /** Server-allowed client actions for this facet. */
+  clientActions: string[];
+  /** `render_buttons` (default) or `auto_prompt`; from `GET /me/facets`. */
+  presentation: string | undefined;
+}
+
 /**
- * Map of action-facet id → the `client_actions` the backend allows for it
- * (from `GET /me/facets`). This list is the server-side gate for what the
- * model may propose via `propose_client_action`; the add-in additionally
- * intersects it with the actions it actually implements before offering
- * anything to the user. Facets without client actions are omitted.
+ * Map of action-facet id → its client-action config from `GET /me/facets`.
+ * `clientActions` is the server-side gate for what the model may propose via
+ * `propose_client_action`; the add-in additionally intersects it with the
+ * actions it actually implements before offering anything to the user.
+ * Facets without client actions are omitted.
  */
-export function useActionFacetClientActions(): Map<string, string[]> {
+export function useActionFacetClientActions(): Map<
+  string,
+  ActionFacetClientActionInfo
+> {
   const { data } = useFacets({});
   return useMemo(
     () =>
       new Map(
         (data?.action_facets ?? []).flatMap((facet) =>
           facet.client_actions && facet.client_actions.length > 0
-            ? [[facet.id, facet.client_actions] as const]
+            ? [
+                [
+                  facet.id,
+                  {
+                    clientActions: facet.client_actions,
+                    presentation: facet.presentation,
+                  },
+                ] as const,
+              ]
             : [],
         ),
       ),

--- a/office-addin/src/hooks/useAvailableActionFacets.ts
+++ b/office-addin/src/hooks/useAvailableActionFacets.ts
@@ -21,10 +21,17 @@ export function useAvailableActionFacetIds(): Set<string> {
 }
 
 export interface ActionFacetClientActionInfo {
+  /** Human readable facet name, for settings UIs. */
+  displayName: string;
   /** Server-allowed client actions for this facet. */
   clientActions: string[];
   /** `render_buttons` (default) or `auto_prompt`; from `GET /me/facets`. */
   presentation: string | undefined;
+  /**
+   * Actions the deployment enforces a per-use confirmation for — "always
+   * allow" must be greyed out and stored grants ignored for these.
+   */
+  alwaysAskActions: string[];
 }
 
 /**
@@ -48,8 +55,10 @@ export function useActionFacetClientActions(): Map<
                 [
                   facet.id,
                   {
+                    displayName: facet.display_name,
                     clientActions: facet.client_actions,
                     presentation: facet.presentation,
+                    alwaysAskActions: facet.client_actions_always_ask ?? [],
                   },
                 ] as const,
               ]

--- a/office-addin/src/hooks/useAvailableActionFacets.ts
+++ b/office-addin/src/hooks/useAvailableActionFacets.ts
@@ -19,3 +19,25 @@ export function useAvailableActionFacetIds(): Set<string> {
     [data],
   );
 }
+
+/**
+ * Map of action-facet id → the `client_actions` the backend allows for it
+ * (from `GET /me/facets`). This list is the server-side gate for what the
+ * model may propose via `propose_client_action`; the add-in additionally
+ * intersects it with the actions it actually implements before offering
+ * anything to the user. Facets without client actions are omitted.
+ */
+export function useActionFacetClientActions(): Map<string, string[]> {
+  const { data } = useFacets({});
+  return useMemo(
+    () =>
+      new Map(
+        (data?.action_facets ?? []).flatMap((facet) =>
+          facet.client_actions && facet.client_actions.length > 0
+            ? [[facet.id, facet.client_actions] as const]
+            : [],
+        ),
+      ),
+    [data],
+  );
+}

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -244,6 +244,21 @@ msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Dem Absender antworten"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Allen Empfängern antworten"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.alwaysAllowLocked"
+msgstr "Ihre Organisation verlangt für diese Aktion jedes Mal eine Bestätigung."
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Kopiert!"
@@ -295,8 +310,8 @@ msgstr "Allen antworten"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr "\"Allen antworten\" öffnen"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirm"
+#~ msgstr "\"Allen antworten\" öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -305,13 +320,13 @@ msgstr "{confirmRecipientCount, plural, one {Dies öffnet eine Antwort an # Pers
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr "Allen Empfängern antworten?"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+#~ msgstr "Allen Empfängern antworten?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr "Antwort öffnen"
+#~ msgid "officeAddin.emailRenderer.replyConfirm"
+#~ msgstr "Antwort öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -320,8 +335,8 @@ msgstr "Dies öffnet eine vorausgefüllte Antwort an den Absender der E-Mail, di
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr "Diese Antwort öffnen?"
+#~ msgid "officeAddin.emailRenderer.replyConfirmTitle"
+#~ msgstr "Diese Antwort öffnen?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -475,6 +490,51 @@ msgstr "Letzten Chat auswählen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.helper"
+msgstr "Führt die Aktion ohne Nachfrage aus. Es wird nichts gesendet, bis Sie in Outlook auf Senden klicken."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.label"
+msgstr "Immer erlauben"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.locked"
+msgstr "Gesperrt: Ihre Organisation verlangt für diese Aktion jedes Mal eine Bestätigung."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.helper"
+msgstr "Zeigt einen Bestätigungsschritt im Chat an, bevor etwas geöffnet wird."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.label"
+msgstr "Jedes Mal fragen"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.intro"
+msgstr "Ihre Entscheidungen aus der Bestätigung im Chat werden hier gespeichert und können jederzeit geändert werden. Es wird nichts gesendet, bis Sie in Outlook auf Senden klicken."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.legend"
+msgstr "Vom Assistenten vorgeschlagene Aktionen"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.helper"
+msgstr "Blendet diese Aktion aus und ignoriert den Vorschlag des Assistenten."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.label"
+msgstr "Nie"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.composeInherits.helper"
 msgstr "Beim Antworten oder Weiterleiten einer E-Mail den aktuellen Chat beibehalten, anstatt einen neuen zu starten."
 
@@ -530,53 +590,53 @@ msgstr "Letzten Chat fortsetzen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr "Zeigt eine Bestätigung an, bevor das Antwortfenster geöffnet wird."
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+#~ msgstr "Zeigt eine Bestätigung an, bevor das Antwortfenster geöffnet wird."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr "Erst fragen"
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+#~ msgstr "Erst fragen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr "Blendet diese Aktion aus und ignoriert den Vorschlag des Assistenten."
+#~ msgid "officeAddin.settings.addin.replyActions.deny.helper"
+#~ msgstr "Blendet diese Aktion aus und ignoriert den Vorschlag des Assistenten."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr "Nie"
+#~ msgid "officeAddin.settings.addin.replyActions.deny.label"
+#~ msgstr "Nie"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr "Öffnet das vorausgefüllte Outlook-Antwortfenster ohne Nachfrage. Es wird nichts gesendet, bis Sie auf Senden klicken."
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+#~ msgstr "Öffnet das vorausgefüllte Outlook-Antwortfenster ohne Nachfrage. Es wird nichts gesendet, bis Sie auf Senden klicken."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr "Sofort öffnen"
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+#~ msgstr "Sofort öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr "Gilt für den Lesemodus. Antworten werden nur als vorausgefüllter Outlook-Entwurf geöffnet – das Senden bleibt immer Ihr manueller Schritt."
+#~ msgid "officeAddin.settings.addin.replyActions.intro"
+#~ msgstr "Gilt für den Lesemodus. Antworten werden nur als vorausgefüllter Outlook-Entwurf geöffnet – das Senden bleibt immer Ihr manueller Schritt."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr "Wenn der Assistent vorschlägt, auf eine E-Mail zu antworten"
+#~ msgid "officeAddin.settings.addin.replyActions.legend"
+#~ msgstr "Wenn der Assistent vorschlägt, auf eine E-Mail zu antworten"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr "Dem Absender antworten"
+#~ msgid "officeAddin.settings.addin.replyActions.reply.legend"
+#~ msgstr "Dem Absender antworten"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr "Allen Empfängern antworten"
+#~ msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+#~ msgstr "Allen Empfängern antworten"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -275,8 +275,48 @@ msgstr "Wird eingefügt..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.opening"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replaceSelection"
 msgstr "Auswahl ersetzen"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.reply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyTooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -276,7 +276,7 @@ msgstr "Wird eingefügt..."
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.opening"
-msgstr ""
+msgstr "Wird geöffnet..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -286,57 +286,57 @@ msgstr "Auswahl ersetzen"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.reply"
-msgstr ""
+msgstr "Antworten"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAll"
-msgstr ""
+msgstr "Allen antworten"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr ""
+msgstr "\"Allen antworten\" öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr ""
+msgstr "{confirmRecipientCount, plural, one {Dies öffnet eine Antwort an # Person aus der E-Mail, die Sie gerade lesen. Es wird nichts gesendet, bis Sie in Outlook auf Senden klicken.} other {Dies öffnet eine Antwort an # Personen aus der E-Mail, die Sie gerade lesen. Es wird nichts gesendet, bis Sie in Outlook auf Senden klicken.}}"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr ""
+msgstr "Allen Empfängern antworten?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr ""
+msgstr "Antwort öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmMessage"
-msgstr ""
+msgstr "Dies öffnet eine vorausgefüllte Antwort an den Absender der E-Mail, die Sie gerade lesen. Es wird nichts gesendet, bis Sie in Outlook auf Senden klicken."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr ""
+msgstr "Diese Antwort öffnen?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
-msgstr ""
+msgstr "Das Antwortfenster konnte nicht geöffnet werden. Stellen Sie sicher, dass die empfangene E-Mail noch geöffnet ist, oder verwenden Sie Kopieren."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyStaleItem"
-msgstr ""
+msgstr "Dieser Entwurf wurde für eine andere E-Mail verfasst. Öffnen Sie diese E-Mail erneut oder verwenden Sie Kopieren."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
-msgstr ""
+msgstr "Der Entwurf ist zu groß zum Vorausfüllen einer Antwort. Verwenden Sie Kopieren und fügen Sie ihn in eine Antwort ein."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
@@ -531,52 +531,52 @@ msgstr "Letzten Chat fortsetzen"
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr ""
+msgstr "Zeigt eine Bestätigung an, bevor das Antwortfenster geöffnet wird."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr ""
+msgstr "Erst fragen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr ""
+msgstr "Blendet diese Aktion aus und ignoriert den Vorschlag des Assistenten."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr ""
+msgstr "Nie"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr ""
+msgstr "Öffnet das vorausgefüllte Outlook-Antwortfenster ohne Nachfrage. Es wird nichts gesendet, bis Sie auf Senden klicken."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr ""
+msgstr "Sofort öffnen"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr ""
+msgstr "Gilt für den Lesemodus. Antworten werden nur als vorausgefüllter Outlook-Entwurf geöffnet – das Senden bleibt immer Ihr manueller Schritt."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr ""
+msgstr "Wenn der Assistent vorschlägt, auf eine E-Mail zu antworten"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr ""
+msgstr "Dem Absender antworten"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr ""
+msgstr "Allen Empfängern antworten"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx
@@ -777,6 +777,13 @@ msgstr "Generiertes Manifest hochladen"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "und laden Sie die heruntergeladene Datei dort hoch."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/OutlookEratoEmailRenderer.tsx
+#~ msgid "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
+#~ msgstr ""
 
 # ==============================
 # Unstable IDs

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -224,6 +224,16 @@ msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Datei überschreitet das Serverlimit von {globalMaxFormatted}"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Dem Absender antworten"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Allen Empfängern antworten"
+
+#. js-lingui-explicit-id
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
 msgstr ""
@@ -242,16 +252,6 @@ msgstr ""
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.reply"
-msgstr "Dem Absender antworten"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.replyAll"
-msgstr "Allen Empfängern antworten"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -325,6 +325,11 @@ msgstr "{confirmRecipientCount, plural, one {Dies öffnet eine Antwort an # Pers
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllFormOpened"
+msgstr "Antwortfenster für alle Empfänger geöffnet"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 #~ msgid "officeAddin.emailRenderer.replyConfirm"
 #~ msgstr "Antwort öffnen"
 
@@ -342,6 +347,16 @@ msgstr "Dies öffnet eine vorausgefüllte Antwort an den Absender der E-Mail, di
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "Das Antwortfenster konnte nicht geöffnet werden. Stellen Sie sicher, dass die empfangene E-Mail noch geöffnet ist, oder verwenden Sie Kopieren."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormNotOpened"
+msgstr "Antwortfenster konnte nicht geöffnet werden"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormOpened"
+msgstr "Antwortfenster geöffnet"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -330,6 +330,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyStaleItem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
 msgstr ""
 

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -310,6 +310,21 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr ""
 
@@ -507,6 +522,56 @@ msgstr "Beim Öffnen oder Wechseln von E-Mails den vorherigen Chat automatisch w
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.mode.resume.label"
 msgstr "Letzten Chat fortsetzen"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.intro"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.reply.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -330,6 +330,11 @@ msgstr "Failed to open the reply form. Make sure the received email is still ope
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyStaleItem"
+msgstr "This draft was written for a different email. Open that email again, or use Copy."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
 msgstr "Draft is too large to prefill a reply. Use Copy and paste it into a reply instead."
 

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -310,6 +310,21 @@ msgstr "Reply to all recipients?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirm"
+msgstr "Open Reply"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmMessage"
+msgstr "This opens a prefilled reply to the sender of the email you are reading. Nothing is sent until you press Send in Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmTitle"
+msgstr "Open this reply?"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "Failed to open the reply form. Make sure the received email is still open, or use Copy."
 
@@ -507,6 +522,56 @@ msgstr "Reopens the previous conversation when opening or switching emails."
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.mode.resume.label"
 msgstr "Resume last chat"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+msgstr "Shows a confirmation before opening the reply window."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+msgstr "Ask first"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.helper"
+msgstr "Hides this action and ignores the assistant's suggestion."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.label"
+msgstr "Never"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+msgstr "Opens the prefilled Outlook reply window without asking. Nothing is sent until you press Send."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+msgstr "Open immediately"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.intro"
+msgstr "Applies to reading mode. Replies only open as a prefilled Outlook draft — sending always stays your manual step."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.legend"
+msgstr "When the assistant suggests replying to an email"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.reply.legend"
+msgstr "Reply to sender"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+msgstr "Reply to all recipients"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -275,8 +275,48 @@ msgstr "Inserting..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.opening"
+msgstr "Opening..."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replaceSelection"
 msgstr "Replace Selection"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.reply"
+msgstr "Reply"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAll"
+msgstr "Reply All"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirm"
+msgstr "Open Reply All"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
+msgstr "This opens a reply addressed to {replyAllRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+msgstr "Reply to all recipients?"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFailed"
+msgstr "Failed to open the reply form. Make sure the received email is still open, or use Copy."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyTooLarge"
+msgstr "Draft is too large to prefill a reply. Use Copy and paste it into a reply instead."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -244,6 +244,21 @@ msgid "officeAddin.email.signInToLoad.title"
 msgstr "Sign in to load email"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Reply to sender"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Reply to all recipients"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.alwaysAllowLocked"
+msgstr "Your organization requires confirmation for this action every time."
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copied!"
@@ -295,8 +310,8 @@ msgstr "Reply All"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr "Open Reply All"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirm"
+#~ msgstr "Open Reply All"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -305,13 +320,13 @@ msgstr "{confirmRecipientCount, plural, one {This opens a reply addressed to # p
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr "Reply to all recipients?"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+#~ msgstr "Reply to all recipients?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr "Open Reply"
+#~ msgid "officeAddin.emailRenderer.replyConfirm"
+#~ msgstr "Open Reply"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -320,8 +335,8 @@ msgstr "This opens a prefilled reply to the sender of the email you are reading.
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr "Open this reply?"
+#~ msgid "officeAddin.emailRenderer.replyConfirmTitle"
+#~ msgstr "Open this reply?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -475,6 +490,51 @@ msgstr "Pick a recent chat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.helper"
+msgstr "Performs the action without asking. Nothing is sent until you press Send in Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.label"
+msgstr "Always allow"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.locked"
+msgstr "Locked: your organization requires confirmation for this action every time."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.helper"
+msgstr "Shows a confirmation step in the chat before opening anything."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.label"
+msgstr "Ask every time"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.intro"
+msgstr "Your decisions from the in-chat confirmation are stored here and can be changed any time. Nothing is sent until you press Send in Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.legend"
+msgstr "Assistant-suggested actions"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.helper"
+msgstr "Hides this action and ignores the assistant's suggestion."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.label"
+msgstr "Never"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.composeInherits.helper"
 msgstr "When replying or forwarding an email, keep the current chat instead of starting a new one."
 
@@ -530,53 +590,53 @@ msgstr "Resume last chat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr "Shows a confirmation before opening the reply window."
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+#~ msgstr "Shows a confirmation before opening the reply window."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr "Ask first"
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+#~ msgstr "Ask first"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr "Hides this action and ignores the assistant's suggestion."
+#~ msgid "officeAddin.settings.addin.replyActions.deny.helper"
+#~ msgstr "Hides this action and ignores the assistant's suggestion."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr "Never"
+#~ msgid "officeAddin.settings.addin.replyActions.deny.label"
+#~ msgstr "Never"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr "Opens the prefilled Outlook reply window without asking. Nothing is sent until you press Send."
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+#~ msgstr "Opens the prefilled Outlook reply window without asking. Nothing is sent until you press Send."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr "Open immediately"
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+#~ msgstr "Open immediately"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr "Applies to reading mode. Replies only open as a prefilled Outlook draft — sending always stays your manual step."
+#~ msgid "officeAddin.settings.addin.replyActions.intro"
+#~ msgstr "Applies to reading mode. Replies only open as a prefilled Outlook draft — sending always stays your manual step."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr "When the assistant suggests replying to an email"
+#~ msgid "officeAddin.settings.addin.replyActions.legend"
+#~ msgstr "When the assistant suggests replying to an email"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr "Reply to sender"
+#~ msgid "officeAddin.settings.addin.replyActions.reply.legend"
+#~ msgstr "Reply to sender"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr "Reply to all recipients"
+#~ msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+#~ msgstr "Reply to all recipients"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -301,7 +301,7 @@ msgstr "Open Reply All"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr "This opens a reply addressed to {replyAllRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook."
+msgstr "This opens a reply addressed to {confirmRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -301,7 +301,7 @@ msgstr "Open Reply All"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr "This opens a reply addressed to {confirmRecipientCount} people from the email you are reading. Nothing is sent until you press Send in Outlook."
+msgstr "{confirmRecipientCount, plural, one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -777,6 +777,13 @@ msgstr "Upload the generated manifest"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "and upload the downloaded file there."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/OutlookEratoEmailRenderer.tsx
+#~ msgid "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
+#~ msgstr "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
 
 # ==============================
 # Unstable IDs

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -224,6 +224,16 @@ msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "File exceeds the server limit of {globalMaxFormatted}"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Reply to sender"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Reply to all recipients"
+
+#. js-lingui-explicit-id
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
 msgstr "Signed in. Add the email again to attach it."
@@ -242,16 +252,6 @@ msgstr "This email wasn't attached because reading it needs a quick sign-in."
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
 msgstr "Sign in to load email"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.reply"
-msgstr "Reply to sender"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.replyAll"
-msgstr "Reply to all recipients"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -325,6 +325,11 @@ msgstr "{confirmRecipientCount, plural, one {This opens a reply addressed to # p
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllFormOpened"
+msgstr "Reply All form opened"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 #~ msgid "officeAddin.emailRenderer.replyConfirm"
 #~ msgstr "Open Reply"
 
@@ -342,6 +347,16 @@ msgstr "This opens a prefilled reply to the sender of the email you are reading.
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "Failed to open the reply form. Make sure the received email is still open, or use Copy."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormNotOpened"
+msgstr "Reply form could not be opened"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormOpened"
+msgstr "Reply form opened"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -310,6 +310,21 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr ""
 
@@ -507,6 +522,56 @@ msgstr "Retoma el chat anterior al abrir o cambiar de correo."
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.mode.resume.label"
 msgstr "Retomar último chat"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.intro"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.reply.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -275,8 +275,48 @@ msgstr "Insertando..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.opening"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replaceSelection"
 msgstr "Reemplazar selección"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.reply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyTooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -244,6 +244,21 @@ msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Responder al remitente"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Responder a todos los destinatarios"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.alwaysAllowLocked"
+msgstr "Tu organización requiere confirmación para esta acción cada vez."
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copiado"
@@ -295,8 +310,8 @@ msgstr "Responder a todos"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr "Abrir Responder a todos"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirm"
+#~ msgstr "Abrir Responder a todos"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -305,13 +320,13 @@ msgstr "{confirmRecipientCount, plural, one {Esto abre una respuesta dirigida a 
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr "¿Responder a todos los destinatarios?"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+#~ msgstr "¿Responder a todos los destinatarios?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr "Abrir respuesta"
+#~ msgid "officeAddin.emailRenderer.replyConfirm"
+#~ msgstr "Abrir respuesta"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -320,8 +335,8 @@ msgstr "Esto abre una respuesta precompletada al remitente del correo que estás
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr "¿Abrir esta respuesta?"
+#~ msgid "officeAddin.emailRenderer.replyConfirmTitle"
+#~ msgstr "¿Abrir esta respuesta?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -475,6 +490,51 @@ msgstr "Elige un chat reciente"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.helper"
+msgstr "Realiza la acción sin preguntar. No se envía nada hasta que pulses Enviar en Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.label"
+msgstr "Permitir siempre"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.locked"
+msgstr "Bloqueado: tu organización requiere confirmación para esta acción cada vez."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.helper"
+msgstr "Muestra un paso de confirmación en el chat antes de abrir nada."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.label"
+msgstr "Preguntar cada vez"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.intro"
+msgstr "Tus decisiones de la confirmación en el chat se guardan aquí y pueden cambiarse en cualquier momento. No se envía nada hasta que pulses Enviar en Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.legend"
+msgstr "Acciones sugeridas por el asistente"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.helper"
+msgstr "Oculta esta acción e ignora la sugerencia del asistente."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.label"
+msgstr "Nunca"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.composeInherits.helper"
 msgstr "Al responder o reenviar un correo, mantiene el chat actual en lugar de iniciar uno nuevo."
 
@@ -530,53 +590,53 @@ msgstr "Retomar último chat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr "Muestra una confirmación antes de abrir la ventana de respuesta."
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+#~ msgstr "Muestra una confirmación antes de abrir la ventana de respuesta."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr "Preguntar primero"
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+#~ msgstr "Preguntar primero"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr "Oculta esta acción e ignora la sugerencia del asistente."
+#~ msgid "officeAddin.settings.addin.replyActions.deny.helper"
+#~ msgstr "Oculta esta acción e ignora la sugerencia del asistente."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr "Nunca"
+#~ msgid "officeAddin.settings.addin.replyActions.deny.label"
+#~ msgstr "Nunca"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr "Abre la ventana de respuesta precompletada de Outlook sin preguntar. No se envía nada hasta que pulses Enviar."
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+#~ msgstr "Abre la ventana de respuesta precompletada de Outlook sin preguntar. No se envía nada hasta que pulses Enviar."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr "Abrir inmediatamente"
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+#~ msgstr "Abrir inmediatamente"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr "Se aplica al modo de lectura. Las respuestas solo se abren como borrador precompletado de Outlook: enviar siempre es tu paso manual."
+#~ msgid "officeAddin.settings.addin.replyActions.intro"
+#~ msgstr "Se aplica al modo de lectura. Las respuestas solo se abren como borrador precompletado de Outlook: enviar siempre es tu paso manual."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr "Cuando el asistente sugiere responder a un correo"
+#~ msgid "officeAddin.settings.addin.replyActions.legend"
+#~ msgstr "Cuando el asistente sugiere responder a un correo"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr "Responder al remitente"
+#~ msgid "officeAddin.settings.addin.replyActions.reply.legend"
+#~ msgstr "Responder al remitente"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr "Responder a todos los destinatarios"
+#~ msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+#~ msgstr "Responder a todos los destinatarios"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -330,6 +330,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyStaleItem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
 msgstr ""
 

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -224,6 +224,16 @@ msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "El archivo supera el límite del servidor de {globalMaxFormatted}"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Responder al remitente"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Responder a todos los destinatarios"
+
+#. js-lingui-explicit-id
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
 msgstr ""
@@ -242,16 +252,6 @@ msgstr ""
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.reply"
-msgstr "Responder al remitente"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.replyAll"
-msgstr "Responder a todos los destinatarios"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -325,6 +325,11 @@ msgstr "{confirmRecipientCount, plural, one {Esto abre una respuesta dirigida a 
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllFormOpened"
+msgstr "Se abrió el formulario de respuesta a todos"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 #~ msgid "officeAddin.emailRenderer.replyConfirm"
 #~ msgstr "Abrir respuesta"
 
@@ -342,6 +347,16 @@ msgstr "Esto abre una respuesta precompletada al remitente del correo que estás
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "No se pudo abrir el formulario de respuesta. Asegúrate de que el correo recibido siga abierto o usa Copiar."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormNotOpened"
+msgstr "No se pudo abrir el formulario de respuesta"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormOpened"
+msgstr "Se abrió el formulario de respuesta"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -276,7 +276,7 @@ msgstr "Insertando..."
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.opening"
-msgstr ""
+msgstr "Abriendo..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -286,57 +286,57 @@ msgstr "Reemplazar selección"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.reply"
-msgstr ""
+msgstr "Responder"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAll"
-msgstr ""
+msgstr "Responder a todos"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr ""
+msgstr "Abrir Responder a todos"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr ""
+msgstr "{confirmRecipientCount, plural, one {Esto abre una respuesta dirigida a # persona del correo que estás leyendo. No se envía nada hasta que pulses Enviar en Outlook.} other {Esto abre una respuesta dirigida a # personas del correo que estás leyendo. No se envía nada hasta que pulses Enviar en Outlook.}}"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr ""
+msgstr "¿Responder a todos los destinatarios?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr ""
+msgstr "Abrir respuesta"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmMessage"
-msgstr ""
+msgstr "Esto abre una respuesta precompletada al remitente del correo que estás leyendo. No se envía nada hasta que pulses Enviar en Outlook."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr ""
+msgstr "¿Abrir esta respuesta?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
-msgstr ""
+msgstr "No se pudo abrir el formulario de respuesta. Asegúrate de que el correo recibido siga abierto o usa Copiar."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyStaleItem"
-msgstr ""
+msgstr "Este borrador se redactó para otro correo. Vuelve a abrir ese correo o usa Copiar."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
-msgstr ""
+msgstr "El borrador es demasiado grande para precompletar una respuesta. Usa Copiar y pégalo en una respuesta."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
@@ -531,52 +531,52 @@ msgstr "Retomar último chat"
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr ""
+msgstr "Muestra una confirmación antes de abrir la ventana de respuesta."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr ""
+msgstr "Preguntar primero"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr ""
+msgstr "Oculta esta acción e ignora la sugerencia del asistente."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr ""
+msgstr "Nunca"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr ""
+msgstr "Abre la ventana de respuesta precompletada de Outlook sin preguntar. No se envía nada hasta que pulses Enviar."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr ""
+msgstr "Abrir inmediatamente"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr ""
+msgstr "Se aplica al modo de lectura. Las respuestas solo se abren como borrador precompletado de Outlook: enviar siempre es tu paso manual."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr ""
+msgstr "Cuando el asistente sugiere responder a un correo"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr ""
+msgstr "Responder al remitente"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr ""
+msgstr "Responder a todos los destinatarios"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx
@@ -777,6 +777,13 @@ msgstr "Cargue el manifiesto generado"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "y cargue allí el archivo descargado."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/OutlookEratoEmailRenderer.tsx
+#~ msgid "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
+#~ msgstr ""
 
 # ==============================
 # Unstable IDs

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -224,6 +224,16 @@ msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Le fichier dépasse la limite du serveur de {globalMaxFormatted}"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Répondre à l'expéditeur"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Répondre à tous les destinataires"
+
+#. js-lingui-explicit-id
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
 msgstr ""
@@ -242,16 +252,6 @@ msgstr ""
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.reply"
-msgstr "Répondre à l'expéditeur"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.replyAll"
-msgstr "Répondre à tous les destinataires"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -325,6 +325,11 @@ msgstr "{confirmRecipientCount, plural, one {Ceci ouvre une réponse adressée �
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllFormOpened"
+msgstr "Formulaire de réponse à tous ouvert"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 #~ msgid "officeAddin.emailRenderer.replyConfirm"
 #~ msgstr "Ouvrir la réponse"
 
@@ -342,6 +347,16 @@ msgstr "Ceci ouvre une réponse préremplie à l'expéditeur de l'e-mail que vou
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "Impossible d'ouvrir le formulaire de réponse. Vérifiez que l'e-mail reçu est toujours ouvert, ou utilisez Copier."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormNotOpened"
+msgstr "Le formulaire de réponse n'a pas pu être ouvert"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormOpened"
+msgstr "Formulaire de réponse ouvert"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -276,7 +276,7 @@ msgstr "Insertion..."
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.opening"
-msgstr ""
+msgstr "Ouverture..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -286,57 +286,57 @@ msgstr "Remplacer la sélection"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.reply"
-msgstr ""
+msgstr "Répondre"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAll"
-msgstr ""
+msgstr "Répondre à tous"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr ""
+msgstr "Ouvrir Répondre à tous"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr ""
+msgstr "{confirmRecipientCount, plural, one {Ceci ouvre une réponse adressée à # personne de l'e-mail que vous lisez. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer dans Outlook.} other {Ceci ouvre une réponse adressée à # personnes de l'e-mail que vous lisez. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer dans Outlook.}}"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr ""
+msgstr "Répondre à tous les destinataires ?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr ""
+msgstr "Ouvrir la réponse"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmMessage"
-msgstr ""
+msgstr "Ceci ouvre une réponse préremplie à l'expéditeur de l'e-mail que vous lisez. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer dans Outlook."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr ""
+msgstr "Ouvrir cette réponse ?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
-msgstr ""
+msgstr "Impossible d'ouvrir le formulaire de réponse. Vérifiez que l'e-mail reçu est toujours ouvert, ou utilisez Copier."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyStaleItem"
-msgstr ""
+msgstr "Ce brouillon a été rédigé pour un autre e-mail. Rouvrez cet e-mail ou utilisez Copier."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
-msgstr ""
+msgstr "Le brouillon est trop volumineux pour préremplir une réponse. Utilisez Copier et collez-le dans une réponse."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
@@ -531,52 +531,52 @@ msgstr "Reprendre le dernier chat"
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr ""
+msgstr "Affiche une confirmation avant d'ouvrir la fenêtre de réponse."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr ""
+msgstr "Demander d'abord"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr ""
+msgstr "Masque cette action et ignore la suggestion de l'assistant."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr ""
+msgstr "Jamais"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr ""
+msgstr "Ouvre la fenêtre de réponse préremplie d'Outlook sans demander. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr ""
+msgstr "Ouvrir immédiatement"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr ""
+msgstr "S'applique au mode lecture. Les réponses s'ouvrent uniquement comme brouillon prérempli dans Outlook — l'envoi reste toujours votre action manuelle."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr ""
+msgstr "Quand l'assistant suggère de répondre à un e-mail"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr ""
+msgstr "Répondre à l'expéditeur"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr ""
+msgstr "Répondre à tous les destinataires"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx
@@ -777,6 +777,13 @@ msgstr "Téléverser le manifeste généré"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "et téléversez-y le fichier téléchargé."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/OutlookEratoEmailRenderer.tsx
+#~ msgid "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
+#~ msgstr ""
 
 # ==============================
 # Unstable IDs

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -275,8 +275,48 @@ msgstr "Insertion..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.opening"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replaceSelection"
 msgstr "Remplacer la sélection"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.reply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyTooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -330,6 +330,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyStaleItem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
 msgstr ""
 

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -244,6 +244,21 @@ msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Répondre à l'expéditeur"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Répondre à tous les destinataires"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.alwaysAllowLocked"
+msgstr "Votre organisation exige une confirmation pour cette action à chaque fois."
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Copié"
@@ -295,8 +310,8 @@ msgstr "Répondre à tous"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr "Ouvrir Répondre à tous"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirm"
+#~ msgstr "Ouvrir Répondre à tous"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -305,13 +320,13 @@ msgstr "{confirmRecipientCount, plural, one {Ceci ouvre une réponse adressée �
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr "Répondre à tous les destinataires ?"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+#~ msgstr "Répondre à tous les destinataires ?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr "Ouvrir la réponse"
+#~ msgid "officeAddin.emailRenderer.replyConfirm"
+#~ msgstr "Ouvrir la réponse"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -320,8 +335,8 @@ msgstr "Ceci ouvre une réponse préremplie à l'expéditeur de l'e-mail que vou
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr "Ouvrir cette réponse ?"
+#~ msgid "officeAddin.emailRenderer.replyConfirmTitle"
+#~ msgstr "Ouvrir cette réponse ?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -475,6 +490,51 @@ msgstr "Choisir un chat récent"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.helper"
+msgstr "Exécute l'action sans demander. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer dans Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.label"
+msgstr "Toujours autoriser"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.locked"
+msgstr "Verrouillé : votre organisation exige une confirmation pour cette action à chaque fois."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.helper"
+msgstr "Affiche une étape de confirmation dans la discussion avant d'ouvrir quoi que ce soit."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.label"
+msgstr "Demander à chaque fois"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.intro"
+msgstr "Vos décisions prises lors de la confirmation dans la discussion sont enregistrées ici et peuvent être modifiées à tout moment. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer dans Outlook."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.legend"
+msgstr "Actions suggérées par l'assistant"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.helper"
+msgstr "Masque cette action et ignore la suggestion de l'assistant."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.label"
+msgstr "Jamais"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.composeInherits.helper"
 msgstr "Lors d'une réponse ou d'un transfert d'e-mail, conserver le chat en cours plutôt que d'en démarrer un nouveau."
 
@@ -530,53 +590,53 @@ msgstr "Reprendre le dernier chat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr "Affiche une confirmation avant d'ouvrir la fenêtre de réponse."
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+#~ msgstr "Affiche une confirmation avant d'ouvrir la fenêtre de réponse."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr "Demander d'abord"
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+#~ msgstr "Demander d'abord"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr "Masque cette action et ignore la suggestion de l'assistant."
+#~ msgid "officeAddin.settings.addin.replyActions.deny.helper"
+#~ msgstr "Masque cette action et ignore la suggestion de l'assistant."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr "Jamais"
+#~ msgid "officeAddin.settings.addin.replyActions.deny.label"
+#~ msgstr "Jamais"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr "Ouvre la fenêtre de réponse préremplie d'Outlook sans demander. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer."
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+#~ msgstr "Ouvre la fenêtre de réponse préremplie d'Outlook sans demander. Rien n'est envoyé tant que vous n'appuyez pas sur Envoyer."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr "Ouvrir immédiatement"
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+#~ msgstr "Ouvrir immédiatement"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr "S'applique au mode lecture. Les réponses s'ouvrent uniquement comme brouillon prérempli dans Outlook — l'envoi reste toujours votre action manuelle."
+#~ msgid "officeAddin.settings.addin.replyActions.intro"
+#~ msgstr "S'applique au mode lecture. Les réponses s'ouvrent uniquement comme brouillon prérempli dans Outlook — l'envoi reste toujours votre action manuelle."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr "Quand l'assistant suggère de répondre à un e-mail"
+#~ msgid "officeAddin.settings.addin.replyActions.legend"
+#~ msgstr "Quand l'assistant suggère de répondre à un e-mail"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr "Répondre à l'expéditeur"
+#~ msgid "officeAddin.settings.addin.replyActions.reply.legend"
+#~ msgstr "Répondre à l'expéditeur"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr "Répondre à tous les destinataires"
+#~ msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+#~ msgstr "Répondre à tous les destinataires"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -310,6 +310,21 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr ""
 
@@ -507,6 +522,56 @@ msgstr "Rouvre le chat précédent lors de l'ouverture ou du changement d'e-mail
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.mode.resume.label"
 msgstr "Reprendre le dernier chat"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.intro"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.reply.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -275,8 +275,48 @@ msgstr "Wstawianie..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.opening"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replaceSelection"
 msgstr "Zastąp zaznaczenie"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.reply"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAll"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyTooLarge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -224,6 +224,16 @@ msgid "officeAddin.chatInput.validation.tooLarge"
 msgstr "Plik przekracza limit serwera wynoszący {globalMaxFormatted}"
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Odpowiedz nadawcy"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Odpowiedz wszystkim odbiorcom"
+
+#. js-lingui-explicit-id
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
 msgstr ""
@@ -242,16 +252,6 @@ msgstr ""
 #: src/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.reply"
-msgstr "Odpowiedz nadawcy"
-
-#. js-lingui-explicit-id
-#: src/utils/outlookClientActions.ts
-msgid "officeAddin.clientActions.replyAll"
-msgstr "Odpowiedz wszystkim odbiorcom"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -325,6 +325,11 @@ msgstr "{confirmRecipientCount, plural, one {Spowoduje to otwarcie odpowiedzi za
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyAllFormOpened"
+msgstr "Otwarto formularz odpowiedzi do wszystkich"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 #~ msgid "officeAddin.emailRenderer.replyConfirm"
 #~ msgstr "Otwórz odpowiedź"
 
@@ -342,6 +347,16 @@ msgstr "Spowoduje to otwarcie wstępnie wypełnionej odpowiedzi do nadawcy czyta
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr "Nie udało się otworzyć formularza odpowiedzi. Upewnij się, że otrzymana wiadomość jest nadal otwarta, lub użyj Kopiuj."
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormNotOpened"
+msgstr "Nie udało się otworzyć formularza odpowiedzi"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyFormOpened"
+msgstr "Otwarto formularz odpowiedzi"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -244,6 +244,21 @@ msgid "officeAddin.email.signInToLoad.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.reply"
+msgstr "Odpowiedz nadawcy"
+
+#. js-lingui-explicit-id
+#: src/utils/outlookClientActions.ts
+msgid "officeAddin.clientActions.replyAll"
+msgstr "Odpowiedz wszystkim odbiorcom"
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.alwaysAllowLocked"
+msgstr "Twoja organizacja wymaga potwierdzenia tej akcji za każdym razem."
+
+#. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.copied"
 msgstr "Skopiowano"
@@ -295,8 +310,8 @@ msgstr "Odpowiedz wszystkim"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr "Otwórz Odpowiedz wszystkim"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirm"
+#~ msgstr "Otwórz Odpowiedz wszystkim"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -305,13 +320,13 @@ msgstr "{confirmRecipientCount, plural, one {Spowoduje to otwarcie odpowiedzi za
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr "Odpowiedzieć wszystkim odbiorcom?"
+#~ msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
+#~ msgstr "Odpowiedzieć wszystkim odbiorcom?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr "Otwórz odpowiedź"
+#~ msgid "officeAddin.emailRenderer.replyConfirm"
+#~ msgstr "Otwórz odpowiedź"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -320,8 +335,8 @@ msgstr "Spowoduje to otwarcie wstępnie wypełnionej odpowiedzi do nadawcy czyta
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
-msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr "Otworzyć tę odpowiedź?"
+#~ msgid "officeAddin.emailRenderer.replyConfirmTitle"
+#~ msgstr "Otworzyć tę odpowiedź?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -475,6 +490,51 @@ msgstr "Wybierz ostatni czat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.helper"
+msgstr "Wykonuje akcję bez pytania. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.label"
+msgstr "Zawsze zezwalaj"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.always.locked"
+msgstr "Zablokowane: Twoja organizacja wymaga potwierdzenia tej akcji za każdym razem."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.helper"
+msgstr "Wyświetla krok potwierdzenia na czacie przed otwarciem czegokolwiek."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.ask.label"
+msgstr "Pytaj za każdym razem"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.intro"
+msgstr "Twoje decyzje z potwierdzenia na czacie są zapisywane tutaj i można je zmienić w dowolnym momencie. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.legend"
+msgstr "Akcje sugerowane przez asystenta"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.helper"
+msgstr "Ukrywa tę akcję i ignoruje sugestię asystenta."
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.clientActions.never.label"
+msgstr "Nigdy"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.composeInherits.helper"
 msgstr "Podczas odpowiadania na wiadomość lub jej przesyłania dalej zachowaj bieżący czat zamiast rozpoczynać nowy."
 
@@ -530,53 +590,53 @@ msgstr "Wznów ostatni czat"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr "Wyświetla potwierdzenie przed otwarciem okna odpowiedzi."
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+#~ msgstr "Wyświetla potwierdzenie przed otwarciem okna odpowiedzi."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr "Najpierw zapytaj"
+#~ msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+#~ msgstr "Najpierw zapytaj"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr "Ukrywa tę akcję i ignoruje sugestię asystenta."
+#~ msgid "officeAddin.settings.addin.replyActions.deny.helper"
+#~ msgstr "Ukrywa tę akcję i ignoruje sugestię asystenta."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr "Nigdy"
+#~ msgid "officeAddin.settings.addin.replyActions.deny.label"
+#~ msgstr "Nigdy"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr "Otwiera wstępnie wypełnione okno odpowiedzi Outlooka bez pytania. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij."
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+#~ msgstr "Otwiera wstępnie wypełnione okno odpowiedzi Outlooka bez pytania. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr "Otwieraj od razu"
+#~ msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+#~ msgstr "Otwieraj od razu"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr "Dotyczy trybu czytania. Odpowiedzi otwierają się wyłącznie jako wstępnie wypełniony szkic w Outlooku — wysyłanie zawsze pozostaje Twoim ręcznym krokiem."
+#~ msgid "officeAddin.settings.addin.replyActions.intro"
+#~ msgstr "Dotyczy trybu czytania. Odpowiedzi otwierają się wyłącznie jako wstępnie wypełniony szkic w Outlooku — wysyłanie zawsze pozostaje Twoim ręcznym krokiem."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr "Gdy asystent sugeruje odpowiedź na wiadomość"
+#~ msgid "officeAddin.settings.addin.replyActions.legend"
+#~ msgstr "Gdy asystent sugeruje odpowiedź na wiadomość"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr "Odpowiedz nadawcy"
+#~ msgid "officeAddin.settings.addin.replyActions.reply.legend"
+#~ msgstr "Odpowiedz nadawcy"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
-msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr "Odpowiedz wszystkim odbiorcom"
+#~ msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+#~ msgstr "Odpowiedz wszystkim odbiorcom"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -330,6 +330,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyStaleItem"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
 msgstr ""
 

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -276,7 +276,7 @@ msgstr "Wstawianie..."
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.opening"
-msgstr ""
+msgstr "Otwieranie..."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
@@ -286,57 +286,57 @@ msgstr "Zastąp zaznaczenie"
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.reply"
-msgstr ""
+msgstr "Odpowiedz"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAll"
-msgstr ""
+msgstr "Odpowiedz wszystkim"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirm"
-msgstr ""
+msgstr "Otwórz Odpowiedz wszystkim"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmMessage"
-msgstr ""
+msgstr "{confirmRecipientCount, plural, one {Spowoduje to otwarcie odpowiedzi zaadresowanej do # osoby z czytanej wiadomości. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku.} few {Spowoduje to otwarcie odpowiedzi zaadresowanej do # osób z czytanej wiadomości. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku.} many {Spowoduje to otwarcie odpowiedzi zaadresowanej do # osób z czytanej wiadomości. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku.} other {Spowoduje to otwarcie odpowiedzi zaadresowanej do # osoby z czytanej wiadomości. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku.}}"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyAllConfirmTitle"
-msgstr ""
+msgstr "Odpowiedzieć wszystkim odbiorcom?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirm"
-msgstr ""
+msgstr "Otwórz odpowiedź"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmMessage"
-msgstr ""
+msgstr "Spowoduje to otwarcie wstępnie wypełnionej odpowiedzi do nadawcy czytanej wiadomości. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij w Outlooku."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyConfirmTitle"
-msgstr ""
+msgstr "Otworzyć tę odpowiedź?"
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
-msgstr ""
+msgstr "Nie udało się otworzyć formularza odpowiedzi. Upewnij się, że otrzymana wiadomość jest nadal otwarta, lub użyj Kopiuj."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyStaleItem"
-msgstr ""
+msgstr "Ten szkic został napisany dla innej wiadomości. Otwórz ponownie tę wiadomość lub użyj Kopiuj."
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyTooLarge"
-msgstr ""
+msgstr "Szkic jest zbyt duży, aby wstępnie wypełnić odpowiedź. Użyj Kopiuj i wklej go do odpowiedzi."
 
 #. js-lingui-explicit-id
 #: src/components/AddinFileSourceSelector.tsx
@@ -531,52 +531,52 @@ msgstr "Wznów ostatni czat"
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
-msgstr ""
+msgstr "Wyświetla potwierdzenie przed otwarciem okna odpowiedzi."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
-msgstr ""
+msgstr "Najpierw zapytaj"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.helper"
-msgstr ""
+msgstr "Ukrywa tę akcję i ignoruje sugestię asystenta."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.deny.label"
-msgstr ""
+msgstr "Nigdy"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
-msgstr ""
+msgstr "Otwiera wstępnie wypełnione okno odpowiedzi Outlooka bez pytania. Nic nie zostanie wysłane, dopóki nie klikniesz Wyślij."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
-msgstr ""
+msgstr "Otwieraj od razu"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.intro"
-msgstr ""
+msgstr "Dotyczy trybu czytania. Odpowiedzi otwierają się wyłącznie jako wstępnie wypełniony szkic w Outlooku — wysyłanie zawsze pozostaje Twoim ręcznym krokiem."
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.legend"
-msgstr ""
+msgstr "Gdy asystent sugeruje odpowiedź na wiadomość"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.reply.legend"
-msgstr ""
+msgstr "Odpowiedz nadawcy"
 
 #. js-lingui-explicit-id
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
-msgstr ""
+msgstr "Odpowiedz wszystkim odbiorcom"
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx
@@ -777,6 +777,13 @@ msgstr "Prześlij wygenerowany manifest"
 #: src/pages/AddinSetupPage.tsx
 msgid "officeAddin.setup.uploadInstruction"
 msgstr "i prześlij tam pobrany plik."
+
+# ==============================
+# Unstable IDs
+# ==============================
+#: src/components/OutlookEratoEmailRenderer.tsx
+#~ msgid "{confirmRecipientCount, plural, id {officeAddin.emailRenderer.replyAllConfirmMessage} one {This opens a reply addressed to # person from the email you are reading. Nothing is sent until you press Send in Outlook.} other {This opens a reply addressed to # people from the email you are reading. Nothing is sent until you press Send in Outlook.}}"
+#~ msgstr ""
 
 # ==============================
 # Unstable IDs

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -310,6 +310,21 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmMessage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
+msgid "officeAddin.emailRenderer.replyConfirmTitle"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/OutlookEratoEmailRenderer.tsx
 msgid "officeAddin.emailRenderer.replyFailed"
 msgstr ""
 
@@ -507,6 +522,56 @@ msgstr "Wznawia poprzedni czat po otwarciu lub przełączeniu wiadomości."
 #: src/components/BehaviorTabContent.tsx
 msgid "officeAddin.settings.addin.mode.resume.label"
 msgstr "Wznów ostatni czat"
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.alwaysAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.deny.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.helper"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.dontAsk.label"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.intro"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.reply.legend"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/BehaviorTabContent.tsx
+msgid "officeAddin.settings.addin.replyActions.replyAll.legend"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/AddinSettingsDialog.tsx

--- a/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
+++ b/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  CLIENT_ACTION_DECISIONS_KEY,
   clientActionDecisionsPersistedOptions,
   decisionKey,
   effectiveDecision,
   isActionDenied,
+  mergeIntoStoredDecisions,
+  parseDecisionKey,
   resolveAutoPromptBehavior,
   resolveClickBehavior,
   type ClientActionDecisionMap,
@@ -97,6 +100,9 @@ describe("resolveAutoPromptBehavior", () => {
     facetId: FACET,
     proposedAction: REPLY,
     isFreshCompletion: true,
+    isLatestAssistantMessage: true,
+    expectedItemIdentity: "item-1",
+    currentItemIdentity: "item-1",
     decisions: {} as ClientActionDecisionMap,
     enforcedAskActions: [] as string[],
   };
@@ -145,6 +151,70 @@ describe("resolveAutoPromptBehavior", () => {
       }),
     ).toBe("none");
   });
+
+  it("fails closed when no send-time identity was recorded", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...auto, expectedItemIdentity: undefined }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({ ...auto, expectedItemIdentity: null }),
+    ).toBe("none");
+  });
+
+  it("stays silent for an identity-unknown completion degraded to history-like (not fresh, no identity)", () => {
+    // The shape AddinChat emits when a regenerate/edit completes but the
+    // original exchange's send-time identity is no longer known (e.g. after
+    // a reload): not stamped fresh, no identity. Even a stored grant must
+    // not let it auto-open — only the user's explicit click may act on it.
+    expect(
+      resolveAutoPromptBehavior({
+        ...auto,
+        isFreshCompletion: false,
+        expectedItemIdentity: undefined,
+        decisions: { [decisionKey(FACET, REPLY)]: "always" },
+      }),
+    ).toBe("none");
+  });
+
+  it("stays silent when the open item differs from the send-time item", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...auto, currentItemIdentity: "item-2" }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({ ...auto, currentItemIdentity: null }),
+    ).toBe("none");
+  });
+
+  it("keeps the decision-driven behavior when the identities match", () => {
+    expect(resolveAutoPromptBehavior(auto)).toBe("confirm");
+    expect(
+      resolveAutoPromptBehavior({
+        ...auto,
+        decisions: { [decisionKey(FACET, REPLY)]: "always" },
+      }),
+    ).toBe("execute");
+  });
+
+  it("stays silent for a message that is no longer the latest assistant message", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...auto, isLatestAssistantMessage: false }),
+    ).toBe("none");
+  });
+});
+
+describe("parseDecisionKey", () => {
+  it("splits at the LAST separator — facet ids may themselves contain one", () => {
+    expect(parseDecisionKey(decisionKey("team/eu/replies", REPLY))).toEqual({
+      facetId: "team/eu/replies",
+      action: REPLY,
+    });
+  });
+
+  it("rejects keys without a facet or action side", () => {
+    expect(parseDecisionKey("no-separator")).toBeNull();
+    expect(parseDecisionKey("/outlook.reply")).toBeNull();
+    expect(parseDecisionKey("facet/")).toBeNull();
+  });
 });
 
 describe("clientActionDecisionsPersistedOptions.parse", () => {
@@ -160,6 +230,20 @@ describe("clientActionDecisionsPersistedOptions.parse", () => {
       [decisionKey(FACET, REPLY)]: "always",
       [decisionKey(FACET, REPLY_ALL)]: "never",
     });
+  });
+
+  it("keeps a persistent deny for a facet id containing a separator", () => {
+    const facetWithSlash = "team/eu/replies";
+    const stored = parse({ [decisionKey(facetWithSlash, REPLY)]: "never" });
+    expect(stored).toEqual({ [decisionKey(facetWithSlash, REPLY)]: "never" });
+    expect(
+      effectiveDecision({
+        facetId: facetWithSlash,
+        action: REPLY,
+        decisions: stored ?? {},
+        enforcedAskActions: [],
+      }),
+    ).toBe("never");
   });
 
   it("drops malformed or unimplemented entries instead of resetting everything", () => {
@@ -181,5 +265,64 @@ describe("clientActionDecisionsPersistedOptions.parse", () => {
     expect(parse("always")).toBeNull();
     expect(parse(null)).toBeNull();
     expect(parse(["always"])).toBeNull();
+  });
+});
+
+describe("mergeIntoStoredDecisions / serialize round-trip", () => {
+  afterEach(() => {
+    localStorage.removeItem(CLIENT_ACTION_DECISIONS_KEY);
+  });
+
+  it("preserves entries this build cannot parse while replacing its own", () => {
+    expect(
+      mergeIntoStoredDecisions(
+        {
+          [decisionKey(FACET, "outlook.future_action")]: "always",
+          [decisionKey(FACET, REPLY_ALL)]: "always_for_session",
+          [decisionKey(FACET, REPLY)]: "never",
+          "no-separator": "always",
+        },
+        {
+          [decisionKey(FACET, REPLY)]: "always",
+          // Same key as the preserved unknown-decision entry: the new value
+          // wins — keyed collisions never duplicate.
+          [decisionKey(FACET, REPLY_ALL)]: "never",
+        },
+      ),
+    ).toEqual({
+      [decisionKey(FACET, "outlook.future_action")]: "always",
+      "no-separator": "always",
+      [decisionKey(FACET, REPLY)]: "always",
+      [decisionKey(FACET, REPLY_ALL)]: "never",
+    });
+  });
+
+  it("lets owned removals stick — an entry absent from the new map is dropped", () => {
+    expect(
+      mergeIntoStoredDecisions({ [decisionKey(FACET, REPLY)]: "always" }, {}),
+    ).toEqual({});
+  });
+
+  it("starts from the new map alone when the stored value is not an object", () => {
+    expect(
+      mergeIntoStoredDecisions("corrupt", {
+        [decisionKey(FACET, REPLY)]: "never",
+      }),
+    ).toEqual({ [decisionKey(FACET, REPLY)]: "never" });
+  });
+
+  it("serialize keeps an unknown-action entry across a write", () => {
+    const futureKey = decisionKey(FACET, "outlook.future_action");
+    localStorage.setItem(
+      CLIENT_ACTION_DECISIONS_KEY,
+      JSON.stringify({ [futureKey]: "never" }),
+    );
+    const written = clientActionDecisionsPersistedOptions.serialize?.({
+      [decisionKey(FACET, REPLY)]: "always",
+    });
+    expect(JSON.parse(written ?? "")).toEqual({
+      [futureKey]: "never",
+      [decisionKey(FACET, REPLY)]: "always",
+    });
   });
 });

--- a/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
+++ b/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
@@ -146,4 +146,11 @@ describe("clientActionPreferencesPersistedOptions.parse", () => {
     expect(parse("dont_ask")).toBeNull();
     expect(parse(null)).toBeNull();
   });
+
+  it("clamps stored modes to the per-action floor (hand-edited storage)", () => {
+    expect(parse({ "outlook.reply_all": "dont_ask" })).toEqual({
+      "outlook.reply": "dont_ask",
+      "outlook.reply_all": "always_ask",
+    });
+  });
 });

--- a/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
+++ b/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_CLIENT_ACTION_PREFERENCES,
+  clientActionPreferencesPersistedOptions,
+  effectiveApprovalMode,
+  isActionDenied,
+  resolveAutoPromptBehavior,
+  resolveClickBehavior,
+  type ClientActionPreferences,
+} from "../clientActionPolicy";
+
+const prefs = (
+  overrides: Partial<ClientActionPreferences> = {},
+): ClientActionPreferences => ({
+  ...DEFAULT_CLIENT_ACTION_PREFERENCES,
+  ...overrides,
+});
+
+describe("effectiveApprovalMode", () => {
+  it("defaults reproduce pre-settings behavior", () => {
+    expect(effectiveApprovalMode("outlook.reply", prefs())).toBe("dont_ask");
+    expect(effectiveApprovalMode("outlook.reply_all", prefs())).toBe(
+      "always_ask",
+    );
+  });
+
+  it("clamps reply_all to its always_ask floor — local settings cannot make it silent", () => {
+    expect(
+      effectiveApprovalMode(
+        "outlook.reply_all",
+        prefs({ "outlook.reply_all": "dont_ask" }),
+      ),
+    ).toBe("always_ask");
+  });
+
+  it("allows stricter settings everywhere", () => {
+    expect(
+      effectiveApprovalMode(
+        "outlook.reply",
+        prefs({ "outlook.reply": "deny" }),
+      ),
+    ).toBe("deny");
+    expect(
+      effectiveApprovalMode(
+        "outlook.reply_all",
+        prefs({ "outlook.reply_all": "deny" }),
+      ),
+    ).toBe("deny");
+  });
+});
+
+describe("isActionDenied / resolveClickBehavior", () => {
+  it("deny hides, always_ask confirms, dont_ask executes", () => {
+    expect(
+      isActionDenied("outlook.reply", prefs({ "outlook.reply": "deny" })),
+    ).toBe(true);
+    expect(resolveClickBehavior("outlook.reply", prefs())).toBe("execute");
+    expect(
+      resolveClickBehavior(
+        "outlook.reply",
+        prefs({ "outlook.reply": "always_ask" }),
+      ),
+    ).toBe("confirm");
+    expect(resolveClickBehavior("outlook.reply_all", prefs())).toBe("confirm");
+  });
+});
+
+describe("resolveAutoPromptBehavior", () => {
+  const base = {
+    presentation: "auto_prompt",
+    proposedAction: "outlook.reply" as const,
+    isFreshCompletion: true,
+    preferences: prefs(),
+  };
+
+  it("executes for a fresh proposal under dont_ask", () => {
+    expect(resolveAutoPromptBehavior(base)).toBe("execute");
+  });
+
+  it("confirms when the user prefers always_ask", () => {
+    expect(
+      resolveAutoPromptBehavior({
+        ...base,
+        preferences: prefs({ "outlook.reply": "always_ask" }),
+      }),
+    ).toBe("confirm");
+  });
+
+  it("confirms for reply_all even if storage claims dont_ask (floor)", () => {
+    expect(
+      resolveAutoPromptBehavior({
+        ...base,
+        proposedAction: "outlook.reply_all",
+        preferences: prefs({ "outlook.reply_all": "dont_ask" }),
+      }),
+    ).toBe("confirm");
+  });
+
+  it("never fires without auto_prompt presentation", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...base, presentation: "render_buttons" }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({ ...base, presentation: undefined }),
+    ).toBe("none");
+  });
+
+  it("never fires for stale (history) completions", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...base, isFreshCompletion: false }),
+    ).toBe("none");
+  });
+
+  it("never fires without a validated proposal or when denied", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...base, proposedAction: undefined }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({
+        ...base,
+        preferences: prefs({ "outlook.reply": "deny" }),
+      }),
+    ).toBe("none");
+  });
+});
+
+describe("clientActionPreferencesPersistedOptions.parse", () => {
+  const parse = clientActionPreferencesPersistedOptions.parse;
+
+  it("accepts a valid stored shape", () => {
+    expect(
+      parse({ "outlook.reply": "deny", "outlook.reply_all": "always_ask" }),
+    ).toEqual({ "outlook.reply": "deny", "outlook.reply_all": "always_ask" });
+  });
+
+  it("fills missing actions with defaults (forward compatible)", () => {
+    expect(parse({ "outlook.reply": "always_ask" })).toEqual({
+      "outlook.reply": "always_ask",
+      "outlook.reply_all": "always_ask",
+    });
+  });
+
+  it("rejects unknown modes and non-object values", () => {
+    expect(parse({ "outlook.reply": "yolo" })).toBeNull();
+    expect(parse("dont_ask")).toBeNull();
+    expect(parse(null)).toBeNull();
+  });
+});

--- a/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
+++ b/office-addin/src/utils/__tests__/clientActionPolicy.test.ts
@@ -1,156 +1,185 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  DEFAULT_CLIENT_ACTION_PREFERENCES,
-  clientActionPreferencesPersistedOptions,
-  effectiveApprovalMode,
+  clientActionDecisionsPersistedOptions,
+  decisionKey,
+  effectiveDecision,
   isActionDenied,
   resolveAutoPromptBehavior,
   resolveClickBehavior,
-  type ClientActionPreferences,
+  type ClientActionDecisionMap,
 } from "../clientActionPolicy";
 
-const prefs = (
-  overrides: Partial<ClientActionPreferences> = {},
-): ClientActionPreferences => ({
-  ...DEFAULT_CLIENT_ACTION_PREFERENCES,
-  ...overrides,
+const FACET = "outlook_reply_from_read";
+const REPLY = "outlook.reply" as const;
+const REPLY_ALL = "outlook.reply_all" as const;
+
+const base = {
+  facetId: FACET,
+  decisions: {} as ClientActionDecisionMap,
+  enforcedAskActions: [] as string[],
+};
+
+describe("effectiveDecision", () => {
+  it("defaults every action to ask — no pre-granted permissions", () => {
+    expect(effectiveDecision({ ...base, action: REPLY })).toBe("ask");
+    expect(effectiveDecision({ ...base, action: REPLY_ALL })).toBe("ask");
+  });
+
+  it("honors a stored user grant", () => {
+    expect(
+      effectiveDecision({
+        ...base,
+        action: REPLY,
+        decisions: { [decisionKey(FACET, REPLY)]: "always" },
+      }),
+    ).toBe("always");
+  });
+
+  it("clamps a stored grant back to ask when the deployment enforces confirmation", () => {
+    expect(
+      effectiveDecision({
+        ...base,
+        action: REPLY_ALL,
+        decisions: { [decisionKey(FACET, REPLY_ALL)]: "always" },
+        enforcedAskActions: [REPLY_ALL],
+      }),
+    ).toBe("ask");
+  });
+
+  it("honors never regardless of enforcement (stricter than server is fine)", () => {
+    expect(
+      effectiveDecision({
+        ...base,
+        action: REPLY_ALL,
+        decisions: { [decisionKey(FACET, REPLY_ALL)]: "never" },
+        enforcedAskActions: [REPLY_ALL],
+      }),
+    ).toBe("never");
+  });
+
+  it("scopes decisions per facet — a grant for one facet never leaks to another", () => {
+    const decisions = { [decisionKey(FACET, REPLY)]: "always" } as const;
+    expect(
+      effectiveDecision({
+        facetId: "some_other_facet",
+        action: REPLY,
+        decisions,
+        enforcedAskActions: [],
+      }),
+    ).toBe("ask");
+  });
 });
 
-describe("effectiveApprovalMode", () => {
-  it("defaults reproduce pre-settings behavior", () => {
-    expect(effectiveApprovalMode("outlook.reply", prefs())).toBe("dont_ask");
-    expect(effectiveApprovalMode("outlook.reply_all", prefs())).toBe(
-      "always_ask",
-    );
-  });
-
-  it("clamps reply_all to its always_ask floor — local settings cannot make it silent", () => {
+describe("resolveClickBehavior / isActionDenied", () => {
+  it("ask confirms, always executes, never hides", () => {
+    expect(resolveClickBehavior({ ...base, action: REPLY })).toBe("confirm");
     expect(
-      effectiveApprovalMode(
-        "outlook.reply_all",
-        prefs({ "outlook.reply_all": "dont_ask" }),
-      ),
-    ).toBe("always_ask");
-  });
-
-  it("allows stricter settings everywhere", () => {
+      resolveClickBehavior({
+        ...base,
+        action: REPLY,
+        decisions: { [decisionKey(FACET, REPLY)]: "always" },
+      }),
+    ).toBe("execute");
     expect(
-      effectiveApprovalMode(
-        "outlook.reply",
-        prefs({ "outlook.reply": "deny" }),
-      ),
-    ).toBe("deny");
-    expect(
-      effectiveApprovalMode(
-        "outlook.reply_all",
-        prefs({ "outlook.reply_all": "deny" }),
-      ),
-    ).toBe("deny");
-  });
-});
-
-describe("isActionDenied / resolveClickBehavior", () => {
-  it("deny hides, always_ask confirms, dont_ask executes", () => {
-    expect(
-      isActionDenied("outlook.reply", prefs({ "outlook.reply": "deny" })),
+      isActionDenied({
+        ...base,
+        action: REPLY,
+        decisions: { [decisionKey(FACET, REPLY)]: "never" },
+      }),
     ).toBe(true);
-    expect(resolveClickBehavior("outlook.reply", prefs())).toBe("execute");
-    expect(
-      resolveClickBehavior(
-        "outlook.reply",
-        prefs({ "outlook.reply": "always_ask" }),
-      ),
-    ).toBe("confirm");
-    expect(resolveClickBehavior("outlook.reply_all", prefs())).toBe("confirm");
   });
 });
 
 describe("resolveAutoPromptBehavior", () => {
-  const base = {
+  const auto = {
     presentation: "auto_prompt",
-    proposedAction: "outlook.reply" as const,
+    facetId: FACET,
+    proposedAction: REPLY,
     isFreshCompletion: true,
-    preferences: prefs(),
+    decisions: {} as ClientActionDecisionMap,
+    enforcedAskActions: [] as string[],
   };
 
-  it("executes for a fresh proposal under dont_ask", () => {
-    expect(resolveAutoPromptBehavior(base)).toBe("execute");
+  it("surfaces the card by default (ask)", () => {
+    expect(resolveAutoPromptBehavior(auto)).toBe("confirm");
   });
 
-  it("confirms when the user prefers always_ask", () => {
+  it("executes only after a user-granted always", () => {
     expect(
       resolveAutoPromptBehavior({
-        ...base,
-        preferences: prefs({ "outlook.reply": "always_ask" }),
+        ...auto,
+        decisions: { [decisionKey(FACET, REPLY)]: "always" },
+      }),
+    ).toBe("execute");
+  });
+
+  it("never executes when the deployment enforces confirmation", () => {
+    expect(
+      resolveAutoPromptBehavior({
+        ...auto,
+        proposedAction: REPLY_ALL,
+        decisions: { [decisionKey(FACET, REPLY_ALL)]: "always" },
+        enforcedAskActions: [REPLY_ALL],
       }),
     ).toBe("confirm");
   });
 
-  it("confirms for reply_all even if storage claims dont_ask (floor)", () => {
+  it("stays silent without auto_prompt, freshness, proposal, or when denied", () => {
+    expect(
+      resolveAutoPromptBehavior({ ...auto, presentation: "render_buttons" }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({ ...auto, isFreshCompletion: false }),
+    ).toBe("none");
+    expect(
+      resolveAutoPromptBehavior({ ...auto, proposedAction: undefined }),
+    ).toBe("none");
+    expect(resolveAutoPromptBehavior({ ...auto, facetId: undefined })).toBe(
+      "none",
+    );
     expect(
       resolveAutoPromptBehavior({
-        ...base,
-        proposedAction: "outlook.reply_all",
-        preferences: prefs({ "outlook.reply_all": "dont_ask" }),
-      }),
-    ).toBe("confirm");
-  });
-
-  it("never fires without auto_prompt presentation", () => {
-    expect(
-      resolveAutoPromptBehavior({ ...base, presentation: "render_buttons" }),
-    ).toBe("none");
-    expect(
-      resolveAutoPromptBehavior({ ...base, presentation: undefined }),
-    ).toBe("none");
-  });
-
-  it("never fires for stale (history) completions", () => {
-    expect(
-      resolveAutoPromptBehavior({ ...base, isFreshCompletion: false }),
-    ).toBe("none");
-  });
-
-  it("never fires without a validated proposal or when denied", () => {
-    expect(
-      resolveAutoPromptBehavior({ ...base, proposedAction: undefined }),
-    ).toBe("none");
-    expect(
-      resolveAutoPromptBehavior({
-        ...base,
-        preferences: prefs({ "outlook.reply": "deny" }),
+        ...auto,
+        decisions: { [decisionKey(FACET, REPLY)]: "never" },
       }),
     ).toBe("none");
   });
 });
 
-describe("clientActionPreferencesPersistedOptions.parse", () => {
-  const parse = clientActionPreferencesPersistedOptions.parse;
+describe("clientActionDecisionsPersistedOptions.parse", () => {
+  const parse = clientActionDecisionsPersistedOptions.parse;
 
-  it("accepts a valid stored shape", () => {
+  it("accepts a valid stored map", () => {
     expect(
-      parse({ "outlook.reply": "deny", "outlook.reply_all": "always_ask" }),
-    ).toEqual({ "outlook.reply": "deny", "outlook.reply_all": "always_ask" });
-  });
-
-  it("fills missing actions with defaults (forward compatible)", () => {
-    expect(parse({ "outlook.reply": "always_ask" })).toEqual({
-      "outlook.reply": "always_ask",
-      "outlook.reply_all": "always_ask",
+      parse({
+        [decisionKey(FACET, REPLY)]: "always",
+        [decisionKey(FACET, REPLY_ALL)]: "never",
+      }),
+    ).toEqual({
+      [decisionKey(FACET, REPLY)]: "always",
+      [decisionKey(FACET, REPLY_ALL)]: "never",
     });
   });
 
-  it("rejects unknown modes and non-object values", () => {
-    expect(parse({ "outlook.reply": "yolo" })).toBeNull();
-    expect(parse("dont_ask")).toBeNull();
+  it("drops malformed or unimplemented entries instead of resetting everything", () => {
+    expect(
+      parse({
+        [decisionKey(FACET, REPLY)]: "always",
+        "no-separator": "always",
+        [decisionKey(FACET, "outlook.unknown")]: "always",
+        [decisionKey(FACET, REPLY_ALL)]: "yolo",
+      }),
+    ).toEqual({ [decisionKey(FACET, REPLY)]: "always" });
+  });
+
+  it("normalizes redundant ask entries away", () => {
+    expect(parse({ [decisionKey(FACET, REPLY)]: "ask" })).toEqual({});
+  });
+
+  it("rejects non-object values", () => {
+    expect(parse("always")).toBeNull();
     expect(parse(null)).toBeNull();
-  });
-
-  it("clamps stored modes to the per-action floor (hand-edited storage)", () => {
-    expect(parse({ "outlook.reply_all": "dont_ask" })).toEqual({
-      "outlook.reply": "dont_ask",
-      "outlook.reply_all": "always_ask",
-    });
+    expect(parse(["always"])).toBeNull();
   });
 });

--- a/office-addin/src/utils/__tests__/freshCompletionTracker.test.ts
+++ b/office-addin/src/utils/__tests__/freshCompletionTracker.test.ts
@@ -71,6 +71,90 @@ describe("FreshCompletionTracker", () => {
     ).toEqual([]);
   });
 
+  it("marks a single-chunk completion fresh (placeholder swapped for an already-complete real id)", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe(
+      {
+        old: message("old", "assistant", "complete"),
+        "temp-assistant-1": message("temp-assistant-1", "assistant", "sending"),
+      },
+      ["old", "temp-assistant-1"],
+    );
+    expect(
+      tracker.observe(
+        {
+          old: message("old", "assistant", "complete"),
+          real: message("real", "assistant", "complete"),
+        },
+        ["old", "real"],
+      ),
+    ).toEqual(["real"]);
+  });
+
+  it("does NOT apply the replacement rule when previously-complete messages also vanished (chat switch)", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe(
+      {
+        old: message("old", "assistant", "complete"),
+        "temp-assistant-1": message("temp-assistant-1", "assistant", "sending"),
+      },
+      ["old", "temp-assistant-1"],
+    );
+    expect(
+      tracker.observe({ other: message("other", "assistant", "complete") }, [
+        "other",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("does NOT apply the replacement rule when several complete ids appear at once (refetch)", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe(
+      {
+        "temp-assistant-1": message("temp-assistant-1", "assistant", "sending"),
+      },
+      ["temp-assistant-1"],
+    );
+    expect(
+      tracker.observe(
+        {
+          a: message("a", "assistant", "complete"),
+          b: message("b", "assistant", "complete"),
+        },
+        ["a", "b"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("does NOT apply the replacement rule without a disappearing incomplete id", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]);
+    expect(
+      tracker.observe(
+        {
+          a: message("a", "assistant", "complete"),
+          b: message("b", "assistant", "complete"),
+        },
+        ["a", "b"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not double-report when the placeholder swap coincides with a transition", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe(
+      {
+        a: message("a", "assistant", "sending"),
+        "temp-assistant-1": message("temp-assistant-1", "assistant", "sending"),
+      },
+      ["a", "temp-assistant-1"],
+    );
+    // "a" transitions; temp disappears; no NEW complete id appears.
+    expect(
+      tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]),
+    ).toEqual(["a"]);
+  });
+
   it("handles multiple streams completing across snapshots", () => {
     const tracker = new FreshCompletionTracker();
     tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]);

--- a/office-addin/src/utils/__tests__/freshCompletionTracker.test.ts
+++ b/office-addin/src/utils/__tests__/freshCompletionTracker.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { FreshCompletionTracker } from "../freshCompletionTracker";
+
+import type { Message } from "@erato/frontend/library";
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  status: Message["status"],
+): Message {
+  return {
+    id,
+    role,
+    status,
+    content: [],
+    createdAt: "2026-06-09T00:00:00Z",
+  };
+}
+
+describe("FreshCompletionTracker", () => {
+  it("treats the initial snapshot as history — nothing is fresh", () => {
+    const tracker = new FreshCompletionTracker();
+    expect(
+      tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]),
+    ).toEqual([]);
+  });
+
+  it("marks a sending → complete transition as fresh", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe({ a: message("a", "assistant", "sending") }, ["a"]);
+    expect(
+      tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]),
+    ).toEqual(["a"]);
+  });
+
+  it("reports a fresh id only once", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe({ a: message("a", "assistant", "sending") }, ["a"]);
+    tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]);
+    expect(
+      tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]),
+    ).toEqual([]);
+  });
+
+  it("ignores messages that APPEAR already complete mid-session (refetch)", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe({}, []);
+    expect(
+      tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]),
+    ).toEqual([]);
+  });
+
+  it("ignores user messages and error completions", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe(
+      {
+        u: message("u", "user", "sending"),
+        a: message("a", "assistant", "sending"),
+      },
+      ["u", "a"],
+    );
+    expect(
+      tracker.observe(
+        {
+          u: message("u", "user", "complete"),
+          a: message("a", "assistant", "error"),
+        },
+        ["u", "a"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("handles multiple streams completing across snapshots", () => {
+    const tracker = new FreshCompletionTracker();
+    tracker.observe({ a: message("a", "assistant", "complete") }, ["a"]);
+    tracker.observe(
+      {
+        a: message("a", "assistant", "complete"),
+        b: message("b", "assistant", "sending"),
+      },
+      ["a", "b"],
+    );
+    expect(
+      tracker.observe(
+        {
+          a: message("a", "assistant", "complete"),
+          b: message("b", "assistant", "complete"),
+        },
+        ["a", "b"],
+      ),
+    ).toEqual(["b"]);
+  });
+});

--- a/office-addin/src/utils/__tests__/outlookActionFacet.test.ts
+++ b/office-addin/src/utils/__tests__/outlookActionFacet.test.ts
@@ -15,6 +15,8 @@ const base: OutlookActionFacetInput = {
   bodyFormat: undefined,
   isComposeMode: false,
   composeEmailAvailable: false,
+  isReadMode: false,
+  replyFromReadAvailable: false,
 };
 
 describe("resolveOutlookActionFacet", () => {
@@ -177,5 +179,39 @@ describe("resolveOutlookActionFacet", () => {
     });
 
     expect(result.facet?.id).toBe("outlook_rewrite_selection");
+  });
+
+  it("sends outlook_reply_from_read in read mode when the facet is available", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      isReadMode: true,
+      replyFromReadAvailable: true,
+    });
+
+    expect(result.facet).toEqual({
+      id: "outlook_reply_from_read",
+      args: { body_format: "html" },
+    });
+    expect(result.sentDraftBody).toBeNull();
+  });
+
+  it("does NOT send outlook_reply_from_read when the facet is unavailable (avoids a 400)", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      isReadMode: true,
+      replyFromReadAvailable: false,
+    });
+
+    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+  });
+
+  it("does NOT send outlook_reply_from_read outside read mode", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      isReadMode: false,
+      replyFromReadAvailable: true,
+    });
+
+    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
   });
 });

--- a/office-addin/src/utils/__tests__/outlookClientActions.test.ts
+++ b/office-addin/src/utils/__tests__/outlookClientActions.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  CLIENT_ACTION_TOOL_NAME,
+  extractProposedClientAction,
+  isImplementedClientAction,
+  offerableClientActions,
+} from "../outlookClientActions";
+
+import type { ContentPart } from "@erato/frontend/library";
+
+const ALLOWED = ["outlook.reply", "outlook.reply_all"];
+
+function toolUsePart(overrides: Record<string, unknown> = {}): ContentPart {
+  return {
+    content_type: "tool_use",
+    tool_call_id: "call-1",
+    tool_name: CLIENT_ACTION_TOOL_NAME,
+    status: "success",
+    input: { action: "outlook.reply_all" },
+    output: { status: "proposed", action: "outlook.reply_all" },
+    ...overrides,
+  } as unknown as ContentPart;
+}
+
+describe("offerableClientActions", () => {
+  it("intersects backend-allowed actions with the implemented registry", () => {
+    expect(
+      offerableClientActions([
+        "outlook.reply_all",
+        "outlook.reply",
+        "outlook.delete_mailbox",
+      ]),
+    ).toEqual(["outlook.reply", "outlook.reply_all"]);
+  });
+
+  it("returns nothing for missing or empty allowed actions", () => {
+    expect(offerableClientActions(undefined)).toEqual([]);
+    expect(offerableClientActions([])).toEqual([]);
+    expect(offerableClientActions(["not.implemented"])).toEqual([]);
+  });
+});
+
+describe("isImplementedClientAction", () => {
+  it("accepts only registry actions", () => {
+    expect(isImplementedClientAction("outlook.reply")).toBe(true);
+    expect(isImplementedClientAction("outlook.reply_all")).toBe(true);
+    expect(isImplementedClientAction("outlook.send")).toBe(false);
+    expect(isImplementedClientAction("")).toBe(false);
+  });
+});
+
+describe("extractProposedClientAction", () => {
+  it("extracts a valid successful proposal", () => {
+    expect(extractProposedClientAction([toolUsePart()], ALLOWED)).toBe(
+      "outlook.reply_all",
+    );
+  });
+
+  it("ignores other tools and non-tool parts", () => {
+    const parts: ContentPart[] = [
+      { content_type: "text", text: "use reply_all please" },
+      toolUsePart({ tool_name: "some_mcp_tool" }),
+    ];
+    expect(extractProposedClientAction(parts, ALLOWED)).toBeUndefined();
+  });
+
+  it("ignores proposals the backend marked as failed", () => {
+    expect(
+      extractProposedClientAction([toolUsePart({ status: "error" })], ALLOWED),
+    ).toBeUndefined();
+    expect(
+      extractProposedClientAction(
+        [toolUsePart({ status: "in_progress" })],
+        ALLOWED,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("ignores malformed inputs", () => {
+    expect(
+      extractProposedClientAction([toolUsePart({ input: null })], ALLOWED),
+    ).toBeUndefined();
+    expect(
+      extractProposedClientAction([toolUsePart({ input: "reply" })], ALLOWED),
+    ).toBeUndefined();
+    expect(
+      extractProposedClientAction(
+        [toolUsePart({ input: { action: 42 } })],
+        ALLOWED,
+      ),
+    ).toBeUndefined();
+    expect(
+      extractProposedClientAction([toolUsePart({ input: {} })], ALLOWED),
+    ).toBeUndefined();
+  });
+
+  it("rejects actions outside the facet's allowed list, even if implemented", () => {
+    expect(
+      extractProposedClientAction(
+        [toolUsePart({ input: { action: "outlook.reply_all" } })],
+        ["outlook.reply"],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects allowed-but-unimplemented actions", () => {
+    expect(
+      extractProposedClientAction(
+        [toolUsePart({ input: { action: "teams.post" } })],
+        ["teams.post"],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("handles empty content", () => {
+    expect(extractProposedClientAction(undefined, ALLOWED)).toBeUndefined();
+    expect(extractProposedClientAction([], ALLOWED)).toBeUndefined();
+  });
+});

--- a/office-addin/src/utils/__tests__/outlookReadReply.test.ts
+++ b/office-addin/src/utils/__tests__/outlookReadReply.test.ts
@@ -16,14 +16,16 @@ type OfficeGlobal = { Office?: unknown };
 function installOffice({
   item,
   supportedSets = ["Mailbox 1.1", "Mailbox 1.9"],
+  userEmailAddress = "me@example.com",
 }: {
   item: Record<string, unknown> | null;
   supportedSets?: string[];
+  userEmailAddress?: string;
 }) {
   (globalThis as OfficeGlobal).Office = {
     AsyncResultStatus: { Succeeded: "succeeded", Failed: "failed" },
     context: {
-      mailbox: { item },
+      mailbox: { item, userProfile: { emailAddress: userEmailAddress } },
       requirements: {
         isSetSupported: (name: string, version: string) =>
           supportedSets.includes(`${name} ${version}`),
@@ -119,11 +121,73 @@ describe("isReadReplySupported", () => {
 });
 
 describe("getReadModeRecipientSummary", () => {
-  it("summarizes sender and recipients, preferring display names", () => {
+  it("always shows the address and excludes the reading user from To/Cc", () => {
     installOffice({ item: readModeItem() });
     expect(getReadModeRecipientSummary()).toEqual({
-      sender: "Alice",
-      recipients: ["Me", "bob@example.com"],
+      sender: "Alice <alice@example.com>",
+      recipients: ["bob@example.com"],
+    });
+  });
+
+  it("excludes the user's own address case-insensitively", () => {
+    installOffice({
+      item: readModeItem({
+        to: [{ displayName: "Me", emailAddress: "ME@Example.COM" }],
+        cc: [],
+      }),
+    });
+    expect(getReadModeRecipientSummary()).toEqual({
+      sender: "Alice <alice@example.com>",
+      recipients: [],
+    });
+  });
+
+  it("does not double-list a sender who is also on To/Cc", () => {
+    installOffice({
+      item: readModeItem({
+        to: [
+          { displayName: "Alice", emailAddress: "Alice@example.com" },
+          { displayName: "Carol", emailAddress: "carol@example.com" },
+        ],
+        cc: [],
+      }),
+    });
+    expect(getReadModeRecipientSummary()).toEqual({
+      sender: "Alice <alice@example.com>",
+      recipients: ["Carol <carol@example.com>"],
+    });
+  });
+
+  it("dedupes recipients listed on both To and Cc", () => {
+    installOffice({
+      item: readModeItem({
+        to: [{ displayName: "Bob", emailAddress: "bob@example.com" }],
+        cc: [{ displayName: "", emailAddress: "BOB@example.com" }],
+      }),
+    });
+    expect(getReadModeRecipientSummary()).toEqual({
+      sender: "Alice <alice@example.com>",
+      recipients: ["Bob <bob@example.com>"],
+    });
+  });
+
+  it("never lets a display name replace or spoof the address", () => {
+    installOffice({
+      item: readModeItem({
+        from: {
+          displayName: "ceo@example.com",
+          emailAddress: "attacker@evil.example",
+        },
+        to: [
+          // Display name equal to the address adds nothing — bare address.
+          { displayName: "bob@example.com", emailAddress: "bob@example.com" },
+        ],
+        cc: [],
+      }),
+    });
+    expect(getReadModeRecipientSummary()).toEqual({
+      sender: "ceo@example.com <attacker@evil.example>",
+      recipients: ["bob@example.com"],
     });
   });
 

--- a/office-addin/src/utils/__tests__/outlookReadReply.test.ts
+++ b/office-addin/src/utils/__tests__/outlookReadReply.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  REPLY_FORM_BODY_LIMIT_BYTES,
+  ReplyBodyTooLargeError,
+  buildReplyFormBody,
+  escapeTextAsHtml,
+  getReadModeRecipientSummary,
+  isReadReplySupported,
+  isReplyFormBodyTooLarge,
+  openReplyForm,
+} from "../outlookReadReply";
+
+vi.mock("@erato/frontend/library", () => ({
+  sanitizeHtmlPreview: (html: string) => `sanitized:${html}`,
+}));
+
+type OfficeGlobal = { Office?: unknown };
+
+function installOffice({
+  item,
+  supportedSets = ["Mailbox 1.1", "Mailbox 1.9"],
+}: {
+  item: Record<string, unknown> | null;
+  supportedSets?: string[];
+}) {
+  (globalThis as OfficeGlobal).Office = {
+    AsyncResultStatus: { Succeeded: "succeeded", Failed: "failed" },
+    context: {
+      mailbox: { item },
+      requirements: {
+        isSetSupported: (name: string, version: string) =>
+          supportedSets.includes(`${name} ${version}`),
+      },
+    },
+  };
+}
+
+function readModeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    // isMessageRead type-guards on a string subject.
+    subject: "Quarterly numbers",
+    from: { displayName: "Alice", emailAddress: "alice@example.com" },
+    to: [{ displayName: "Me", emailAddress: "me@example.com" }],
+    cc: [{ displayName: "", emailAddress: "bob@example.com" }],
+    displayReplyFormAsync: vi.fn(
+      (_body: string, cb: (r: { status: string; value: undefined }) => void) =>
+        cb({ status: "succeeded", value: undefined }),
+    ),
+    displayReplyAllFormAsync: vi.fn(
+      (_body: string, cb: (r: { status: string; value: undefined }) => void) =>
+        cb({ status: "succeeded", value: undefined }),
+    ),
+    displayReplyForm: vi.fn(),
+    displayReplyAllForm: vi.fn(),
+    ...overrides,
+  };
+}
+
+function composeModeItem() {
+  // Compose items expose subject as an object (Office.SubjectCompose).
+  return { subject: { getAsync: vi.fn() } };
+}
+
+afterEach(() => {
+  delete (globalThis as OfficeGlobal).Office;
+  vi.restoreAllMocks();
+});
+
+describe("escapeTextAsHtml", () => {
+  it("escapes HTML entities and converts newlines", () => {
+    expect(escapeTextAsHtml('Hi <b>"you"</b> & co\r\nBye\nNow')).toBe(
+      "Hi &lt;b&gt;&quot;you&quot;&lt;/b&gt; &amp; co<br>Bye<br>Now",
+    );
+  });
+});
+
+describe("buildReplyFormBody", () => {
+  it("sanitizes HTML content", () => {
+    expect(buildReplyFormBody("<p>hello</p>", true)).toBe(
+      "sanitized:<p>hello</p>",
+    );
+  });
+
+  it("escapes plain text content", () => {
+    expect(buildReplyFormBody("a < b\nc", false)).toBe("a &lt; b<br>c");
+  });
+});
+
+describe("isReplyFormBodyTooLarge", () => {
+  it("enforces the 32 KB UTF-8 limit", () => {
+    expect(
+      isReplyFormBodyTooLarge("x".repeat(REPLY_FORM_BODY_LIMIT_BYTES)),
+    ).toBe(false);
+    expect(
+      isReplyFormBodyTooLarge("x".repeat(REPLY_FORM_BODY_LIMIT_BYTES + 1)),
+    ).toBe(true);
+    // Multi-byte characters count in bytes, not chars.
+    expect(
+      isReplyFormBodyTooLarge("ü".repeat(REPLY_FORM_BODY_LIMIT_BYTES / 2 + 1)),
+    ).toBe(true);
+  });
+});
+
+describe("isReadReplySupported", () => {
+  it("is true for a read-mode item on a supporting host", () => {
+    installOffice({ item: readModeItem() });
+    expect(isReadReplySupported()).toBe(true);
+  });
+
+  it("is false in compose mode", () => {
+    installOffice({ item: composeModeItem() });
+    expect(isReadReplySupported()).toBe(false);
+  });
+
+  it("is false without an item or without Mailbox 1.1", () => {
+    installOffice({ item: null });
+    expect(isReadReplySupported()).toBe(false);
+    installOffice({ item: readModeItem(), supportedSets: [] });
+    expect(isReadReplySupported()).toBe(false);
+  });
+});
+
+describe("getReadModeRecipientSummary", () => {
+  it("summarizes sender and recipients, preferring display names", () => {
+    installOffice({ item: readModeItem() });
+    expect(getReadModeRecipientSummary()).toEqual({
+      sender: "Alice",
+      recipients: ["Me", "bob@example.com"],
+    });
+  });
+
+  it("returns null outside read mode", () => {
+    installOffice({ item: composeModeItem() });
+    expect(getReadModeRecipientSummary()).toBeNull();
+  });
+});
+
+describe("openReplyForm", () => {
+  it("opens the async reply form with the escaped text body", async () => {
+    const item = readModeItem();
+    installOffice({ item });
+    await openReplyForm("outlook.reply", "Hello\nWorld", false);
+    expect(item.displayReplyFormAsync).toHaveBeenCalledWith(
+      "Hello<br>World",
+      expect.any(Function),
+    );
+    expect(item.displayReplyAllFormAsync).not.toHaveBeenCalled();
+  });
+
+  it("opens the reply-all form with the sanitized HTML body", async () => {
+    const item = readModeItem();
+    installOffice({ item });
+    await openReplyForm("outlook.reply_all", "<p>Hi</p>", true);
+    expect(item.displayReplyAllFormAsync).toHaveBeenCalledWith(
+      "sanitized:<p>Hi</p>",
+      expect.any(Function),
+    );
+  });
+
+  it("falls back to the sync API when Mailbox 1.9 is unsupported", async () => {
+    const item = readModeItem();
+    installOffice({ item, supportedSets: ["Mailbox 1.1"] });
+    await openReplyForm("outlook.reply", "Hi", false);
+    expect(item.displayReplyForm).toHaveBeenCalledWith("Hi");
+    expect(item.displayReplyFormAsync).not.toHaveBeenCalled();
+  });
+
+  it("throws ReplyBodyTooLargeError for oversized drafts without calling Office", async () => {
+    const item = readModeItem();
+    installOffice({ item });
+    await expect(
+      openReplyForm(
+        "outlook.reply",
+        "x".repeat(REPLY_FORM_BODY_LIMIT_BYTES + 1),
+        false,
+      ),
+    ).rejects.toBeInstanceOf(ReplyBodyTooLargeError);
+    expect(item.displayReplyFormAsync).not.toHaveBeenCalled();
+    expect(item.displayReplyForm).not.toHaveBeenCalled();
+  });
+
+  it("throws when the current item is not a read-mode message", async () => {
+    installOffice({ item: composeModeItem() });
+    await expect(openReplyForm("outlook.reply", "Hi", false)).rejects.toThrow(
+      /not an open received email/,
+    );
+  });
+
+  it("propagates Office async failures", async () => {
+    const item = readModeItem({
+      displayReplyFormAsync: vi.fn(
+        (
+          _body: string,
+          cb: (r: { status: string; error: { message: string } }) => void,
+        ) => cb({ status: "failed", error: { message: "nope" } }),
+      ),
+    });
+    installOffice({ item });
+    await expect(openReplyForm("outlook.reply", "Hi", false)).rejects.toThrow(
+      "nope",
+    );
+  });
+});

--- a/office-addin/src/utils/__tests__/outlookReadReply.test.ts
+++ b/office-addin/src/utils/__tests__/outlookReadReply.test.ts
@@ -11,10 +11,6 @@ import {
   openReplyForm,
 } from "../outlookReadReply";
 
-vi.mock("@erato/frontend/library", () => ({
-  sanitizeHtmlPreview: (html: string) => `sanitized:${html}`,
-}));
-
 type OfficeGlobal = { Office?: unknown };
 
 function installOffice({
@@ -76,10 +72,11 @@ describe("escapeTextAsHtml", () => {
 });
 
 describe("buildReplyFormBody", () => {
-  it("sanitizes HTML content", () => {
-    expect(buildReplyFormBody("<p>hello</p>", true)).toBe(
-      "sanitized:<p>hello</p>",
-    );
+  it("sanitizes HTML content with the outbound config", () => {
+    expect(buildReplyFormBody("<p>hello</p>", true)).toBe("<p>hello</p>");
+    expect(
+      buildReplyFormBody('<p onclick="x()">hi<script>x()</script></p>', true),
+    ).toBe("<p>hi</p>");
   });
 
   it("escapes plain text content", () => {
@@ -151,9 +148,13 @@ describe("openReplyForm", () => {
   it("opens the reply-all form with the sanitized HTML body", async () => {
     const item = readModeItem();
     installOffice({ item });
-    await openReplyForm("outlook.reply_all", "<p>Hi</p>", true);
+    await openReplyForm(
+      "outlook.reply_all",
+      "<p>Hi<script>x()</script></p>",
+      true,
+    );
     expect(item.displayReplyAllFormAsync).toHaveBeenCalledWith(
-      "sanitized:<p>Hi</p>",
+      "<p>Hi</p>",
       expect.any(Function),
     );
   });

--- a/office-addin/src/utils/__tests__/sanitizeReplyFormHtml.test.ts
+++ b/office-addin/src/utils/__tests__/sanitizeReplyFormHtml.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeReplyFormHtml } from "../sanitizeReplyFormHtml";
+
+describe("sanitizeReplyFormHtml", () => {
+  it("keeps basic text structure and safe links", () => {
+    expect(
+      sanitizeReplyFormHtml(
+        '<p>Hi <strong>Bob</strong>,<br>see <a href="https://example.com">this</a></p>',
+      ),
+    ).toBe(
+      '<p>Hi <strong>Bob</strong>,<br>see <a href="https://example.com">this</a></p>',
+    );
+    expect(sanitizeReplyFormHtml('<a href="mailto:a@b.c">mail</a>')).toBe(
+      '<a href="mailto:a@b.c">mail</a>',
+    );
+  });
+
+  it("strips scripts, event handlers, and javascript: URLs", () => {
+    expect(sanitizeReplyFormHtml("<p>hi<script>x()</script></p>")).toBe(
+      "<p>hi</p>",
+    );
+    expect(sanitizeReplyFormHtml('<p onclick="x()">hi</p>')).toBe("<p>hi</p>");
+    expect(sanitizeReplyFormHtml('<a href="javascript:x()">hi</a>')).toBe(
+      "<a>hi</a>",
+    );
+  });
+
+  it("strips style tags/attributes, images, and tables (outbound is stricter than preview)", () => {
+    expect(sanitizeReplyFormHtml('<p style="color:red">hi</p>')).toBe(
+      "<p>hi</p>",
+    );
+    expect(
+      sanitizeReplyFormHtml("<style>p{display:none}</style><p>hi</p>"),
+    ).toBe("<p>hi</p>");
+    expect(sanitizeReplyFormHtml('<p><img src="https://x/y.png">hi</p>')).toBe(
+      "<p>hi</p>",
+    );
+    expect(sanitizeReplyFormHtml("<table><tr><td>cell</td></tr></table>")).toBe(
+      "cell",
+    );
+    expect(sanitizeReplyFormHtml('<a href="data:text/html,x">hi</a>')).toBe(
+      "<a>hi</a>",
+    );
+  });
+});

--- a/office-addin/src/utils/clientActionPolicy.ts
+++ b/office-addin/src/utils/clientActionPolicy.ts
@@ -122,7 +122,9 @@ export function resolveAutoPromptBehavior(input: {
 /**
  * Persisted-state options: unknown shapes reset to defaults, unknown modes
  * reject the stored value, actions absent from storage keep their default
- * (so adding a future action never invalidates existing settings).
+ * (so adding a future action never invalidates existing settings). Stored
+ * modes are clamped to each action's floor so the settings UI never shows
+ * a state below it (e.g. a hand-edited reply_all "dont_ask").
  */
 export const clientActionPreferencesPersistedOptions: PersistedStateOptions<ClientActionPreferences> =
   {
@@ -141,6 +143,9 @@ export const clientActionPreferencesPersistedOptions: PersistedStateOptions<Clie
           return null;
         }
         result[action] = mode;
+      }
+      for (const action of IMPLEMENTED_CLIENT_ACTIONS) {
+        result[action] = effectiveApprovalMode(action, result);
       }
       return result;
     },

--- a/office-addin/src/utils/clientActionPolicy.ts
+++ b/office-addin/src/utils/clientActionPolicy.ts
@@ -34,6 +34,24 @@ export function decisionKey(facetId: string, action: string): string {
   return `${facetId}/${action}`;
 }
 
+/**
+ * Inverse of `decisionKey`. Facet ids are free-form erato.toml keys and may
+ * themselves contain `/`; action ids never do, so the LAST separator is the
+ * unambiguous split. Returns `null` when either side would be empty.
+ */
+export function parseDecisionKey(
+  key: string,
+): { facetId: string; action: string } | null {
+  const separator = key.lastIndexOf("/");
+  if (separator <= 0 || separator === key.length - 1) {
+    return null;
+  }
+  return {
+    facetId: key.slice(0, separator),
+    action: key.slice(separator + 1),
+  };
+}
+
 export function isClientActionDecision(
   value: unknown,
 ): value is ClientActionDecision {
@@ -77,18 +95,27 @@ export type AutoPromptBehavior = "execute" | "confirm" | "none";
 
 /**
  * Whether (and how) a proposal may auto-surface without a click. Requires ALL
- * of: the facet configured `auto_prompt`, a validated proposal, and a FRESH
- * assistant completion (never history reloads/refetches). The effective
- * decision then applies: `never` → nothing, `ask` (the default) → the inline
- * card surfaces, `always` (user-granted, not server-enforced-ask) → the
- * action executes. Outlook's own Send button remains the final gate in every
- * path.
+ * of: the facet configured `auto_prompt`, a validated proposal, a FRESH
+ * assistant completion (never history reloads/refetches) that is still the
+ * LATEST assistant message, and a send-time item identity that matches the
+ * currently open item — a missing identity means capture failed and is
+ * treated like a mismatch (fail closed: a missed auto-open, never a reply
+ * form on the wrong email). The effective decision then applies: `never` →
+ * nothing, `ask` (the default) → the inline card surfaces, `always`
+ * (user-granted, not server-enforced-ask) → the action executes. Outlook's
+ * own Send button remains the final gate in every path.
  */
 export function resolveAutoPromptBehavior(input: {
   presentation: string | undefined;
   facetId: string | undefined;
   proposedAction: OutlookClientAction | undefined;
   isFreshCompletion: boolean;
+  /** Whether the proposing message is the latest assistant message. */
+  isLatestAssistantMessage: boolean;
+  /** Send-time item identity stamped on the artifact, if capture succeeded. */
+  expectedItemIdentity: string | null | undefined;
+  /** Identity of the currently open Outlook item. */
+  currentItemIdentity: string | null | undefined;
   decisions: ClientActionDecisionMap;
   enforcedAskActions: readonly string[];
 }): AutoPromptBehavior {
@@ -96,6 +123,15 @@ export function resolveAutoPromptBehavior(input: {
     return "none";
   }
   if (!input.facetId || !input.proposedAction || !input.isFreshCompletion) {
+    return "none";
+  }
+  if (!input.isLatestAssistantMessage) {
+    return "none";
+  }
+  if (
+    !input.expectedItemIdentity ||
+    input.expectedItemIdentity !== input.currentItemIdentity
+  ) {
     return "none";
   }
   const decision = effectiveDecision({
@@ -111,13 +147,62 @@ export function resolveAutoPromptBehavior(input: {
 }
 
 /**
+ * Whether a stored entry is fully described by this build's model — an
+ * implemented action with a known decision value. Only such entries belong
+ * to the in-memory map; everything else (future actions, future decision
+ * kinds, foreign key shapes) is preserved verbatim across writes.
+ */
+function isOwnedStoredEntry(key: string, decision: unknown): boolean {
+  const parsed = parseDecisionKey(key);
+  return (
+    parsed !== null &&
+    isImplementedClientAction(parsed.action) &&
+    isClientActionDecision(decision)
+  );
+}
+
+/**
+ * Merge the in-memory map into the previously stored raw object: entries
+ * this build owns are replaced wholesale (so removals stick), while unknown
+ * entries survive the write — saving from an older build must never erase a
+ * newer build's decisions (including persistent denies).
+ */
+export function mergeIntoStoredDecisions(
+  stored: unknown,
+  decisions: ClientActionDecisionMap,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  if (stored !== null && typeof stored === "object" && !Array.isArray(stored)) {
+    for (const [key, decision] of Object.entries(
+      stored as Record<string, unknown>,
+    )) {
+      if (!isOwnedStoredEntry(key, decision)) {
+        merged[key] = decision;
+      }
+    }
+  }
+  return Object.assign(merged, decisions);
+}
+
+function readStoredDecisionsRaw(): unknown {
+  try {
+    const raw = localStorage.getItem(CLIENT_ACTION_DECISIONS_KEY);
+    return raw === null ? null : (JSON.parse(raw) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Persisted-state options: unknown shapes reset to defaults; entries with
  * malformed keys, unknown decision values, or unimplemented actions are
- * dropped individually (forward compatible — a future build's entries never
- * invalidate the rest). Server enforcement is deliberately NOT applied here:
- * it depends on live `/me/facets` data and is clamped at read time by
- * `effectiveDecision`, so a temporarily unreachable backend can't silently
- * erase a user's stored grant.
+ * dropped individually on read but survive writes via
+ * `mergeIntoStoredDecisions` (forward compatible — a future build's entries
+ * never invalidate the rest and are never erased by saving here). Server
+ * enforcement is deliberately NOT applied here: it depends on live
+ * `/me/facets` data and is clamped at read time by `effectiveDecision`, so a
+ * temporarily unreachable backend can't silently erase a user's stored
+ * grant.
  */
 export const clientActionDecisionsPersistedOptions: PersistedStateOptions<ClientActionDecisionMap> =
   {
@@ -129,12 +214,8 @@ export const clientActionDecisionsPersistedOptions: PersistedStateOptions<Client
       for (const [key, decision] of Object.entries(
         value as Record<string, unknown>,
       )) {
-        const separator = key.indexOf("/");
-        if (separator <= 0) {
-          continue;
-        }
-        const action = key.slice(separator + 1);
-        if (!isImplementedClientAction(action)) {
+        const parsed = parseDecisionKey(key);
+        if (!parsed || !isImplementedClientAction(parsed.action)) {
           continue;
         }
         if (!isClientActionDecision(decision)) {
@@ -148,4 +229,6 @@ export const clientActionDecisionsPersistedOptions: PersistedStateOptions<Client
       }
       return result;
     },
+    serialize: (value) =>
+      JSON.stringify(mergeIntoStoredDecisions(readStoredDecisionsRaw(), value)),
   };

--- a/office-addin/src/utils/clientActionPolicy.ts
+++ b/office-addin/src/utils/clientActionPolicy.ts
@@ -1,0 +1,147 @@
+import {
+  IMPLEMENTED_CLIENT_ACTIONS,
+  type OutlookClientAction,
+} from "./outlookClientActions";
+
+import type { PersistedStateOptions } from "@erato/frontend/library";
+
+/**
+ * Local approval policy for client actions, pure and unit-testable.
+ *
+ * Two inputs combine into the effective behavior:
+ * - the facet's server-side `presentation` (`render_buttons` | `auto_prompt`)
+ *   from `GET /me/facets`, and
+ * - the user's local per-action preference below.
+ *
+ * The local preference can always make behavior STRICTER than the server
+ * intent (deny an action, force a confirmation), never more permissive than
+ * the per-action floor allows.
+ */
+export type ClientActionApprovalMode = "always_ask" | "dont_ask" | "deny";
+
+export type ClientActionPreferences = Record<
+  OutlookClientAction,
+  ClientActionApprovalMode
+>;
+
+export const CLIENT_ACTION_PREFERENCES_KEY =
+  "erato.outlookAddin.clientActionPreferences";
+
+/**
+ * Defaults reproduce the pre-settings behavior exactly: reply executes on
+ * click, reply-all confirms first.
+ */
+export const DEFAULT_CLIENT_ACTION_PREFERENCES: ClientActionPreferences = {
+  "outlook.reply": "dont_ask",
+  "outlook.reply_all": "always_ask",
+};
+
+/**
+ * Per-action strictness floors local settings cannot go below. Reply-all is
+ * floored at `always_ask`: the confirmation doubles as the fresh-recipient
+ * check, so it can be denied but never made silent.
+ */
+const APPROVAL_FLOORS: Partial<
+  Record<OutlookClientAction, ClientActionApprovalMode>
+> = {
+  "outlook.reply_all": "always_ask",
+};
+
+const STRICTNESS: Record<ClientActionApprovalMode, number> = {
+  dont_ask: 0,
+  always_ask: 1,
+  deny: 2,
+};
+
+export function isApprovalMode(
+  value: unknown,
+): value is ClientActionApprovalMode {
+  return value === "always_ask" || value === "dont_ask" || value === "deny";
+}
+
+/** The user's preference for an action, clamped to the action's floor. */
+export function effectiveApprovalMode(
+  action: OutlookClientAction,
+  preferences: ClientActionPreferences,
+): ClientActionApprovalMode {
+  const preferred =
+    preferences[action] ?? DEFAULT_CLIENT_ACTION_PREFERENCES[action];
+  const floor = APPROVAL_FLOORS[action];
+  if (floor && STRICTNESS[preferred] < STRICTNESS[floor]) {
+    return floor;
+  }
+  return preferred;
+}
+
+export function isActionDenied(
+  action: OutlookClientAction,
+  preferences: ClientActionPreferences,
+): boolean {
+  return effectiveApprovalMode(action, preferences) === "deny";
+}
+
+/** What an explicit button click does for an (offered, non-denied) action. */
+export function resolveClickBehavior(
+  action: OutlookClientAction,
+  preferences: ClientActionPreferences,
+): "execute" | "confirm" {
+  return effectiveApprovalMode(action, preferences) === "dont_ask"
+    ? "execute"
+    : "confirm";
+}
+
+export type AutoPromptBehavior = "execute" | "confirm" | "none";
+
+/**
+ * Whether (and how) a proposal may auto-surface without a click. Requires ALL
+ * of: the facet configured `auto_prompt`, a validated proposal, and a FRESH
+ * assistant completion (never history reloads/refetches). The user's local
+ * preference then decides: deny → nothing, always_ask → confirmation dialog,
+ * dont_ask → open the prefilled reply form directly. Outlook's own Send
+ * button remains the final gate in every path.
+ */
+export function resolveAutoPromptBehavior(input: {
+  presentation: string | undefined;
+  proposedAction: OutlookClientAction | undefined;
+  isFreshCompletion: boolean;
+  preferences: ClientActionPreferences;
+}): AutoPromptBehavior {
+  if (input.presentation !== "auto_prompt") {
+    return "none";
+  }
+  if (!input.proposedAction || !input.isFreshCompletion) {
+    return "none";
+  }
+  const mode = effectiveApprovalMode(input.proposedAction, input.preferences);
+  if (mode === "deny") {
+    return "none";
+  }
+  return mode === "dont_ask" ? "execute" : "confirm";
+}
+
+/**
+ * Persisted-state options: unknown shapes reset to defaults, unknown modes
+ * reject the stored value, actions absent from storage keep their default
+ * (so adding a future action never invalidates existing settings).
+ */
+export const clientActionPreferencesPersistedOptions: PersistedStateOptions<ClientActionPreferences> =
+  {
+    parse: (value) => {
+      if (value === null || typeof value !== "object") {
+        return null;
+      }
+      const candidate = value as Record<string, unknown>;
+      const result = { ...DEFAULT_CLIENT_ACTION_PREFERENCES };
+      for (const action of IMPLEMENTED_CLIENT_ACTIONS) {
+        const mode = candidate[action];
+        if (mode === undefined) {
+          continue;
+        }
+        if (!isApprovalMode(mode)) {
+          return null;
+        }
+        result[action] = mode;
+      }
+      return result;
+    },
+  };

--- a/office-addin/src/utils/clientActionPolicy.ts
+++ b/office-addin/src/utils/clientActionPolicy.ts
@@ -1,93 +1,76 @@
-import {
-  IMPLEMENTED_CLIENT_ACTIONS,
-  type OutlookClientAction,
-} from "./outlookClientActions";
+import { isImplementedClientAction } from "./outlookClientActions";
 
+import type { OutlookClientAction } from "./outlookClientActions";
 import type { PersistedStateOptions } from "@erato/frontend/library";
 
 /**
- * Local approval policy for client actions, pure and unit-testable.
+ * Local decision store for client actions, pure and unit-testable.
  *
- * Two inputs combine into the effective behavior:
- * - the facet's server-side `presentation` (`render_buttons` | `auto_prompt`)
- *   from `GET /me/facets`, and
- * - the user's local per-action preference below.
- *
- * The local preference can always make behavior STRICTER than the server
- * intent (deny an action, force a confirmation), never more permissive than
- * the per-action floor allows.
+ * Browser-permission semantics: every action defaults to `ask` — the inline
+ * card asks on each proposal, and "allow once" / "deny" on the card apply to
+ * that proposal only. Only an explicit "always allow" persists (written by
+ * the card or the settings page); `never` is a persistent deny set in
+ * settings. The deployment config is the policy authority: actions listed in
+ * the facet's `client_actions_always_ask` can never resolve to `always` —
+ * a stored grant is clamped back to `ask`, and the UI greys the option out
+ * with a reason. Users may always be STRICTER than the server (deny).
  */
-export type ClientActionApprovalMode = "always_ask" | "dont_ask" | "deny";
+export type ClientActionDecision = "ask" | "always" | "never";
 
-export type ClientActionPreferences = Record<
-  OutlookClientAction,
-  ClientActionApprovalMode
->;
+/** Stored decisions, keyed by `decisionKey(facetId, action)`. */
+export type ClientActionDecisionMap = Record<string, ClientActionDecision>;
 
-export const CLIENT_ACTION_PREFERENCES_KEY =
-  "erato.outlookAddin.clientActionPreferences";
+export const CLIENT_ACTION_DECISIONS_KEY =
+  "erato.outlookAddin.clientActionDecisions";
+
+export const DEFAULT_CLIENT_ACTION_DECISIONS: ClientActionDecisionMap = {};
 
 /**
- * Defaults reproduce the pre-settings behavior exactly: reply executes on
- * click, reply-all confirms first.
+ * Decisions are scoped per facet AND action: "always allow reply for the
+ * read-mode facet" must not silently pre-grant a future facet that happens
+ * to reuse the same action id.
  */
-export const DEFAULT_CLIENT_ACTION_PREFERENCES: ClientActionPreferences = {
-  "outlook.reply": "dont_ask",
-  "outlook.reply_all": "always_ask",
-};
-
-/**
- * Per-action strictness floors local settings cannot go below. Reply-all is
- * floored at `always_ask`: the confirmation doubles as the fresh-recipient
- * check, so it can be denied but never made silent.
- */
-const APPROVAL_FLOORS: Partial<
-  Record<OutlookClientAction, ClientActionApprovalMode>
-> = {
-  "outlook.reply_all": "always_ask",
-};
-
-const STRICTNESS: Record<ClientActionApprovalMode, number> = {
-  dont_ask: 0,
-  always_ask: 1,
-  deny: 2,
-};
-
-export function isApprovalMode(
-  value: unknown,
-): value is ClientActionApprovalMode {
-  return value === "always_ask" || value === "dont_ask" || value === "deny";
+export function decisionKey(facetId: string, action: string): string {
+  return `${facetId}/${action}`;
 }
 
-/** The user's preference for an action, clamped to the action's floor. */
-export function effectiveApprovalMode(
-  action: OutlookClientAction,
-  preferences: ClientActionPreferences,
-): ClientActionApprovalMode {
-  const preferred =
-    preferences[action] ?? DEFAULT_CLIENT_ACTION_PREFERENCES[action];
-  const floor = APPROVAL_FLOORS[action];
-  if (floor && STRICTNESS[preferred] < STRICTNESS[floor]) {
-    return floor;
+export function isClientActionDecision(
+  value: unknown,
+): value is ClientActionDecision {
+  return value === "ask" || value === "always" || value === "never";
+}
+
+/**
+ * The decision in effect for an action: the stored decision (default `ask`),
+ * with a server-enforced per-use confirmation clamping `always` back to
+ * `ask`. `never` is honored regardless — stricter than the server is fine.
+ */
+export function effectiveDecision(input: {
+  facetId: string;
+  action: OutlookClientAction;
+  decisions: ClientActionDecisionMap;
+  /** The facet's `client_actions_always_ask` from `GET /me/facets`. */
+  enforcedAskActions: readonly string[];
+}): ClientActionDecision {
+  const stored =
+    input.decisions[decisionKey(input.facetId, input.action)] ?? "ask";
+  if (stored === "always" && input.enforcedAskActions.includes(input.action)) {
+    return "ask";
   }
-  return preferred;
+  return stored;
 }
 
 export function isActionDenied(
-  action: OutlookClientAction,
-  preferences: ClientActionPreferences,
+  input: Parameters<typeof effectiveDecision>[0],
 ): boolean {
-  return effectiveApprovalMode(action, preferences) === "deny";
+  return effectiveDecision(input) === "never";
 }
 
 /** What an explicit button click does for an (offered, non-denied) action. */
 export function resolveClickBehavior(
-  action: OutlookClientAction,
-  preferences: ClientActionPreferences,
+  input: Parameters<typeof effectiveDecision>[0],
 ): "execute" | "confirm" {
-  return effectiveApprovalMode(action, preferences) === "dont_ask"
-    ? "execute"
-    : "confirm";
+  return effectiveDecision(input) === "always" ? "execute" : "confirm";
 }
 
 export type AutoPromptBehavior = "execute" | "confirm" | "none";
@@ -95,57 +78,73 @@ export type AutoPromptBehavior = "execute" | "confirm" | "none";
 /**
  * Whether (and how) a proposal may auto-surface without a click. Requires ALL
  * of: the facet configured `auto_prompt`, a validated proposal, and a FRESH
- * assistant completion (never history reloads/refetches). The user's local
- * preference then decides: deny → nothing, always_ask → confirmation dialog,
- * dont_ask → open the prefilled reply form directly. Outlook's own Send
- * button remains the final gate in every path.
+ * assistant completion (never history reloads/refetches). The effective
+ * decision then applies: `never` → nothing, `ask` (the default) → the inline
+ * card surfaces, `always` (user-granted, not server-enforced-ask) → the
+ * action executes. Outlook's own Send button remains the final gate in every
+ * path.
  */
 export function resolveAutoPromptBehavior(input: {
   presentation: string | undefined;
+  facetId: string | undefined;
   proposedAction: OutlookClientAction | undefined;
   isFreshCompletion: boolean;
-  preferences: ClientActionPreferences;
+  decisions: ClientActionDecisionMap;
+  enforcedAskActions: readonly string[];
 }): AutoPromptBehavior {
   if (input.presentation !== "auto_prompt") {
     return "none";
   }
-  if (!input.proposedAction || !input.isFreshCompletion) {
+  if (!input.facetId || !input.proposedAction || !input.isFreshCompletion) {
     return "none";
   }
-  const mode = effectiveApprovalMode(input.proposedAction, input.preferences);
-  if (mode === "deny") {
+  const decision = effectiveDecision({
+    facetId: input.facetId,
+    action: input.proposedAction,
+    decisions: input.decisions,
+    enforcedAskActions: input.enforcedAskActions,
+  });
+  if (decision === "never") {
     return "none";
   }
-  return mode === "dont_ask" ? "execute" : "confirm";
+  return decision === "always" ? "execute" : "confirm";
 }
 
 /**
- * Persisted-state options: unknown shapes reset to defaults, unknown modes
- * reject the stored value, actions absent from storage keep their default
- * (so adding a future action never invalidates existing settings). Stored
- * modes are clamped to each action's floor so the settings UI never shows
- * a state below it (e.g. a hand-edited reply_all "dont_ask").
+ * Persisted-state options: unknown shapes reset to defaults; entries with
+ * malformed keys, unknown decision values, or unimplemented actions are
+ * dropped individually (forward compatible — a future build's entries never
+ * invalidate the rest). Server enforcement is deliberately NOT applied here:
+ * it depends on live `/me/facets` data and is clamped at read time by
+ * `effectiveDecision`, so a temporarily unreachable backend can't silently
+ * erase a user's stored grant.
  */
-export const clientActionPreferencesPersistedOptions: PersistedStateOptions<ClientActionPreferences> =
+export const clientActionDecisionsPersistedOptions: PersistedStateOptions<ClientActionDecisionMap> =
   {
     parse: (value) => {
-      if (value === null || typeof value !== "object") {
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
         return null;
       }
-      const candidate = value as Record<string, unknown>;
-      const result = { ...DEFAULT_CLIENT_ACTION_PREFERENCES };
-      for (const action of IMPLEMENTED_CLIENT_ACTIONS) {
-        const mode = candidate[action];
-        if (mode === undefined) {
+      const result: ClientActionDecisionMap = {};
+      for (const [key, decision] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        const separator = key.indexOf("/");
+        if (separator <= 0) {
           continue;
         }
-        if (!isApprovalMode(mode)) {
-          return null;
+        const action = key.slice(separator + 1);
+        if (!isImplementedClientAction(action)) {
+          continue;
         }
-        result[action] = mode;
-      }
-      for (const action of IMPLEMENTED_CLIENT_ACTIONS) {
-        result[action] = effectiveApprovalMode(action, result);
+        if (!isClientActionDecision(decision)) {
+          continue;
+        }
+        // Storing the default is allowed but redundant; normalize it away.
+        if (decision === "ask") {
+          continue;
+        }
+        result[key] = decision;
       }
       return result;
     },

--- a/office-addin/src/utils/freshCompletionTracker.ts
+++ b/office-addin/src/utils/freshCompletionTracker.ts
@@ -4,16 +4,26 @@ import type { Message } from "@erato/frontend/library";
  * Tracks which assistant messages finished streaming DURING this session.
  *
  * Auto-prompt must never fire for messages loaded from history, refetches,
- * or chat switches — only for a completion the user just watched happen. The
- * reliable signal is a status transition observed across snapshots:
- * a message we previously saw as non-`complete` (streaming messages carry
- * `status: "sending"`) that is now `complete`.
+ * or chat switches — only for a completion the user just watched happen.
  *
- * Deliberately conservative: the very first snapshot is treated as history
- * (nothing is fresh), and a message that APPEARS already complete mid-session
- * (refetch, pagination) is not fresh either. The failure direction is
- * under-firing — a missed auto-open still leaves the buttons — never a
- * surprise window from old data.
+ * Two signals mark a message fresh:
+ *
+ * 1. Transition: a message previously observed as non-`complete` (streaming
+ *    messages carry `status: "sending"`) that is now `complete`.
+ * 2. Replacement: very short responses (or buffering proxies) can deliver
+ *    `assistant_message_started` and the completion in one network chunk, so
+ *    the optimistic placeholder id is swapped for the real id with no
+ *    intermediate `sending` render. That snapshot shows: a tracked
+ *    non-complete id disappeared, exactly ONE new id appeared already
+ *    `complete`, and every previously-tracked complete id is still present
+ *    (ruling out chat switches and list replacements).
+ *
+ * Deliberately conservative beyond that: the first snapshot is history
+ * (nothing fresh), and a message that merely APPEARS complete mid-session
+ * (refetch, pagination) is not fresh. The failure direction is under-firing —
+ * a missed auto-open still leaves the buttons — never a surprise window from
+ * old data. The owner must additionally discard the tracker on chat switches
+ * (see AddinChat), which removes the residual cross-chat ambiguity.
  */
 export class FreshCompletionTracker {
   private prevStatuses: Map<string, string | undefined> | null = null;
@@ -25,6 +35,7 @@ export class FreshCompletionTracker {
   ): string[] {
     const next = new Map<string, string | undefined>();
     const newlyFresh: string[] = [];
+    const appearedComplete: string[] = [];
     for (const id of messageOrder) {
       const message = messages[id];
       if (!message || message.role !== "assistant") {
@@ -34,10 +45,30 @@ export class FreshCompletionTracker {
       if (this.prevStatuses === null) {
         continue;
       }
-      const sawIncomplete =
-        this.prevStatuses.has(id) && this.prevStatuses.get(id) !== "complete";
-      if (sawIncomplete && message.status === "complete") {
-        newlyFresh.push(id);
+      if (this.prevStatuses.has(id)) {
+        const sawIncomplete = this.prevStatuses.get(id) !== "complete";
+        if (sawIncomplete && message.status === "complete") {
+          newlyFresh.push(id);
+        }
+      } else if (message.status === "complete") {
+        appearedComplete.push(id);
+      }
+    }
+    if (this.prevStatuses !== null && appearedComplete.length === 1) {
+      let incompleteDisappeared = false;
+      let allCompleteRetained = true;
+      for (const [id, status] of this.prevStatuses) {
+        if (next.has(id)) {
+          continue;
+        }
+        if (status === "complete") {
+          allCompleteRetained = false;
+        } else {
+          incompleteDisappeared = true;
+        }
+      }
+      if (incompleteDisappeared && allCompleteRetained) {
+        newlyFresh.push(appearedComplete[0]);
       }
     }
     this.prevStatuses = next;

--- a/office-addin/src/utils/freshCompletionTracker.ts
+++ b/office-addin/src/utils/freshCompletionTracker.ts
@@ -1,0 +1,46 @@
+import type { Message } from "@erato/frontend/library";
+
+/**
+ * Tracks which assistant messages finished streaming DURING this session.
+ *
+ * Auto-prompt must never fire for messages loaded from history, refetches,
+ * or chat switches — only for a completion the user just watched happen. The
+ * reliable signal is a status transition observed across snapshots:
+ * a message we previously saw as non-`complete` (streaming messages carry
+ * `status: "sending"`) that is now `complete`.
+ *
+ * Deliberately conservative: the very first snapshot is treated as history
+ * (nothing is fresh), and a message that APPEARS already complete mid-session
+ * (refetch, pagination) is not fresh either. The failure direction is
+ * under-firing — a missed auto-open still leaves the buttons — never a
+ * surprise window from old data.
+ */
+export class FreshCompletionTracker {
+  private prevStatuses: Map<string, string | undefined> | null = null;
+
+  /** Observe the current snapshot; returns ids that JUST completed. */
+  observe(
+    messages: Record<string, Message>,
+    messageOrder: readonly string[],
+  ): string[] {
+    const next = new Map<string, string | undefined>();
+    const newlyFresh: string[] = [];
+    for (const id of messageOrder) {
+      const message = messages[id];
+      if (!message || message.role !== "assistant") {
+        continue;
+      }
+      next.set(id, message.status);
+      if (this.prevStatuses === null) {
+        continue;
+      }
+      const sawIncomplete =
+        this.prevStatuses.has(id) && this.prevStatuses.get(id) !== "complete";
+      if (sawIncomplete && message.status === "complete") {
+        newlyFresh.push(id);
+      }
+    }
+    this.prevStatuses = next;
+    return newlyFresh;
+  }
+}

--- a/office-addin/src/utils/outlookActionFacet.ts
+++ b/office-addin/src/utils/outlookActionFacet.ts
@@ -1,3 +1,5 @@
+import { OUTLOOK_REPLY_FROM_READ_FACET_ID } from "./outlookClientActions";
+
 import type { ActionFacetRequest } from "@erato/frontend/library";
 
 /**
@@ -41,6 +43,14 @@ export interface OutlookActionFacetInput {
    * false and the empty-draft case simply sends no facet (today's behavior).
    */
   composeEmailAvailable: boolean;
+  /** The user is reading a received email (read mode, not compose). */
+  isReadMode: boolean;
+  /**
+   * Whether the backend reports the `outlook_reply_from_read` facet as
+   * available (from `GET /me/facets`). Config-defined (erato.toml only) and
+   * gated exactly like `compose_email`: never attached unless advertised.
+   */
+  replyFromReadAvailable: boolean;
 }
 
 export interface OutlookActionFacetResult {
@@ -113,6 +123,21 @@ export function resolveOutlookActionFacet(
       facet: {
         id: "compose_email",
         args: { body_format: input.bodyFormat ?? "text" },
+      },
+      sentDraftBody: null,
+    };
+  }
+
+  // Read mode: the user is looking at a received email. The facet primes the
+  // model to draft a reply (in an erato-email fence) and to propose
+  // reply-vs-reply-all via the backend's `propose_client_action` tool when —
+  // and only when — the user actually asks for a reply; other requests are
+  // answered normally. The reply form prefill is HTML, so request html output.
+  if (input.replyFromReadAvailable && input.isReadMode) {
+    return {
+      facet: {
+        id: OUTLOOK_REPLY_FROM_READ_FACET_ID,
+        args: { body_format: "html" },
       },
       sentDraftBody: null,
     };

--- a/office-addin/src/utils/outlookClientActions.ts
+++ b/office-addin/src/utils/outlookClientActions.ts
@@ -1,3 +1,5 @@
+import { t } from "@lingui/core/macro";
+
 import type { ContentPart } from "@erato/frontend/library";
 
 /**
@@ -29,6 +31,22 @@ export function isImplementedClientAction(
   action: string,
 ): action is OutlookClientAction {
   return (IMPLEMENTED_CLIENT_ACTIONS as readonly string[]).includes(action);
+}
+
+/**
+ * Human-readable description of an action, shared by the permission card
+ * payload and the settings decision toggles.
+ */
+export function clientActionDisplayLabel(action: OutlookClientAction): string {
+  return action === "outlook.reply_all"
+    ? t({
+        id: "officeAddin.clientActions.replyAll",
+        message: "Reply to all recipients",
+      })
+    : t({
+        id: "officeAddin.clientActions.reply",
+        message: "Reply to sender",
+      });
 }
 
 /**

--- a/office-addin/src/utils/outlookClientActions.ts
+++ b/office-addin/src/utils/outlookClientActions.ts
@@ -1,0 +1,93 @@
+import type { ContentPart } from "@erato/frontend/library";
+
+/**
+ * Id of the config-defined action facet (erato.toml only) that lets the model
+ * draft a reply to the email the user is currently reading and propose
+ * opening Outlook's reply / reply-all form.
+ */
+export const OUTLOOK_REPLY_FROM_READ_FACET_ID = "outlook_reply_from_read";
+
+/**
+ * Name of the backend's synthetic tool through which the model proposes a
+ * client action. Must match `CLIENT_ACTION_TOOL_NAME` in the backend.
+ */
+export const CLIENT_ACTION_TOOL_NAME = "propose_client_action";
+
+/**
+ * Client actions this add-in implements. A fixed, code-defined allowlist —
+ * never extended at runtime. Anything the model (or backend config) proposes
+ * outside this list is ignored.
+ */
+export const IMPLEMENTED_CLIENT_ACTIONS = [
+  "outlook.reply",
+  "outlook.reply_all",
+] as const;
+
+export type OutlookClientAction = (typeof IMPLEMENTED_CLIENT_ACTIONS)[number];
+
+export function isImplementedClientAction(
+  action: string,
+): action is OutlookClientAction {
+  return (IMPLEMENTED_CLIENT_ACTIONS as readonly string[]).includes(action);
+}
+
+/**
+ * The client actions the renderer may offer for a message: the facet's
+ * backend-advertised `client_actions`, intersected with what this add-in
+ * implements, in the fixed registry order.
+ */
+export function offerableClientActions(
+  allowedActions: readonly string[] | undefined,
+): OutlookClientAction[] {
+  if (!allowedActions || allowedActions.length === 0) {
+    return [];
+  }
+  return IMPLEMENTED_CLIENT_ACTIONS.filter((action) =>
+    allowedActions.includes(action),
+  );
+}
+
+/**
+ * Extract the model's validated client-action proposal from an assistant
+ * message's content parts.
+ *
+ * The proposal is only accepted when ALL of the following hold — anything
+ * else returns `undefined` (render plain buttons, never "best effort"):
+ * - a `propose_client_action` tool_use part exists with status `"success"`
+ *   (the backend already validated the input against the facet's enum),
+ * - its `input.action` is a string,
+ * - the action is in `allowedActions` (the facet's `client_actions` from
+ *   `GET /me/facets` — revalidated here, never trusted from message text),
+ * - the action is implemented by this add-in.
+ */
+export function extractProposedClientAction(
+  content: ContentPart[] | undefined,
+  allowedActions: readonly string[],
+): OutlookClientAction | undefined {
+  for (const part of content ?? []) {
+    if (part.content_type !== "tool_use") {
+      continue;
+    }
+    if (part.tool_name !== CLIENT_ACTION_TOOL_NAME) {
+      continue;
+    }
+    if (part.status !== "success") {
+      continue;
+    }
+    const input: unknown = part.input;
+    if (typeof input !== "object" || input === null || Array.isArray(input)) {
+      continue;
+    }
+    const action = (input as Record<string, unknown>).action;
+    if (typeof action !== "string") {
+      continue;
+    }
+    if (!allowedActions.includes(action)) {
+      continue;
+    }
+    if (isImplementedClientAction(action)) {
+      return action;
+    }
+  }
+  return undefined;
+}

--- a/office-addin/src/utils/outlookReadReply.ts
+++ b/office-addin/src/utils/outlookReadReply.ts
@@ -1,6 +1,5 @@
-import { sanitizeHtmlPreview } from "@erato/frontend/library";
-
 import { callOfficeAsync } from "./officeAsync";
+import { sanitizeReplyFormHtml } from "./sanitizeReplyFormHtml";
 import { isMessageRead } from "../sessionPolicy/outlookAnchor";
 
 import type { OutlookClientAction } from "./outlookClientActions";
@@ -34,12 +33,12 @@ export function escapeTextAsHtml(text: string): string {
 }
 
 /**
- * Build the HTML body passed to the reply form: sanitized for model-produced
- * HTML fragments (same DOMPurify config as the in-chat preview), escaped for
- * plain text.
+ * Build the HTML body passed to the reply form: outbound-grade sanitization
+ * for model-produced HTML fragments (stricter than the in-chat preview — the
+ * output becomes the user's draft), entity-escaping for plain text.
  */
 export function buildReplyFormBody(content: string, isHtml: boolean): string {
-  return isHtml ? sanitizeHtmlPreview(content) : escapeTextAsHtml(content);
+  return isHtml ? sanitizeReplyFormHtml(content) : escapeTextAsHtml(content);
 }
 
 export function isReplyFormBodyTooLarge(body: string): boolean {

--- a/office-addin/src/utils/outlookReadReply.ts
+++ b/office-addin/src/utils/outlookReadReply.ts
@@ -72,28 +72,62 @@ export function isReadReplySupported(): boolean {
 }
 
 export interface ReadModeRecipientSummary {
-  /** Sender display name or address — the target of a plain reply. */
+  /** Formatted sender entry — the target of a plain reply. */
   sender: string | null;
-  /** Display names/addresses on To + Cc of the message being read. */
+  /**
+   * Formatted To + Cc entries of the message being read, deduplicated by
+   * address and excluding the reading user and the sender (the reply form
+   * never re-addresses the user, and the sender is already listed above).
+   */
   recipients: string[];
+}
+
+/**
+ * Display names are sender-controlled: one could spoof another address or
+ * fake extra entries via commas. The SMTP address is therefore always part
+ * of the entry, never replaced by the display name.
+ */
+function formatRecipientEntry(details: Office.EmailAddressDetails): string {
+  const name = details.displayName?.trim();
+  return name && name.toLowerCase() !== details.emailAddress.toLowerCase()
+    ? `${name} <${details.emailAddress}>`
+    : details.emailAddress;
 }
 
 /**
  * Re-read the recipients of the CURRENT read-mode item at confirmation time.
  * Outlook itself derives the actual reply-all recipient set when the form
  * opens; this summary exists so the user confirms against fresh data, not
- * against whatever the chat message was generated from.
+ * against whatever the chat message was generated from. Every listed entry
+ * counts: the confirmation copy's recipient count is the number of entries
+ * shown.
  */
 export function getReadModeRecipientSummary(): ReadModeRecipientSummary | null {
   const item = getReadModeItem();
   if (!item) {
     return null;
   }
-  const format = (details: Office.EmailAddressDetails): string =>
-    details.displayName || details.emailAddress;
+  const ownAddress =
+    Office.context.mailbox.userProfile?.emailAddress?.toLowerCase() ?? null;
+  const senderAddress = item.from?.emailAddress.toLowerCase() ?? null;
+  const seen = new Set<string>();
+  const recipients = [...(item.to ?? []), ...(item.cc ?? [])]
+    .filter((details) => {
+      const address = details.emailAddress.toLowerCase();
+      if (
+        address === ownAddress ||
+        address === senderAddress ||
+        seen.has(address)
+      ) {
+        return false;
+      }
+      seen.add(address);
+      return true;
+    })
+    .map(formatRecipientEntry);
   return {
-    sender: item.from ? format(item.from) : null,
-    recipients: [...(item.to ?? []), ...(item.cc ?? [])].map(format),
+    sender: item.from ? formatRecipientEntry(item.from) : null,
+    recipients,
   };
 }
 

--- a/office-addin/src/utils/outlookReadReply.ts
+++ b/office-addin/src/utils/outlookReadReply.ts
@@ -1,0 +1,142 @@
+import { sanitizeHtmlPreview } from "@erato/frontend/library";
+
+import { callOfficeAsync } from "./officeAsync";
+import { isMessageRead } from "../sessionPolicy/outlookAnchor";
+
+import type { OutlookClientAction } from "./outlookClientActions";
+
+/**
+ * Office.js rejects reply form bodies above 32 KB (displayReplyForm /
+ * displayReplyFormAsync throw on oversized string parameters).
+ */
+export const REPLY_FORM_BODY_LIMIT_BYTES = 32 * 1024;
+
+/** Thrown when the draft can't be prefilled; the UI falls back to Copy. */
+export class ReplyBodyTooLargeError extends Error {
+  constructor() {
+    super("Reply draft exceeds the Office.js reply form body limit");
+    this.name = "ReplyBodyTooLargeError";
+  }
+}
+
+/**
+ * Escape model-produced plain text for use in a reply form body. The form
+ * data parameter is interpreted as HTML, so raw text must be escaped and
+ * newlines converted to keep the draft's line structure.
+ */
+export function escapeTextAsHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/\r\n|\r|\n/g, "<br>");
+}
+
+/**
+ * Build the HTML body passed to the reply form: sanitized for model-produced
+ * HTML fragments (same DOMPurify config as the in-chat preview), escaped for
+ * plain text.
+ */
+export function buildReplyFormBody(content: string, isHtml: boolean): string {
+  return isHtml ? sanitizeHtmlPreview(content) : escapeTextAsHtml(content);
+}
+
+export function isReplyFormBodyTooLarge(body: string): boolean {
+  return new TextEncoder().encode(body).length > REPLY_FORM_BODY_LIMIT_BYTES;
+}
+
+function getReadModeItem(): Office.MessageRead | null {
+  const item = Office.context?.mailbox?.item as
+    | Office.MessageRead
+    | Office.MessageCompose
+    | null
+    | undefined;
+  if (!item || !isMessageRead(item)) {
+    return null;
+  }
+  return item;
+}
+
+/**
+ * Whether the current Office context can open a reply form right now: a
+ * read-mode message is open and the host supports the reply form APIs
+ * (Mailbox 1.1; not available on Outlook mobile).
+ */
+export function isReadReplySupported(): boolean {
+  if (!getReadModeItem()) {
+    return false;
+  }
+  return (
+    Office.context.requirements?.isSetSupported?.("Mailbox", "1.1") ?? false
+  );
+}
+
+export interface ReadModeRecipientSummary {
+  /** Sender display name or address — the target of a plain reply. */
+  sender: string | null;
+  /** Display names/addresses on To + Cc of the message being read. */
+  recipients: string[];
+}
+
+/**
+ * Re-read the recipients of the CURRENT read-mode item at confirmation time.
+ * Outlook itself derives the actual reply-all recipient set when the form
+ * opens; this summary exists so the user confirms against fresh data, not
+ * against whatever the chat message was generated from.
+ */
+export function getReadModeRecipientSummary(): ReadModeRecipientSummary | null {
+  const item = getReadModeItem();
+  if (!item) {
+    return null;
+  }
+  const format = (details: Office.EmailAddressDetails): string =>
+    details.displayName || details.emailAddress;
+  return {
+    sender: item.from ? format(item.from) : null,
+    recipients: [...(item.to ?? []), ...(item.cc ?? [])].map(format),
+  };
+}
+
+/**
+ * Open Outlook's native reply / reply-all form prefilled with the draft.
+ * This never sends anything — the user reviews and sends (or discards) the
+ * draft in Outlook's own compose window.
+ *
+ * Throws when the current item is not a read-mode message (e.g. the user
+ * switched to a compose window since the draft was generated) or when the
+ * body exceeds the Office.js limit.
+ */
+export async function openReplyForm(
+  action: OutlookClientAction,
+  content: string,
+  isHtml: boolean,
+): Promise<void> {
+  const item = getReadModeItem();
+  if (!item) {
+    throw new Error("The current Outlook item is not an open received email.");
+  }
+  const body = buildReplyFormBody(content, isHtml);
+  if (isReplyFormBodyTooLarge(body)) {
+    throw new ReplyBodyTooLargeError();
+  }
+  const supportsAsync =
+    Office.context.requirements?.isSetSupported?.("Mailbox", "1.9") ?? false;
+  if (action === "outlook.reply_all") {
+    if (supportsAsync) {
+      await callOfficeAsync<void>((callback) =>
+        item.displayReplyAllFormAsync(body, callback),
+      );
+    } else {
+      item.displayReplyAllForm(body);
+    }
+    return;
+  }
+  if (supportsAsync) {
+    await callOfficeAsync<void>((callback) =>
+      item.displayReplyFormAsync(body, callback),
+    );
+  } else {
+    item.displayReplyForm(body);
+  }
+}

--- a/office-addin/src/utils/sanitizeReplyFormHtml.ts
+++ b/office-addin/src/utils/sanitizeReplyFormHtml.ts
@@ -1,0 +1,47 @@
+import DOMPurify from "dompurify";
+
+// Outbound-grade sanitization for model-produced HTML fragments handed to
+// Office.js displayReplyForm(Async). Deliberately STRICTER than the in-chat
+// preview (`sanitizeHtmlPreview`): the output becomes the user's draft, so
+// only basic text structure and plain http(s)/mailto/tel links survive — no
+// style tags or attributes, no images, no tables-as-layout tricks, nothing
+// that could visually spoof content in the composed email.
+const ALLOWED_TAGS = [
+  "a",
+  "b",
+  "strong",
+  "i",
+  "em",
+  "u",
+  "s",
+  "p",
+  "br",
+  "hr",
+  "div",
+  "span",
+  "ul",
+  "ol",
+  "li",
+  "blockquote",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "pre",
+  "code",
+];
+
+const ALLOWED_ATTR = ["href"];
+
+const ALLOWED_URI_REGEXP = /^(?:https?|mailto|tel):/i;
+
+export function sanitizeReplyFormHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    ALLOWED_URI_REGEXP,
+    ALLOW_DATA_ATTR: false,
+  });
+}


### PR DESCRIPTION
## What

In Outlook **read mode**, the assistant can now draft a reply to the email the user is reading and recommend **Reply** vs **Reply All**. The draft renders like our existing email artifacts, with Reply / Reply All buttons (the recommended one is primary). Clicking opens Outlook's **native reply form prefilled with the draft** — the add-in never sends anything; sending stays a manual step in Outlook's own compose window.

For faster flows (e.g. conversation mode), a facet can additionally opt into **`auto_prompt`**: right after the assistant finishes, the proposed reply surfaces on its own — as a confirmation dialog or directly as the prefilled reply window, governed by **per-action local approval settings** (always ask / don't ask / deny) in the add-in behavior settings.

This is built on a new, generic primitive: **client-action proposals for action facets**.

## Why a new primitive

We want the LLM to make a decision (reply vs reply_all) that the frontend can consume *reliably*. Parsing it out of markdown/text is not acceptable (hallucination + prompt-injection surface). Instead:

> **The LLM proposes through a constrained tool; the client validates and executes only after policy and user approval.**

## How it works

1. **Config** (`erato.toml`): an action facet may declare `client_actions = ["outlook.reply", "outlook.reply_all"]` and optionally `presentation = "render_buttons" | "auto_prompt"` (validated at startup). The facet template itself stays deployment-local config — it is intentionally **not** in this repo (only generic field docs in `erato.template.toml`).
2. **Backend** (`services/client_actions.rs`, `message_streaming.rs`): while such a facet is active on a request, the model is offered a synthetic `propose_client_action` tool whose input schema is **enum-constrained** to exactly the configured actions. The tool is intercepted in the tool-call loop — never dispatched to MCP, never executed server-side. The input is validated against the enum (read back from the request's own tool set), recorded as a normal `tool_use` content part, and the model gets a tool response telling it the user will confirm client-side. Invalid calls produce an `error`-status part and a corrective tool response. If an MCP tool ever claims the same name, the MCP tool wins (no duplicate tool names, no misrouted dispatch).
3. **`GET /me/facets`** now exposes `client_actions` and `presentation` per facet, so the client revalidates proposals against a typed server source.
4. **Add-in**:
   - Read-mode sends attach the `outlook_reply_from_read` facet — gated on backend advertisement exactly like `compose_email` (unknown facet ids 400 the request).
   - `AddinChat` stamps the proposal onto the message's `outlookArtifact` only after revalidation: tool name + `status === "success"` + action ∈ backend `client_actions` ∩ a **fixed, code-defined registry** (`outlookClientActions.ts`). Nothing is ever parsed from message text.
   - `OutlookEratoEmailRenderer` (read mode): Reply / Reply All + Copy. The proposal only chooses which button is primary. **Confirmations render as an inline ActionConfirmationCard within the message (not a modal), with recipients re-read from the current Outlook item at confirmation time.** The card is a shared, execution-agnostic frontend primitive designed to also serve future server-gated approvals (e.g. gated web-search facets). Execution (`outlookReadReply.ts`) re-checks read mode at click time, gates on Mailbox 1.9 (`displayReply*FormAsync`) with a 1.1 sync fallback, enforces the Office.js **32 KB** body limit, and passes DOMPurify-sanitized HTML or entity-escaped text. Any validation/capability failure falls back to plain buttons or Copy — never best-effort execution.
   - Compose mode behavior (insert/replace) is unchanged.

## Permission model & auto-prompt (`clientActionPolicy.ts`)

- **Browser-style permission step**: every proposal surfaces the same three decisions — *Allow once*, *Always allow*, *Deny*. Allow-once and deny apply to that proposal only (asks again next time); only an explicit "Always allow" persists. **Everything defaults to ask** — no pre-granted permissions; the fast path is earned by the user's first "Always allow".
- **The deployment config is the policy authority**: `client_actions_always_ask` on the facet (validated subset of `client_actions`, exposed via `/me/facets`) enforces per-use confirmation — "Always allow" renders greyed out with the reason, and stored grants are clamped back to ask at read time. Users may still be stricter (deny).
- **Decisions are stored per facet + action** (a grant for one facet never leaks to another reusing the action id), written by the inline card and mirrored in settings, which render dynamically from the facets the backend advertises.
- **Auto-prompt fires only for fresh completions**: `FreshCompletionTracker` watches message status transitions (`sending → complete`) within the session. History loads, refetches, chat switches, and messages that appear already complete never auto-open anything (conservative by construction — the failure direction is a missed auto-open with buttons still available, never a surprise window from old data). A module-level fired set caps auto-prompt at once per message across remounts.

## Security model (summary)

- Office.js cannot send a reply programmatically — `displayReplyForm*` only opens a prefilled compose window, so Outlook itself enforces the final human gate in every path, including auto-prompt.
- Action selection: enum-constrained tool → backend validation → typed `tool_use` part → frontend revalidation against `/me/facets` + fixed registry → local approval policy → click or policy-gated auto-surface (+ recipient confirmation for reply-all). No markdown-derived actions anywhere.
- Email content is treated as untrusted input end to end; the draft body is sanitized/escaped before it touches Office.js.

## Review hardening (post-review commits)

Four review passes (backend, add-in logic, security, UI reuse) ran over the branch; all findings are addressed:
- **History replay**: `propose_client_action` tool_use parts are stripped from replay (the synthetic tool isn't offered on later requests, and some providers reject tool messages referencing unknown tools).
- **Item-identity guard**: the Outlook item identity is captured at fresh completion and checked before any click, confirmation, or auto-prompt opens a reply — a draft can no longer open against a different email than it was written for.
- **Single proposal**: the backend accepts at most one successful proposal per generation; duplicates get an error.
- **UI**: primary button uses the library primary tokens, error text has `role="alert"` + theme error token, approval groups are proper radiogroups, per-action busy labels, deduplicated status timers, stored prefs clamped to floors.

Accepted residual risks (documented): a same-named MCP tool could forge a proposal (bounded by the reply-all confirmation floor and manual send); `sanitizeHtmlPreview` is preview-grade for the outbound body (user reviews in Outlook before sending); a completion whose start+complete SSE events arrive in one network chunk fails toward buttons-only (never toward a surprise window).

## Not supported

- Outlook iOS/Android (platform limitation: reply-form APIs unavailable); the buttons simply don't appear there.

## Testing

- Backend: unit tests for the tool schema/validation round-trip; integration tests for `client_actions` + `presentation` exposure on `/me/facets`; startup validation for invalid `presentation`; full suite green (3 pre-existing env-dependent failures unrelated to this change). `gen-openapi --check` and `gen-config-reference --check` pass.
- Add-in: 60 new vitest cases (facet resolution, proposal extraction/validation incl. injection-shaped inputs, executor limits/escaping/capability fallbacks, approval-policy floors/clamping, persisted-prefs parsing, freshness-tracker transitions); lint/typecheck/format clean (374 total).

To try it locally you need an `outlook_reply_from_read` facet in your `erato.toml` with `client_actions`, optionally `presentation = "auto_prompt"`, `allowed_args = ["body_format"]`, and a reply-drafting template following the documented conventions in `erato.template.toml` (per-turn prefix, `erato-email`/`erato-email-html` fences, single tool call).


