### PR TITLE
Add backend-configured toggle for Settings data tab

### DIFF
--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -2200,15 +2200,27 @@ pub struct UserPreferencesConfig {
     // Defaults to `true`.
     #[serde(default = "default_user_preferences_enabled")]
     pub enabled: bool,
+
+    // Whether the data tab should be shown in the frontend preferences dialog.
+    // Defaults to `true`.
+    #[serde(default = "default_user_preferences_data_tab_enabled")]
+    pub data_tab_enabled: bool,
 }
 
 impl Default for UserPreferencesConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            data_tab_enabled: true,
+        }
     }
 }
 
 fn default_user_preferences_enabled() -> bool {
+    true
+}
+
+fn default_user_preferences_data_tab_enabled() -> bool {
     true
 }
 

--- a/backend/erato/src/frontend_environment.rs
+++ b/backend/erato/src/frontend_environment.rs
@@ -36,6 +36,8 @@ const FRONTEND_ENV_KEY_ASSISTANTS_MAX_SYSTEM_PROMPT_LENGTH: &str =
 const FRONTEND_ENV_KEY_STARTER_PROMPTS_ENABLED: &str = "STARTER_PROMPTS_ENABLED";
 const FRONTEND_ENV_KEY_PROMPT_OPTIMIZER_ENABLED: &str = "PROMPT_OPTIMIZER_ENABLED";
 const FRONTEND_ENV_KEY_USER_PREFERENCES_ENABLED: &str = "USER_PREFERENCES_ENABLED";
+const FRONTEND_ENV_KEY_USER_PREFERENCES_DATA_TAB_ENABLED: &str =
+    "USER_PREFERENCES_DATA_TAB_ENABLED";
 const FRONTEND_ENV_KEY_MCP_SERVERS_TAB_ENABLED: &str = "MCP_SERVERS_TAB_ENABLED";
 const FRONTEND_ENV_KEY_SHAREPOINT_ENABLED: &str = "SHAREPOINT_ENABLED";
 const FRONTEND_ENV_KEY_SHAREPOINT_SHOW_DISCLAIMER: &str = "SHAREPOINT_SHOW_DISCLAIMER";
@@ -235,6 +237,10 @@ fn build_frontend_environment(
     env.additional_environment.insert(
         FRONTEND_ENV_KEY_USER_PREFERENCES_ENABLED.to_string(),
         Value::Bool(config.user_preferences.enabled),
+    );
+    env.additional_environment.insert(
+        FRONTEND_ENV_KEY_USER_PREFERENCES_DATA_TAB_ENABLED.to_string(),
+        Value::Bool(config.user_preferences.data_tab_enabled),
     );
     env.additional_environment.insert(
         FRONTEND_ENV_KEY_MCP_SERVERS_TAB_ENABLED.to_string(),

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -2375,6 +2375,7 @@ config = { bucket = "test-bucket", endpoint = "http://localhost:8333", region = 
         .expect("Failed to deserialize config");
 
     assert!(config.user_preferences.enabled);
+    assert!(config.user_preferences.data_tab_enabled);
 }
 
 #[test]
@@ -2414,6 +2415,47 @@ enabled = false
         .expect("Failed to deserialize config");
 
     assert!(!config.user_preferences.enabled);
+    assert!(config.user_preferences.data_tab_enabled);
+}
+
+#[test]
+fn test_user_preferences_data_tab_enabled_can_be_disabled() {
+    let mut temp_file = Builder::new()
+        .suffix(".toml")
+        .tempfile()
+        .expect("Failed to create temporary file");
+    let config_content = r#"
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4.1"
+
+[file_storage_providers.test]
+provider_kind = "s3"
+config = { bucket = "test-bucket", endpoint = "http://localhost:8333", region = "us-east-1" }
+
+[user_preferences]
+data_tab_enabled = false
+"#;
+
+    temp_file
+        .write_all(config_content.as_bytes())
+        .expect("Failed to write to temporary file");
+    temp_file.flush().expect("Failed to flush temporary file");
+
+    let temp_path = temp_file.path().to_str().unwrap();
+    let mut builder = AppConfig::config_schema_builder(Some(vec![temp_path.to_string()]), false)
+        .expect("Failed to create config builder");
+    builder = builder
+        .set_override("database_url", "postgres://user:pass@localhost:5432/test")
+        .unwrap();
+
+    let config_schema = builder.build().expect("Failed to build config schema");
+    let config: AppConfig = config_schema
+        .try_deserialize()
+        .expect("Failed to deserialize config");
+
+    assert!(config.user_preferences.enabled);
+    assert!(!config.user_preferences.data_tab_enabled);
 }
 
 #[test]

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -422,5 +422,6 @@
   "starter_prompts.prompts.<prompt-id>.selected_facets.[]": {},
   "starter_prompts.prompts.<prompt-id>.subtitle": {},
   "starter_prompts.prompts.<prompt-id>.title": {},
+  "user_preferences.data_tab_enabled": {},
   "user_preferences.enabled": {}
 }

