### PR TITLE
ERMAIN-379: RMS speech-onset cue + WebKit/iOS audio hardening

### DIFF
--- a/frontend/src/hooks/audio/__tests__/audioDictationWorklet.test.ts
+++ b/frontend/src/hooks/audio/__tests__/audioDictationWorklet.test.ts
@@ -1,0 +1,84 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The worklet runs in AudioWorkletGlobalScope, which declares
+// `AudioWorkletProcessor` and `registerProcessor` as ambient globals. Shim
+// them so the module can be imported and exercised in a plain test
+// environment, capturing the registered processor class and every frame it
+// posts. This tests the SHIPPED worklet code directly — no refactor.
+const FRAME_SIZE = 4096;
+
+let ProcessorClass: any;
+let posted: Float32Array[] = [];
+
+beforeAll(async () => {
+  class FakeAudioWorkletProcessor {
+    port = {
+      postMessage: (data: Float32Array) => {
+        posted.push(data);
+      },
+    };
+  }
+  vi.stubGlobal("AudioWorkletProcessor", FakeAudioWorkletProcessor);
+  vi.stubGlobal("registerProcessor", (_name: string, cls: any) => {
+    ProcessorClass = cls;
+  });
+  // The worklet is a self-contained AudioWorklet script with no top-level
+  // export (it can't import anything — it runs in AudioWorkletGlobalScope),
+  // so TS treats it as a non-module. The runtime import works fine here.
+  // @ts-expect-error -- audio-dictation-worklet.ts is a classic script, not a module
+  await import("../audio-dictation-worklet");
+});
+
+beforeEach(() => {
+  posted = [];
+});
+
+function filled(value: number, length = FRAME_SIZE) {
+  return new Float32Array(length).fill(value);
+}
+
+describe("audio-dictation-worklet down-mix", () => {
+  it("passes a single channel through unchanged (mono fast path)", () => {
+    const processor = new ProcessorClass();
+    const mono = new Float32Array(FRAME_SIZE);
+    for (let i = 0; i < FRAME_SIZE; i += 1) mono[i] = (i % 200) / 200;
+
+    const keepGoing = processor.process([[mono]]);
+
+    expect(keepGoing).toBe(true);
+    expect(posted).toHaveLength(1);
+    expect(Array.from(posted[0])).toEqual(Array.from(mono));
+  });
+
+  it("averages stereo channels (Safari raw-capture case)", () => {
+    const processor = new ProcessorClass();
+
+    processor.process([[filled(1), filled(0)]]);
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0].every((sample) => sample === 0.5)).toBe(true);
+  });
+
+  it("guards ragged channels using each channel's own length", () => {
+    const processor = new ProcessorClass();
+    const left = filled(1, FRAME_SIZE);
+    const right = filled(0, FRAME_SIZE / 2); // short channel
+
+    processor.process([[left, right]]);
+
+    expect(posted).toHaveLength(1);
+    // Where both channels exist: mean of 1 and 0 = 0.5.
+    expect(posted[0][0]).toBe(0.5);
+    // Past the short channel's end: only the long channel contributes = 1.
+    expect(posted[0][FRAME_SIZE - 1]).toBe(1);
+  });
+
+  it("emits nothing when there is no audio (empty / missing channels)", () => {
+    const processor = new ProcessorClass();
+
+    expect(processor.process([[new Float32Array(0)]])).toBe(true);
+    expect(processor.process([[]])).toBe(true);
+    expect(processor.process([])).toBe(true);
+    expect(posted).toHaveLength(0);
+  });
+});

--- a/frontend/src/hooks/audio/__tests__/audioEnvironment.test.ts
+++ b/frontend/src/hooks/audio/__tests__/audioEnvironment.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  audioEnvironmentForEngine,
+  detectBrowserEngine,
+  getAudioEnvironment,
+} from "../audioEnvironment";
+
+const UA = {
+  desktopSafari:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+  iphoneSafari:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+  chromeOnIos:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/124.0 Mobile/15E148 Safari/604.1",
+  desktopChrome:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+  desktopFirefox:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0",
+  androidChrome:
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36",
+};
+
+describe("detectBrowserEngine", () => {
+  it("classifies desktop Safari and all iOS browsers as webkit", () => {
+    expect(detectBrowserEngine(UA.desktopSafari)).toBe("webkit");
+    expect(detectBrowserEngine(UA.iphoneSafari)).toBe("webkit");
+    expect(detectBrowserEngine(UA.chromeOnIos)).toBe("webkit");
+  });
+
+  it("classifies desktop/Android Chrome as chromium and Firefox as firefox", () => {
+    expect(detectBrowserEngine(UA.desktopChrome)).toBe("chromium");
+    expect(detectBrowserEngine(UA.androidChrome)).toBe("chromium");
+    expect(detectBrowserEngine(UA.desktopFirefox)).toBe("firefox");
+  });
+});
+
+describe("audioEnvironmentForEngine", () => {
+  it("sets WebKit capture-quirk flags only for webkit", () => {
+    const webkit = audioEnvironmentForEngine("webkit");
+    expect(webkit.warmUpEmitsNoiseFloor).toBe(true);
+    expect(webkit.mayReturnStereoWithoutEchoCancellation).toBe(true);
+    expect(webkit.needsGestureResume).toBe(true);
+
+    for (const engine of ["chromium", "firefox", "unknown"] as const) {
+      const env = audioEnvironmentForEngine(engine);
+      expect(env.warmUpEmitsNoiseFloor).toBe(false);
+      expect(env.mayReturnStereoWithoutEchoCancellation).toBe(false);
+      expect(env.needsGestureResume).toBe(false);
+    }
+  });
+});
+
+describe("getAudioEnvironment", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses an explicitly passed userAgent over navigator", () => {
+    expect(getAudioEnvironment(UA.iphoneSafari).engine).toBe("webkit");
+    expect(getAudioEnvironment(UA.desktopChrome).engine).toBe("chromium");
+  });
+
+  it("falls back to navigator.userAgent when no argument is given", () => {
+    vi.stubGlobal("navigator", { userAgent: UA.desktopSafari });
+    expect(getAudioEnvironment().engine).toBe("webkit");
+    expect(getAudioEnvironment().needsGestureResume).toBe(true);
+  });
+
+  it("returns the all-false 'unknown' environment with no resolvable UA", () => {
+    const env = getAudioEnvironment("");
+    expect(env.engine).toBe("unknown");
+    expect(env.warmUpEmitsNoiseFloor).toBe(false);
+    expect(env.mayReturnStereoWithoutEchoCancellation).toBe(false);
+    expect(env.needsGestureResume).toBe(false);
+  });
+});

