### PR TITLE
Fix stale newlyCreatedChatId redirect undoing New chat in add-in

### DIFF
--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1953,6 +1953,22 @@ export function useChatMessaging(
     ],
   );
 
+  // Consumers that navigate by state instead of by route (the Office add-in)
+  // never remount this hook, so `newlyCreatedChatId` survives past the
+  // navigation that consumed it. A stale id re-triggers navigation effects the
+  // next time chatId goes null (new chat, archive, session-policy "new"),
+  // bouncing the user back into the previous chat. Such consumers must clear
+  // the id once they have acted on it — both the local copy and the store
+  // copy, which otherwise keeps `renderStreamKey` pointed at the old chat's
+  // stream while chatId is null.
+  const clearNewlyCreatedChatId = useCallback(() => {
+    logger.log(
+      "[DEBUG_REDIRECT] clearNewlyCreatedChatId: Clearing local and store newlyCreatedChatId.",
+    );
+    setNewlyCreatedChatId(null);
+    setNewlyCreatedChatIdInStore(null);
+  }, [setNewlyCreatedChatIdInStore]);
+
   // isPendingResponse is true from the moment send is clicked until streaming completes
   // This is different from isStreaming which only becomes true after the first chunk arrives
   const isPendingResponse =
@@ -1974,6 +1990,7 @@ export function useChatMessaging(
     cancelMessage,
     refetch: chatMessagesQuery.refetch,
     newlyCreatedChatId,
+    clearNewlyCreatedChatId,
     messageOrder, // Keep messageOrder in the return object
   };
 }

--- a/office-addin/src/providers/AddinChatProvider.tsx
+++ b/office-addin/src/providers/AddinChatProvider.tsx
@@ -219,6 +219,15 @@ export function AddinChatProvider({ children }: { children: ReactNode }) {
 
   const { currentChatLastModel } = useModelHistory({ currentChatId, chats });
 
+  // `useChatMessaging` keeps `newlyCreatedChatId` set after the first-message
+  // redirect below consumes it (this provider never remounts the hook, unlike
+  // the web app's route-based navigation). Every path that abandons the
+  // current chat by setting chatId to null must clear it, or the redirect
+  // effect immediately navigates back into the stale chat. The hook is called
+  // further down, so these earlier callbacks reach the clear function through
+  // a ref — same pattern as `createNewChatRef` below.
+  const clearNewlyCreatedChatIdRef = useRef<() => void>(() => {});
+
   const createNewChat = useCallback(async () => {
     setNewChatCounter((previous) => previous + 1);
     setCurrentChatId(null, currentAnchor);
@@ -226,6 +235,7 @@ export function AddinChatProvider({ children }: { children: ReactNode }) {
     useMessagingStore.getState().abortActiveSSE();
     useMessagingStore.getState().clearUserMessages();
     useMessagingStore.getState().resetStreaming();
+    clearNewlyCreatedChatIdRef.current();
 
     return `temp-${Date.now()}`;
   }, [currentAnchor, setCurrentChatId]);
@@ -247,6 +257,7 @@ export function AddinChatProvider({ children }: { children: ReactNode }) {
       if (currentChatId === chatId) {
         setCurrentChatId(null, currentAnchor);
         setNewChatCounter((previous) => previous + 1);
+        clearNewlyCreatedChatIdRef.current();
       }
     },
     [
@@ -330,6 +341,7 @@ export function AddinChatProvider({ children }: { children: ReactNode }) {
           useMessagingStore.getState().abortActiveSSE();
           useMessagingStore.getState().clearUserMessages();
           useMessagingStore.getState().resetStreaming();
+          clearNewlyCreatedChatIdRef.current();
         } else {
           setSession({ chatId: null, anchor: currentAnchor });
         }
@@ -404,21 +416,28 @@ export function AddinChatProvider({ children }: { children: ReactNode }) {
     cancelMessage,
     refetch: refetchMessages,
     newlyCreatedChatId,
+    clearNewlyCreatedChatId,
   } = useChatMessaging({
     chatId: effectiveChatId,
     silentChatId,
     platform: host?.toLowerCase() ?? "office-addin",
   });
+  clearNewlyCreatedChatIdRef.current = clearNewlyCreatedChatId;
 
   useEffect(() => {
     if (newlyCreatedChatId && !currentChatId && !isPendingResponse) {
       useMessagingStore.getState().setNavigationTransition(true);
       setCurrentChatId(newlyCreatedChatId, currentAnchor);
+      // Consume the id once acted on. The navigation transition suppresses
+      // the hook's own mount-effect reset, so without this the id would stay
+      // set and re-fire this effect the next time chatId goes null.
+      clearNewlyCreatedChatId();
       setTimeout(() => {
         useMessagingStore.getState().setNavigationTransition(false);
       }, 100);
     }
   }, [
+    clearNewlyCreatedChatId,
     currentAnchor,
     currentChatId,
     isPendingResponse,


### PR DESCRIPTION
This pull request addresses a bug in the Office Add-in chat experience where stale `newlyCreatedChatId` values could cause users to be redirected back into an old chat after navigating away. The fix ensures that `newlyCreatedChatId` is properly cleared both locally and in the store after navigation, preventing unintended re-navigation. The changes introduce a new `clearNewlyCreatedChatId` function, propagate it through the relevant hooks and providers, and ensure it is called at all points where the chat session is abandoned or changed.

**Office Add-in Chat Navigation Fixes:**

* Added a `clearNewlyCreatedChatId` function to the `useChatMessaging` hook, which clears the `newlyCreatedChatId` both locally and in the store to prevent stale navigation state. [[1]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1956-R1971) [[2]](diffhunk://#diff-c746fcf1b19db201159672ef81096d68ffdc9aa783740c712ed7797a3d59e1efR1993)
* In `AddinChatProvider`, introduced a `clearNewlyCreatedChatIdRef` to allow callbacks to clear the `newlyCreatedChatId` at every code path where the chat session is abandoned or reset, ensuring the redirect effect does not re-fire with a stale id. [[1]](diffhunk://#diff-cd9c3f097e862b2f9f3b673e0d4fa938a0b4af58fe1b93c7c61573608083d4afR222-R238) [[2]](diffhunk://#diff-cd9c3f097e862b2f9f3b673e0d4fa938a0b4af58fe1b93c7c61573608083d4afR260) [[3]](diffhunk://#diff-cd9c3f097e862b2f9f3b673e0d4fa938a0b4af58fe1b93c7c61573608083d4afR344) [[4]](diffhunk://#diff-cd9c3f097e862b2f9f3b673e0d4fa938a0b4af58fe1b93c7c61573608083d4afR419-R440)
* Updated the effect that handles navigation to a newly created chat to call `clearNewlyCreatedChatId` immediately after acting on the id, ensuring it cannot trigger another navigation unexpectedly.