### PR TITLE
Fix read-mode reply card gating (ERMAIN-364)

### DIFF
--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -755,4 +755,93 @@ describe("MessageContent", () => {
     expect(screen.getByRole("button", { name: /Copy/ })).toBeInTheDocument();
     expect(screen.getByText(/kurze Email/)).toBeInTheDocument();
   });
+
+  it("does NOT whole-body-fallback for a client-action facet (reply) with no proposed action", () => {
+    renderWithTheme(
+      <MessageContent
+        content={textContent(
+          "It is a long thread about several tickets. The latest message is from Jakob.",
+        )}
+        outlookArtifact={{
+          facetId: "outlook_reply_from_read",
+          bodyFormat: "html",
+          renderMode: "body",
+          allowedClientActions: ["outlook.reply", "outlook.reply_all"],
+          // The producer (AddinChat) stamps suppression for an ambient reply
+          // facet that produced a plain answer (offerable actions but no
+          // proposal). The gate reads this single verdict.
+          shouldRenderEmailCard: false,
+        }}
+      />,
+    );
+
+    // The reply facet is attached ambiently to every read-mode message; a plain
+    // summary (no fence, suppressed by the producer) must NOT become an email card.
+    expect(screen.queryByRole("button", { name: /Copy/ })).toBeNull();
+    expect(screen.getByText(/latest message is from Jakob/).tagName).toBe("P");
+  });
+
+  it("DOES whole-body-fallback for a reply facet when the model proposed a client action", () => {
+    renderWithTheme(
+      <MessageContent
+        content={textContent(
+          "Hallo Herr Wolf-Sebottendorff,\n\nvielen Dank fuer das Update.",
+        )}
+        outlookArtifact={{
+          facetId: "outlook_reply_from_read",
+          bodyFormat: "html",
+          renderMode: "body",
+          allowedClientActions: ["outlook.reply", "outlook.reply_all"],
+          proposedClientAction: "outlook.reply",
+          // The producer did NOT suppress (the model proposed), so the
+          // verdict is absent → the gate defaults to card. The proposal field
+          // itself is not read by the gate; it is the producer's reason.
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Copy/ })).toBeInTheDocument();
+    expect(screen.getByText(/vielen Dank/)).toBeInTheDocument();
+  });
+
+  it("still cards a FENCED reply draft for a client-action facet even without a proposed action", () => {
+    renderWithTheme(
+      <MessageContent
+        content={textContent("```erato-email\nHallo, anbei mein Entwurf.\n```")}
+        outlookArtifact={{
+          facetId: "outlook_reply_from_read",
+          bodyFormat: "html",
+          renderMode: "body",
+          allowedClientActions: ["outlook.reply", "outlook.reply_all"],
+          // Even with the producer's verdict set to SUPPRESS, a fenced draft
+          // must still card: the fence path runs ahead of the whole-body gate.
+          shouldRenderEmailCard: false,
+        }}
+      />,
+    );
+
+    // A fenced draft routes through the fenced-block path, never the whole-body
+    // gate, so the suppression verdict must not reach it.
+    expect(screen.getByRole("button", { name: /Copy/ })).toBeInTheDocument();
+    expect(screen.getByText(/anbei mein Entwurf/)).toBeInTheDocument();
+  });
+
+  it("treats an empty allowedClientActions list as a non-client-action facet (still cards)", () => {
+    renderWithTheme(
+      <MessageContent
+        content={textContent("Hallo Frau Berger,\n\nvielen Dank.")}
+        outlookArtifact={{
+          facetId: "outlook_rewrite_selection",
+          bodyFormat: "text",
+          renderMode: "body",
+          allowedClientActions: [],
+        }}
+      />,
+    );
+
+    // A non-suppressed artifact (the producer stamps nothing for a compose /
+    // rewrite facet, so the flag is absent → defaults to card).
+    expect(screen.getByRole("button", { name: /Copy/ })).toBeInTheDocument();
+    expect(screen.getByText(/vielen Dank/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -816,7 +816,12 @@ export const MessageContent = memo(function MessageContent({
   // block for the tolerant tag-matching to catch, so treat the message text
   // itself as the insert/replace artifact. Gated to completed messages and to
   // `renderMode === "body"`: `"suggestions"` facets (review/critique) are
-  // feedback, not a single drop-in body, so they keep normal markdown.
+  // feedback, not a single drop-in body, so they keep normal markdown. The
+  // producer (add-in AddinChat) decides whether an ambient-reply facet's plain
+  // answer should card and stamps the verdict as `shouldRenderEmailCard`;
+  // absent (web app, or a facet that always cards) is treated as `true`. This
+  // single field is the source of truth shared with the add-in renderer — see
+  // {@link OutlookArtifact.shouldRenderEmailCard}.
   const textForArtifact = React.useMemo(
     () =>
       content
@@ -830,7 +835,8 @@ export const MessageContent = memo(function MessageContent({
     !isStreaming &&
     !showRaw &&
     textForArtifact.trim().length > 0 &&
-    !containsMarkdownFence(textForArtifact)
+    !containsMarkdownFence(textForArtifact) &&
+    (outlookArtifact.shouldRenderEmailCard ?? true)
       ? outlookArtifact
       : null;
 

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -79,6 +79,21 @@ export interface OutlookArtifact {
    */
   proposedClientAction?: string;
   /**
+   * Producer-computed verdict (add-in only) for whether an UNFENCED whole
+   * `"body"`-mode response should render as the insertable email card. Computed
+   * once in AddinChat as `!isClientActionFacet || proposedClientAction != null`,
+   * where `isClientActionFacet` is keyed off the OFFERABLE actions (the backend
+   * `allowedClientActions` intersected with the actions the add-in actually
+   * implements) — so an ambient reply facet that produced a plain answer (no
+   * proposal) suppresses the card, while a compose/rewrite facet (no offerable
+   * actions) always cards. Stamped only when it SUPPRESSES (`false`); absent is
+   * treated as `true`. Undefined on the web app (the producer runs only in the
+   * add-in), which leaves web rendering unchanged. Single source of truth for
+   * carding so the gate and the add-in renderer cannot drift; a future
+   * backend draft-intent signal folds into this one field.
+   */
+  shouldRenderEmailCard?: boolean;
+  /**
    * The producing facet's `presentation` from `GET /me/facets`:
    * `render_buttons` (default) or `auto_prompt`.
    */

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -50,7 +50,10 @@ import {
   OUTLOOK_GRAPH_MESSAGE_TIMEOUT_MS,
   runWithGraphTimeout,
 } from "../utils/graphRequestTimeout";
-import { extractProposedClientAction } from "../utils/outlookClientActions";
+import {
+  computeShouldRenderEmailCard,
+  extractProposedClientAction,
+} from "../utils/outlookClientActions";
 import { parseDroppedFiles } from "../utils/parseDroppedFiles";
 import { parseEmlBytes } from "../utils/parsedEmail";
 
@@ -758,6 +761,12 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
       const proposedClientAction = allowedClientActions
         ? extractProposedClientAction(message.content, allowedClientActions)
         : undefined;
+      // Single source of truth for carding (see OutlookArtifact.shouldRenderEmailCard).
+      // Stamped below only when it SUPPRESSES (false); absent ⇒ cards.
+      const shouldRenderEmailCard = computeShouldRenderEmailCard({
+        allowedClientActions,
+        proposedClientAction,
+      });
       if (next === messages) {
         next = { ...messages };
       }
@@ -769,6 +778,9 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           renderMode,
           messageId: id,
           ...(allowedClientActions ? { allowedClientActions } : {}),
+          ...(renderMode === "body" && !shouldRenderEmailCard
+            ? { shouldRenderEmailCard: false }
+            : {}),
           ...(clientActionInfo && clientActionInfo.alwaysAskActions.length > 0
             ? { alwaysAskClientActions: clientActionInfo.alwaysAskActions }
             : {}),

--- a/office-addin/src/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/components/OutlookEratoEmailRenderer.tsx
@@ -28,7 +28,7 @@ import { replaceComposeSelection } from "../utils/outlookComposeWrite";
 import {
   ReplyBodyTooLargeError,
   getReadModeRecipientSummary,
-  isReadReplySupported,
+  isReplyFormHostSupported,
   openReplyForm,
   type ReadModeRecipientSummary,
 } from "../utils/outlookReadReply";
@@ -130,7 +130,14 @@ export function OutlookEratoEmailRenderer({
 
   const readActions = useMemo<OutlookClientAction[]>(
     () =>
-      isReadMode && isReadReplySupported()
+      // Gate on the REACTIVE read-item signal (`isReadMode`, synced to the live
+      // item by OutlookMailItemProvider) plus the host-static capability check
+      // — NOT the live `isReadReplySupported()`, which reads Office state
+      // outside this dep array and could cache an empty result when the item
+      // was momentarily unavailable (e.g. a pinned-pane reload), permanently
+      // hiding the reply buttons. Execution re-checks the live item in
+      // openReplyForm, so offering optimistically here fails closed on click.
+      isReadMode && isReplyFormHostSupported()
         ? offerableClientActions(artifact?.allowedClientActions).filter(
             (action) =>
               !isActionDenied({

--- a/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
+++ b/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
@@ -78,7 +78,7 @@ vi.mock("../../hooks/useOutlookComposeSelection", () => ({
 
 vi.mock("../../utils/outlookReadReply", () => ({
   ReplyBodyTooLargeError: class ReplyBodyTooLargeError extends Error {},
-  isReadReplySupported: () => true,
+  isReplyFormHostSupported: () => true,
   getReadModeRecipientSummary: () => mockGetReadModeRecipientSummary(),
   openReplyForm: (...args: unknown[]) => mockOpenReplyForm(...args),
 }));
@@ -554,5 +554,57 @@ describe("OutlookEratoEmailRenderer — resolved confirmation card", () => {
       "data-status",
       "pending",
     );
+  });
+});
+
+describe("OutlookEratoEmailRenderer — read-reply gate tracks the reactive item signal", () => {
+  // Stale-memo fix (ERMAIN-364): read actions gate on the REACTIVE isReadMode
+  // (from the mail-item provider) plus the host-static isReplyFormHostSupported
+  // (mocked true), never a live item read — so reply buttons appear in read
+  // mode and are withheld when the provider reports compose / no item, instead
+  // of caching a stale empty result.
+  function primeMailItem(mailItem: unknown) {
+    const artifact = makeArtifact();
+    mockUseOutlookArtifact.mockReturnValue(artifact);
+    mockUseOutlookMailItem.mockReturnValue({
+      mailItem,
+      itemIdentity: "item-a",
+    });
+    mockUseChatContext.mockReturnValue({
+      messages: {
+        [artifact.messageId]: { id: artifact.messageId, role: "assistant" },
+      },
+      messageOrder: [artifact.messageId],
+    });
+    mockUsePersistedState.mockReturnValue([{}, vi.fn()]);
+    mockGetReadModeRecipientSummary.mockReturnValue({
+      sender: "Alice Sender",
+      recipients: ["Bob"],
+    });
+  }
+
+  it("offers Reply / Reply All in read mode", () => {
+    primeMailItem({ isComposeMode: false });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(screen.getByRole("button", { name: "Reply" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reply All" }),
+    ).toBeInTheDocument();
+  });
+
+  it("withholds the reply buttons when the provider reports compose mode", () => {
+    primeMailItem({ isComposeMode: true });
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reply All" })).toBeNull();
+  });
+
+  it("withholds the reply buttons when the provider reports no open item", () => {
+    primeMailItem(null);
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
   });
 });

--- a/office-addin/src/utils/__tests__/outlookClientActions.test.ts
+++ b/office-addin/src/utils/__tests__/outlookClientActions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   CLIENT_ACTION_TOOL_NAME,
+  computeShouldRenderEmailCard,
   extractProposedClientAction,
   isImplementedClientAction,
   offerableClientActions,
@@ -116,5 +117,68 @@ describe("extractProposedClientAction", () => {
   it("handles empty content", () => {
     expect(extractProposedClientAction(undefined, ALLOWED)).toBeUndefined();
     expect(extractProposedClientAction([], ALLOWED)).toBeUndefined();
+  });
+});
+
+describe("computeShouldRenderEmailCard", () => {
+  it("suppresses an ambient reply facet that produced no proposal", () => {
+    // The reply facet offers reply/reply-all but the model only answered
+    // (no proposal) — a plain summary must NOT become an email card.
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: ALLOWED,
+        proposedClientAction: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("cards a reply facet once the model has proposed a client action", () => {
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: ALLOWED,
+        proposedClientAction: "outlook.reply",
+      }),
+    ).toBe(true);
+  });
+
+  it("cards a facet that advertises ONLY an unimplemented action", () => {
+    // The intentional Finding-2 behavior: keyed off the OFFERABLE set, so an
+    // action the add-in does not implement does not make this a client-action
+    // facet. If this were keyed off the RAW allowed list it would (wrongly)
+    // suppress. This is the assertion that fails if the offerable intersection
+    // is dropped.
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: ["outlook.forward"],
+        proposedClientAction: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("still suppresses when a mix of implemented + unimplemented actions is offered without a proposal", () => {
+    // outlook.reply IS offerable, so this is a client-action facet and a plain
+    // answer (no proposal) must suppress — outlook.forward being present and
+    // unimplemented does not change that.
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: ["outlook.forward", "outlook.reply"],
+        proposedClientAction: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("always cards a facet with no client actions (compose / rewrite)", () => {
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: [],
+        proposedClientAction: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      computeShouldRenderEmailCard({
+        allowedClientActions: undefined,
+        proposedClientAction: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/office-addin/src/utils/__tests__/outlookReadReply.test.ts
+++ b/office-addin/src/utils/__tests__/outlookReadReply.test.ts
@@ -8,6 +8,7 @@ import {
   getReadModeRecipientSummary,
   isReadReplySupported,
   isReplyFormBodyTooLarge,
+  isReplyFormHostSupported,
   openReplyForm,
 } from "../outlookReadReply";
 
@@ -116,6 +117,32 @@ describe("isReadReplySupported", () => {
     installOffice({ item: null });
     expect(isReadReplySupported()).toBe(false);
     installOffice({ item: readModeItem(), supportedSets: [] });
+    expect(isReadReplySupported()).toBe(false);
+  });
+});
+
+describe("isReplyFormHostSupported", () => {
+  it("reflects only host capability, independent of the live item", () => {
+    // Host-static: the render gate uses this so it never goes stale as the
+    // open item transitions (a live item is NOT required to be true here).
+    installOffice({ item: null });
+    expect(isReplyFormHostSupported()).toBe(true);
+    installOffice({ item: composeModeItem() });
+    expect(isReplyFormHostSupported()).toBe(true);
+  });
+
+  it("is false when the host lacks Mailbox 1.1", () => {
+    installOffice({ item: readModeItem(), supportedSets: [] });
+    expect(isReplyFormHostSupported()).toBe(false);
+  });
+
+  it("diverges from isReadReplySupported when the live item is momentarily gone on a supporting host", () => {
+    // The exact stale state the render-gate swap targets: the host supports
+    // replies, but a live item read returns nothing. The host-static check
+    // stays true (so the reactive render gate can recover) while the live
+    // execution guard correctly reports false.
+    installOffice({ item: null });
+    expect(isReplyFormHostSupported()).toBe(true);
     expect(isReadReplySupported()).toBe(false);
   });
 });

--- a/office-addin/src/utils/outlookClientActions.ts
+++ b/office-addin/src/utils/outlookClientActions.ts
@@ -109,3 +109,24 @@ export function extractProposedClientAction(
   }
   return undefined;
 }
+
+/**
+ * Producer-side verdict for {@link OutlookArtifact.shouldRenderEmailCard}:
+ * whether an UNFENCED, `"body"`-mode response should render as the insertable
+ * email card. A facet that OFFERS client actions (reply / reply-all) is
+ * attached ambiently to every read-mode message, so a plain answer with no
+ * proposal must NOT card; a facet with no offerable actions — compose /
+ * rewrite-selection, or a facet advertising ONLY actions this add-in does not
+ * implement — always cards. Keyed off the OFFERABLE set (`allowedClientActions`
+ * intersected with the implemented registry) so the carding verdict matches
+ * what the renderer can actually act on. A fenced draft never reaches this
+ * verdict; the renderer's fence path handles it.
+ */
+export function computeShouldRenderEmailCard(args: {
+  allowedClientActions: readonly string[] | undefined;
+  proposedClientAction: string | undefined;
+}): boolean {
+  const isClientActionFacet =
+    offerableClientActions(args.allowedClientActions).length > 0;
+  return !isClientActionFacet || args.proposedClientAction != null;
+}

--- a/office-addin/src/utils/outlookReadReply.ts
+++ b/office-addin/src/utils/outlookReadReply.ts
@@ -58,17 +58,32 @@ function getReadModeItem(): Office.MessageRead | null {
 }
 
 /**
+ * Whether the host supports the reply form APIs at all (Mailbox 1.1; not
+ * available on Outlook mobile). Host-static for the session — does NOT read the
+ * live `Office.context.mailbox.item`, so it is safe to call from a render path
+ * without going stale as the open item changes. Pair it with the REACTIVE
+ * read-item signal (`isReadMode`, from OutlookMailItemProvider) to decide
+ * whether to OFFER reply actions; use `isReadReplySupported()` /
+ * `getReadModeItem()` to GUARD execution against the live item.
+ */
+export function isReplyFormHostSupported(): boolean {
+  return (
+    Office.context.requirements?.isSetSupported?.("Mailbox", "1.1") ?? false
+  );
+}
+
+/**
  * Whether the current Office context can open a reply form right now: a
- * read-mode message is open and the host supports the reply form APIs
- * (Mailbox 1.1; not available on Outlook mobile).
+ * read-mode message is open and the host supports the reply form APIs. Reads
+ * the LIVE item, so use this to GUARD execution (e.g. `openReplyForm`), never
+ * to gate render — a render gate must track the reactive item state via
+ * `isReadMode` + `isReplyFormHostSupported`, or it caches stale results.
  */
 export function isReadReplySupported(): boolean {
   if (!getReadModeItem()) {
     return false;
   }
-  return (
-    Office.context.requirements?.isSetSupported?.("Mailbox", "1.1") ?? false
-  );
+  return isReplyFormHostSupported();
 }
 
 export interface ReadModeRecipientSummary {


### PR DESCRIPTION
- Gate reply buttons on the reactive read-item + host-static capability check instead of a live-item read that could cache an empty result.
- Unify the email-card verdict into one producer-stamped shouldRenderEmailCard flag so the gate and renderer can't drift.