--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -224,6 +224,7 @@ vi.mock("@/app/env", () => ({
     messageFeedbackEnabled: false,
     messageFeedbackCommentsEnabled: false,
     userPreferencesEnabled: true,
+    userPreferencesDataTabEnabled: true,
   }),
 }));
 

--- a/frontend/src/app/env.ts
+++ b/frontend/src/app/env.ts
@@ -21,6 +21,7 @@ export type Env = {
   starterPromptsEnabled: boolean;
   promptOptimizerEnabled: boolean;
   userPreferencesEnabled: boolean;
+  userPreferencesDataTabEnabled: boolean;
   mcpServersTabEnabled: boolean;
   sharepointEnabled: boolean;
   sharepointShowDisclaimer: boolean;
@@ -68,6 +69,7 @@ declare global {
     STARTER_PROMPTS_ENABLED?: boolean;
     PROMPT_OPTIMIZER_ENABLED?: boolean;
     USER_PREFERENCES_ENABLED?: boolean;
+    USER_PREFERENCES_DATA_TAB_ENABLED?: boolean;
     MCP_SERVERS_TAB_ENABLED?: boolean;
     SHAREPOINT_ENABLED?: boolean;
     SHAREPOINT_SHOW_DISCLAIMER?: boolean;
@@ -212,6 +214,10 @@ export const env = (): Env => {
     import.meta.env.VITE_USER_PREFERENCES_ENABLED === "false"
       ? false
       : (window.USER_PREFERENCES_ENABLED ?? true);
+  const userPreferencesDataTabEnabled =
+    import.meta.env.VITE_USER_PREFERENCES_DATA_TAB_ENABLED === "false"
+      ? false
+      : (window.USER_PREFERENCES_DATA_TAB_ENABLED ?? true);
   const mcpServersTabEnabled =
     import.meta.env.VITE_MCP_SERVERS_TAB_ENABLED === "true"
       ? true
@@ -326,6 +332,7 @@ export const env = (): Env => {
     starterPromptsEnabled,
     promptOptimizerEnabled,
     userPreferencesEnabled,
+    userPreferencesDataTabEnabled,
     mcpServersTabEnabled,
     sharepointEnabled,
     sharepointShowDisclaimer,

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -44,6 +44,7 @@ const createMockEnv = (overrides: Partial<Env> = {}): Env => ({
   messageFeedbackEnabled: false,
   messageFeedbackCommentsEnabled: false,
   userPreferencesEnabled: true,
+  userPreferencesDataTabEnabled: true,
   mcpServersTabEnabled: false,
   messageFeedbackEditTimeLimitSeconds: null,
   maxUploadSizeBytes: 20971520,

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
@@ -95,6 +95,7 @@ function renderDialog({
   initialEntries = ["/"],
   initialTab,
   mcpServersTabEnabled = true,
+  dataTabEnabled = true,
   audioTranscriptionEnabled = false,
   onMcpOauthCallbackHandled,
   pendingMcpOauthCallback = null,
@@ -116,6 +117,7 @@ function renderDialog({
     | "mcpServers"
     | "data";
   mcpServersTabEnabled?: boolean;
+  dataTabEnabled?: boolean;
   audioTranscriptionEnabled?: boolean;
   onMcpOauthCallbackHandled?: () => void;
   pendingMcpOauthCallback?: {
@@ -135,6 +137,7 @@ function renderDialog({
         config={{
           userPreferences: {
             enabled: userPreferencesEnabled,
+            dataTabEnabled,
             mcpServersTabEnabled,
           },
           audioTranscription: {
@@ -307,6 +310,14 @@ describe("UserPreferencesDialog", () => {
     expect(
       screen.queryByRole("tab", { name: "MCP servers" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides the Data tab when the feature flag is disabled", () => {
+    renderDialog({
+      dataTabEnabled: false,
+    });
+
+    expect(screen.queryByRole("tab", { name: "Data" })).not.toBeInTheDocument();
   });
 
   it("shows an Audio tab when audio transcription is enabled and persists the selected microphone", async () => {

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
@@ -78,8 +78,11 @@ export function UserPreferencesDialog({
   const navigate = useNavigate();
   const tabGroupId = useId();
   const queryClient = useQueryClient();
-  const { enabled: personalizationEnabled, mcpServersTabEnabled } =
-    useUserPreferencesFeature();
+  const {
+    enabled: personalizationEnabled,
+    dataTabEnabled,
+    mcpServersTabEnabled,
+  } = useUserPreferencesFeature();
   const { enabled: audioTranscriptionEnabled } = useAudioTranscriptionFeature();
   const { enabled: audioDictationEnabled } = useAudioDictationFeature();
   const audioInputSettingsEnabled =
@@ -131,7 +134,7 @@ export function UserPreferencesDialog({
               ? // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal preferences tab id
                 (["mcpServers"] as const)
               : []),
-            "data",
+            ...(dataTabEnabled ? (["data"] as const) : []),
           ]
         : [
             "appearance",
@@ -140,9 +143,14 @@ export function UserPreferencesDialog({
               ? // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal preferences tab id
                 (["mcpServers"] as const)
               : []),
-            "data",
+            ...(dataTabEnabled ? (["data"] as const) : []),
           ]) satisfies PreferencesTab[],
-    [audioInputSettingsEnabled, mcpServersTabEnabled, personalizationEnabled],
+    [
+      audioInputSettingsEnabled,
+      dataTabEnabled,
+      mcpServersTabEnabled,
+      personalizationEnabled,
+    ],
   );
   const handledOauthCallbackKeyRef = useRef<string | null>(null);
   const requestedDefaultTab =

--- a/frontend/src/config/__tests__/themeConfig.test.ts
+++ b/frontend/src/config/__tests__/themeConfig.test.ts
@@ -51,6 +51,7 @@ describe("themeConfig", () => {
     messageFeedbackEnabled: false,
     messageFeedbackCommentsEnabled: false,
     userPreferencesEnabled: true,
+    userPreferencesDataTabEnabled: true,
     mcpServersTabEnabled: false,
     messageFeedbackEditTimeLimitSeconds: null,
     maxUploadSizeBytes: 20971520,

--- a/frontend/src/hooks/ui/__tests__/useSidebar.test.tsx
+++ b/frontend/src/hooks/ui/__tests__/useSidebar.test.tsx
@@ -58,6 +58,7 @@ beforeEach(() => {
     messageFeedbackEnabled: false,
     messageFeedbackCommentsEnabled: false,
     userPreferencesEnabled: true,
+    userPreferencesDataTabEnabled: true,
     messageFeedbackEditTimeLimitSeconds: null,
     maxUploadSizeBytes: 20971520,
     sidebarCollapsedMode: "hidden",

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -95,6 +95,8 @@ interface StarterPromptsFeatureConfig {
 interface UserPreferencesFeatureConfig {
   /** Whether the user preferences feature is enabled */
   enabled: boolean;
+  /** Whether the data tab is shown in the preferences dialog */
+  dataTabEnabled: boolean;
   /** Whether the MCP servers tab is shown in the preferences dialog */
   mcpServersTabEnabled: boolean;
 }
@@ -222,6 +224,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   },
   userPreferences: {
     enabled: false,
+    dataTabEnabled: true,
     mcpServersTabEnabled: false,
   },
   cloudProviders: {
@@ -312,6 +315,7 @@ function createFeatureConfig(
     },
     userPreferences: {
       enabled: environment.userPreferencesEnabled,
+      dataTabEnabled: environment.userPreferencesDataTabEnabled,
       mcpServersTabEnabled: environment.mcpServersTabEnabled,
     },
     cloudProviders: {

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -71,6 +71,7 @@ describe("FeatureConfigProvider", () => {
       messageFeedbackEnabled: false,
       messageFeedbackCommentsEnabled: false,
       userPreferencesEnabled: true,
+      userPreferencesDataTabEnabled: true,
       messageFeedbackEditTimeLimitSeconds: null,
       maxUploadSizeBytes: 20971520, // 20 MB - matches backend default
       audioTranscriptionEnabled: false,
@@ -156,6 +157,7 @@ describe("FeatureConfigProvider", () => {
         },
         userPreferences: {
           enabled: true,
+          dataTabEnabled: true,
           mcpServersTabEnabled: false,
         },
         cloudProviders: {
@@ -195,6 +197,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -230,6 +233,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -280,6 +284,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -315,6 +320,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -378,6 +384,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -439,6 +446,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -473,6 +481,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -544,6 +553,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         audioTranscriptionEnabled: true,
         audioTranscriptionMaxRecordingDurationSeconds: 1200,
@@ -637,6 +647,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         maxUploadSizeBytes: 20971520,
       });
 
@@ -685,6 +696,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -735,6 +747,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         audioTranscriptionEnabled: false,
@@ -809,6 +822,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: true,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -844,6 +858,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: true,
         messageFeedbackCommentsEnabled: true,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -908,6 +923,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "slim",
@@ -969,6 +985,7 @@ describe("FeatureConfigProvider", () => {
         messageFeedbackEnabled: false,
         messageFeedbackCommentsEnabled: false,
         userPreferencesEnabled: false,
+        userPreferencesDataTabEnabled: true,
         messageFeedbackEditTimeLimitSeconds: null,
         maxUploadSizeBytes: 20971520,
         sidebarCollapsedMode: "hidden",
@@ -982,6 +999,43 @@ describe("FeatureConfigProvider", () => {
       });
 
       expect(result.current.enabled).toBe(false);
+      expect(result.current.dataTabEnabled).toBe(true);
+    });
+
+    it("should return user preferences data tab disabled when configured", () => {
+      mockEnv.mockReturnValue({
+        apiRootUrl: "/api/",
+        themeCustomerName: null,
+        themePath: null,
+        themeConfigPath: null,
+        themeLogoPath: null,
+        themeLogoDarkPath: null,
+        themeAssistantAvatarPath: null,
+        disableUpload: false,
+        disableChatInputAutofocus: false,
+        disableLogout: false,
+        assistantsEnabled: false,
+        assistantsShowRecentItems: false,
+        sharepointEnabled: false,
+        sharepointShowDisclaimer: false,
+        messageFeedbackEnabled: false,
+        messageFeedbackCommentsEnabled: false,
+        userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: false,
+        messageFeedbackEditTimeLimitSeconds: null,
+        maxUploadSizeBytes: 20971520,
+        sidebarCollapsedMode: "hidden",
+        sidebarLogoPath: null,
+        sidebarLogoDarkPath: null,
+        sidebarChatHistoryShowMetadata: true,
+      });
+
+      const { result } = renderHook(() => useUserPreferencesFeature(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.dataTabEnabled).toBe(false);
     });
   });
 });

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -2713,7 +2713,8 @@ Configuration for the user preferences feature.
 
 Whether to enable the user preferences feature.
 
-When disabled, the frontend hides the Preferences item in the user profile dropdown.
+When disabled, the frontend hides the Personalization tab in the preferences dialog.
+Other preferences tabs can still be shown.
 
 **Default value:** `true`
 
@@ -2724,6 +2725,26 @@ When disabled, the frontend hides the Preferences item in the user profile dropd
 ```toml
 [user_preferences]
 enabled = false
+```
+
+#### `user_preferences.data_tab_enabled`
+
+{/* erato_toml_config_key: user_preferences.data_tab_enabled */}
+
+Whether the Data tab should be shown in the frontend preferences dialog.
+
+This only controls frontend visibility of the tab. It does not change backend
+availability of account data actions.
+
+**Default value:** `true`
+
+**Type:** `boolean`
+
+**Example:**
+
+```toml
+[user_preferences]
+data_tab_enabled = false
 ```
 
 ### `experimental_assistants`


### PR DESCRIPTION
## Summary

Adds a backend-configured feature flag for hiding the Settings dialog's Data tab, which currently contains the account-wide "Archive all chats" action.

The new setting is:

```toml
[user_preferences]
data_tab_enabled = false
```

By default, `data_tab_enabled` is `true`, so existing deployments keep the current Data tab behavior unless they explicitly disable it.

Linear: https://linear.app/erato-labs/issue/ERMAIN-363/add-backend-configured-toggle-for-settings-data-tab

## What Changed

- Added `user_preferences.data_tab_enabled` to backend config with a `true` default.
- Injected the value into the served frontend as `window.USER_PREFERENCES_DATA_TAB_ENABLED`.
- Added frontend env parsing, including `VITE_USER_PREFERENCES_DATA_TAB_ENABLED=false` support.
- Exposed the flag through `FeatureConfigProvider` as `userPreferences.dataTabEnabled`.
- Made `UserPreferencesDialog` conditionally include the `Data` tab based on the flag.
- Added backend config tests and frontend provider/dialog tests.
- Regenerated `backend/generated/config_reference.json`.
- Updated docs for the new setting and corrected the existing `user_preferences.enabled` description to match actual behavior: it hides the Personalization tab, not the whole Settings entry/dialog.

## Notes

This is frontend visibility only, matching the existing MCP servers tab visibility flag. It does not disable the `/api/v1beta/me/chats/archive_all` endpoint on the backend.

`frontend.additional_environment` can still override injected window globals when deployments intentionally provide duplicate keys, consistent with the existing frontend environment behavior.

## Validation

- `pnpm test --run src/providers/__tests__/FeatureConfigProvider.test.tsx src/components/ui/Settings/UserPreferencesDialog.test.tsx`
- `cargo test -p erato test_user_preferences --test integration_tests`
- `cargo run --bin gen-config-reference -- --check`
- `pnpm exec tsc --noEmit`
- `pnpm lint:strict && pnpm typecheck`
- `just check_config_reference_docs`