### PR TITLE
Fix start/end-of-speech truncation in audio recorders (ERMAIN-334)

### DIFF
--- a/backend/erato/src/server/api/v1beta/audio_transcription.rs
+++ b/backend/erato/src/server/api/v1beta/audio_transcription.rs
@@ -1529,6 +1529,18 @@ async fn transcribe_audio_chunk_genai(
         .exec_chat("PLACEHOLDER_MODEL", chat_request, Some(&chat_options))
         .await?;
     let transcript = response.first_text().unwrap_or_default().trim().to_string();
+    let transcript = if is_punctuation_only_transcript(&transcript) {
+        if !transcript.is_empty() {
+            debug!(
+                chunk_index = pending.chunk_index,
+                raw_transcript = %transcript,
+                "Discarding punctuation-only transcript as a silence hallucination"
+            );
+        }
+        String::new()
+    } else {
+        transcript
+    };
     debug!(
         chunk_index = pending.chunk_index,
         provider_id = %provider.chat_provider_id,
@@ -1539,6 +1551,17 @@ async fn transcribe_audio_chunk_genai(
     );
 
     Ok(transcript)
+}
+
+/// Audio models reliably hallucinate on (near-)silent excerpts despite the
+/// prompt asking for an empty string — a lone "." or other punctuation-only
+/// output is the canonical signature (silent chunks are guaranteed to occur:
+/// the client prepends a synthetic silence primer and trailing VAD
+/// redemption silence). No real utterance transcribes to pure punctuation,
+/// so treat any transcript without a single alphanumeric character as
+/// "no audible speech".
+fn is_punctuation_only_transcript(transcript: &str) -> bool {
+    !transcript.chars().any(char::is_alphanumeric)
 }
 
 fn max_output_tokens_for_chunk(
@@ -1879,6 +1902,18 @@ mod tests {
             canonical_audio_max_bytes_for_config(&dictation_config)
                 < canonical_audio_max_bytes_for_config(&transcription_config)
         );
+    }
+
+    #[test]
+    fn discards_punctuation_only_transcripts_as_silence_hallucinations() {
+        assert!(is_punctuation_only_transcript(""));
+        assert!(is_punctuation_only_transcript("."));
+        assert!(is_punctuation_only_transcript("…!?"));
+        assert!(is_punctuation_only_transcript(". . ."));
+        assert!(!is_punctuation_only_transcript("ok."));
+        assert!(!is_punctuation_only_transcript("ja"));
+        assert!(!is_punctuation_only_transcript("好"));
+        assert!(!is_punctuation_only_transcript("42"));
     }
 
     #[test]

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1058,6 +1058,10 @@ describe("ChatInput", () => {
       isDictating: true,
       isDictationStarting: false,
       isDictationCompleting: false,
+      // Real audio is flowing — the waveform shows at full opacity and
+      // the status announces active dictation (when false, the button
+      // dims and announces the mic warm-up instead).
+      isCapturingAudio: true,
       dictationError: null,
       setDictationError: vi.fn(),
       dictationBars: [2, 5, 8, 5, 2],

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2056,18 +2056,14 @@ export const ChatInput = ({
                 )}
               {isAudioMode &&
                 isPendingResponse &&
-                isConversationalAudioActive && (
+                isConversationalAudioActive &&
+                (isCapturingAudio && isDictating ? (
                   <WaveformButton
                     onClick={handleAudioModeButtonToggle}
                     bars={dictationBars}
-                    isBuffering={!isCapturingAudio || !isDictating}
                     disabled={disabled || isLoading || isDictationCompleting}
                     ariaLabel={t`Stop audio mode`}
-                    statusLabel={
-                      isCapturingAudio && isDictating
-                        ? t`Listening for your next message`
-                        : t`Microphone is starting — wait for the level meter before speaking`
-                    }
+                    statusLabel={t`Listening for your next message`}
                     testIds={{
                       root: "chat-input-audio-mode-pending-recording",
                       waveform:
@@ -2076,31 +2072,52 @@ export const ChatInput = ({
                         "chat-input-audio-mode-pending-recording-stop-icon",
                     }}
                   />
-                )}
-              {audioTranscriptionEnabled && !isAudioMode && isRecording && (
-                <WaveformButton
-                  onClick={toggleAudioRecording}
-                  bars={recordingBars}
-                  // Dimmed until real (non-zero) audio flows, so the user
-                  // isn't invited to speak into a still-warming mic.
-                  isBuffering={!isRecordingCapturingAudio}
-                  disabled={disabled || isLoading}
-                  ariaLabel={t`Stop audio transcript recording`}
-                  statusLabel={
-                    isRecordingCapturingAudio
-                      ? t`Recording audio transcript`
-                      : t`Microphone is starting — wait for the level meter before speaking`
-                  }
-                  testIds={{
-                    root: "chat-input-record-audio-transcript",
-                    waveform: "chat-input-record-audio-transcript-waveform",
-                    stopIcon: "chat-input-record-audio-transcript-stop-icon",
-                  }}
-                />
-              )}
+                ) : (
+                  // Re-arming between turns: the mic is being re-acquired
+                  // and is not yet capturing — show the spinner, not a
+                  // live-looking waveform.
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    icon={
+                      <LoadingIcon
+                        className="size-4 animate-spin text-[var(--theme-fg-primary)]"
+                        data-testid="chat-input-audio-mode-pending-loading-icon"
+                      />
+                    }
+                    onClick={handleAudioModeButtonToggle}
+                    disabled={disabled || isLoading || isDictationCompleting}
+                    data-testid="chat-input-audio-mode-pending-recording"
+                    aria-label={t`Stop audio mode`}
+                    title={t`Stop audio mode`}
+                  />
+                ))}
               {audioTranscriptionEnabled &&
                 !isAudioMode &&
-                isRecordingUpload && (
+                isRecording &&
+                isRecordingCapturingAudio && (
+                  <WaveformButton
+                    onClick={toggleAudioRecording}
+                    bars={recordingBars}
+                    disabled={disabled || isLoading}
+                    ariaLabel={t`Stop audio transcript recording`}
+                    statusLabel={t`Recording audio transcript`}
+                    testIds={{
+                      root: "chat-input-record-audio-transcript",
+                      waveform: "chat-input-record-audio-transcript-waveform",
+                      stopIcon: "chat-input-record-audio-transcript-stop-icon",
+                    }}
+                  />
+                )}
+              {audioTranscriptionEnabled &&
+                !isAudioMode &&
+                (isRecordingUpload ||
+                  (isRecording && !isRecordingCapturingAudio)) && (
+                  // The spinner covers the session handshake AND the mic
+                  // warm-up: the waveform appears only once real audio is
+                  // flowing, so its appearance is the "speak now" cue.
+                  // During warm-up the button stays clickable to stop.
                   <Button
                     type="button"
                     variant="secondary"
@@ -2111,26 +2128,35 @@ export const ChatInput = ({
                         data-testid="chat-input-record-audio-transcript-loading-icon"
                       />
                     }
-                    disabled
+                    onClick={isRecording ? toggleAudioRecording : undefined}
+                    disabled={!isRecording}
                     data-testid="chat-input-record-audio-transcript"
-                    aria-label={t`Finishing audio transcript`}
-                    title={t`Finishing audio transcript`}
+                    aria-label={
+                      isRecording
+                        ? t`Starting audio transcript recording`
+                        : t`Finishing audio transcript`
+                    }
+                    title={
+                      isRecording
+                        ? t`Starting audio transcript recording`
+                        : t`Finishing audio transcript`
+                    }
                   />
                 )}
               {audioDictationEnabled &&
                 !isAudioMode &&
                 !isRecording &&
                 !isRecordingUpload &&
-                (isCapturingAudio || isDictating ? (
+                // The live waveform appears only once the session is ready
+                // AND real (non-zero) audio is flowing; until then the
+                // loading spinner stays. A single spinner → waveform
+                // transition is the "speak now" cue — showing the waveform
+                // during the mic's cold warm-up invited users to speak too
+                // early and lose their first words (ERMAIN-334).
+                (isCapturingAudio && isDictating ? (
                   <WaveformButton
                     onClick={toggleDictationForCurrentTarget}
                     bars={dictationBars}
-                    // Stay dimmed until BOTH the session is ready and real
-                    // (non-zero) audio is flowing. Gating on isDictating
-                    // alone invited users to speak during the mic's cold
-                    // warm-up window, losing the first words (ERMAIN-334).
-                    // Matches the conversational pending button above.
-                    isBuffering={!isCapturingAudio || !isDictating}
                     disabled={
                       disabled ||
                       isLoading ||
@@ -2139,18 +2165,8 @@ export const ChatInput = ({
                       isFileButtonProcessing ||
                       isAnyTokenLimitExceeded
                     }
-                    ariaLabel={
-                      isDictating
-                        ? t`Stop dictation`
-                        : t`Cancel starting dictation`
-                    }
-                    statusLabel={
-                      isDictating && isCapturingAudio
-                        ? t`Dictating audio`
-                        : isDictating
-                          ? t`Microphone is starting — wait for the level meter before speaking`
-                          : t`Capturing audio — waiting for transcription to start`
-                    }
+                    ariaLabel={t`Stop dictation`}
+                    statusLabel={t`Dictating audio`}
                     testIds={{
                       root: "chat-input-record-audio",
                       waveform: "chat-input-dictation-waveform",
@@ -2163,7 +2179,10 @@ export const ChatInput = ({
                     variant="secondary"
                     size="sm"
                     icon={
-                      isDictationStarting || isDictationCompleting ? (
+                      isDictationStarting ||
+                      isDictating ||
+                      isCapturingAudio ||
+                      isDictationCompleting ? (
                         <LoadingIcon
                           className="size-4 animate-spin text-[var(--theme-fg-primary)]"
                           data-testid="chat-input-dictation-loading-icon"
@@ -2184,14 +2203,14 @@ export const ChatInput = ({
                     }
                     data-testid="chat-input-record-audio"
                     aria-label={
-                      isDictationStarting
+                      isDictationStarting || isDictating || isCapturingAudio
                         ? t`Starting dictation`
                         : isDictationCompleting
                           ? t`Finishing dictation`
                           : t`Start dictation`
                     }
                     title={
-                      isDictationStarting
+                      isDictationStarting || isDictating || isCapturingAudio
                         ? t`Starting dictation`
                         : isDictationCompleting
                           ? t`Finishing dictation`
@@ -2214,6 +2233,10 @@ export const ChatInput = ({
                   <ChatInputAudioModeButton
                     isRecording
                     recordingBars={dictationBars}
+                    // Spinner until the session is live AND real audio
+                    // flows — the waveform's appearance is the "speak
+                    // now" cue (ERMAIN-334).
+                    isStarting={!isCapturingAudio || !isDictating}
                     onToggle={handleAudioModeButtonToggle}
                     disabled={isAudioModeButtonDisabled}
                   />

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -484,6 +484,7 @@ export const ChatInput = ({
 
   const {
     isRecording,
+    isCapturingAudio: isRecordingCapturingAudio,
     isRecordingUpload,
     recordingError,
     setRecordingError,
@@ -2062,7 +2063,11 @@ export const ChatInput = ({
                     isBuffering={!isCapturingAudio || !isDictating}
                     disabled={disabled || isLoading || isDictationCompleting}
                     ariaLabel={t`Stop audio mode`}
-                    statusLabel={t`Listening for your next message`}
+                    statusLabel={
+                      isCapturingAudio && isDictating
+                        ? t`Listening for your next message`
+                        : t`Microphone is starting — wait for the level meter before speaking`
+                    }
                     testIds={{
                       root: "chat-input-audio-mode-pending-recording",
                       waveform:
@@ -2076,9 +2081,16 @@ export const ChatInput = ({
                 <WaveformButton
                   onClick={toggleAudioRecording}
                   bars={recordingBars}
+                  // Dimmed until real (non-zero) audio flows, so the user
+                  // isn't invited to speak into a still-warming mic.
+                  isBuffering={!isRecordingCapturingAudio}
                   disabled={disabled || isLoading}
                   ariaLabel={t`Stop audio transcript recording`}
-                  statusLabel={t`Recording audio transcript`}
+                  statusLabel={
+                    isRecordingCapturingAudio
+                      ? t`Recording audio transcript`
+                      : t`Microphone is starting — wait for the level meter before speaking`
+                  }
                   testIds={{
                     root: "chat-input-record-audio-transcript",
                     waveform: "chat-input-record-audio-transcript-waveform",
@@ -2113,7 +2125,12 @@ export const ChatInput = ({
                   <WaveformButton
                     onClick={toggleDictationForCurrentTarget}
                     bars={dictationBars}
-                    isBuffering={!isDictating}
+                    // Stay dimmed until BOTH the session is ready and real
+                    // (non-zero) audio is flowing. Gating on isDictating
+                    // alone invited users to speak during the mic's cold
+                    // warm-up window, losing the first words (ERMAIN-334).
+                    // Matches the conversational pending button above.
+                    isBuffering={!isCapturingAudio || !isDictating}
                     disabled={
                       disabled ||
                       isLoading ||
@@ -2128,9 +2145,11 @@ export const ChatInput = ({
                         : t`Cancel starting dictation`
                     }
                     statusLabel={
-                      isDictating
+                      isDictating && isCapturingAudio
                         ? t`Dictating audio`
-                        : t`Capturing audio — waiting for transcription to start`
+                        : isDictating
+                          ? t`Microphone is starting — wait for the level meter before speaking`
+                          : t`Capturing audio — waiting for transcription to start`
                     }
                     testIds={{
                       root: "chat-input-record-audio",

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -3,6 +3,7 @@ import { t } from "@lingui/core/macro";
 import { Waveform, audioLevelsToBarHeights } from "./Waveform";
 import { WaveformButton } from "./WaveformButton";
 import { Button } from "../Controls/Button";
+import { LoadingIcon } from "../icons";
 
 // Symmetric, gently peaked pattern shown in idle (resting) state. Values
 // flow through the same `max(v, 2) * 2` scale + 14px clamp as live bars,
@@ -26,6 +27,14 @@ type ChatInputAudioModeButtonRecordingProps =
     isRecording: true;
     /** Live bar heights from the active conversational dictation session. */
     recordingBars: readonly number[];
+    /**
+     * True while the session is still starting up (handshake, VAD model
+     * load, mic warm-up) — i.e. before real audio is captured. Shows a
+     * loading spinner instead of a live-looking waveform so the user
+     * isn't invited to speak before the microphone actually delivers
+     * audio (ERMAIN-334). Clicking still stops/cancels audio mode.
+     */
+    isStarting?: boolean;
   };
 
 type ChatInputAudioModeButtonProps =
@@ -39,6 +48,27 @@ type ChatInputAudioModeButtonProps =
  */
 export function ChatInputAudioModeButton(props: ChatInputAudioModeButtonProps) {
   if (props.isRecording) {
+    if (props.isStarting) {
+      return (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={props.onToggle}
+          disabled={props.disabled}
+          aria-label={t`Stop audio mode`}
+          title={t`Stop audio mode`}
+          data-testid="chat-input-audio-mode-stop"
+          icon={
+            <LoadingIcon
+              className="size-4 animate-spin text-[var(--theme-fg-primary)]"
+              data-testid="chat-input-audio-mode-starting-icon"
+            />
+          }
+        />
+      );
+    }
+
     return (
       <WaveformButton
         onClick={props.onToggle}

--- a/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
@@ -298,6 +298,7 @@ describe("useAudioDictationRecorder", () => {
     MockWebSocket.instances.length = 0;
     MockAudioWorkletNode.instances.length = 0;
     vadMock.engines.length = 0;
+    vadMock.createRicky0123VadEngine.mockClear();
 
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
@@ -551,6 +552,64 @@ describe("useAudioDictationRecorder", () => {
       MockWebSocket.instances[0].emitJson({ type: "completed" });
     });
     await waitFor(() => expect(result.current.isDictating).toBe(false));
+    // The engine is kept warm across sessions: teardown only stop()s it
+    // so the loaded ONNX/WASM session survives; destroy() is reserved
+    // for unmount.
+    expect(vadMock.engines[0].stop).toHaveBeenCalled();
+    expect(vadMock.engines[0].destroy).not.toHaveBeenCalled();
+  });
+
+  it("reuses the warm VAD engine across sessions and destroys it on unmount", async () => {
+    const { result, unmount } = renderDictationHook(vi.fn(), {
+      vadAutoStopEnabled: true,
+    });
+
+    await act(async () => {
+      result.current.toggleDictation();
+    });
+    await waitFor(() => expect(vadMock.engines).toHaveLength(1));
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+
+    act(() => {
+      MockWebSocket.instances[0].emit("open");
+    });
+    await waitFor(() =>
+      expect(MockWebSocket.instances[0].sentJsonFrames).toContainEqual({
+        mode: "dictation",
+        type: "start",
+      }),
+    );
+    act(() => {
+      MockWebSocket.instances[0].emitJson({
+        type: "session_state",
+        next_chunk_index: 0,
+        chunk_duration_ms: 100,
+      });
+    });
+    await waitFor(() => expect(result.current.isDictating).toBe(true));
+
+    await act(async () => {
+      result.current.toggleDictation();
+    });
+    act(() => {
+      MockWebSocket.instances[0].emitJson({ type: "completed" });
+    });
+    await waitFor(() =>
+      expect(result.current.isDictationCompleting).toBe(false),
+    );
+    expect(vadMock.engines[0].stop).toHaveBeenCalled();
+
+    // Second session: the SAME engine instance is re-started instead of
+    // a new one being created (no second model load).
+    await act(async () => {
+      result.current.toggleDictation();
+    });
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));
+    expect(vadMock.engines).toHaveLength(1);
+    expect(vadMock.engines[0].start).toHaveBeenCalledTimes(2);
+    expect(vadMock.createRicky0123VadEngine).toHaveBeenCalledTimes(1);
+
+    unmount();
     expect(vadMock.engines[0].destroy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/audio/__tests__/useAudioTranscriptionRecorder.test.tsx
+++ b/frontend/src/hooks/audio/__tests__/useAudioTranscriptionRecorder.test.tsx
@@ -49,6 +49,10 @@ vi.mock("@/lib/voice-runtime", () => ({
     mockCreateRicky0123VadEngine(...args),
 }));
 
+vi.mock("../audio-dictation-worklet.ts?worker&url", () => ({
+  default: "blob:mock-audio-dictation-worklet",
+}));
+
 const fixturePath = join(
   process.cwd(),
   "src/hooks/audio/__tests__/fixtures/sales-summary-1-3.wav",
@@ -117,20 +121,14 @@ class MockMediaStream {
 }
 
 class MockAnalyserNode {
-  fftSize = 64;
-  frequencyBinCount = 32;
+  fftSize = 256;
+  smoothingTimeConstant = 0;
 
   disconnect = vi.fn();
 
-  getByteFrequencyData(data: Uint8Array) {
-    data.fill(16);
+  getByteTimeDomainData(data: Uint8Array) {
+    data.fill(128);
   }
-}
-
-class MockGainNode {
-  gain = { value: 1 };
-  connect = vi.fn();
-  disconnect = vi.fn();
 }
 
 class MockMediaStreamAudioSourceNode {
@@ -138,18 +136,34 @@ class MockMediaStreamAudioSourceNode {
   disconnect = vi.fn();
 }
 
-class MockScriptProcessorNode {
-  onaudioprocess: ((event: AudioProcessingEvent) => void) | null = null;
-  connect = vi.fn();
-  disconnect = vi.fn();
+class MockMessagePort {
+  onmessage: ((event: MessageEvent<Float32Array>) => void) | null = null;
+  postMessage = vi.fn();
 }
 
-const mockProcessors: MockScriptProcessorNode[] = [];
+class MockAudioWorkletNode {
+  static instances: MockAudioWorkletNode[] = [];
+  port = new MockMessagePort();
+  connect = vi.fn();
+  disconnect = vi.fn();
+
+  constructor(
+    public readonly context: unknown,
+    public readonly name: string,
+  ) {
+    MockAudioWorkletNode.instances.push(this);
+  }
+}
+
+class MockAudioWorklet {
+  addModule = vi.fn(async () => undefined);
+}
 
 class MockAudioContext {
   sampleRate = 16000;
   state = "running";
   destination = {};
+  audioWorklet = new MockAudioWorklet();
 
   createMediaStreamSource() {
     return new MockMediaStreamAudioSourceNode();
@@ -159,41 +173,16 @@ class MockAudioContext {
     return new MockAnalyserNode();
   }
 
-  createScriptProcessor() {
-    const processor = new MockScriptProcessorNode();
-    mockProcessors.push(processor);
-    return processor;
-  }
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
 
-  createGain() {
-    return new MockGainNode();
-  }
+  suspend = vi.fn(async () => {
+    this.state = "suspended";
+  });
 
   close = vi.fn(async () => {
     this.state = "closed";
-  });
-}
-
-class MockMediaRecorder extends EventTarget {
-  static instances: MockMediaRecorder[] = [];
-  state: "inactive" | "recording" = "inactive";
-  mimeType = "audio/webm";
-  ondataavailable: ((event: BlobEvent) => void) | null = null;
-  onstop: (() => void) | null = null;
-  onerror: ((event: Event) => void) | null = null;
-
-  constructor() {
-    super();
-    MockMediaRecorder.instances.push(this);
-  }
-
-  start = vi.fn(() => {
-    this.state = "recording";
-  });
-
-  stop = vi.fn(() => {
-    this.state = "inactive";
-    this.onstop?.();
   });
 }
 
@@ -204,6 +193,9 @@ type MockWebSocketEvent = {
 class MockWebSocket {
   static OPEN = 1;
   static instances: MockWebSocket[] = [];
+  /** When false, the mock withholds the automatic session_state reply so
+   *  tests can drive the handshake manually (pre-handshake capture). */
+  static autoRespondSessionState = true;
   readyState = MockWebSocket.OPEN;
   sentJsonFrames: Record<string, unknown>[] = [];
   sentBinaryFrames: Uint8Array[] = [];
@@ -239,7 +231,7 @@ class MockWebSocket {
       const frame = JSON.parse(data) as Record<string, unknown>;
       this.sentJsonFrames.push(frame);
 
-      if (frame.type === "start") {
+      if (frame.type === "start" && MockWebSocket.autoRespondSessionState) {
         this.emitJson({
           type: "session_state",
           file_upload_id: audioFileUpload.id,
@@ -334,7 +326,7 @@ class MockWebSocket {
     this.emit("close", {});
   });
 
-  private emitJson(frame: Record<string, unknown>) {
+  emitJson(frame: Record<string, unknown>) {
     globalThis.queueMicrotask(() =>
       this.emit("message", { data: JSON.stringify(frame) }),
     );
@@ -346,16 +338,12 @@ class MockWebSocket {
 }
 
 function emitAudioSamples(samples: Float32Array) {
-  const processor = mockProcessors.at(-1);
-  if (!processor?.onaudioprocess) {
-    throw new Error("Script processor was not initialized");
+  const processor = MockAudioWorkletNode.instances.at(-1);
+  if (!processor?.port.onmessage) {
+    throw new Error("Audio worklet node was not initialized");
   }
 
-  processor.onaudioprocess({
-    inputBuffer: {
-      getChannelData: () => samples,
-    },
-  } as unknown as AudioProcessingEvent);
+  processor.port.onmessage({ data: samples } as MessageEvent<Float32Array>);
 }
 
 describe("useAudioTranscriptionRecorder", () => {
@@ -363,9 +351,9 @@ describe("useAudioTranscriptionRecorder", () => {
     vi.restoreAllMocks();
     mockFetchGetFile.mockReset();
     mockUseCreateChat.mockReset();
-    mockProcessors.length = 0;
-    MockMediaRecorder.instances.length = 0;
+    MockAudioWorkletNode.instances.length = 0;
     MockWebSocket.instances.length = 0;
+    MockWebSocket.autoRespondSessionState = true;
     mockVadListeners.length = 0;
     mockVadEngine.start.mockClear();
     mockVadEngine.stop.mockClear();
@@ -388,7 +376,7 @@ describe("useAudioTranscriptionRecorder", () => {
     });
 
     vi.stubGlobal("AudioContext", MockAudioContext);
-    vi.stubGlobal("MediaRecorder", MockMediaRecorder);
+    vi.stubGlobal("AudioWorkletNode", MockAudioWorkletNode);
     vi.stubGlobal("WebSocket", MockWebSocket);
     vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
     vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
@@ -488,6 +476,75 @@ describe("useAudioTranscriptionRecorder", () => {
         }),
       ]),
     );
+  });
+
+  it("captures speech during the socket handshake and ships it once the session is ready", async () => {
+    MockWebSocket.autoRespondSessionState = false;
+    let attachedFiles: FileUploadItem[] = [];
+    const setAttachedFiles = vi.fn((nextAttachedFiles: FileUploadItem[]) => {
+      attachedFiles = nextAttachedFiles;
+    });
+    const { result } = renderHook(() =>
+      useAudioTranscriptionRecorder({
+        audioTranscriptionEnabled: true,
+        uploadEnabled: true,
+        maxRecordingDurationSeconds: 1200,
+        chatId: "chat-1",
+        silentChatId: null,
+        setSilentChatId: vi.fn(),
+        attachedFiles,
+        setAttachedFiles,
+      }),
+    );
+
+    await act(async () => {
+      result.current.toggleAudioRecording();
+    });
+
+    // Regression test for ERMAIN-334's tap-after-handshake truncation:
+    // the worklet must already be capturing while the server has NOT
+    // yet replied with session_state.
+    await waitFor(() => expect(MockAudioWorkletNode.instances).toHaveLength(1));
+    await waitFor(() =>
+      expect(MockWebSocket.instances[0].sentJsonFrames).toContainEqual(
+        expect.objectContaining({ type: "start" }),
+      ),
+    );
+
+    // Speak during the handshake: samples buffer client-side and
+    // nothing is transmitted yet.
+    act(() => {
+      emitAudioSamples(new Float32Array(1600).fill(0.5));
+    });
+    expect(MockWebSocket.instances[0].sentBinaryFrames).toHaveLength(0);
+    expect(result.current.isRecording).toBe(false);
+
+    // Server completes the handshake.
+    await act(async () => {
+      MockWebSocket.instances[0].emitJson({
+        type: "session_state",
+        file_upload_id: audioFileUpload.id,
+        next_chunk_index: 0,
+        stored_offset: 0,
+        chunk_duration_ms: 100,
+        audio_transcription: audioFileUpload.audio_transcription,
+      });
+    });
+    await waitFor(() => expect(result.current.isRecording).toBe(true));
+
+    // The 300ms zero primer (4800 samples at the mocked 16kHz rate) plus
+    // the 1600 pre-handshake speech samples drain into exactly four
+    // 100ms chunks: three zero primer chunks, then the speech.
+    await waitFor(() =>
+      expect(MockWebSocket.instances[0].sentBinaryFrames).toHaveLength(4),
+    );
+    const frames = MockWebSocket.instances[0].sentBinaryFrames;
+    expect(String.fromCharCode(...frames[0].slice(0, 4))).toBe("RIFF");
+    // 0.5 resamples 1:1 at the mocked rate and packs as int16 0x3fff
+    // little-endian — the speech spoken during the handshake reached
+    // the server instead of being dropped.
+    expect(frames[3][0]).toBe(0xff);
+    expect(frames[3][1]).toBe(0x3f);
   });
 
   it("auto-stops a live recording when VAD detects speech end", async () => {

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -239,6 +239,26 @@ export function useAudioDictationRecorder({
   const recordingDurationTimerRef = useRef<number | null>(null);
   const onTranscriptChunkRef = useRef(onTranscriptChunk);
   const vadEngineRef = useRef<VoiceVadEngine | null>(null);
+  /**
+   * VAD engine instance kept warm ACROSS dictation sessions. The first
+   * `vadEngine.start()` pays a multi-megabyte onnxruntime-web WASM +
+   * Silero ONNX model load; the engine supports cheap `stop()` + reset
+   * reuse, so we create it once and re-start it per session instead of
+   * destroying and re-downloading every conversational turn. Destroyed
+   * only in the unmount cleanup. `vadEngineRef` stays the "active and
+   * listening" signal consumed by the worklet frame feed.
+   */
+  const persistentVadEngineRef = useRef<VoiceVadEngine | null>(null);
+  /** Per-session VAD listener detach; called on every stop so a reused
+   *  engine never fires stale callbacks into a finished session. */
+  const vadEngineUnsubscribeRef = useRef<(() => void) | null>(null);
+  /**
+   * Serializes `vadEngine.start()` calls on the shared engine. A
+   * stop-then-restart while the cold model load is still in flight
+   * would otherwise run two concurrent `MicVAD.new()` loads inside the
+   * same instance and leak one ORT session.
+   */
+  const vadEngineStartQueueRef = useRef<Promise<void>>(Promise.resolve());
   const vadAutoStopTriggeredRef = useRef(false);
   const onVadAutoStopRef = useRef(onVadAutoStop);
   /**
@@ -271,7 +291,13 @@ export function useAudioDictationRecorder({
   }, []);
 
   const stopVadEngine = useCallback(() => {
-    vadEngineRef.current?.destroy();
+    vadEngineUnsubscribeRef.current?.();
+    vadEngineUnsubscribeRef.current = null;
+    // stop() — NOT destroy() — so the loaded WASM/ONNX session stays
+    // warm in persistentVadEngineRef for the next dictation turn;
+    // re-start is then a cheap state reset instead of a multi-second
+    // model reload. destroy() happens only on unmount.
+    vadEngineRef.current?.stop();
     vadEngineRef.current = null;
     vadAutoStopTriggeredRef.current = false;
     if (isMounted()) {
@@ -764,63 +790,6 @@ export function useAudioDictationRecorder({
         analyser.fftSize = 256;
         analyser.smoothingTimeConstant = 0.65;
         sourceSampleRate = audioContext.sampleRate;
-        if (vadAutoStopEnabled) {
-          let vadEngine: VoiceVadEngine | null = null;
-          try {
-            vadEngine = createRicky0123VadEngine({
-              model: "silero-v5",
-              redemptionMs: 1800,
-              preSpeechPadMs: 500,
-              minSpeechMs: 400,
-            });
-            vadEngine.subscribe((event) => {
-              if (event.type === "error") {
-                stopVadEngine();
-                return;
-              }
-              if (
-                event.type === "speech_start" ||
-                event.type === "speech_real_start"
-              ) {
-                if (isMounted()) {
-                  setIsVadSpeechActive(true);
-                }
-                return;
-              }
-              if (event.type === "vad_misfire") {
-                if (isMounted()) {
-                  setIsVadSpeechActive(false);
-                }
-                return;
-              }
-              if (event.type !== "speech_end") {
-                return;
-              }
-
-              if (isMounted()) {
-                setIsVadSpeechActive(false);
-              }
-              if (vadAutoStopTriggeredRef.current) {
-                return;
-              }
-              vadAutoStopTriggeredRef.current = true;
-              onVadAutoStopRef.current?.();
-              stopDictation();
-            });
-            await vadEngine.start();
-            vadEngineRef.current = vadEngine;
-            if (isMounted()) {
-              setIsVadListening(true);
-            }
-          } catch {
-            vadEngine?.destroy();
-            vadEngineRef.current = null;
-            if (isMounted()) {
-              setIsVadListening(false);
-              setIsVadSpeechActive(false);
-            }
-          }
-        }
         // Synthetic silence primer: seeds the pre-session buffer with a
         // fixed amount of zero samples so the audio sent to the server
         // always starts with the same calibration window for its VAD,
@@ -932,6 +901,96 @@ export function useAudioDictationRecorder({
         source.connect(analyser);
         source.connect(processor);
         audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
+
+        if (vadAutoStopEnabled) {
+          // Start (or re-start) the VAD engine only AFTER the capture
+          // graph is connected: samples buffer into preSessionSamplesRef
+          // while the model loads, so the first-time onnxruntime WASM +
+          // Silero ONNX fetch no longer eats the start of the first
+          // utterance (ERMAIN-334). The await therefore delays only the
+          // session handshake below, never audio capture. The engine is
+          // created once and reused warm across turns.
+          const vadEngine =
+            persistentVadEngineRef.current ??
+            createRicky0123VadEngine({
+              model: "silero-v5",
+              redemptionMs: 1800,
+              preSpeechPadMs: 500,
+              minSpeechMs: 400,
+            });
+          persistentVadEngineRef.current = vadEngine;
+          const unsubscribeVad = vadEngine.subscribe((event) => {
+            if (event.type === "error") {
+              stopVadEngine();
+              return;
+            }
+            if (
+              event.type === "speech_start" ||
+              event.type === "speech_real_start"
+            ) {
+              if (isMounted()) {
+                setIsVadSpeechActive(true);
+              }
+              return;
+            }
+            if (event.type === "vad_misfire") {
+              if (isMounted()) {
+                setIsVadSpeechActive(false);
+              }
+              return;
+            }
+            if (event.type !== "speech_end") {
+              return;
+            }
+
+            if (isMounted()) {
+              setIsVadSpeechActive(false);
+            }
+            if (vadAutoStopTriggeredRef.current) {
+              return;
+            }
+            vadAutoStopTriggeredRef.current = true;
+            onVadAutoStopRef.current?.();
+            stopDictation();
+          });
+          vadEngineUnsubscribeRef.current = unsubscribeVad;
+          const vadStartPromise = vadEngineStartQueueRef.current
+            .catch(() => undefined)
+            .then(() => vadEngine.start());
+          vadEngineStartQueueRef.current = vadStartPromise.then(
+            () => undefined,
+            () => undefined,
+          );
+          try {
+            await vadStartPromise;
+            if (audioProcessorRef.current === processor) {
+              vadEngineRef.current = vadEngine;
+              if (isMounted()) {
+                setIsVadListening(true);
+              }
+            } else {
+              // The session was torn down while the model loaded; leave
+              // the engine warm but detached. Guard the ref compare so a
+              // newer session's subscription is never ripped out.
+              unsubscribeVad();
+              if (vadEngineUnsubscribeRef.current === unsubscribeVad) {
+                vadEngineUnsubscribeRef.current = null;
+              }
+              vadEngine.stop();
+            }
+          } catch {
+            // Model load failed — continue without auto-stop; the warm
+            // instance is retained so the next session can retry.
+            unsubscribeVad();
+            if (vadEngineUnsubscribeRef.current === unsubscribeVad) {
+              vadEngineUnsubscribeRef.current = null;
+            }
+            if (isMounted()) {
+              setIsVadListening(false);
+              setIsVadSpeechActive(false);
+            }
+          }
+        }
       } else {
         setDictationBars((existingBars) =>
           existingBars.length === AUDIO_BARS_COUNT
@@ -1039,6 +1098,10 @@ export function useAudioDictationRecorder({
       liveSessionRef.current = null;
       pendingSocketRef.current = null;
       stopVadEngine();
+      // stopVadEngine only stop()s the engine so it stays warm between
+      // sessions; on unmount release the ONNX/WASM session for real.
+      persistentVadEngineRef.current?.destroy();
+      persistentVadEngineRef.current = null;
       stopRecordingVisualizer(false);
       // stopRecordingVisualizer suspends the AudioContext between
       // sessions; close it for real on unmount so the audio rendering

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -1,5 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useMountedState } from "react-use";
 import { useThrottledCallback } from "use-debounce";
 /* eslint-disable lingui/no-unlocalized-strings */
 
@@ -11,9 +12,18 @@ import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext"
 import { createRicky0123VadEngine } from "@/lib/voice-runtime";
 import { createLogger } from "@/utils/debugLogger";
 
+// `?worker&url` routes the worklet through Vite's worker bundling
+// pipeline — see useAudioDictationRecorder for why the canonical
+// `new URL(..., import.meta.url)` pattern does not work for TS worklets.
+import audioDictationWorkletUrl from "./audio-dictation-worklet.ts?worker&url";
 import {
   AUDIO_BARS_COUNT,
+  CANONICAL_AUDIO_BYTES_PER_SAMPLE,
+  CANONICAL_AUDIO_SAMPLE_RATE_HZ,
+  CANONICAL_AUDIO_WAV_HEADER_BYTES,
+  createCanonicalWavBytesFromPcm,
   getAudioLevelBarsFromTimeDomainData,
+  resampleMonoFloat32ToPcm16,
 } from "./audio-pcm-codec";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 
@@ -24,11 +34,24 @@ import type {
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { VoiceVadEngine } from "@/lib/voice-runtime";
 
-const CANONICAL_AUDIO_SAMPLE_RATE_HZ = 16_000;
-const CANONICAL_AUDIO_WAV_HEADER_BYTES = 44;
-const CANONICAL_AUDIO_BYTES_PER_SAMPLE = 2;
 const DEFAULT_AUDIO_TRANSCRIPTION_CHUNK_DURATION_MS = 30_000;
 const VAD_DEBUG_FRAME_LOG_INTERVAL_MS = 2_000;
+
+/**
+ * The transcription recorder shares the dictation recorder's worklet
+ * module (and therefore its registered processor name): both need the
+ * same "batch render quanta to 4096-sample frames on the audio render
+ * thread" behavior.
+ */
+const AUDIO_TRANSCRIPTION_WORKLET_PROCESSOR_NAME = "audio-dictation-processor";
+
+/**
+ * Synthetic silence prefix prepended before the captured audio, and the
+ * floor between pipeline-ready and the visible `isCapturingAudio` flip.
+ * Both mirror useAudioDictationRecorder — see the rationale there.
+ */
+const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
+const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
 
 const logger = createLogger("HOOK", "useAudioTranscriptionRecorder");
 
@@ -94,6 +117,9 @@ type AudioTranscriptionChunk = {
 type LiveAudioTranscriptionSession = {
   socket: WebSocket;
   fileUploadId: string;
+  /** Recording filename; carried on the session so the deferred
+   *  finalization can build the retry source File after teardown. */
+  filename: string;
   chunkDurationMs: number;
   nextChunkIndex: number;
   startedAtMs: number;
@@ -101,6 +127,10 @@ type LiveAudioTranscriptionSession = {
   pcmParts: Uint8Array[];
   pendingSourceSamples: number[];
   sourceSampleRate: number;
+  /** Cumulative canonical-PCM bytes accepted for sending (tracked
+   *  synchronously at enqueue time), used to clamp the recording to the
+   *  configured maximum duration the backend enforces strictly. */
+  queuedPcmBytes: number;
 };
 
 export type AudioRecordingDiagnostics = {
@@ -128,40 +158,6 @@ type UseAudioTranscriptionRecorderOptions = {
 
 function isAudioTranscriptionAttachment(file: FileUploadItem): boolean {
   return Boolean(file.audio_transcription);
-}
-
-function writeAscii(view: DataView, offset: number, value: string) {
-  for (let index = 0; index < value.length; index += 1) {
-    view.setUint8(offset + index, value.charCodeAt(index));
-  }
-}
-
-function createCanonicalWavBytesFromPcm(pcmBytes: Uint8Array): Uint8Array {
-  const wavBytes = new Uint8Array(
-    CANONICAL_AUDIO_WAV_HEADER_BYTES + pcmBytes.length,
-  );
-  const view = new DataView(wavBytes.buffer);
-
-  writeAscii(view, 0, "RIFF");
-  view.setUint32(4, 36 + pcmBytes.length, true);
-  writeAscii(view, 8, "WAVE");
-  writeAscii(view, 12, "fmt ");
-  view.setUint32(16, 16, true);
-  view.setUint16(20, 1, true);
-  view.setUint16(22, 1, true);
-  view.setUint32(24, CANONICAL_AUDIO_SAMPLE_RATE_HZ, true);
-  view.setUint32(
-    28,
-    CANONICAL_AUDIO_SAMPLE_RATE_HZ * CANONICAL_AUDIO_BYTES_PER_SAMPLE,
-    true,
-  );
-  view.setUint16(32, CANONICAL_AUDIO_BYTES_PER_SAMPLE, true);
-  view.setUint16(34, 16, true);
-  writeAscii(view, 36, "data");
-  view.setUint32(40, pcmBytes.length, true);
-  wavBytes.set(pcmBytes, CANONICAL_AUDIO_WAV_HEADER_BYTES);
-
-  return wavBytes;
 }
 
 function validateCanonicalWavBytes(bytes: Uint8Array): void {
@@ -266,6 +262,18 @@ function waitForAudioTranscriptionFrame(
   predicate: (frame: AudioTranscriptionSocketFrame) => boolean,
 ): Promise<AudioTranscriptionSocketFrame> {
   return new Promise<AudioTranscriptionSocketFrame>((resolve, reject) => {
+    // A clean server/proxy close fires only "close" (no "error"), and a
+    // socket that died mid-recording is already CLOSED by the time the
+    // finalization attaches listeners — both would otherwise leave this
+    // promise (and the stop finalization awaiting it) hanging forever.
+    if (
+      socket.readyState === WebSocket.CLOSING ||
+      socket.readyState === WebSocket.CLOSED
+    ) {
+      reject(new Error(t`Audio transcription connection closed unexpectedly.`));
+      return;
+    }
+
     const handleMessage = (event: MessageEvent) => {
       if (typeof event.data !== "string") {
         return;
@@ -298,13 +306,20 @@ function waitForAudioTranscriptionFrame(
       reject(new Error(t`Audio transcription connection failed.`));
     };
 
+    const handleClose = () => {
+      cleanup();
+      reject(new Error(t`Audio transcription connection closed unexpectedly.`));
+    };
+
     const cleanup = () => {
       socket.removeEventListener("message", handleMessage);
       socket.removeEventListener("error", handleError);
+      socket.removeEventListener("close", handleClose);
     };
 
     socket.addEventListener("message", handleMessage);
     socket.addEventListener("error", handleError);
+    socket.addEventListener("close", handleClose);
   });
 }
 
@@ -319,45 +334,6 @@ function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
   });
 
   return bytes;
-}
-
-function resampleMonoFloat32ToPcm16(
-  samples: Float32Array,
-  sourceSampleRate: number,
-): Uint8Array {
-  const targetSampleCount = Math.max(
-    1,
-    Math.round(
-      (samples.length * CANONICAL_AUDIO_SAMPLE_RATE_HZ) / sourceSampleRate,
-    ),
-  );
-  const pcmBytes = new Uint8Array(
-    targetSampleCount * CANONICAL_AUDIO_BYTES_PER_SAMPLE,
-  );
-  const view = new DataView(pcmBytes.buffer);
-  const rateRatio = sourceSampleRate / CANONICAL_AUDIO_SAMPLE_RATE_HZ;
-
-  for (
-    let targetSampleIndex = 0;
-    targetSampleIndex < targetSampleCount;
-    targetSampleIndex += 1
-  ) {
-    const sourcePosition = targetSampleIndex * rateRatio;
-    const sourceIndex = Math.floor(sourcePosition);
-    const nextSourceIndex = Math.min(sourceIndex + 1, samples.length - 1);
-    const interpolation = sourcePosition - sourceIndex;
-    const sample =
-      samples[sourceIndex] * (1 - interpolation) +
-      samples[nextSourceIndex] * interpolation;
-    const clampedSample = Math.max(-1, Math.min(1, sample));
-    view.setInt16(
-      targetSampleIndex * CANONICAL_AUDIO_BYTES_PER_SAMPLE,
-      clampedSample < 0 ? clampedSample * 0x8000 : clampedSample * 0x7fff,
-      true,
-    );
-  }
-
-  return pcmBytes;
 }
 
 function mediaTrackSettingsToDiagnostics(
@@ -412,6 +388,12 @@ export function useAudioTranscriptionRecorder({
   setAttachedFiles,
 }: UseAudioTranscriptionRecorderOptions) {
   const [isRecording, setIsRecording] = useState(false);
+  /**
+   * True once the worklet has delivered the first non-zero sample —
+   * the mic is really live, as opposed to streaming OS warm-up zeros.
+   * Drives the UI "speak now" cue; mirrors useAudioDictationRecorder.
+   */
+  const [isCapturingAudio, setIsCapturingAudio] = useState(false);
   const [isRecordingUpload, setIsRecordingUpload] = useState(false);
   const [recordingError, setRecordingError] = useState<string | null>(null);
   const [retryingAudioFileId, setRetryingAudioFileId] = useState<string | null>(
@@ -430,19 +412,33 @@ export function useAudioTranscriptionRecorder({
   const [isVadListening, setIsVadListening] = useState(false);
   const [isVadSpeechActive, setIsVadSpeechActive] = useState(false);
 
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-  const mediaChunksRef = useRef<BlobPart[]>([]);
   const liveSessionRef = useRef<LiveAudioTranscriptionSession | null>(null);
   const recordedAudioFilesRef = useRef(new Map<string, File>());
   const attachedFilesRef = useRef(attachedFiles);
+  /**
+   * Pre-session sample buffer: holds Float32 samples captured between
+   * the worklet's first frame and the live session being ready, so the
+   * user's first words aren't dropped during the chat-create + socket
+   * handshake. Mirrors useAudioDictationRecorder (ERMAIN-334).
+   */
+  const preSessionSamplesRef = useRef<number[]>([]);
+  /**
+   * AudioContext persists across recordings (suspend between sessions,
+   * close only on unmount) and the worklet module registers once per
+   * context — both mirror useAudioDictationRecorder.
+   */
   const audioContextRef = useRef<AudioContext | null>(null);
+  const workletModuleLoadedRef = useRef(false);
   const audioAnalyserRef = useRef<AnalyserNode | null>(null);
   const audioSourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
-  const audioProcessorRef = useRef<ScriptProcessorNode | null>(null);
-  const audioProcessorSinkRef = useRef<GainNode | null>(null);
+  const audioProcessorRef = useRef<AudioWorkletNode | null>(null);
   const audioLevelDataRef = useRef<Uint8Array | null>(null);
   const audioFrameRef = useRef<number | null>(null);
+  /** Defers the isCapturingAudio flip when real audio arrives sooner
+   *  than MIN_AUDIO_CAPTURE_DELAY_MS; cleared on teardown. */
+  const capturingFlipTimerRef = useRef<number | null>(null);
+  const startInFlightRef = useRef(false);
   const vadEngineRef = useRef<VoiceVadEngine | null>(null);
   const vadAutoStopTriggeredRef = useRef(false);
   const vadDebugLastFrameLogAtRef = useRef(0);
@@ -452,7 +448,11 @@ export function useAudioTranscriptionRecorder({
   const createChatMutation = useCreateChat();
   const { fetcherOptions: fileFetchOptions } = useV1betaApiContext();
   const fileFetchOptionsRef = useRef(fileFetchOptions);
-  const { selectedAudioInputDeviceId } = useAudioInputDevicePreference();
+  /** Mounted getter for the awaits in startAudioRecording and the
+   *  deferred finalization — mirrors useAudioDictationRecorder. */
+  const isMounted = useMountedState();
+  const { selectedAudioInputDeviceId, setSelectedAudioInputDeviceId } =
+    useAudioInputDevicePreference();
 
   useEffect(() => {
     fileFetchOptionsRef.current = fileFetchOptions;
@@ -519,6 +519,10 @@ export function useAudioTranscriptionRecorder({
   );
 
   const stopRecordingVisualizer = useCallback(() => {
+    if (capturingFlipTimerRef.current !== null) {
+      window.clearTimeout(capturingFlipTimerRef.current);
+      capturingFlipTimerRef.current = null;
+    }
     if (audioFrameRef.current !== null) {
       window.cancelAnimationFrame(audioFrameRef.current);
       audioFrameRef.current = null;
@@ -528,16 +532,23 @@ export function useAudioTranscriptionRecorder({
     audioAnalyserRef.current = null;
     audioSourceNodeRef.current?.disconnect();
     audioSourceNodeRef.current = null;
-    audioProcessorRef.current?.disconnect();
-    audioProcessorRef.current = null;
-    audioProcessorSinkRef.current?.disconnect();
-    audioProcessorSinkRef.current = null;
+    if (audioProcessorRef.current) {
+      audioProcessorRef.current.port.onmessage = null;
+      audioProcessorRef.current.disconnect();
+      audioProcessorRef.current = null;
+    }
     audioLevelDataRef.current = null;
 
-    if (audioContextRef.current && audioContextRef.current.state !== "closed") {
-      void audioContextRef.current.close();
+    // Suspend rather than close: each recording gets fresh source /
+    // analyser / worklet nodes, but the AudioContext itself, its audio
+    // rendering thread, and the registered worklet module stay warm.
+    // Closing + re-creating the context paid an audio-thread spin-up
+    // cost on every restart. Close only happens on unmount.
+    if (audioContextRef.current?.state === "running") {
+      void audioContextRef.current.suspend();
     }
-    audioContextRef.current = null;
+    preSessionSamplesRef.current = [];
+    setIsCapturingAudio(false);
     // Drop any pending throttled bar updates before resetting to the idle
     // pattern, so a stale RAF frame can't overwrite the reset.
     setRecordingBarsThrottled.cancel();
@@ -576,8 +587,66 @@ export function useAudioTranscriptionRecorder({
     stopRecordingVisualizer();
   }, [clearRecordingDurationTimer, stopRecordingVisualizer, stopVadEngine]);
 
+  /**
+   * Returns a ready-to-use AudioContext with the shared dictation
+   * worklet module registered and the context in the `running` state.
+   * Reuses the existing context across recordings (resume) and creates
+   * a fresh one only when the previous one was closed. Returns `null`
+   * when the host browser doesn't support Web Audio / AudioWorkletNode.
+   * Mirrors useAudioDictationRecorder.ensureAudioContextReady.
+   */
+  const ensureAudioContextReady = useCallback(
+    async (preferredSampleRate?: number): Promise<AudioContext | null> => {
+      if (
+        typeof AudioContext === "undefined" ||
+        typeof AudioWorkletNode === "undefined"
+      ) {
+        return null;
+      }
+
+      let audioContext = audioContextRef.current;
+      if (!audioContext || audioContext.state === "closed") {
+        try {
+          audioContext = preferredSampleRate
+            ? new AudioContext({ sampleRate: preferredSampleRate })
+            : new AudioContext();
+        } catch {
+          // Browser refused the requested sample rate; fall back to the
+          // default rate — the PCM resampler handles 16 kHz either way.
+          audioContext = new AudioContext();
+        }
+        audioContextRef.current = audioContext;
+        workletModuleLoadedRef.current = false;
+      }
+
+      if (!workletModuleLoadedRef.current) {
+        await audioContext.audioWorklet.addModule(audioDictationWorkletUrl);
+        workletModuleLoadedRef.current = true;
+      }
+
+      // resume() is a no-op when already running; it matters when
+      // reusing a context suspended at the end of the prior recording,
+      // and on hosts where a fresh context starts suspended (embedded
+      // webviews / lapsed user activation). The transcription recorder
+      // previously never resumed, which silently produced zero capture
+      // on suspended-start hosts (ERMAIN-334).
+      try {
+        await audioContext.resume();
+      } catch {
+        // Resume can reject when user activation has fully expired; the
+        // context still works once the source is connected.
+      }
+
+      return audioContext;
+    },
+    [],
+  );
+
   const startLiveAudioTranscriptionSession = useCallback(
-    async (filename: string): Promise<LiveAudioTranscriptionSession> => {
+    async (
+      filename: string,
+      sourceSampleRate: number,
+    ): Promise<LiveAudioTranscriptionSession> => {
       if (!audioTranscriptionEnabled) {
         throw new Error(
           t`Audio transcription is not available in this environment.`,
@@ -632,46 +701,58 @@ export function useAudioTranscriptionRecorder({
         setRecordingError(t`Audio transcription connection failed.`);
       });
 
-      await waitForSocketOpen(socket);
-      const sessionStatePromise = waitForAudioTranscriptionFrame(
-        socket,
-        (frame) => frame.type === "session_state",
-      );
+      try {
+        await waitForSocketOpen(socket);
+        const sessionStatePromise = waitForAudioTranscriptionFrame(
+          socket,
+          (frame) => frame.type === "session_state",
+        );
 
-      sendAudioTranscriptionControlFrame(socket, {
-        type: "start",
-        chat_id: uploadChatId,
-        filename,
-        content_type: "audio/wav",
-      });
+        sendAudioTranscriptionControlFrame(socket, {
+          type: "start",
+          chat_id: uploadChatId,
+          filename,
+          content_type: "audio/wav",
+        });
 
-      const sessionFrame = await sessionStatePromise;
-      if (sessionFrame.type !== "session_state") {
-        throw new Error(t`Audio transcription did not start.`);
+        const sessionFrame = await sessionStatePromise;
+        if (sessionFrame.type !== "session_state") {
+          throw new Error(t`Audio transcription did not start.`);
+        }
+
+        const initialFile = await fetchGetFile({
+          ...fileFetchOptionsRef.current,
+          pathParams: { fileId: sessionFrame.file_upload_id },
+        });
+        upsertAudioTranscriptionAttachment(initialFile);
+
+        // The caller drains the pre-session sample buffer into this
+        // session and only then publishes it to liveSessionRef — the
+        // drain → ref-assign → flush sequence must stay one synchronous
+        // block there so no audio frame can interleave.
+        const session: LiveAudioTranscriptionSession = {
+          socket,
+          fileUploadId: sessionFrame.file_upload_id,
+          filename,
+          chunkDurationMs:
+            sessionFrame.chunk_duration_ms ??
+            DEFAULT_AUDIO_TRANSCRIPTION_CHUNK_DURATION_MS,
+          nextChunkIndex: sessionFrame.next_chunk_index ?? 0,
+          startedAtMs: Date.now(),
+          sendQueue: Promise.resolve(),
+          pcmParts: [],
+          pendingSourceSamples: [],
+          sourceSampleRate,
+          queuedPcmBytes: 0,
+        };
+        setIsRecordingUpload(false);
+        return session;
+      } catch (error) {
+        // The session was never published to liveSessionRef, so the
+        // socket would otherwise leak on handshake failure.
+        socket.close();
+        throw error;
       }
-
-      const initialFile = await fetchGetFile({
-        ...fileFetchOptionsRef.current,
-        pathParams: { fileId: sessionFrame.file_upload_id },
-      });
-      upsertAudioTranscriptionAttachment(initialFile);
-
-      const session: LiveAudioTranscriptionSession = {
-        socket,
-        fileUploadId: sessionFrame.file_upload_id,
-        chunkDurationMs:
-          sessionFrame.chunk_duration_ms ??
-          DEFAULT_AUDIO_TRANSCRIPTION_CHUNK_DURATION_MS,
-        nextChunkIndex: sessionFrame.next_chunk_index ?? 0,
-        startedAtMs: Date.now(),
-        sendQueue: Promise.resolve(),
-        pcmParts: [],
-        pendingSourceSamples: [],
-        sourceSampleRate: CANONICAL_AUDIO_SAMPLE_RATE_HZ,
-      };
-      liveSessionRef.current = session;
-      setIsRecordingUpload(false);
-      return session;
     },
     [
       assistantId,
@@ -686,53 +767,82 @@ export function useAudioTranscriptionRecorder({
     ],
   );
 
-  const sendLivePcmChunk = useCallback((pcmBytes: Uint8Array) => {
-    const session = liveSessionRef.current;
-    if (!session || pcmBytes.length === 0) {
-      return;
-    }
-
-    session.sendQueue = session.sendQueue.then(async () => {
-      if (session.socket.readyState !== WebSocket.OPEN) {
+  const sendLivePcmChunk = useCallback(
+    (session: LiveAudioTranscriptionSession, pcmBytes: Uint8Array) => {
+      if (pcmBytes.length === 0) {
         return;
       }
 
-      const chunkIndex = session.nextChunkIndex;
-      const startMs = chunkIndex * session.chunkDurationMs;
-      const chunkDurationMs = Math.ceil(
-        (pcmBytes.length /
-          CANONICAL_AUDIO_BYTES_PER_SAMPLE /
-          CANONICAL_AUDIO_SAMPLE_RATE_HZ) *
-          1000,
-      );
-      const endMs =
-        startMs + Math.min(chunkDurationMs, session.chunkDurationMs);
-      const isFirstChunk = chunkIndex === 0;
-      const canonicalAudioBytes = isFirstChunk
-        ? createCanonicalWavBytesFromPcm(pcmBytes)
-        : null;
+      // Clamp the cumulative recording to the configured maximum: the
+      // 300ms primer plus the pre-handshake capture push a recording
+      // that runs to the cap slightly past the backend's strict
+      // duration/byte limits, which would reject the FINAL chunk (the
+      // end of the user's speech) and break the retry path. Trimming
+      // the overflow client-side keeps the last chunk's end_ms exactly
+      // at the limit.
+      const maxSessionPcmBytes =
+        Math.floor(
+          maxRecordingDurationSeconds * CANONICAL_AUDIO_SAMPLE_RATE_HZ,
+        ) * CANONICAL_AUDIO_BYTES_PER_SAMPLE;
+      const remainingPcmBytes = maxSessionPcmBytes - session.queuedPcmBytes;
+      if (remainingPcmBytes <= 0) {
+        return;
+      }
+      const boundedPcmBytes =
+        pcmBytes.length > remainingPcmBytes
+          ? pcmBytes.slice(
+              0,
+              remainingPcmBytes -
+                (remainingPcmBytes % CANONICAL_AUDIO_BYTES_PER_SAMPLE),
+            )
+          : pcmBytes;
+      if (boundedPcmBytes.length === 0) {
+        return;
+      }
+      session.queuedPcmBytes += boundedPcmBytes.length;
 
-      session.nextChunkIndex += 1;
-      session.pcmParts.push(pcmBytes);
+      session.sendQueue = session.sendQueue.then(async () => {
+        if (session.socket.readyState !== WebSocket.OPEN) {
+          return;
+        }
 
-      sendAudioTranscriptionControlFrame(session.socket, {
-        type: "chunk_metadata",
-        chunk_index: chunkIndex,
-        start_ms: startMs,
-        end_ms: endMs,
-        content_type: isFirstChunk ? "audio/wav" : "audio/pcm",
+        const chunkIndex = session.nextChunkIndex;
+        const startMs = chunkIndex * session.chunkDurationMs;
+        const chunkDurationMs = Math.ceil(
+          (boundedPcmBytes.length /
+            CANONICAL_AUDIO_BYTES_PER_SAMPLE /
+            CANONICAL_AUDIO_SAMPLE_RATE_HZ) *
+            1000,
+        );
+        const endMs =
+          startMs + Math.min(chunkDurationMs, session.chunkDurationMs);
+        const isFirstChunk = chunkIndex === 0;
+        const canonicalAudioBytes = isFirstChunk
+          ? createCanonicalWavBytesFromPcm(boundedPcmBytes)
+          : null;
+
+        session.nextChunkIndex += 1;
+        session.pcmParts.push(boundedPcmBytes);
+
+        sendAudioTranscriptionControlFrame(session.socket, {
+          type: "chunk_metadata",
+          chunk_index: chunkIndex,
+          start_ms: startMs,
+          end_ms: endMs,
+          content_type: isFirstChunk ? "audio/wav" : "audio/pcm",
+        });
+        session.socket.send(canonicalAudioBytes ?? boundedPcmBytes);
       });
-      session.socket.send(canonicalAudioBytes ?? pcmBytes);
-    });
-  }, []);
+    },
+    [maxRecordingDurationSeconds],
+  );
 
+  // Takes the session explicitly (rather than reading liveSessionRef) so
+  // the deferred stop finalization keeps flushing ITS session even after
+  // the ref was cleared at stop time — and so a freshly started
+  // recording can never be routed into a dying one.
   const flushLiveAudioSamples = useCallback(
-    (flushFinalChunk: boolean) => {
-      const session = liveSessionRef.current;
-      if (!session) {
-        return;
-      }
-
+    (session: LiveAudioTranscriptionSession, flushFinalChunk: boolean) => {
       const sourceSamplesPerChunk = Math.max(
         1,
         Math.floor((session.sourceSampleRate * session.chunkDurationMs) / 1000),
@@ -750,6 +860,7 @@ export function useAudioTranscriptionRecorder({
           session.pendingSourceSamples.splice(0, sourceSampleCount),
         );
         sendLivePcmChunk(
+          session,
           resampleMonoFloat32ToPcm16(sourceSamples, session.sourceSampleRate),
         );
       }
@@ -759,13 +870,21 @@ export function useAudioTranscriptionRecorder({
 
   useEffect(() => {
     return () => {
-      if (mediaRecorderRef.current) {
-        mediaRecorderRef.current.stop();
-      }
-
+      startInFlightRef.current = false;
       liveSessionRef.current?.socket.close();
       liveSessionRef.current = null;
       stopMediaRecordingStream();
+      // stopRecordingVisualizer suspends the AudioContext between
+      // recordings; close it for real on unmount so the audio rendering
+      // thread and the registered worklet are released.
+      if (
+        audioContextRef.current &&
+        audioContextRef.current.state !== "closed"
+      ) {
+        void audioContextRef.current.close();
+      }
+      audioContextRef.current = null;
+      workletModuleLoadedRef.current = false;
     };
   }, [stopMediaRecordingStream]);
 
@@ -1010,15 +1129,79 @@ export function useAudioTranscriptionRecorder({
     [uploadRecordedAudio],
   );
 
-  const stopAudioRecording = useCallback(() => {
-    if (mediaRecorderRef.current?.state === "recording") {
-      mediaRecorderRef.current.stop();
-      return;
-    }
+  /**
+   * Deferred completion of a live session after the capture graph is
+   * torn down: flush the remaining buffered samples, send `finish`,
+   * await the server's `completed` frame, and retain the assembled WAV
+   * for retries. Takes the session explicitly — the caller clears
+   * liveSessionRef synchronously at stop time, so a recording started
+   * while this finalization awaits the server can never be routed into
+   * or clobbered by the dying session. Replaces the former
+   * MediaRecorder.onstop driver.
+   */
+  const finalizeLiveTranscriptionSession = useCallback(
+    async (session: LiveAudioTranscriptionSession | null) => {
+      try {
+        if (!session) {
+          return;
+        }
 
+        flushLiveAudioSamples(session, true);
+        await session.sendQueue;
+
+        if (session.pcmParts.length === 0) {
+          removeAudioTranscriptionAttachment(session.fileUploadId);
+          if (isMounted()) {
+            setRecordingError(
+              t`No audio was captured. Please try recording again.`,
+            );
+          }
+          return;
+        }
+
+        const completedFramePromise = waitForAudioTranscriptionFrame(
+          session.socket,
+          (frame) => frame.type === "completed",
+        );
+        sendAudioTranscriptionControlFrame(session.socket, {
+          type: "finish",
+        });
+        await completedFramePromise;
+
+        const audioFile = new File(
+          [createCanonicalWavBytesFromPcm(concatUint8Arrays(session.pcmParts))],
+          session.filename,
+          { type: "audio/wav" },
+        );
+        recordedAudioFilesRef.current.set(session.fileUploadId, audioFile);
+      } catch (error) {
+        if (isMounted()) {
+          setRecordingError(
+            error instanceof Error
+              ? error.message
+              : t`Failed to upload audio recording for transcription.`,
+          );
+        }
+      } finally {
+        session?.socket.close();
+      }
+    },
+    [flushLiveAudioSamples, isMounted, removeAudioTranscriptionAttachment],
+  );
+
+  const stopAudioRecording = useCallback(() => {
+    // Detach the session BEFORE tearing down: from this point no worklet
+    // frame can be routed into the dying session, and a follow-up
+    // recording owns the ref exclusively.
+    const session = liveSessionRef.current;
+    liveSessionRef.current = null;
     setIsRecording(false);
+    // Tear the capture graph down (stop tracks, disconnect the worklet,
+    // suspend the context), then complete the protocol exchange on
+    // whatever was already delivered to the JS side.
     stopMediaRecordingStream();
-  }, [stopMediaRecordingStream]);
+    void finalizeLiveTranscriptionSession(session);
+  }, [finalizeLiveTranscriptionSession, stopMediaRecordingStream]);
 
   const startAudioRecording = useCallback(async () => {
     if (!audioTranscriptionEnabled || !uploadEnabled) {
@@ -1039,27 +1222,219 @@ export function useAudioTranscriptionRecorder({
       return;
     }
 
+    if (startInFlightRef.current) {
+      return;
+    }
+    startInFlightRef.current = true;
+
+    const baseAudioConstraints: MediaTrackConstraints = {
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+      channelCount: { ideal: 1 },
+      sampleRate: { ideal: CANONICAL_AUDIO_SAMPLE_RATE_HZ },
+    };
+
     try {
-      const stream = await mediaDevices.getUserMedia({
-        audio: {
-          ...(selectedAudioInputDeviceId
-            ? { deviceId: { exact: selectedAudioInputDeviceId } }
-            : {}),
-          echoCancellation: false,
-          noiseSuppression: false,
-          autoGainControl: false,
-          channelCount: { ideal: 1 },
-          sampleRate: { ideal: CANONICAL_AUDIO_SAMPLE_RATE_HZ },
-        },
-      });
+      let stream: MediaStream;
+      try {
+        stream = await mediaDevices.getUserMedia({
+          audio: selectedAudioInputDeviceId
+            ? {
+                deviceId: { exact: selectedAudioInputDeviceId },
+                ...baseAudioConstraints,
+              }
+            : baseAudioConstraints,
+        });
+      } catch (firstError) {
+        // A stored deviceId can go stale between enumeration and
+        // getUserMedia (e.g. a Bluetooth disconnect). On
+        // OverconstrainedError, retry once with the system-default mic
+        // and clear the stale stored id — mirrors the dictation recorder.
+        if (
+          selectedAudioInputDeviceId &&
+          firstError instanceof DOMException &&
+          firstError.name === "OverconstrainedError"
+        ) {
+          stream = await mediaDevices.getUserMedia({
+            audio: baseAudioConstraints,
+          });
+          setSelectedAudioInputDeviceId("");
+        } else {
+          throw firstError;
+        }
+      }
+      if (!isMounted()) {
+        // Unmounted while the permission prompt / device open was
+        // pending: the unmount cleanup already ran (and saw a null
+        // stream ref), so stop the tracks here or the mic stays hot.
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
       mediaStreamRef.current = stream;
       const audioTrack = stream.getAudioTracks()[0];
-      setRecordingDiagnostics(
-        mediaTrackSettingsToDiagnostics(audioTrack.getSettings()),
-      );
+      const trackSettings = audioTrack.getSettings();
+      setRecordingDiagnostics(mediaTrackSettingsToDiagnostics(trackSettings));
 
       const filename = formatAudioRecordingFilename(new Date());
-      const liveSession = await startLiveAudioTranscriptionSession(filename);
+
+      // Build the audio pipeline BEFORE the chat-create + socket
+      // handshake (the dictation recorder's anti-truncation pattern,
+      // ERMAIN-334): once the worklet is connected, samples land in
+      // preSessionSamplesRef until the live session is ready, so the
+      // words spoken during the handshake are no longer lost. The
+      // previous ordering tapped the microphone only after the full
+      // handshake resolved, dropping everything spoken until then.
+      let sourceSampleRate = CANONICAL_AUDIO_SAMPLE_RATE_HZ;
+      const audioContext = await ensureAudioContextReady(
+        trackSettings.sampleRate,
+      );
+      if (!isMounted()) {
+        stream.getTracks().forEach((track) => track.stop());
+        // The unmount cleanup already closed (and nulled) the previous
+        // context, so a context created by the await above would leak.
+        if (audioContext && audioContext.state !== "closed") {
+          void audioContext.close();
+        }
+        audioContextRef.current = null;
+        return;
+      }
+      if (audioContext) {
+        const source = audioContext.createMediaStreamSource(stream);
+        const analyser = audioContext.createAnalyser();
+        const processor = new AudioWorkletNode(
+          audioContext,
+          AUDIO_TRANSCRIPTION_WORKLET_PROCESSOR_NAME,
+        );
+        // Match the dictation recorder: time-domain sampling with a
+        // 256-sample FFT and a touch of smoothing reads voice energy
+        // across the whole window instead of bucketing it into one
+        // low-frequency bin, so all five bars react to speech.
+        analyser.fftSize = 256;
+        analyser.smoothingTimeConstant = 0.65;
+        sourceSampleRate = audioContext.sampleRate;
+        logger.log("Audio worklet connected", {
+          sampleRate: audioContext.sampleRate,
+          vadAutoStopEnabled,
+        });
+
+        // Synthetic silence primer — see useAudioDictationRecorder for
+        // the rationale (server-side VAD onset calibration).
+        const primerSampleCount = Math.max(
+          0,
+          Math.floor(
+            (audioContext.sampleRate * PRE_SPEECH_SILENCE_PRIMER_MS) / 1000,
+          ),
+        );
+        const primer: number[] = [];
+        primer.length = primerSampleCount;
+        primer.fill(0);
+        preSessionSamplesRef.current = primer;
+
+        // The worklet posts every render quantum, including zero-filled
+        // OS warm-up frames — those belong in the stream sent to the
+        // server. The "speak now" UI cue waits for real audio though:
+        // scan each frame for a non-zero sample and flip
+        // isCapturingAudio on the first one.
+        let audioFlowing = false;
+        const pipelineReadyAt = Date.now();
+        const flipCapturingAudio = () => {
+          // Guard against late firings after teardown or unmount: the
+          // processor ref will be null or point at a different node.
+          if (!isMounted() || audioProcessorRef.current !== processor) {
+            return;
+          }
+          setIsCapturingAudio(true);
+        };
+        processor.port.onmessage = (event: MessageEvent<Float32Array>) => {
+          const input = event.data;
+          const vadFrame = vadEngineRef.current
+            ? new Float32Array(input)
+            : null;
+          if (!audioFlowing) {
+            for (let index = 0; index < input.length; index += 1) {
+              if (input[index] !== 0) {
+                audioFlowing = true;
+                const elapsed = Date.now() - pipelineReadyAt;
+                const remaining = MIN_AUDIO_CAPTURE_DELAY_MS - elapsed;
+                if (remaining > 0) {
+                  capturingFlipTimerRef.current = window.setTimeout(() => {
+                    capturingFlipTimerRef.current = null;
+                    flipCapturingAudio();
+                  }, remaining);
+                } else {
+                  flipCapturingAudio();
+                }
+                break;
+              }
+            }
+          }
+          const session = liveSessionRef.current;
+          if (session) {
+            for (let index = 0; index < input.length; index += 1) {
+              session.pendingSourceSamples.push(input[index]);
+            }
+            flushLiveAudioSamples(session, false);
+          } else {
+            const preBuffer = preSessionSamplesRef.current;
+            for (let index = 0; index < input.length; index += 1) {
+              preBuffer.push(input[index]);
+            }
+          }
+          if (vadFrame && vadEngineRef.current) {
+            void vadEngineRef.current
+              .acceptFrame({
+                samples: vadFrame,
+                sampleRate: audioContext.sampleRate,
+                timestampMs: Date.now(),
+              })
+              .catch((error) => {
+                logger.warn(
+                  "VAD frame processing failed; disabling VAD",
+                  error,
+                );
+                stopVadEngine();
+              });
+          }
+        };
+
+        const levelData = new Uint8Array(analyser.fftSize);
+
+        const analyzeLevel = () => {
+          if (!audioAnalyserRef.current || !audioLevelDataRef.current) {
+            return;
+          }
+
+          audioAnalyserRef.current.getByteTimeDomainData(
+            audioLevelDataRef.current,
+          );
+
+          setRecordingBarsThrottled(
+            getAudioLevelBarsFromTimeDomainData(audioLevelDataRef.current),
+          );
+          audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
+        };
+
+        audioContextRef.current = audioContext;
+        audioAnalyserRef.current = analyser;
+        audioSourceNodeRef.current = source;
+        audioProcessorRef.current = processor;
+        audioLevelDataRef.current = levelData;
+        source.connect(analyser);
+        source.connect(processor);
+        audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
+      } else {
+        setRecordingBars((existingBars) =>
+          existingBars.length === AUDIO_BARS_COUNT
+            ? [2, 2, 6, 2, 2]
+            : Array.from({ length: AUDIO_BARS_COUNT }, () => 2),
+        );
+      }
+
+      // The VAD model load below and the session handshake after it no
+      // longer gate capture — the connected worklet is already filling
+      // the pre-session buffer.
       let vadEngine: VoiceVadEngine | null = null;
       if (vadAutoStopEnabled) {
         const vadOptions = {
@@ -1147,173 +1522,34 @@ export function useAudioTranscriptionRecorder({
         }
       }
 
-      if (typeof AudioContext !== "undefined") {
-        const audioContext = new AudioContext();
-        const source = audioContext.createMediaStreamSource(stream);
-        const analyser = audioContext.createAnalyser();
-        const processor = audioContext.createScriptProcessor(4096, 1, 1);
-        const processorSink = audioContext.createGain();
-        // Match the dictation recorder: time-domain sampling with a
-        // 256-sample FFT and a touch of smoothing reads voice energy
-        // across the whole window instead of bucketing it into one
-        // low-frequency bin, so all five bars react to speech.
-        analyser.fftSize = 256;
-        analyser.smoothingTimeConstant = 0.65;
-        processorSink.gain.value = 0;
-        source.connect(analyser);
-        source.connect(processor);
-        processor.connect(processorSink);
-        processorSink.connect(audioContext.destination);
-        liveSession.sourceSampleRate = audioContext.sampleRate;
-        logger.log("Audio processor connected", {
-          sampleRate: audioContext.sampleRate,
-          bufferSize: 4096,
-          vadAutoStopEnabled: Boolean(vadEngineRef.current),
-        });
-        processor.onaudioprocess = (event) => {
-          const session = liveSessionRef.current;
-          if (!session) {
-            return;
-          }
-
-          const input = event.inputBuffer.getChannelData(0);
-          const vadFrame = vadEngineRef.current
-            ? new Float32Array(input)
-            : null;
-          for (let index = 0; index < input.length; index += 1) {
-            session.pendingSourceSamples.push(input[index]);
-          }
-          flushLiveAudioSamples(false);
-          if (vadFrame && vadEngineRef.current) {
-            void vadEngineRef.current
-              .acceptFrame({
-                samples: vadFrame,
-                sampleRate: audioContext.sampleRate,
-                timestampMs: Date.now(),
-              })
-              .catch((error) => {
-                logger.warn(
-                  "VAD frame processing failed; disabling VAD",
-                  error,
-                );
-                stopVadEngine();
-              });
-          }
-        };
-
-        const levelData = new Uint8Array(analyser.fftSize);
-
-        const analyzeLevel = () => {
-          if (!audioAnalyserRef.current || !audioLevelDataRef.current) {
-            return;
-          }
-
-          audioAnalyserRef.current.getByteTimeDomainData(
-            audioLevelDataRef.current,
-          );
-
-          setRecordingBarsThrottled(
-            getAudioLevelBarsFromTimeDomainData(audioLevelDataRef.current),
-          );
-          audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
-        };
-
-        audioContextRef.current = audioContext;
-        audioAnalyserRef.current = analyser;
-        audioSourceNodeRef.current = source;
-        audioProcessorRef.current = processor;
-        audioProcessorSinkRef.current = processorSink;
-        audioLevelDataRef.current = levelData;
-        audioFrameRef.current = window.requestAnimationFrame(analyzeLevel);
-      } else {
-        setRecordingBars((existingBars) =>
-          existingBars.length === AUDIO_BARS_COUNT
-            ? [2, 2, 6, 2, 2]
-            : Array.from({ length: AUDIO_BARS_COUNT }, () => 2),
-        );
+      const liveSession = await startLiveAudioTranscriptionSession(
+        filename,
+        sourceSampleRate,
+      );
+      if (!isMounted() || mediaStreamRef.current !== stream) {
+        // Unmounted, or the capture graph was torn down (e.g. VAD
+        // auto-stop) while the handshake was in flight — don't resurrect
+        // a recording on a dead graph.
+        liveSession.socket.close();
+        return;
       }
 
-      const mediaRecorder = new MediaRecorder(stream);
-
-      mediaChunksRef.current = [];
-      mediaRecorderRef.current = mediaRecorder;
-      mediaRecorder.ondataavailable = (event: BlobEvent) => {
-        if (event.data.size > 0) {
-          mediaChunksRef.current.push(event.data);
+      // Drain pre-buffered samples into the new session in their
+      // original order, THEN publish the session ref. Order matters:
+      // until `liveSessionRef.current` is set, the worklet handler keeps
+      // pushing to `preSessionSamplesRef`. The drain → ref-assign →
+      // flush sequence is one synchronous block, so no audio frame can
+      // interleave and split samples across the two buffers.
+      const preBuffer = preSessionSamplesRef.current;
+      if (preBuffer.length > 0) {
+        for (let index = 0; index < preBuffer.length; index += 1) {
+          liveSession.pendingSourceSamples.push(preBuffer[index]);
         }
-      };
+        preSessionSamplesRef.current = [];
+      }
+      liveSessionRef.current = liveSession;
+      flushLiveAudioSamples(liveSession, false);
 
-      mediaRecorder.onstop = () => {
-        clearRecordingDurationTimer();
-        setIsRecording(false);
-        stopMediaRecordingStream();
-        mediaChunksRef.current = [];
-
-        void (async () => {
-          const session = liveSessionRef.current;
-          try {
-            if (!session) {
-              return;
-            }
-
-            flushLiveAudioSamples(true);
-            await session.sendQueue;
-
-            if (session.pcmParts.length === 0) {
-              removeAudioTranscriptionAttachment(session.fileUploadId);
-              setRecordingError(
-                t`No audio was captured. Please try recording again.`,
-              );
-              return;
-            }
-
-            const completedFramePromise = waitForAudioTranscriptionFrame(
-              session.socket,
-              (frame) => frame.type === "completed",
-            );
-            sendAudioTranscriptionControlFrame(session.socket, {
-              type: "finish",
-            });
-            await completedFramePromise;
-
-            const audioFile = new File(
-              [
-                createCanonicalWavBytesFromPcm(
-                  concatUint8Arrays(session.pcmParts),
-                ),
-              ],
-              filename,
-              { type: "audio/wav" },
-            );
-            recordedAudioFilesRef.current.set(session.fileUploadId, audioFile);
-          } catch (error) {
-            setRecordingError(
-              error instanceof Error
-                ? error.message
-                : t`Failed to upload audio recording for transcription.`,
-            );
-          } finally {
-            liveSessionRef.current = null;
-            session?.socket.close();
-          }
-        })();
-      };
-
-      mediaRecorder.onerror = (event: Event) => {
-        const error = (event as ErrorEvent).error;
-        liveSessionRef.current?.socket.close();
-        liveSessionRef.current = null;
-        stopMediaRecordingStream();
-        setIsRecording(false);
-        setIsRecordingUpload(false);
-        setRecordingError(
-          error instanceof Error
-            ? error.message
-            : t`Could not complete audio recording.`,
-        );
-      };
-
-      mediaRecorder.start();
       clearRecordingDurationTimer();
       const recordingLimitMs = Math.max(
         1,
@@ -1361,6 +1597,8 @@ export function useAudioTranscriptionRecorder({
             : t`Could not start audio recording.`,
         );
       }
+    } finally {
+      startInFlightRef.current = false;
     }
   }, [
     audioTranscriptionEnabled,
@@ -1368,11 +1606,13 @@ export function useAudioTranscriptionRecorder({
     stopMediaRecordingStream,
     maxRecordingDurationSeconds,
     clearRecordingDurationTimer,
+    ensureAudioContextReady,
+    isMounted,
     stopAudioRecording,
     startLiveAudioTranscriptionSession,
     flushLiveAudioSamples,
-    removeAudioTranscriptionAttachment,
     selectedAudioInputDeviceId,
+    setSelectedAudioInputDeviceId,
     setRecordingBarsThrottled,
     stopVadEngine,
     vadAutoStopEnabled,
@@ -1412,6 +1652,7 @@ export function useAudioTranscriptionRecorder({
 
   return {
     isRecording,
+    isCapturingAudio,
     isRecordingUpload,
     recordingError,
     setRecordingError,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2042,8 +2042,8 @@ msgstr ""
 #~ msgstr "Audiodiktat konnte nicht abgeschlossen werden."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
-msgid "Could not complete audio recording."
-msgstr ""
+#~ msgid "Could not complete audio recording."
+#~ msgstr ""
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Could not load audio input devices."
@@ -2419,6 +2419,10 @@ msgstr "Nachrichten"
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Microphone {microphoneIndex}"
 msgstr "Mikrofon {microphoneIndex}"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Microphone is starting — wait for the level meter before speaking"
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1901,8 +1901,8 @@ msgid "Cancel action"
 msgstr "Aktion abbrechen"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Cancel starting dictation"
-msgstr "Diktatstart abbrechen"
+#~ msgid "Cancel starting dictation"
+#~ msgstr "Diktatstart abbrechen"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Canceled"
@@ -1917,8 +1917,8 @@ msgid "Cannot send: Token limit exceeded"
 msgstr "Senden nicht möglich: Token-Limit überschritten"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Capturing audio — waiting for transcription to start"
-msgstr "Audio wird aufgenommen — warten auf den Start der Transkription"
+#~ msgid "Capturing audio — waiting for transcription to start"
+#~ msgstr "Audio wird aufgenommen — warten auf den Start der Transkription"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Cc"
@@ -2421,8 +2421,8 @@ msgid "Microphone {microphoneIndex}"
 msgstr "Mikrofon {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr "Das Mikrofon wird gestartet – warten Sie auf die Pegelanzeige, bevor Sie sprechen"
+#~ msgid "Microphone is starting — wait for the level meter before speaking"
+#~ msgstr "Das Mikrofon wird gestartet – warten Sie auf die Pegelanzeige, bevor Sie sprechen"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."
@@ -2748,6 +2748,10 @@ msgstr ""
 #: src/components/ui/Chat/StarterPromptsSection.tsx
 #: src/hooks/chat/useStarterPrompts.ts
 msgid "starter_prompts.<starter-prompt-id>.title"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Starting audio transcript recording"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2422,7 +2422,7 @@ msgstr "Mikrofon {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr ""
+msgstr "Das Mikrofon wird gestartet – warten Sie auf die Pegelanzeige, bevor Sie sprechen"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1901,8 +1901,8 @@ msgid "Cancel action"
 msgstr "Cancel action"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Cancel starting dictation"
-msgstr "Cancel starting dictation"
+#~ msgid "Cancel starting dictation"
+#~ msgstr "Cancel starting dictation"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Canceled"
@@ -1917,8 +1917,8 @@ msgid "Cannot send: Token limit exceeded"
 msgstr "Cannot send: Token limit exceeded"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Capturing audio — waiting for transcription to start"
-msgstr "Capturing audio — waiting for transcription to start"
+#~ msgid "Capturing audio — waiting for transcription to start"
+#~ msgstr "Capturing audio — waiting for transcription to start"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Cc"
@@ -2421,8 +2421,8 @@ msgid "Microphone {microphoneIndex}"
 msgstr "Microphone {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr "Microphone is starting — wait for the level meter before speaking"
+#~ msgid "Microphone is starting — wait for the level meter before speaking"
+#~ msgstr "Microphone is starting — wait for the level meter before speaking"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."
@@ -2749,6 +2749,10 @@ msgstr "starter_prompts.<starter-prompt-id>.subtitle"
 #: src/hooks/chat/useStarterPrompts.ts
 msgid "starter_prompts.<starter-prompt-id>.title"
 msgstr "starter_prompts.<starter-prompt-id>.title"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Starting audio transcript recording"
+msgstr "Starting audio transcript recording"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Starting dictation"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2042,8 +2042,8 @@ msgstr "Copy code"
 #~ msgstr "Could not complete audio dictation."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
-msgid "Could not complete audio recording."
-msgstr "Could not complete audio recording."
+#~ msgid "Could not complete audio recording."
+#~ msgstr "Could not complete audio recording."
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Could not load audio input devices."
@@ -2419,6 +2419,10 @@ msgstr "messages"
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Microphone {microphoneIndex}"
 msgstr "Microphone {microphoneIndex}"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Microphone is starting — wait for the level meter before speaking"
+msgstr "Microphone is starting — wait for the level meter before speaking"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2042,8 +2042,8 @@ msgstr ""
 #~ msgstr "No se pudo completar el dictado de audio."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
-msgid "Could not complete audio recording."
-msgstr ""
+#~ msgid "Could not complete audio recording."
+#~ msgstr ""
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Could not load audio input devices."
@@ -2419,6 +2419,10 @@ msgstr "mensajes"
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Microphone {microphoneIndex}"
 msgstr "Micrófono {microphoneIndex}"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Microphone is starting — wait for the level meter before speaking"
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1901,8 +1901,8 @@ msgid "Cancel action"
 msgstr "Cancelar acción"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Cancel starting dictation"
-msgstr "Cancelar inicio del dictado"
+#~ msgid "Cancel starting dictation"
+#~ msgstr "Cancelar inicio del dictado"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Canceled"
@@ -1917,8 +1917,8 @@ msgid "Cannot send: Token limit exceeded"
 msgstr "No se puede enviar: Límite de tokens excedido"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Capturing audio — waiting for transcription to start"
-msgstr "Capturando audio — esperando a que comience la transcripción"
+#~ msgid "Capturing audio — waiting for transcription to start"
+#~ msgstr "Capturando audio — esperando a que comience la transcripción"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Cc"
@@ -2421,8 +2421,8 @@ msgid "Microphone {microphoneIndex}"
 msgstr "Micrófono {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr "El micrófono se está iniciando; espera a que aparezca el medidor de nivel antes de hablar"
+#~ msgid "Microphone is starting — wait for the level meter before speaking"
+#~ msgstr "El micrófono se está iniciando; espera a que aparezca el medidor de nivel antes de hablar"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."
@@ -2748,6 +2748,10 @@ msgstr ""
 #: src/components/ui/Chat/StarterPromptsSection.tsx
 #: src/hooks/chat/useStarterPrompts.ts
 msgid "starter_prompts.<starter-prompt-id>.title"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Starting audio transcript recording"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2422,7 +2422,7 @@ msgstr "Micrófono {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr ""
+msgstr "El micrófono se está iniciando; espera a que aparezca el medidor de nivel antes de hablar"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2422,7 +2422,7 @@ msgstr "Microphone {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr ""
+msgstr "Le microphone démarre ; attendez l'indicateur de niveau avant de parler"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1901,8 +1901,8 @@ msgid "Cancel action"
 msgstr "Annuler l'action"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Cancel starting dictation"
-msgstr "Annuler le démarrage de la dictée"
+#~ msgid "Cancel starting dictation"
+#~ msgstr "Annuler le démarrage de la dictée"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Canceled"
@@ -1917,8 +1917,8 @@ msgid "Cannot send: Token limit exceeded"
 msgstr "Impossible d'envoyer : limite de tokens dépassée"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Capturing audio — waiting for transcription to start"
-msgstr "Capture audio en cours — en attente du démarrage de la transcription"
+#~ msgid "Capturing audio — waiting for transcription to start"
+#~ msgstr "Capture audio en cours — en attente du démarrage de la transcription"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Cc"
@@ -2421,8 +2421,8 @@ msgid "Microphone {microphoneIndex}"
 msgstr "Microphone {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr "Le microphone démarre ; attendez l'indicateur de niveau avant de parler"
+#~ msgid "Microphone is starting — wait for the level meter before speaking"
+#~ msgstr "Le microphone démarre ; attendez l'indicateur de niveau avant de parler"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."
@@ -2748,6 +2748,10 @@ msgstr ""
 #: src/components/ui/Chat/StarterPromptsSection.tsx
 #: src/hooks/chat/useStarterPrompts.ts
 msgid "starter_prompts.<starter-prompt-id>.title"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Starting audio transcript recording"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2042,8 +2042,8 @@ msgstr ""
 #~ msgstr "Impossible de terminer la dictée audio."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
-msgid "Could not complete audio recording."
-msgstr ""
+#~ msgid "Could not complete audio recording."
+#~ msgstr ""
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Could not load audio input devices."
@@ -2419,6 +2419,10 @@ msgstr "messages"
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Microphone {microphoneIndex}"
 msgstr "Microphone {microphoneIndex}"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Microphone is starting — wait for the level meter before speaking"
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2042,8 +2042,8 @@ msgstr ""
 #~ msgstr "Nie udało się ukończyć dyktowania audio."
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
-msgid "Could not complete audio recording."
-msgstr ""
+#~ msgid "Could not complete audio recording."
+#~ msgstr ""
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Could not load audio input devices."
@@ -2419,6 +2419,10 @@ msgstr "wiadomości"
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 msgid "Microphone {microphoneIndex}"
 msgstr "Mikrofon {microphoneIndex}"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Microphone is starting — wait for the level meter before speaking"
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2422,7 +2422,7 @@ msgstr "Mikrofon {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr ""
+msgstr "Mikrofon się uruchamia; zaczekaj na miernik poziomu, zanim zaczniesz mówić"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1901,8 +1901,8 @@ msgid "Cancel action"
 msgstr "Anuluj akcję"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Cancel starting dictation"
-msgstr "Anuluj uruchamianie dyktowania"
+#~ msgid "Cancel starting dictation"
+#~ msgstr "Anuluj uruchamianie dyktowania"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Canceled"
@@ -1917,8 +1917,8 @@ msgid "Cannot send: Token limit exceeded"
 msgstr "Nie można wysłać: Przekroczony limit tokenów"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Capturing audio — waiting for transcription to start"
-msgstr "Przechwytywanie dźwięku — oczekiwanie na rozpoczęcie transkrypcji"
+#~ msgid "Capturing audio — waiting for transcription to start"
+#~ msgstr "Przechwytywanie dźwięku — oczekiwanie na rozpoczęcie transkrypcji"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Cc"
@@ -2421,8 +2421,8 @@ msgid "Microphone {microphoneIndex}"
 msgstr "Mikrofon {microphoneIndex}"
 
 #: src/components/ui/Chat/ChatInput.tsx
-msgid "Microphone is starting — wait for the level meter before speaking"
-msgstr "Mikrofon się uruchamia; zaczekaj na miernik poziomu, zanim zaczniesz mówić"
+#~ msgid "Microphone is starting — wait for the level meter before speaking"
+#~ msgstr "Mikrofon się uruchamia; zaczekaj na miernik poziomu, zanim zaczniesz mówić"
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "Microphone permission denied. Allow access to test the microphone."
@@ -2748,6 +2748,10 @@ msgstr ""
 #: src/components/ui/Chat/StarterPromptsSection.tsx
 #: src/hooks/chat/useStarterPrompts.ts
 msgid "starter_prompts.<starter-prompt-id>.title"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Starting audio transcript recording"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx


### PR DESCRIPTION
This pull request brings significant improvements to our audio dictation and transcription features, focusing on user experience and performance. The main enhancements are: (1) UI feedback for microphone readiness, ensuring users only speak when the mic is ready and audio is flowing, and (2) performance improvements by keeping the Voice Activity Detection (VAD) engine warm across sessions, avoiding repeated heavy model loads. Additionally, the test suite has been updated to mock the new audio pipeline and verify these behaviors, including edge cases like pre-handshake audio capture.

**User Experience Improvements:**

* Updated the `ChatInput` component to distinguish between microphone warm-up and active dictation/recording. The UI now dims the waveform and shows a "Microphone is starting" status until real audio is flowing, preventing users from speaking too early and losing initial words. This applies to both dictation and audio transcription modes. [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L2065-R2070) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R2084-R2093) [[3]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L2116-R2133) [[4]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L2131-R2151) [[5]](diffhunk://#diff-ebd85a320bdbd775161f707179c4278967c01b08acac7cc21cd7d840bb3d4623R1061-R1064)

**Performance and Engine Lifecycle:**

* Refactored `useAudioDictationRecorder` to keep the VAD engine instance alive across dictation sessions, only stopping (not destroying) it between uses. The engine is destroyed only on component unmount, reducing repeated ONNX/WASM model loads and improving responsiveness for users. [[1]](diffhunk://#diff-d4fd99150cbfe3531bea9d68abebeac8af7103bee7bfc021da9d5c4d13ac5dc7R242-R261) [[2]](diffhunk://#diff-d4fd99150cbfe3531bea9d68abebeac8af7103bee7bfc021da9d5c4d13ac5dc7L274-R300)

**Testing Enhancements:**

* Expanded test coverage in `useAudioDictationRecorder.test.ts` to verify that the VAD engine is reused across sessions and only destroyed on unmount, and that engine listeners are properly cleaned up between sessions. [[1]](diffhunk://#diff-dbf2f945f823bede9f222d681d04ad0f5059647f3af128570cbe6dba10e8bc47R555-R612) [[2]](diffhunk://#diff-dbf2f945f823bede9f222d681d04ad0f5059647f3af128570cbe6dba10e8bc47R301)
* Overhauled mocks in `useAudioTranscriptionRecorder.test.tsx` to support the new audio worklet pipeline, including realistic simulation of audio flow, WebSocket handshake timing, and pre-handshake audio buffering. Added a regression test to ensure speech captured during the handshake is delivered after the session starts. [[1]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950R52-R55) [[2]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L120-R166) [[3]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L162-R185) [[4]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950R196-R198) [[5]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L242-R234) [[6]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L337-R329) [[7]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L349-R356) [[8]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950L391-R379) [[9]](diffhunk://#diff-b6c333a9332019fed7340f6acee82979ece2ba9de5297cdff2c6a51b96479950R481-R549)

These changes collectively make the audio experience more robust, responsive, and user-friendly, while ensuring our tests accurately reflect real-world usage and edge cases.