--- a/frontend/src/hooks/audio/__tests__/onsetDetector.test.ts
+++ b/frontend/src/hooks/audio/__tests__/onsetDetector.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import { removeDcAndRms } from "../audio-pcm-codec";
+import { ONSET_TUNING } from "../audioTuning";
+import { createOnsetDetector } from "../onsetDetector";
+
+const SAMPLE_RATE = 48_000;
+const FRAME_SIZE = 4096;
+
+/** A constant-amplitude sine frame; RMS of a sine of amplitude a is a/√2. */
+function sineFrame(amplitude: number, dcBias = 0, length = FRAME_SIZE) {
+  const frame = new Float32Array(length);
+  for (let index = 0; index < length; index += 1) {
+    frame[index] =
+      dcBias + amplitude * Math.sin((2 * Math.PI * 440 * index) / SAMPLE_RATE);
+  }
+  return frame;
+}
+
+function zeroFrame(length = FRAME_SIZE) {
+  return new Float32Array(length);
+}
+
+describe("removeDcAndRms", () => {
+  it("returns 0 for an empty or all-zero window", () => {
+    expect(removeDcAndRms(new Float32Array(0))).toBe(0);
+    expect(removeDcAndRms(new Float32Array(512))).toBe(0);
+  });
+
+  it("removes DC bias so a constant offset reads as zero energy", () => {
+    const constant = new Float32Array(512).fill(0.4);
+    expect(removeDcAndRms(constant)).toBeCloseTo(0, 6);
+  });
+
+  it("measures sine RMS as amplitude/√2 regardless of DC offset", () => {
+    const amplitude = 0.2;
+    const expected = amplitude / Math.SQRT2;
+    expect(removeDcAndRms(sineFrame(amplitude, 0, 4800))).toBeCloseTo(
+      expected,
+      2,
+    );
+    // DC bias must not change the result.
+    expect(removeDcAndRms(sineFrame(amplitude, 0.5, 4800))).toBeCloseTo(
+      expected,
+      2,
+    );
+  });
+});
+
+describe("createOnsetDetector", () => {
+  it("does not fire on Chrome-style exact-zero warm-up, then fires on speech", () => {
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+
+    // ~256 ms of bit-exact zeros (Chrome cold warm-up) — covers calibration.
+    for (let frame = 0; frame < 3; frame += 1) {
+      expect(detector.accept(zeroFrame()).onset).toBe(false);
+    }
+
+    // Real speech arrives — onset should flip within a couple of frames.
+    let fired = false;
+    for (let frame = 0; frame < 3 && !fired; frame += 1) {
+      fired = detector.accept(sineFrame(0.1)).onset;
+    }
+    expect(fired).toBe(true);
+  });
+
+  it("calibrates above a WebKit-style noise floor and only fires on speech", () => {
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+
+    // WebKit warm-up: low-level noise floor + DC bias, NOT exact zeros.
+    // The old `!== 0` predicate fired here; the RMS gate must not.
+    for (let frame = 0; frame < 4; frame += 1) {
+      expect(detector.accept(sineFrame(0.003, 0.0015)).onset).toBe(false);
+    }
+
+    // Louder speech clears the calibrated threshold.
+    let fired = false;
+    for (let frame = 0; frame < 3 && !fired; frame += 1) {
+      fired = detector.accept(sineFrame(0.1)).onset;
+    }
+    expect(fired).toBe(true);
+  });
+
+  it("clamps epsilon into [epsilonMin, epsilonMax]", () => {
+    // Very loud 'floor' → epsilon would exceed the max → clamped down.
+    const loud = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+    let loudEpsilon: number | null = null;
+    for (let frame = 0; frame < 4 && loudEpsilon === null; frame += 1) {
+      loudEpsilon = loud.accept(sineFrame(0.5)).epsilon;
+    }
+    expect(loudEpsilon).toBe(ONSET_TUNING.epsilonMax);
+
+    // Silent floor → epsilon would be 0 → clamped up to the min.
+    const quiet = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+    let quietEpsilon: number | null = null;
+    for (let frame = 0; frame < 4 && quietEpsilon === null; frame += 1) {
+      quietEpsilon = quiet.accept(zeroFrame()).epsilon;
+    }
+    expect(quietEpsilon).toBe(ONSET_TUNING.epsilonMin);
+  });
+
+  it("force-flips via max-hold when the input is near-silent forever", () => {
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+
+    // Always below threshold: an RMS gate can never trip here, so without
+    // max-hold the spinner would hang. It must flip once enough audio has
+    // flowed (~maxHoldMs).
+    const maxHoldFrames = Math.ceil(
+      ((ONSET_TUNING.maxHoldMs / 1000) * SAMPLE_RATE) / FRAME_SIZE,
+    );
+    let firedFrame = -1;
+    for (let frame = 0; frame < maxHoldFrames + 3; frame += 1) {
+      if (detector.accept(sineFrame(0.001)).onset) {
+        firedFrame = frame;
+        break;
+      }
+    }
+    expect(firedFrame).toBeGreaterThanOrEqual(maxHoldFrames - 1);
+    expect(firedFrame).toBeLessThanOrEqual(maxHoldFrames + 1);
+  });
+
+  it("runs the adaptive floor path at a true 16 kHz track rate (regression)", () => {
+    // At 16 kHz one 4096-sample frame is 256 ms — longer than the 200 ms
+    // calibration window. Crediting time per frame would skip calibration
+    // entirely and fall back to the fixed epsilon; per-sub-window timing
+    // must keep the adaptive clamp(floor × 2.75) path live. The floor here
+    // is chosen so the adaptive epsilon lands strictly inside the clamp
+    // band and is distinct from the fixed fallback.
+    for (const rate of [16_000, 48_000]) {
+      const detector = createOnsetDetector({ sampleRate: rate });
+      const amplitude = 0.004 * Math.SQRT2; // RMS ≈ 0.004 → epsilon ≈ 0.011
+      let epsilon: number | null = null;
+      for (let frame = 0; frame < 8 && epsilon === null; frame += 1) {
+        epsilon = detector.accept(sineFrame(amplitude, 0, FRAME_SIZE)).epsilon;
+      }
+      expect(epsilon).not.toBeNull();
+      expect(epsilon).not.toBe(ONSET_TUNING.fixedFallbackEpsilon);
+      expect(epsilon).toBeGreaterThan(ONSET_TUNING.epsilonMin);
+      expect(epsilon).toBeLessThan(ONSET_TUNING.epsilonMax);
+    }
+  });
+
+  it("survives non-finite samples without wedging epsilon (max-hold still fires)", () => {
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+    const poison = new Float32Array(FRAME_SIZE).fill(Number.NaN);
+    let fired = false;
+    for (let frame = 0; frame < 12 && !fired; frame += 1) {
+      fired = detector.accept(poison).onset;
+    }
+    // A NaN stream can never cross a threshold, but max-hold must still flip.
+    expect(fired).toBe(true);
+  });
+
+  it("reports onset exactly once", () => {
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+    for (let frame = 0; frame < 3; frame += 1) {
+      detector.accept(zeroFrame());
+    }
+    let onsetCount = 0;
+    for (let frame = 0; frame < 10; frame += 1) {
+      if (detector.accept(sineFrame(0.1)).onset) {
+        onsetCount += 1;
+      }
+    }
+    expect(onsetCount).toBe(1);
+  });
+
+  it("sub-windows correctly across ragged frame lengths", () => {
+    // Feeding odd-length frames must not desync the sub-window boundaries.
+    const detector = createOnsetDetector({ sampleRate: SAMPLE_RATE });
+    for (let frame = 0; frame < 6; frame += 1) {
+      detector.accept(zeroFrame(777));
+    }
+    let fired = false;
+    for (let frame = 0; frame < 20 && !fired; frame += 1) {
+      fired = detector.accept(sineFrame(0.1, 0, 777)).onset;
+    }
+    expect(fired).toBe(true);
+  });
+});

--- a/frontend/src/hooks/audio/__tests__/onsetFlipController.test.ts
+++ b/frontend/src/hooks/audio/__tests__/onsetFlipController.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MIN_AUDIO_CAPTURE_DELAY_MS, ONSET_TUNING } from "../audioTuning";
+import { createSpeechOnsetController } from "../onsetFlipController";
+
+const SAMPLE_RATE = 48_000;
+const FRAME_SIZE = 4096;
+
+function zeroFrame() {
+  return new Float32Array(FRAME_SIZE);
+}
+
+function loudFrame() {
+  const frame = new Float32Array(FRAME_SIZE);
+  for (let i = 0; i < FRAME_SIZE; i += 1) {
+    frame[i] = 0.1 * Math.sin((2 * Math.PI * 440 * i) / SAMPLE_RATE);
+  }
+  return frame;
+}
+
+/** Feeds calibration zeros + a loud frame; onset fires within the loud one. */
+function driveToOnset(controller: { acceptFrame: (f: Float32Array) => void }) {
+  controller.acceptFrame(zeroFrame());
+  controller.acceptFrame(zeroFrame());
+  controller.acceptFrame(zeroFrame());
+  controller.acceptFrame(loudFrame());
+}
+
+describe("createSpeechOnsetController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("force-flips via the wall-clock backstop when no frames ever arrive (G1)", () => {
+    const onFlip = vi.fn();
+    createSpeechOnsetController({ sampleRate: SAMPLE_RATE, onFlip });
+
+    // No frames at all — the audio-time max-hold can never advance.
+    expect(onFlip).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(ONSET_TUNING.wallClockBackstopMs);
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose cancels the pending backstop (no flip after teardown)", () => {
+    const onFlip = vi.fn();
+    const controller = createSpeechOnsetController({
+      sampleRate: SAMPLE_RATE,
+      onFlip,
+    });
+
+    controller.dispose();
+    vi.advanceTimersByTime(ONSET_TUNING.wallClockBackstopMs * 2);
+    expect(onFlip).not.toHaveBeenCalled();
+  });
+
+  it("flips once on real onset after the deferral, and cancels the backstop", () => {
+    const onFlip = vi.fn();
+    const controller = createSpeechOnsetController({
+      sampleRate: SAMPLE_RATE,
+      onFlip,
+    });
+
+    driveToOnset(controller);
+    // Onset reached, but the cue is deferred by the min-capture-delay floor.
+    expect(onFlip).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(MIN_AUDIO_CAPTURE_DELAY_MS);
+    expect(onFlip).toHaveBeenCalledTimes(1);
+
+    // Backstop must have been cancelled by the real onset — no second flip.
+    vi.advanceTimersByTime(ONSET_TUNING.wallClockBackstopMs);
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores frames after onset (fire-once)", () => {
+    const onFlip = vi.fn();
+    const controller = createSpeechOnsetController({
+      sampleRate: SAMPLE_RATE,
+      onFlip,
+    });
+
+    driveToOnset(controller);
+    vi.advanceTimersByTime(MIN_AUDIO_CAPTURE_DELAY_MS);
+    expect(onFlip).toHaveBeenCalledTimes(1);
+
+    controller.acceptFrame(loudFrame());
+    controller.acceptFrame(loudFrame());
+    vi.advanceTimersByTime(MIN_AUDIO_CAPTURE_DELAY_MS);
+    expect(onFlip).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes the diagnostics sink per frame until onset, then stops", () => {
+    const log = vi.fn();
+    const controller = createSpeechOnsetController({
+      sampleRate: SAMPLE_RATE,
+      onFlip: vi.fn(),
+      log,
+    });
+
+    // 3 calibration zeros + 1 loud frame that triggers onset = 4 evaluations.
+    driveToOnset(controller);
+    expect(log).toHaveBeenCalledTimes(4);
+    const sample = log.mock.calls[0][0];
+    expect(sample).toHaveProperty("rms");
+    expect(sample).toHaveProperty("epsilon");
+    expect(sample).toHaveProperty("phase");
+
+    // Post-onset frames are short-circuited before the detector / sink run.
+    controller.acceptFrame(loudFrame());
+    expect(log).toHaveBeenCalledTimes(4);
+  });
+});

