### PR TITLE
Veto NAA for on-prem mailboxes despite host support

### DIFF
--- a/office-addin/src/providers/OutlookAuthProvider.tsx
+++ b/office-addin/src/providers/OutlookAuthProvider.tsx
@@ -7,6 +7,7 @@ import { SessionAuthProvider } from "./SessionAuthProvider";
 import { createEntraNaaAuthSource } from "../auth/EntraNaaAuthSource";
 import { UnsupportedAuthSource } from "../auth/UnsupportedAuthSource";
 import { isNestedAppAuthSupported } from "../auth/isNestedAppAuthSupported";
+import { detectExchangeOnPrem } from "../utils/detectExchangeOnPrem";
 
 import type {
   AuthSource,
@@ -24,9 +25,9 @@ import type {
  *     (mode `entra-msal`), redeemed for the proxy session via the client-side
  *     id_token, with the Outlook-only {@link EntraGraphTokenProvider} (Graph
  *     mail tokens) layered on top.
- *   - On-prem-but-hybrid SE (a NAA-less mailbox): the oauth2-proxy redirect
- *     login (popup) via {@link Oauth2ProxyLoginProvider}. NAA is unavailable
- *     here and the add-in is served through oauth2-proxy, so the proxy already
+ *   - On-prem SE (an on-prem mailbox, with or without host NAA support): the
+ *     oauth2-proxy redirect login (popup) via {@link Oauth2ProxyLoginProvider}.
+ *     The add-in is served through oauth2-proxy, so the proxy already
  *     federates to the same Entra tenant and performs the full OIDC login with
  *     ITS OWN app registration — no add-in MSAL app reg, no client-side token,
  *     no redeem-external-token. That provider supplies the {@link
@@ -73,14 +74,20 @@ export function OutlookAuthProvider({
     | { kind: "oauth2-proxy" }
     | { kind: "unsupported"; source: AuthSource }
   >(() => {
-    if (isNestedAppAuthSupported()) {
+    // NAA needs more than host support: classic desktop Outlook reports the
+    // NestedAppAuth requirement set even when the profile is a pure on-prem
+    // Exchange (SE) account. There the host broker has no Entra account
+    // (ACCOUNT_UNAVAILABLE), MSAL silently degrades to a standard popup with
+    // the page URL as redirect URI, and Entra rejects it (AADSTS50011). So an
+    // on-prem mailbox always takes the oauth2-proxy path below, NAA or not.
+    if (isNestedAppAuthSupported() && !detectExchangeOnPrem()) {
       return {
         kind: "naa",
         source: createEntraNaaAuthSource({ resolveLoginHint }),
       };
     }
-    // No NAA. If a mailbox is present, the user is on OWA with an Entra
-    // identity served through oauth2-proxy (hybrid on-prem Exchange SE): the
+    // No usable NAA. If a mailbox is present, the user has an Entra identity
+    // served through oauth2-proxy (on-prem Exchange SE, hybrid or not): the
     // proxy performs its own OIDC redirect login and sets the session cookie,
     // so we run that popup flow rather than a client-side MSAL acquisition. A
     // non-mailbox host has no Entra identity to log in with, so it stays

--- a/office-addin/src/providers/__tests__/OutlookAuthProvider.test.tsx
+++ b/office-addin/src/providers/__tests__/OutlookAuthProvider.test.tsx
@@ -108,11 +108,11 @@ function uninstallNaaOfficeContext() {
   delete (Office as unknown as Record<string, unknown>).auth;
 }
 
-// A NAA-less mailbox (e.g. Exchange SE OWA). With NAA absent but a mailbox
-// present, OutlookAuthProvider picks the oauth2-proxy redirect-login path.
-function installMailbox() {
+// An on-prem (Exchange SE) mailbox. Whether or not the host supports NAA,
+// OutlookAuthProvider picks the oauth2-proxy redirect-login path for it.
+function installMailbox(accountType = "enterprise") {
   (Office.context as unknown as Record<string, unknown>).mailbox = {
-    userProfile: { accountType: "enterprise" },
+    userProfile: { accountType },
   };
 }
 
@@ -465,6 +465,60 @@ describe("OutlookAuthProvider", () => {
     expect(fetcher).not.toHaveBeenCalledWith(
       "/oauth2/redeem-external-token",
       expect.anything(),
+    );
+  });
+
+  it("vetoes NAA for an on-prem mailbox even when the host supports it", async () => {
+    // Classic desktop Outlook with an SE profile: the NestedAppAuth requirement
+    // set is reported as supported, but the host broker has no Entra account.
+    // The plan must take the oauth2-proxy path, never client-side MSAL.
+    installMailbox();
+    const fetcher = stubFetch(new Response("{}", { status: 202 }));
+
+    render(
+      <OutlookAuthProvider>
+        <AuthProbe />
+      </OutlookAuthProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true"),
+    );
+
+    expect(screen.getByTestId("mode")).toHaveTextContent("entra-msal");
+    expect(screen.getByTestId("graph-mounted")).toHaveTextContent("false");
+    expect(createStandardPublicClientApplication).not.toHaveBeenCalled();
+    expect(createNestablePublicClientApplication).not.toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledWith(
+      "/oauth2/auth",
+      expect.objectContaining({ method: "GET", credentials: "include" }),
+    );
+    expect(fetcher).not.toHaveBeenCalledWith(
+      "/oauth2/redeem-external-token",
+      expect.anything(),
+    );
+  });
+
+  it("keeps NAA for a cloud mailbox on a NAA-capable host", async () => {
+    installMailbox("office365");
+    const fetcher = stubFetch(new Response("{}", { status: 202 }));
+
+    render(
+      <OutlookAuthProvider>
+        <AuthProbe />
+      </OutlookAuthProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true"),
+    );
+
+    expect(screen.getByTestId("mode")).toHaveTextContent("entra-msal");
+    expect(screen.getByTestId("graph-mounted")).toHaveTextContent("true");
+    expect(createNestablePublicClientApplication).toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledWith(
+      "/oauth2/redeem-external-token",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
     );
   });
 

--- a/office-addin/src/utils/detectExchangeOnPrem.ts
+++ b/office-addin/src/utils/detectExchangeOnPrem.ts
@@ -1,12 +1,17 @@
 /**
- * Mailbox-location probe for the mail data plane — this module reads
- * `Office.context.mailbox`. It is no longer an auth concern: SE authenticates
- * via the oauth2-proxy redirect login but still reports the `entra-msal` mode
- * (same as EXO), so the mail backend can't be chosen by auth mode. The caller
- * ({@link "../hooks/useOutlookMessageFetcher"}) uses this to pick the mail
- * backend by where the mailbox lives — Microsoft Graph for cloud mailboxes,
- * the EWS SOAP backend (`fetchOutlookMessageEws.ts`) for on-prem ones (Graph
- * can't reach on-prem mailboxes).
+ * Mailbox-location probe — this module reads `Office.context.mailbox`. Two
+ * consumers branch on it:
+ *
+ *   - The mail data plane ({@link "../hooks/useOutlookMessageFetcher"}) picks
+ *     the mail backend by where the mailbox lives — Microsoft Graph for cloud
+ *     mailboxes, the EWS SOAP backend (`fetchOutlookMessageEws.ts`) for
+ *     on-prem ones (Graph can't reach on-prem mailboxes). Auth mode can't
+ *     drive this choice: SE authenticates via the oauth2-proxy redirect login
+ *     but still reports `entra-msal` (same as EXO).
+ *   - The auth composition root ({@link "../providers/OutlookAuthProvider"})
+ *     vetoes NAA for on-prem mailboxes: classic desktop Outlook reports the
+ *     NestedAppAuth requirement set even when the profile has no Entra
+ *     account, so host support alone would pick a broken MSAL path.
  */
 
 /**


### PR DESCRIPTION
This pull request improves the logic for choosing the authentication flow in `OutlookAuthProvider` by ensuring that on-premises Exchange (SE) mailboxes always use the `oauth2-proxy` login path, even if the host claims to support NestedAppAuth (NAA). This prevents broken MSAL flows in classic desktop Outlook scenarios. The changes also clarify mailbox detection logic and expand test coverage for these cases.

Authentication flow improvements:
* Updated `OutlookAuthProvider` to check for on-prem Exchange mailboxes using `detectExchangeOnPrem`, vetoing NAA even if the host supports it, and ensuring the correct `oauth2-proxy` path is always taken for on-prem mailboxes. [[1]](diffhunk://#diff-f9898ad39d66b07d3fa55aea207ee41fb0fbd53ef801a248f7f7775e7d2162e5R10) [[2]](diffhunk://#diff-f9898ad39d66b07d3fa55aea207ee41fb0fbd53ef801a248f7f7775e7d2162e5L76-R90)
* Clarified and updated code comments and documentation to reflect that on-prem mailboxes (with or without NAA support) must always use the `oauth2-proxy` login. [[1]](diffhunk://#diff-f9898ad39d66b07d3fa55aea207ee41fb0fbd53ef801a248f7f7775e7d2162e5L27-R30) [[2]](diffhunk://#diff-6575a0d1c16180494ac37068039a57a938f969a7fca1c6c5ce7b935662ce7bf9L2-R14)

Testing improvements:
* Expanded test coverage in `OutlookAuthProvider.test.tsx` to verify that NAA is vetoed for on-prem mailboxes and retained for cloud mailboxes, ensuring correct authentication path selection in both scenarios.
* Updated mailbox installation helper to allow specifying account type, supporting more flexible test scenarios.