### PR TITLE
feat(frontend): dev-only console forwarding + dev_logged recipe

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+# Captured dev/browser console logs for the coding agent (just dev_logged)
+.agent-dev.log
 
 # env files (can opt-in for committing if needed)
 .env

--- a/frontend/justfile
+++ b/frontend/justfile
@@ -1,3 +1,6 @@
+# Path the coding agent (Claude Code) tails for captured dev/browser logs
+agent_log := justfile_directory() / ".agent-dev.log"
+
 default:
     just --list
 
@@ -38,6 +41,13 @@ dev_nginx_jwt:
     echo "Example: http://localhost:4180/?user=alice"
     echo "To logout: Visit http://localhost:4180/logout"
     pnpm run dev
+
+# Run any dev mode with console output captured to an agent-readable file.
+# Composes with every auth recipe; existing recipes are untouched.
+# Usage: `just dev_logged`  (defaults to `dev`)  |  `just dev_logged dev_entra_id`
+dev_logged mode="dev":
+    @echo "▶ capturing dev output → {{agent_log}} (Claude Code can tail this)"
+    just {{mode}} 2>&1 | tee {{agent_log}}
 
 start:
     pnpm run start

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -129,6 +129,7 @@
     "tailwindcss": "^3.4.19",
     "typescript": "^5",
     "vite": "^6.4.2",
+    "vite-console-forward-plugin": "^2.0.1",
     "vitest": "^4.1.0"
   },
   "peerDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0)
+      vite-console-forward-plugin:
+        specifier: ^2.0.1
+        version: 2.0.1(vite@6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.0
         version: 4.1.7(@types/node@20.17.17)(@vitest/coverage-v8@4.1.7)(jsdom@26.0.0)(msw@2.7.3(@types/node@20.17.17)(typescript@5.7.3))(vite@6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0))
@@ -4785,6 +4788,11 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-console-forward-plugin@2.0.1:
+    resolution: {integrity: sha512-cA2vIWauvEvVwk5H10lRxdxpIGK5JK9Rz4PRDBWhj855aJVxWrZ7v+u6RyTjSpJ+fUPIMwHLN/5FjXyywcpkow==}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -10191,6 +10199,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vite-console-forward-plugin@2.0.1(vite@6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      vite: 6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0)
 
   vite@6.4.2(@types/node@20.17.17)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,7 @@ import {
   type Plugin,
   type ViteDevServer,
 } from "vite";
+import { consoleForwardPlugin } from "vite-console-forward-plugin";
 
 import {
   cleanVoiceRuntimePackageAssetOutput,
@@ -268,6 +269,10 @@ const stagePublicLayoutPlugin = (): Plugin => {
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const silentLinkedBuildOutput = mode === "dev-linked";
+  // Dev-only: forward browser console.* + errors to the Vite terminal so they
+  // can be read off-device (e.g. iOS simulator) and by coding agents. Gated on
+  // mode so it is never added to a production `vite build` (ERMAIN-373).
+  const isProductionBuild = mode === "production";
 
   return {
     customLogger: createDevLinkedBuildLogger(silentLinkedBuildOutput),
@@ -280,6 +285,15 @@ export default defineConfig(({ mode }) => {
       lingui(),
       stagePublicLayoutPlugin(),
       copy404Plugin({ silent: silentLinkedBuildOutput }),
+      // Endpoint lives under "/" so oauth2-proxy routes it to Vite (:3000);
+      // it must NOT be under "/api/" which the proxy sends to the backend.
+      ...(isProductionBuild
+        ? []
+        : [
+            consoleForwardPlugin({
+              endpoint: "/__client-logs",
+            }),
+          ]),
     ],
     publicDir: false,
     server: {


### PR DESCRIPTION
This pull request introduces a development-only feature that captures browser console output and forwards it to the Vite terminal, making it accessible for coding agents and off-device debugging. It does this by integrating the `vite-console-forward-plugin` and adding supporting scripts and configuration. No production code paths are affected.

**Development Logging Enhancements:**

- Added `.agent-dev.log` to `.gitignore` to avoid committing captured development logs.
- Introduced a new `dev_logged` recipe in `justfile` to run any dev mode with output captured to `.agent-dev.log` for agent consumption. [[1]](diffhunk://#diff-306b09e83966cce07e3bca0fc9f2d5d89af003da10ba0a7131292c29697e9001R1-R3) [[2]](diffhunk://#diff-306b09e83966cce07e3bca0fc9f2d5d89af003da10ba0a7131292c29697e9001R45-R51)

**Dependency and Plugin Integration:**

- Added `vite-console-forward-plugin` as a dev dependency in `package.json` and updated `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R132) [[2]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R283-R285) [[3]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R4792-R4796) [[4]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R10203-R10206)
- Imported and configured `consoleForwardPlugin` in `vite.config.ts` to forward browser console output to the Vite terminal during development only (never in production builds). The endpoint for forwarded logs is set to `/__client-logs`. [[1]](diffhunk://#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7cR14) [[2]](diffhunk://#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7cR272-R275) [[3]](diffhunk://#diff-97c6e2c429ec483132c584137a18a1ade2ff6c3f4f6485f4a83db604d0323d7cR288-R296)