--- a/frontend/src/hooks/audio/__tests__/useAudioContextInterruptionRecovery.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useAudioContextInterruptionRecovery.test.ts
@@ -1,0 +1,136 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAudioContextInterruptionRecovery } from "../useAudioContextInterruptionRecovery";
+
+const SAFARI_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+const CHROME_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
+
+type FakeContext = {
+  state: AudioContextState;
+  resume: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  emit: (type: string) => void;
+};
+
+function makeContext(state: AudioContextState): FakeContext {
+  const handlers: Record<string, Array<() => void>> = {};
+  return {
+    state,
+    resume: vi.fn(() => Promise.resolve()),
+    addEventListener: vi.fn((type: string, handler: () => void) => {
+      (handlers[type] ??= []).push(handler);
+    }),
+    removeEventListener: vi.fn((type: string, handler: () => void) => {
+      handlers[type] = (handlers[type] ?? []).filter((h) => h !== handler);
+    }),
+    emit: (type: string) => (handlers[type] ?? []).forEach((h) => h()),
+  };
+}
+
+function renderRecovery(context: FakeContext, processor: unknown) {
+  const audioContextRef = { current: context as unknown as AudioContext };
+  const audioProcessorRef = {
+    current: processor as AudioWorkletNode | null,
+  };
+  const hook = renderHook(() =>
+    useAudioContextInterruptionRecovery({ audioContextRef, audioProcessorRef }),
+  );
+  return { hook, audioContextRef, audioProcessorRef };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useAudioContextInterruptionRecovery on WebKit", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { userAgent: SAFARI_UA });
+  });
+
+  it("resumes a suspended context on statechange during an active capture", () => {
+    const ctx = makeContext("suspended");
+    const { hook } = renderRecovery(ctx, {});
+    hook.result.current.attachStateChangeListener(
+      ctx as unknown as AudioContext,
+    );
+
+    expect(ctx.addEventListener).toHaveBeenCalledWith(
+      "statechange",
+      expect.any(Function),
+    );
+    ctx.emit("statechange");
+    expect(ctx.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT resume when no capture is active (processor null)", () => {
+    const ctx = makeContext("suspended");
+    const { hook } = renderRecovery(ctx, null);
+    hook.result.current.attachStateChangeListener(
+      ctx as unknown as AudioContext,
+    );
+
+    ctx.emit("statechange");
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+
+  it("does NOT resume when the context is already running", () => {
+    const ctx = makeContext("running");
+    const { hook } = renderRecovery(ctx, {});
+    hook.result.current.attachStateChangeListener(
+      ctx as unknown as AudioContext,
+    );
+
+    ctx.emit("statechange");
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+
+  it("resumes on visibilitychange when suspended + active", () => {
+    const ctx = makeContext("suspended");
+    renderRecovery(ctx, {});
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(ctx.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes both listeners on unmount and stops resuming", () => {
+    const ctx = makeContext("suspended");
+    const { hook } = renderRecovery(ctx, {});
+    hook.result.current.attachStateChangeListener(
+      ctx as unknown as AudioContext,
+    );
+
+    hook.unmount();
+    expect(ctx.removeEventListener).toHaveBeenCalledWith(
+      "statechange",
+      expect.any(Function),
+    );
+
+    ctx.resume.mockClear();
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAudioContextInterruptionRecovery on non-WebKit", () => {
+  it("attaches no listeners on Chromium", () => {
+    vi.stubGlobal("navigator", { userAgent: CHROME_UA });
+    const documentAdd = vi.spyOn(document, "addEventListener");
+
+    const ctx = makeContext("suspended");
+    const { hook } = renderRecovery(ctx, {});
+    hook.result.current.attachStateChangeListener(
+      ctx as unknown as AudioContext,
+    );
+
+    expect(ctx.addEventListener).not.toHaveBeenCalled();
+    expect(documentAdd).not.toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.anything(),
+    );
+  });
+});

--- a/frontend/src/hooks/audio/audio-dictation-worklet.ts
+++ b/frontend/src/hooks/audio/audio-dictation-worklet.ts
@@ -30,15 +30,71 @@ const FRAME_SIZE = 4096;
 class AudioDictationProcessor extends AudioWorkletProcessor {
   private readonly buffer = new Float32Array(FRAME_SIZE);
   private writeIndex = 0;
+  // Reused mono down-mix scratch; resized only when the render quantum
+  // length changes (it's normally a stable 128).
+  private monoScratch = new Float32Array(0);
+
+  /**
+   * Reduces the input channels to a single mono Float32 frame. Safari
+   * returns a STEREO MediaStream when `echoCancellation: false` even with
+   * `channelCount: { ideal: 1 }`, so reading channel 0 alone would drop
+   * half the signal; mean-of-channels is correct everywhere. Guards
+   * ragged/empty channels (Firefox warm-up can hand back zero-length or
+   * unequal-length channel arrays) by using each channel's own length, so
+   * a short channel never reads out of bounds. Returns `null` when there's
+   * no audio to emit yet.
+   */
+  private downmixToMono(channels: Float32Array[]): Float32Array | null {
+    let frameLength = 0;
+    for (let channelIndex = 0; channelIndex < channels.length; channelIndex++) {
+      const length = channels[channelIndex]?.length ?? 0;
+      if (length > frameLength) {
+        frameLength = length;
+      }
+    }
+    if (frameLength === 0) {
+      return null;
+    }
+    // Single-channel fast path — no averaging, no allocation.
+    if (channels.length === 1) {
+      return channels[0];
+    }
+    if (this.monoScratch.length !== frameLength) {
+      this.monoScratch = new Float32Array(frameLength);
+    }
+    const mono = this.monoScratch;
+    for (let index = 0; index < frameLength; index++) {
+      let sum = 0;
+      let contributing = 0;
+      for (
+        let channelIndex = 0;
+        channelIndex < channels.length;
+        channelIndex++
+      ) {
+        const channel = channels[channelIndex];
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (channel !== undefined && index < channel.length) {
+          sum += channel[index];
+          contributing += 1;
+        }
+      }
+      mono[index] = contributing > 0 ? sum / contributing : 0;
+    }
+    return mono;
+  }
 
   process(inputs: Float32Array[][]): boolean {
-    const channel: Float32Array | undefined = inputs[0]?.[0];
+    const channels: Float32Array[] | undefined = inputs[0];
     // Defensive against `process()` firing in the brief window between
     // `new AudioWorkletNode(...)` and `source.connect(processor)` where no
     // input channels exist yet, and against the Firefox warm-up window
     // where `inputs[0]` is an empty sequence.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (channel === undefined || channel.length === 0) {
+    if (channels === undefined || channels.length === 0) {
+      return true;
+    }
+    const mono = this.downmixToMono(channels);
+    if (mono === null) {
       return true;
     }
 
@@ -47,14 +103,14 @@ class AudioDictationProcessor extends AudioWorkletProcessor {
     // Server-side VAD needs that leading-silence calibration window to
     // detect speech onset cleanly; trimming it client-side (as we tried
     // previously) makes streaming STT engines drop the first word.
-    // Non-zero detection for the UI "speak now" signal lives in the main
-    // thread's `port.onmessage` handler instead.
+    // Speech-onset detection for the UI "speak now" signal lives in the
+    // main thread's `port.onmessage` handler instead.
     let sourceIndex = 0;
-    while (sourceIndex < channel.length) {
+    while (sourceIndex < mono.length) {
       const remaining = FRAME_SIZE - this.writeIndex;
-      const copyCount = Math.min(remaining, channel.length - sourceIndex);
+      const copyCount = Math.min(remaining, mono.length - sourceIndex);
       this.buffer.set(
-        channel.subarray(sourceIndex, sourceIndex + copyCount),
+        mono.subarray(sourceIndex, sourceIndex + copyCount),
         this.writeIndex,
       );
       this.writeIndex += copyCount;

--- a/frontend/src/hooks/audio/audio-pcm-codec.ts
+++ b/frontend/src/hooks/audio/audio-pcm-codec.ts
@@ -106,6 +106,40 @@ export function resampleMonoFloat32ToPcm16(
   return pcmBytes;
 }
 
+/**
+ * Root-mean-square amplitude of a Float32 PCM window with its DC
+ * component (mean) removed first. DC removal matters on WebKit/Safari
+ * raw capture (echoCancellation/noiseSuppression/autoGainControl all
+ * off), whose warm-up emits a low-level DC bias rather than bit-exact
+ * zeros — a naive RMS would read that bias as energy and trip a
+ * speech-onset gate on silence. Returns a normalized amplitude in
+ * roughly [0, 1] for inputs in [-1, 1].
+ *
+ * Pure and allocation-free over a subarray view — safe to call per
+ * sub-window in a hot audio loop. Reused by the onset detector
+ * (ERMAIN-379) and the mic-quality probe (ERMAIN-380).
+ */
+export function removeDcAndRms(samples: Float32Array): number {
+  const sampleCount = samples.length;
+  if (sampleCount === 0) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (let index = 0; index < sampleCount; index += 1) {
+    sum += samples[index];
+  }
+  const mean = sum / sampleCount;
+
+  let squaredTotal = 0;
+  for (let index = 0; index < sampleCount; index += 1) {
+    const centered = samples[index] - mean;
+    squaredTotal += centered * centered;
+  }
+
+  return Math.sqrt(squaredTotal / sampleCount);
+}
+
 export function mediaTrackSettingsToDiagnostics(
   settings: MediaTrackSettings,
 ): AudioDictationDiagnostics {

--- a/frontend/src/hooks/audio/audioEnvironment.ts
+++ b/frontend/src/hooks/audio/audioEnvironment.ts
@@ -1,0 +1,108 @@
+/**
+ * Browser-engine → named audio-capture capability flags.
+ *
+ * The goal is no raw `if (isSafari)` at call sites in the recorder hooks:
+ * every engine quirk is a named flag, paired with its evidence and an
+ * expiry/removal condition, so a future reader knows *why* the branch
+ * exists and *when* it can be deleted. Pure and userAgent-injectable, so
+ * it unit-tests without a DOM. Mirrors the `isAudioCaptureSupportedPlatform`
+ * capability-probe precedent in `office-addin/src/providers/OfficeProvider.tsx`.
+ *
+ * Scope note (ERMAIN-379): this module covers *audio-capture* engine
+ * quirks only. The Firefox `NetworkError` check in `hooks/files/errors.ts`
+ * is a file-upload concern (opaque NetworkError → treat as HTTP 413), not
+ * audio, so it deliberately stays put rather than being folded in here.
+ */
+
+export type BrowserEngine = "webkit" | "firefox" | "chromium" | "unknown";
+
+export type AudioEnvironment = {
+  engine: BrowserEngine;
+
+  /**
+   * The raw-capture path (echoCancellation/noiseSuppression/autoGainControl
+   * all off) emits a low-level noise floor / DC bias at stream start
+   * instead of bit-exact zeros. An exact-zero onset predicate trips on
+   * this warm-up floor ~1 s before real speech; the RMS onset detector
+   * calibrates above it.
+   *
+   * Evidence: ERMAIN-379 `[AUDIO_DICT]` instrumentation, Chrome vs desktop
+   * Safari, 2026-06. Chrome warm-up is bit-exact zeros; WebKit is not.
+   * Remove if WebKit ships bit-exact-zero warm-up (re-validate on a real
+   * device before deleting — the simulator can emit synthetic zeros).
+   */
+  warmUpEmitsNoiseFloor: boolean;
+
+  /**
+   * May hand back a stereo MediaStream even when `channelCount: { ideal: 1 }`
+   * is requested with echoCancellation disabled. The worklet down-mixes
+   * mean-of-channels unconditionally, so this is informational/diagnostic.
+   *
+   * Evidence: WebKit raw-capture behaviour, observed 2026-06 (ERMAIN-379
+   * Step 2). Remove if WebKit honours the mono constraint with AEC off.
+   */
+  mayReturnStereoWithoutEchoCancellation: boolean;
+
+  /**
+   * An AudioContext can wedge in an `"interrupted"` / `"suspended"` state
+   * (phone call, Siri, tab backgrounding) and not auto-resume, leaving a
+   * dead capture graph. A `statechange` / `visibilitychange` re-resume is
+   * the cheap mitigation (gated to an active session so it never wakes an
+   * intentionally idle-suspended context).
+   *
+   * Evidence: WebKit `"interrupted"` state — WebAudio issue #2585 (2024),
+   * https://github.com/WebAudio/web-audio-api/issues/2585. Android Chrome
+   * is at desktop parity and does not need this. Remove when WebKit
+   * reliably auto-resumes after interruption.
+   */
+  needsGestureResume: boolean;
+};
+
+/**
+ * Classifies a userAgent string into a rendering engine. All browsers on
+ * iOS are WebKit regardless of brand, so iOS device tokens classify as
+ * `webkit` even for "Chrome"/"Firefox" on iOS.
+ */
+export function detectBrowserEngine(userAgent: string): BrowserEngine {
+  const ua = userAgent.toLowerCase();
+  const isIos = /\bip(?:hone|ad|od)\b/.test(ua);
+
+  if (ua.includes("firefox") || ua.includes("fxios")) {
+    return isIos ? "webkit" : "firefox";
+  }
+  if (ua.includes("chrome") || ua.includes("chromium") || ua.includes("crios")) {
+    return isIos ? "webkit" : "chromium";
+  }
+  // Any remaining Safari token classifies as WebKit. This also covers
+  // iPadOS 13+ "desktop" Safari, which reports a Macintosh UA but still
+  // carries the Safari token — so no maxTouchPoints disambiguation is
+  // needed (every real iOS/iPadOS browser's UA contains a Safari token).
+  if (ua.includes("safari") || isIos) {
+    return "webkit";
+  }
+  return "unknown";
+}
+
+/** Derives the capability flags for a given engine. Pure. */
+export function audioEnvironmentForEngine(
+  engine: BrowserEngine,
+): AudioEnvironment {
+  const isWebKit = engine === "webkit";
+  return {
+    engine,
+    warmUpEmitsNoiseFloor: isWebKit,
+    mayReturnStereoWithoutEchoCancellation: isWebKit,
+    needsGestureResume: isWebKit,
+  };
+}
+
+/**
+ * Resolves the audio environment from a userAgent string (defaults to the
+ * live `navigator`). Returns the `unknown` (all-flags-false) environment in
+ * a non-browser context.
+ */
+export function getAudioEnvironment(userAgent?: string): AudioEnvironment {
+  const ua =
+    userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
+  return audioEnvironmentForEngine(detectBrowserEngine(ua));
+}

--- a/frontend/src/hooks/audio/audioEnvironment.ts
+++ b/frontend/src/hooks/audio/audioEnvironment.ts
@@ -35,8 +35,13 @@ export type AudioEnvironment = {
 
   /**
    * May hand back a stereo MediaStream even when `channelCount: { ideal: 1 }`
-   * is requested with echoCancellation disabled. The worklet down-mixes
-   * mean-of-channels unconditionally, so this is informational/diagnostic.
+   * is requested with echoCancellation disabled.
+   *
+   * DOCUMENTATION-ONLY: this flag has no runtime consumer. The worklet
+   * down-mixes mean-of-channels unconditionally (which is correct on every
+   * engine), so nothing branches on it; it exists to record the WebKit
+   * quirk that motivated the unconditional down-mix. If a future code path
+   * needs to branch on stereo capture, wire it here.
    *
    * Evidence: WebKit raw-capture behaviour, observed 2026-06 (ERMAIN-379
    * Step 2). Remove if WebKit honours the mono constraint with AEC off.
@@ -70,7 +75,11 @@ export function detectBrowserEngine(userAgent: string): BrowserEngine {
   if (ua.includes("firefox") || ua.includes("fxios")) {
     return isIos ? "webkit" : "firefox";
   }
-  if (ua.includes("chrome") || ua.includes("chromium") || ua.includes("crios")) {
+  if (
+    ua.includes("chrome") ||
+    ua.includes("chromium") ||
+    ua.includes("crios")
+  ) {
     return isIos ? "webkit" : "chromium";
   }
   // Any remaining Safari token classifies as WebKit. This also covers
@@ -80,6 +89,11 @@ export function detectBrowserEngine(userAgent: string): BrowserEngine {
   if (ua.includes("safari") || isIos) {
     return "webkit";
   }
+  // Fail open to "unknown" → all capability flags false → treated like
+  // Chromium (no WebKit hardening). A WebKit webview with a stripped custom
+  // UA (no Safari token, no ip(hone|ad|od) token) would miss the hardening,
+  // but every mainstream browser carries one of those tokens and the add-in
+  // already blocks audio on Mac WKWebView, so the practical risk is nil.
   return "unknown";
 }
 

--- a/frontend/src/hooks/audio/audioTuning.ts
+++ b/frontend/src/hooks/audio/audioTuning.ts
@@ -75,7 +75,13 @@ export const ONSET_TUNING = {
   /** Lower clamp on epsilon (~−42 dBFS) — never trust a floor below this. */
   epsilonMin: 0.008,
 
-  /** Upper clamp on epsilon (~−34 dBFS) — a very noisy room still flips. */
+  /**
+   * Upper clamp on epsilon (~−34 dBFS) — a very noisy room still flips.
+   * Tradeoff (G6): in a room whose noise floor exceeds ~0.02 RMS, the cue
+   * can early-fire on background noise (epsilon is capped below the floor).
+   * Bounded and no worse than the old Chromium behaviour; revisit only if
+   * UX flags false-positive onsets in loud environments.
+   */
   epsilonMax: 0.02,
 
   /**
@@ -96,8 +102,28 @@ export const ONSET_TUNING = {
    * can never trip on a near-silent input, so without this the spinner
    * would hang forever (UI-only, no data loss, but looks broken). Force
    * the onset flip after this much flowing audio regardless.
+   *
+   * NOTE: this is measured in AUDIO time — it only advances while the
+   * worklet keeps posting frames. If frames stall entirely before onset
+   * (a missed interruption, a stalled/ended track), this never fires; the
+   * wall-clock backstop below is the frame-independent guarantee.
    */
   maxHoldMs: 800,
+
+  /**
+   * Frame-independent wall-clock backstop for the "speak now" cue (G1).
+   * `maxHoldMs` lives in audio time and freezes if frames stop arriving,
+   * so a stalled capture would hang the spinner forever. This timer is
+   * armed once at controller construction and force-flips the cue if
+   * onset still hasn't fired. Set above `maxHoldMs` + first-frame latency
+   * so the normal audio-time path always wins under live frame flow; it
+   * only fires when delivery has genuinely stalled.
+   *
+   * Caveat: this only resolves the *cue*; it cannot tell a dead capture
+   * from a flowing-but-quiet one — that needs track-health handling
+   * (tracked separately as the device-loss follow-up).
+   */
+  wallClockBackstopMs: 1_200,
 } as const;
 
 export type OnsetTuning = typeof ONSET_TUNING;

--- a/frontend/src/hooks/audio/audioTuning.ts
+++ b/frontend/src/hooks/audio/audioTuning.ts
@@ -1,0 +1,103 @@
+/**
+ * Centralized, annotated tunables for the client-side audio-capture
+ * pipeline. These are properties of the browser onset-detection
+ * algorithm — identical across every deployment — not cost/policy
+ * levers, so they live here as frontend constants rather than being
+ * plumbed through `erato.toml`. (Investigated on ERMAIN-379: the backend
+ * `AudioTranscriptionConfig` carries only server-side STT/LLM tuning; no
+ * onset/VAD/calibration field exists, and only `enabled` +
+ * `max_recording_duration_seconds` ever reach the frontend.)
+ *
+ * Pure data — no React, no DOM — shared by both recorder hooks and the
+ * pure `onsetDetector` state machine. ERMAIN-380 (mic-quality probe)
+ * reuses the same RMS/onset math, so keep the knobs in one place.
+ */
+
+/**
+ * Synthetic silence prefix prepended to every session before captured
+ * audio. Mirrors what production streaming-STT VADs require for
+ * speech-onset calibration (OpenAI Realtime `prefix_padding_ms` defaults
+ * to 300 ms; Silero `speech_pad_ms` / sherpa-onnx pre-speech padding land
+ * in the same range). Without it, a back-to-back second dictation finds
+ * the OS audio device still hot, ships near-zero leading silence, and the
+ * server's VAD trims the first word (ERMAIN-334).
+ */
+export const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
+
+/**
+ * Floor between `source.connect(processor)` and the visible
+ * `isCapturingAudio` flip. On a fully-warm audio device the onset signal
+ * can arrive in tens of milliseconds — fast enough that the spinner feels
+ * like a blink and the user starts speaking before finishing the priming
+ * breath. Holding the spinner at least this long gives a consistent
+ * visual rhythm across cold and warm sessions.
+ */
+export const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
+
+/**
+ * Tunables for the RMS-based speech-onset detector (ERMAIN-379). The
+ * detector replaced an exact-zero predicate (`sample !== 0`) that
+ * mistimed on WebKit/Safari, whose raw-capture path emits a low-level
+ * noise floor / DC bias at stream start instead of bit-exact zeros, so
+ * the old cue tripped on the warm-up floor ~1 s before real speech.
+ */
+export const ONSET_TUNING = {
+  /**
+   * Sub-window size (samples) for RMS. A received frame is 4096 samples
+   * at the *track* sample rate, so one frame is ~85 ms at a 48 k track
+   * but ~256 ms at a true-16 k track. Per-frame RMS would lag and average
+   * short onsets away on 16 k devices; 512-sample sub-windows (~11–32 ms)
+   * keep onset detection responsive regardless of track rate. 4096 is an
+   * exact multiple of 512, so frames sub-divide cleanly.
+   */
+  subWindowSamples: 512,
+
+  /**
+   * Noise-floor calibration window, measured against the real incoming
+   * captured frames (OS warm-up / room tone). Note the 300 ms primer is
+   * injected zeros prepended only to the *server* stream and the 150 ms
+   * min-delay only defers *displaying* the cue — neither buys real
+   * calibration dead-time, so this window can overlap speech on a warm
+   * back-to-back session where the user speaks immediately. In that case
+   * the measured floor is inflated; the epsilon clamp (≤ 0.02) and the
+   * 800 ms max-hold bound the resulting late-fire.
+   */
+  calibrationMs: 200,
+
+  /**
+   * epsilon = clamp(floorRMS × floorMultiplier, epsilonMin, epsilonMax).
+   * 2.75× sits comfortably above a measured floor without reaching speech
+   * energy. (The originally proposed 0.005–0.01 fixed threshold was too
+   * low — it overlapped a noisy-room floor and re-introduced early-fire.)
+   */
+  floorMultiplier: 2.75,
+
+  /** Lower clamp on epsilon (~−42 dBFS) — never trust a floor below this. */
+  epsilonMin: 0.008,
+
+  /** Upper clamp on epsilon (~−34 dBFS) — a very noisy room still flips. */
+  epsilonMax: 0.02,
+
+  /**
+   * Fixed epsilon (≈ −37 dBFS) used when no calibration window is
+   * captured (e.g. the first sub-window already exceeds threshold).
+   */
+  fixedFallbackEpsilon: 0.014,
+
+  /**
+   * Consecutive over-threshold sub-windows required to declare onset
+   * (~22–64 ms depending on track rate). Debounces single-sub-window
+   * transients.
+   */
+  consecutiveSubWindowsToFlip: 2,
+
+  /**
+   * Mandatory max-hold fallback. Unlike the old `!== 0` test, an RMS gate
+   * can never trip on a near-silent input, so without this the spinner
+   * would hang forever (UI-only, no data loss, but looks broken). Force
+   * the onset flip after this much flowing audio regardless.
+   */
+  maxHoldMs: 800,
+} as const;
+
+export type OnsetTuning = typeof ONSET_TUNING;

--- a/frontend/src/hooks/audio/onsetDetector.ts
+++ b/frontend/src/hooks/audio/onsetDetector.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure speech-onset state machine (ERMAIN-379). Replaces the exact-zero
+ * predicate (`sample !== 0`) that gated the UI "speak now" cue
+ * (`isCapturingAudio`). Exact-zero detection assumes silence == digital
+ * zero — true on Chromium's capture pipeline, but FALSE on WebKit/Safari
+ * raw capture, which emits a low-level noise floor / DC bias at stream
+ * start, so the old cue tripped ~1 s before real speech.
+ *
+ * The machine runs in three phases:
+ *   1. calibrate — measure the noise-floor RMS over the first
+ *      `calibrationMs` of real incoming audio, then derive an adaptive
+ *      `epsilon` threshold above it.
+ *   2. listen — flip onset after `consecutiveSubWindowsToFlip` sub-windows
+ *      whose DC-removed RMS clears `epsilon`.
+ *   3. max-hold — if neither happens (a near-silent input an RMS gate can
+ *      never trip), force the flip after `maxHoldMs` so the spinner can
+ *      never hang.
+ *
+ * No DOM, no React, no `Date.now()` — time is derived from the running
+ * sample count, so the detector is fully deterministic and unit-testable
+ * against recorded warm-up vs speech fixtures. It gates ONLY the UI cue;
+ * it never sees or alters the bytes streamed to the server.
+ */
+
+import { removeDcAndRms } from "./audio-pcm-codec";
+import { ONSET_TUNING, type OnsetTuning } from "./audioTuning";
+
+export type OnsetPhase = "calibrating" | "listening" | "fired";
+
+export type OnsetFrameOutcome = {
+  /** Detector phase after consuming this frame. */
+  phase: OnsetPhase;
+  /** True on exactly the one frame whose processing triggers the onset. */
+  onset: boolean;
+  /** Highest sub-window RMS observed in this frame (diagnostics only). */
+  frameRms: number;
+  /** Chosen threshold once calibration completes; `null` while calibrating. */
+  epsilon: number | null;
+};
+
+export type OnsetDetector = {
+  /**
+   * Feed one received PCM frame (Float32, any length). Returns the
+   * detector state after consuming it; `onset` is true on exactly one
+   * call. Cheap to keep calling after onset (returns immediately).
+   */
+  accept: (frame: Float32Array) => OnsetFrameOutcome;
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function createOnsetDetector(options: {
+  sampleRate: number;
+  tuning?: OnsetTuning;
+}): OnsetDetector {
+  const tuning = options.tuning ?? ONSET_TUNING;
+  const sampleRate = options.sampleRate > 0 ? options.sampleRate : 1;
+  const subWindowSamples = Math.max(1, tuning.subWindowSamples);
+
+  // Holds samples that didn't fill a complete sub-window on the previous
+  // frame, so sub-windowing is robust to any frame length / boundary.
+  const pending = new Float32Array(subWindowSamples);
+  let pendingCount = 0;
+
+  // Time is measured by sub-windows actually evaluated, NOT by raw frame
+  // length. A received frame is 4096 samples = 256 ms at a 16 k track, so
+  // crediting a whole frame before evaluating its first sub-window would
+  // push `elapsedMs()` past `calibrationMs` (200 ms) before a single
+  // calibration sample is taken — the adaptive floor would never run and
+  // every onset would fall back to the fixed epsilon. Counting per
+  // sub-window keeps calibration live at every track rate.
+  let samplesProcessed = 0;
+  let phase: OnsetPhase = "calibrating";
+  let epsilon: number | null = null;
+
+  let floorSum = 0;
+  let floorCount = 0;
+  let consecutiveOverThreshold = 0;
+  // Highest sub-window RMS seen within the frame currently being consumed.
+  let lastRms = 0;
+
+  const elapsedMs = () => (samplesProcessed / sampleRate) * 1000;
+
+  const finalizeCalibration = () => {
+    epsilon =
+      floorCount > 0
+        ? clamp(
+            (floorSum / floorCount) * tuning.floorMultiplier,
+            tuning.epsilonMin,
+            tuning.epsilonMax,
+          )
+        : tuning.fixedFallbackEpsilon;
+    phase = "listening";
+  };
+
+  // Processes one complete sub-window; returns true if it triggers onset.
+  const processSubWindow = (subWindow: Float32Array): boolean => {
+    // Credit this sub-window's audio to the clock as it is evaluated, so
+    // calibration / max-hold thresholds advance at sub-window granularity.
+    samplesProcessed += subWindowSamples;
+
+    const rms = removeDcAndRms(subWindow);
+    // Guard against a non-finite sample poisoning the running floor sum (and
+    // thus epsilon) for the rest of the session: skip the sub-window but
+    // still let the clock advance so max-hold can fire. Web Audio capture
+    // floats are spec'd finite, so this is belt-and-braces.
+    if (!Number.isFinite(rms)) {
+      return elapsedMs() >= tuning.maxHoldMs ? ((phase = "fired"), true) : false;
+    }
+    lastRms = Math.max(lastRms, rms);
+
+    if (phase === "calibrating") {
+      if (elapsedMs() < tuning.calibrationMs) {
+        floorSum += rms;
+        floorCount += 1;
+        return false;
+      }
+      // Calibration window elapsed — derive epsilon and evaluate this
+      // same sub-window against it rather than discarding it.
+      finalizeCalibration();
+    }
+
+    if (phase === "listening" && epsilon !== null) {
+      if (rms >= epsilon) {
+        consecutiveOverThreshold += 1;
+        if (consecutiveOverThreshold >= tuning.consecutiveSubWindowsToFlip) {
+          phase = "fired";
+          return true;
+        }
+      } else {
+        consecutiveOverThreshold = 0;
+      }
+    }
+
+    // Max-hold: an RMS gate can never trip on near-silent input, so force
+    // the flip regardless once enough audio has flowed.
+    if (elapsedMs() >= tuning.maxHoldMs) {
+      phase = "fired";
+      return true;
+    }
+
+    return false;
+  };
+
+  return {
+    accept(frame: Float32Array): OnsetFrameOutcome {
+      lastRms = 0;
+      if (phase === "fired") {
+        return { phase, onset: false, frameRms: 0, epsilon };
+      }
+
+      let onset = false;
+
+      let sourceIndex = 0;
+      while (sourceIndex < frame.length) {
+        const copyCount = Math.min(
+          subWindowSamples - pendingCount,
+          frame.length - sourceIndex,
+        );
+        pending.set(
+          frame.subarray(sourceIndex, sourceIndex + copyCount),
+          pendingCount,
+        );
+        pendingCount += copyCount;
+        sourceIndex += copyCount;
+
+        if (pendingCount === subWindowSamples) {
+          // `processSubWindow` flips at most once; keep draining the rest
+          // of the frame into `pending` but stop evaluating after onset.
+          if (!onset && processSubWindow(pending)) {
+            onset = true;
+          }
+          pendingCount = 0;
+        }
+      }
+
+      return { phase, onset, frameRms: lastRms, epsilon };
+    },
+  };
+}

--- a/frontend/src/hooks/audio/onsetDetector.ts
+++ b/frontend/src/hooks/audio/onsetDetector.ts
@@ -107,7 +107,9 @@ export function createOnsetDetector(options: {
     // still let the clock advance so max-hold can fire. Web Audio capture
     // floats are spec'd finite, so this is belt-and-braces.
     if (!Number.isFinite(rms)) {
-      return elapsedMs() >= tuning.maxHoldMs ? ((phase = "fired"), true) : false;
+      return elapsedMs() >= tuning.maxHoldMs
+        ? ((phase = "fired"), true)
+        : false;
     }
     lastRms = Math.max(lastRms, rms);
 

--- a/frontend/src/hooks/audio/onsetFlipController.ts
+++ b/frontend/src/hooks/audio/onsetFlipController.ts
@@ -8,7 +8,7 @@
  * fire-once semantics — lives here.
  */
 
-import { MIN_AUDIO_CAPTURE_DELAY_MS } from "./audioTuning";
+import { MIN_AUDIO_CAPTURE_DELAY_MS, ONSET_TUNING } from "./audioTuning";
 import { createOnsetDetector } from "./onsetDetector";
 
 export type OnsetDiagnostics = {
@@ -35,6 +35,27 @@ export function createSpeechOnsetController(options: {
   const pipelineReadyAt = Date.now();
   let onsetReached = false;
   let flipTimerId: number | null = null;
+  let backstopTimerId: number | null = null;
+
+  const clearBackstop = () => {
+    if (backstopTimerId !== null) {
+      window.clearTimeout(backstopTimerId);
+      backstopTimerId = null;
+    }
+  };
+
+  // Wall-clock backstop (G1): the detector's max-hold is measured in audio
+  // time and only advances while frames arrive, so a capture that stalls
+  // before onset would hang the cue forever. This frame-independent timer
+  // guarantees the cue resolves regardless of frame delivery. It normally
+  // never fires — the audio-time path wins under live frame flow.
+  backstopTimerId = window.setTimeout(() => {
+    backstopTimerId = null;
+    if (!onsetReached) {
+      onsetReached = true;
+      options.onFlip();
+    }
+  }, ONSET_TUNING.wallClockBackstopMs);
 
   return {
     acceptFrame(frame) {
@@ -51,6 +72,8 @@ export function createSpeechOnsetController(options: {
         return;
       }
       onsetReached = true;
+      // Onset reached on its own — the backstop is no longer needed.
+      clearBackstop();
 
       // Honor the MIN_AUDIO_CAPTURE_DELAY_MS floor (ERMAIN-379 invariant):
       // hold the cue at least this long after pipeline-ready so a warm
@@ -69,6 +92,7 @@ export function createSpeechOnsetController(options: {
       }
     },
     dispose() {
+      clearBackstop();
       if (flipTimerId !== null) {
         window.clearTimeout(flipTimerId);
         flipTimerId = null;

--- a/frontend/src/hooks/audio/onsetFlipController.ts
+++ b/frontend/src/hooks/audio/onsetFlipController.ts
@@ -1,0 +1,78 @@
+/**
+ * Wires the pure `onsetDetector` to the UI "speak now" cue with the
+ * `MIN_AUDIO_CAPTURE_DELAY_MS` deferral floor, so both recorder hooks
+ * share one onset implementation instead of a copy-pasted message-handler
+ * block (ERMAIN-379). The hook supplies the guarded `onFlip` (it knows
+ * about `isMounted` / the live processor ref) and an optional diagnostics
+ * sink; everything else — detection, debounce, the deferral timer, and
+ * fire-once semantics — lives here.
+ */
+
+import { MIN_AUDIO_CAPTURE_DELAY_MS } from "./audioTuning";
+import { createOnsetDetector } from "./onsetDetector";
+
+export type OnsetDiagnostics = {
+  rms: number;
+  epsilon: number | null;
+  phase: string;
+};
+
+export type SpeechOnsetController = {
+  /** Feed one received PCM frame. No-op after the cue has flipped. */
+  acceptFrame: (frame: Float32Array) => void;
+  /** Cancel any pending deferred flip. Call on capture teardown. */
+  dispose: () => void;
+};
+
+export function createSpeechOnsetController(options: {
+  sampleRate: number;
+  /** Flip the cue. Must itself guard against stale/torn-down pipelines. */
+  onFlip: () => void;
+  /** Optional per-frame diagnostics sink (dev-gated by the caller). */
+  log?: (diagnostics: OnsetDiagnostics) => void;
+}): SpeechOnsetController {
+  const detector = createOnsetDetector({ sampleRate: options.sampleRate });
+  const pipelineReadyAt = Date.now();
+  let onsetReached = false;
+  let flipTimerId: number | null = null;
+
+  return {
+    acceptFrame(frame) {
+      if (onsetReached) {
+        return;
+      }
+      const outcome = detector.accept(frame);
+      options.log?.({
+        rms: outcome.frameRms,
+        epsilon: outcome.epsilon,
+        phase: outcome.phase,
+      });
+      if (!outcome.onset) {
+        return;
+      }
+      onsetReached = true;
+
+      // Honor the MIN_AUDIO_CAPTURE_DELAY_MS floor (ERMAIN-379 invariant):
+      // hold the cue at least this long after pipeline-ready so a warm
+      // device doesn't blink the spinner. In real-time delivery onset
+      // already trails calibration past this floor; the deferral remains
+      // for buffered-burst delivery and to keep the invariant intact.
+      const elapsed = Date.now() - pipelineReadyAt;
+      const remaining = MIN_AUDIO_CAPTURE_DELAY_MS - elapsed;
+      if (remaining > 0) {
+        flipTimerId = window.setTimeout(() => {
+          flipTimerId = null;
+          options.onFlip();
+        }, remaining);
+      } else {
+        options.onFlip();
+      }
+    },
+    dispose() {
+      if (flipTimerId !== null) {
+        window.clearTimeout(flipTimerId);
+        flipTimerId = null;
+      }
+    },
+  };
+}

--- a/frontend/src/hooks/audio/useAudioContextInterruptionRecovery.ts
+++ b/frontend/src/hooks/audio/useAudioContextInterruptionRecovery.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { getAudioEnvironment } from "./audioEnvironment";
+
+/**
+ * iOS/WebKit recovery for a wedged AudioContext, shared by both recorder
+ * hooks (ERMAIN-379). WebKit can drop a context into an `"interrupted"` /
+ * `"suspended"` state on a phone call, Siri, or tab backgrounding and not
+ * auto-resume, leaving a dead capture graph (WebAudio #2585). We re-resume
+ * on `statechange` and on `visibilitychange` (page returning to the
+ * foreground), but ONLY while a capture is active — between sessions the
+ * context is deliberately suspended to stay warm, and recovery must never
+ * wake that intentionally-idle context. Other engines auto-resume, so the
+ * listeners are skipped there entirely.
+ *
+ * Known narrow gap (#2, intentionally not closed here): on session 2+ the
+ * processor ref is null between teardown and the post-`getUserMedia`
+ * reassignment. An interruption landing in that window is gated out, and if
+ * the page never backgrounds no `visibilitychange` fires either — so the
+ * processor can connect to a still-interrupted context. The common path is
+ * covered by `ensureAudioContextReady`'s own `await resume()`; this is a
+ * pre-existing-class edge (no resume listener existed before this branch),
+ * not a regression, so it's documented rather than papered over.
+ */
+export function useAudioContextInterruptionRecovery({
+  audioContextRef,
+  audioProcessorRef,
+}: {
+  audioContextRef: React.MutableRefObject<AudioContext | null>;
+  audioProcessorRef: React.MutableRefObject<AudioWorkletNode | null>;
+}): { attachStateChangeListener: (context: AudioContext) => void } {
+  // The context bound to `statechange`, tracked so we can detach on unmount
+  // / context replacement. Avoids the leak of a property-assigned handler
+  // on a long-lived suspended-not-closed context.
+  const boundContextRef = useRef<AudioContext | null>(null);
+
+  const resumeIfInterrupted = useCallback(() => {
+    const audioContext = audioContextRef.current;
+    if (
+      !audioContext ||
+      audioContext.state === "closed" ||
+      audioContext.state === "running" ||
+      // Active-capture gate: never wake an intentionally idle-suspended
+      // context between sessions.
+      audioProcessorRef.current === null
+    ) {
+      return;
+    }
+    void audioContext.resume().catch(() => {
+      // Resume can reject if user activation has expired; the next gesture
+      // (or ensureAudioContextReady on the next session) retries.
+    });
+  }, [audioContextRef, audioProcessorRef]);
+
+  const attachStateChangeListener = useCallback(
+    (context: AudioContext) => {
+      if (!getAudioEnvironment().needsGestureResume) {
+        return;
+      }
+      if (boundContextRef.current === context) {
+        return;
+      }
+      boundContextRef.current?.removeEventListener(
+        "statechange",
+        resumeIfInterrupted,
+      );
+      context.addEventListener("statechange", resumeIfInterrupted);
+      boundContextRef.current = context;
+    },
+    [resumeIfInterrupted],
+  );
+
+  useEffect(() => {
+    if (
+      typeof document === "undefined" ||
+      !getAudioEnvironment().needsGestureResume
+    ) {
+      return;
+    }
+    document.addEventListener("visibilitychange", resumeIfInterrupted);
+    return () => {
+      document.removeEventListener("visibilitychange", resumeIfInterrupted);
+      boundContextRef.current?.removeEventListener(
+        "statechange",
+        resumeIfInterrupted,
+      );
+      boundContextRef.current = null;
+    };
+  }, [resumeIfInterrupted]);
+
+  return { attachStateChangeListener };
+}

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -15,6 +15,7 @@ import { useThrottledCallback } from "use-debounce";
 // share the same ESM contract on the file format side, so the worker
 // pipeline output is valid as an AudioWorklet module.
 import { createRicky0123VadEngine } from "@/lib/voice-runtime";
+import { createLogger } from "@/utils/debugLogger";
 
 import {
   createAudioDictationWebSocketUrl,
@@ -34,35 +35,24 @@ import {
   resampleMonoFloat32ToPcm16,
   type AudioDictationDiagnostics,
 } from "./audio-pcm-codec";
+import { getAudioEnvironment } from "./audioEnvironment";
+import { PRE_SPEECH_SILENCE_PRIMER_MS } from "./audioTuning";
+import {
+  createSpeechOnsetController,
+  type SpeechOnsetController,
+} from "./onsetFlipController";
+import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 
 import type { VoiceVadEngine } from "@/lib/voice-runtime";
 
 const AUDIO_DICTATION_WORKLET_PROCESSOR_NAME = "audio-dictation-processor";
 
-/**
- * Synthetic silence prefix prepended to every dictation session before the
- * captured audio. Mirrors what production streaming-STT VADs require for
- * speech-onset calibration (OpenAI Realtime `prefix_padding_ms` defaults
- * to 300 ms; Silero `speech_pad_ms`, sherpa-onnx pre-speech padding all
- * land in the same range). Without it, the first dictation after browser
- * startup happens to ship hundreds of milliseconds of OS warm-up zeros
- * which double as the VAD calibration window — but a second dictation
- * back-to-back finds the OS audio device still hot, ships near-zero
- * leading silence, and the server's VAD trims the first word.
- */
-const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
-
-/**
- * Floor between `source.connect(processor)` and the visible
- * `isCapturingAudio` flip. Belt-and-braces alongside the primer: on a
- * fully-warm audio device the worklet's first non-zero frame can arrive
- * in tens of milliseconds, fast enough that the spinner feels like a
- * blink and the user starts speaking before they've finished the priming
- * breath. Holding the spinner for at least this long gives them a
- * consistent visual rhythm across cold and warm dictations.
- */
-const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
+// Dev-gated diagnostics (enable with `localStorage.DEBUG = "true"`). Used
+// for the ERMAIN-379 `[AUDIO_DICT]` validation pass (per-frame RMS + chosen
+// epsilon on Chrome / desktop Safari / a physical iPhone); strip once the
+// onset timing is signed off on real devices.
+const logger = createLogger("HOOK", "useAudioDictationRecorder");
 
 const DEFAULT_AUDIO_DICTATION_CHUNK_DURATION_MS = 30_000;
 
@@ -241,12 +231,11 @@ export function useAudioDictationRecorder({
   const audioLevelDataRef = useRef<Uint8Array | null>(null);
   const audioFrameRef = useRef<number | null>(null);
   /**
-   * Timer that defers the `isCapturingAudio` flip when the first non-zero
-   * frame arrives sooner than `MIN_AUDIO_CAPTURE_DELAY_MS` after the
-   * pipeline was wired. Cleared on any teardown so the deferred flip
+   * Per-session speech-onset controller (detector + deferred-flip timer).
+   * Disposed on any teardown so a pending deferred `isCapturingAudio` flip
    * doesn't fire after the user has already cancelled the session.
    */
-  const capturingFlipTimerRef = useRef<number | null>(null);
+  const onsetControllerRef = useRef<SpeechOnsetController | null>(null);
   const recordingDurationTimerRef = useRef<number | null>(null);
   const onTranscriptChunkRef = useRef(onTranscriptChunk);
   const vadEngineRef = useRef<VoiceVadEngine | null>(null);
@@ -319,10 +308,8 @@ export function useAudioDictationRecorder({
 
   const stopRecordingVisualizer = useCallback(
     (resetBars = true) => {
-      if (capturingFlipTimerRef.current !== null) {
-        window.clearTimeout(capturingFlipTimerRef.current);
-        capturingFlipTimerRef.current = null;
-      }
+      onsetControllerRef.current?.dispose();
+      onsetControllerRef.current = null;
       if (audioFrameRef.current !== null) {
         window.cancelAnimationFrame(audioFrameRef.current);
         audioFrameRef.current = null;
@@ -463,6 +450,11 @@ export function useAudioDictationRecorder({
    * Returns `null` when the host browser doesn't support Web Audio /
    * AudioWorkletNode at all.
    */
+  const { attachStateChangeListener } = useAudioContextInterruptionRecovery({
+    audioContextRef,
+    audioProcessorRef,
+  });
+
   const ensureAudioContextReady = useCallback(
     async (preferredSampleRate?: number): Promise<AudioContext | null> => {
       if (
@@ -488,6 +480,9 @@ export function useAudioDictationRecorder({
         }
         audioContextRef.current = audioContext;
         workletModuleLoadedRef.current = false;
+        // On WebKit, recover from mid-session interruptions. No-op on
+        // engines that auto-resume; idempotent + cleaned up on unmount.
+        attachStateChangeListener(audioContext);
       }
 
       if (!workletModuleLoadedRef.current) {
@@ -510,7 +505,7 @@ export function useAudioDictationRecorder({
 
       return audioContext;
     },
-    [],
+    [attachStateChangeListener],
   );
 
   const startLiveDictationSession = useCallback(
@@ -835,16 +830,15 @@ export function useAudioDictationRecorder({
         preSessionSamplesRef.current = primer;
         // The worklet posts every render quantum, including zero-filled
         // OS warm-up frames — we want those in the stream sent to the
-        // server too. The "speak now" UI cue should still wait for real
-        // audio though, so scan each incoming frame for a non-zero
-        // sample and flip the `isCapturingAudio` signal on the first one
-        // we see. Production STT clients (Deepgram, AssemblyAI, OpenAI
-        // Realtime) send the full stream and rely on server-side prefix
-        // padding — see
-        // https://developers.openai.com/api/docs/guides/realtime-vad
-        // (`prefix_padding_ms`, default 300 ms).
-        let audioFlowing = false;
-        const pipelineReadyAt = Date.now();
+        // server too (it stays dumb; server-side prefix padding handles
+        // onset — https://developers.openai.com/api/docs/guides/realtime-vad,
+        // `prefix_padding_ms` default 300 ms). The "speak now" UI cue is a
+        // separate, UI-only concern: an RMS onset detector flips
+        // `isCapturingAudio` on real speech-level energy. It replaced an
+        // exact-zero predicate (`sample !== 0`) that mistimed on WebKit,
+        // whose raw-capture warm-up emits a noise floor instead of bit-exact
+        // zeros (ERMAIN-379). The detector gates ONLY the cue; it never sees
+        // or alters streamed bytes.
         const flipCapturingAudio = () => {
           // Guard against late firings: if the pipeline was torn down
           // between scheduling and execution, the processor ref will be
@@ -854,29 +848,22 @@ export function useAudioDictationRecorder({
           }
           setIsCapturingAudio(true);
         };
+        const onsetController = createSpeechOnsetController({
+          sampleRate: audioContext.sampleRate,
+          onFlip: flipCapturingAudio,
+          log: (diagnostics) => logger.log("[AUDIO_DICT] frame", diagnostics),
+        });
+        onsetControllerRef.current = onsetController;
+        logger.log("[AUDIO_DICT] onset detector armed", {
+          sampleRate: audioContext.sampleRate,
+          engine: getAudioEnvironment().engine,
+        });
         processor.port.onmessage = (event: MessageEvent<Float32Array>) => {
           const input = event.data;
           const vadFrame = vadEngineRef.current
             ? new Float32Array(input)
             : null;
-          if (!audioFlowing) {
-            for (let index = 0; index < input.length; index += 1) {
-              if (input[index] !== 0) {
-                audioFlowing = true;
-                const elapsed = Date.now() - pipelineReadyAt;
-                const remaining = MIN_AUDIO_CAPTURE_DELAY_MS - elapsed;
-                if (remaining > 0) {
-                  capturingFlipTimerRef.current = window.setTimeout(() => {
-                    capturingFlipTimerRef.current = null;
-                    flipCapturingAudio();
-                  }, remaining);
-                } else {
-                  flipCapturingAudio();
-                }
-                break;
-              }
-            }
-          }
+          onsetController.acceptFrame(input);
           const session = liveSessionRef.current;
           if (session) {
             for (let index = 0; index < input.length; index += 1) {

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -25,6 +25,13 @@ import {
   getAudioLevelBarsFromTimeDomainData,
   resampleMonoFloat32ToPcm16,
 } from "./audio-pcm-codec";
+import { getAudioEnvironment } from "./audioEnvironment";
+import { PRE_SPEECH_SILENCE_PRIMER_MS } from "./audioTuning";
+import {
+  createSpeechOnsetController,
+  type SpeechOnsetController,
+} from "./onsetFlipController";
+import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 
 import type {
@@ -44,14 +51,6 @@ const VAD_DEBUG_FRAME_LOG_INTERVAL_MS = 2_000;
  * thread" behavior.
  */
 const AUDIO_TRANSCRIPTION_WORKLET_PROCESSOR_NAME = "audio-dictation-processor";
-
-/**
- * Synthetic silence prefix prepended before the captured audio, and the
- * floor between pipeline-ready and the visible `isCapturingAudio` flip.
- * Both mirror useAudioDictationRecorder — see the rationale there.
- */
-const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
-const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
 
 const logger = createLogger("HOOK", "useAudioTranscriptionRecorder");
 
@@ -435,9 +434,9 @@ export function useAudioTranscriptionRecorder({
   const audioProcessorRef = useRef<AudioWorkletNode | null>(null);
   const audioLevelDataRef = useRef<Uint8Array | null>(null);
   const audioFrameRef = useRef<number | null>(null);
-  /** Defers the isCapturingAudio flip when real audio arrives sooner
-   *  than MIN_AUDIO_CAPTURE_DELAY_MS; cleared on teardown. */
-  const capturingFlipTimerRef = useRef<number | null>(null);
+  /** Per-recording speech-onset controller (detector + deferred-flip
+   *  timer); disposed on teardown. */
+  const onsetControllerRef = useRef<SpeechOnsetController | null>(null);
   const startInFlightRef = useRef(false);
   const vadEngineRef = useRef<VoiceVadEngine | null>(null);
   const vadAutoStopTriggeredRef = useRef(false);
@@ -519,10 +518,8 @@ export function useAudioTranscriptionRecorder({
   );
 
   const stopRecordingVisualizer = useCallback(() => {
-    if (capturingFlipTimerRef.current !== null) {
-      window.clearTimeout(capturingFlipTimerRef.current);
-      capturingFlipTimerRef.current = null;
-    }
+    onsetControllerRef.current?.dispose();
+    onsetControllerRef.current = null;
     if (audioFrameRef.current !== null) {
       window.cancelAnimationFrame(audioFrameRef.current);
       audioFrameRef.current = null;
@@ -587,6 +584,11 @@ export function useAudioTranscriptionRecorder({
     stopRecordingVisualizer();
   }, [clearRecordingDurationTimer, stopRecordingVisualizer, stopVadEngine]);
 
+  const { attachStateChangeListener } = useAudioContextInterruptionRecovery({
+    audioContextRef,
+    audioProcessorRef,
+  });
+
   /**
    * Returns a ready-to-use AudioContext with the shared dictation
    * worklet module registered and the context in the `running` state.
@@ -617,6 +619,9 @@ export function useAudioTranscriptionRecorder({
         }
         audioContextRef.current = audioContext;
         workletModuleLoadedRef.current = false;
+        // On WebKit, recover from mid-session interruptions. No-op on
+        // engines that auto-resume; idempotent + cleaned up on unmount.
+        attachStateChangeListener(audioContext);
       }
 
       if (!workletModuleLoadedRef.current) {
@@ -639,7 +644,7 @@ export function useAudioTranscriptionRecorder({
 
       return audioContext;
     },
-    [],
+    [attachStateChangeListener],
   );
 
   const startLiveAudioTranscriptionSession = useCallback(
@@ -1334,11 +1339,11 @@ export function useAudioTranscriptionRecorder({
 
         // The worklet posts every render quantum, including zero-filled
         // OS warm-up frames — those belong in the stream sent to the
-        // server. The "speak now" UI cue waits for real audio though:
-        // scan each frame for a non-zero sample and flip
-        // isCapturingAudio on the first one.
-        let audioFlowing = false;
-        const pipelineReadyAt = Date.now();
+        // server (it stays dumb). The "speak now" UI cue is separate and
+        // UI-only: an RMS onset detector flips isCapturingAudio on real
+        // speech-level energy. It replaced an exact-zero predicate that
+        // mistimed on WebKit's noise-floor warm-up — see
+        // useAudioDictationRecorder and onsetDetector (ERMAIN-379).
         const flipCapturingAudio = () => {
           // Guard against late firings after teardown or unmount: the
           // processor ref will be null or point at a different node.
@@ -1347,29 +1352,22 @@ export function useAudioTranscriptionRecorder({
           }
           setIsCapturingAudio(true);
         };
+        const onsetController = createSpeechOnsetController({
+          sampleRate: audioContext.sampleRate,
+          onFlip: flipCapturingAudio,
+          log: (diagnostics) => logger.log("[AUDIO_DICT] frame", diagnostics),
+        });
+        onsetControllerRef.current = onsetController;
+        logger.log("[AUDIO_DICT] onset detector armed", {
+          sampleRate: audioContext.sampleRate,
+          engine: getAudioEnvironment().engine,
+        });
         processor.port.onmessage = (event: MessageEvent<Float32Array>) => {
           const input = event.data;
           const vadFrame = vadEngineRef.current
             ? new Float32Array(input)
             : null;
-          if (!audioFlowing) {
-            for (let index = 0; index < input.length; index += 1) {
-              if (input[index] !== 0) {
-                audioFlowing = true;
-                const elapsed = Date.now() - pipelineReadyAt;
-                const remaining = MIN_AUDIO_CAPTURE_DELAY_MS - elapsed;
-                if (remaining > 0) {
-                  capturingFlipTimerRef.current = window.setTimeout(() => {
-                    capturingFlipTimerRef.current = null;
-                    flipCapturingAudio();
-                  }, remaining);
-                } else {
-                  flipCapturingAudio();
-                }
-                break;
-              }
-            }
-          }
+          onsetController.acceptFrame(input);
           const session = liveSessionRef.current;
           if (session) {
             for (let index = 0; index < input.length; index += 1) {


### PR DESCRIPTION
This pull request introduces a comprehensive set of improvements to the frontend audio capture pipeline, focusing on browser compatibility, speech onset detection, and code testability. The main changes include a new browser audio environment abstraction, a robust RMS-based onset detector to replace the previous zero-sample check, extensive unit tests, and a refactor of the audio worklet to handle multi-channel audio streams more reliably.

**Browser environment detection and capability flags:**

- Added a new `audioEnvironment.ts` module that classifies browser engines (WebKit, Chromium, Firefox, Unknown) and exposes named capability flags for audio capture quirks, such as noise floor on warm-up, stereo capture without echo cancellation, and the need for gesture-based resume. This replaces ad-hoc browser checks with a structured, testable approach.

**Speech onset detection improvements:**

- Introduced a new RMS-based speech onset detector, replacing the previous exact-zero predicate. This approach correctly handles WebKit/Safari's low-level DC bias on raw capture and avoids premature onset triggers. The RMS calculation is implemented in a new pure function `removeDcAndRms`.
- Centralized all tunable parameters related to audio capture and onset detection in a new `audioTuning.ts` module, making tuning and documentation easier and more consistent.

**Audio worklet refactor:**

- Refactored `AudioDictationProcessor` in `audio-dictation-worklet.ts` to robustly down-mix multi-channel input to mono, handling cases where browsers (notably Safari) return stereo streams even when mono is requested. The new down-mixing method is allocation-efficient and handles ragged/empty channels gracefully.
- Updated the worklet's processing logic to use the new mono down-mix and to prepare for the new onset detection flow.

**Testing and reliability:**

- Added comprehensive unit tests for the browser environment detection logic and the onset detector, covering edge cases such as browser-specific behaviors, DC bias, calibration, max-hold fallback, and robustness against non-finite samples. [[1]](diffhunk://#diff-eea56aa94deebffb4c10601622c7c5cffccb6dd8bd70e8a6a824324997fb8f02R1-R77) [[2]](diffhunk://#diff-4f380da2335cc71c3956db6bc8ceebaed30d52deec23b31b1a0337d670f40b89R1-R180)

---

**Browser compatibility and environment detection:**

- Introduced `audioEnvironment.ts` to abstract browser engine quirks into named, testable capability flags, removing scattered browser checks throughout the codebase.
- Added unit tests for browser engine detection and environment flag resolution, ensuring correct classification across major browsers and platforms.

**Speech onset detection and tuning:**

- Replaced the previous exact-zero onset detection with a robust, allocation-free RMS-based approach (`removeDcAndRms`), correctly handling DC bias and noise floors on all browsers.
- Centralized all onset detector and audio capture tunables in `audioTuning.ts`, with detailed documentation and rationale for each parameter.
- Added unit tests for the onset detector, covering calibration, max-hold fallback, channel handling, and edge cases.

**Audio worklet improvements:**

- Refactored `AudioDictationProcessor` to down-mix multi-channel audio to mono using a new efficient method, ensuring compatibility with browsers that return stereo streams even when mono is requested.
- Updated the audio processing loop to use the new mono input and to prepare for the new onset detection logic.