### PR TITLE
ERMAIN-390: capture-track device-loss watchdog (ended/mute/unmute)

### DIFF
--- a/frontend/src/auth/apiRequestAuth.ts
+++ b/frontend/src/auth/apiRequestAuth.ts
@@ -23,10 +23,7 @@ export function mergeApiAuthHeaders(
   // the Office add-in currently leave this null and authenticate via the
   // oauth2-proxy session cookie (the add-in redeems its MSAL id token for that
   // cookie at /oauth2/redeem-external-token rather than sending it per request),
-  // so this branch is inert today. NOTE: do not assume the proxy would reject
-  // such a Bearer — with `skip_jwt_bearer_tokens` and a matching audience it can
-  // accept it; the store is left unused on purpose to keep the cookie the single
-  // source of truth.
+  // so this branch is inert today.
   const idToken = getIdToken();
   if (!idToken) {
     return definedHeaders;

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2147,12 +2147,8 @@ export const ChatInput = ({
                 !isAudioMode &&
                 !isRecording &&
                 !isRecordingUpload &&
-                // The live waveform appears only once the session is ready
-                // AND real (non-zero) audio is flowing; until then the
-                // loading spinner stays. A single spinner → waveform
-                // transition is the "speak now" cue — showing the waveform
-                // during the mic's cold warm-up invited users to speak too
-                // early and lose their first words (ERMAIN-334).
+                // Spinner until capture is live; the waveform appears only
+                // once real audio is flowing.
                 (isCapturingAudio && isDictating ? (
                   <WaveformButton
                     onClick={toggleDictationForCurrentTarget}
@@ -2233,9 +2229,7 @@ export const ChatInput = ({
                   <ChatInputAudioModeButton
                     isRecording
                     recordingBars={dictationBars}
-                    // Spinner until the session is live AND real audio
-                    // flows — the waveform's appearance is the "speak
-                    // now" cue (ERMAIN-334).
+                    // Spinner until capture is live; waveform once real audio flows.
                     isStarting={!isCapturingAudio || !isDictating}
                     onToggle={handleAudioModeButtonToggle}
                     disabled={isAudioModeButtonDisabled}

--- a/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAudioModeButton.tsx
@@ -32,7 +32,7 @@ type ChatInputAudioModeButtonRecordingProps =
      * load, mic warm-up) — i.e. before real audio is captured. Shows a
      * loading spinner instead of a live-looking waveform so the user
      * isn't invited to speak before the microphone actually delivers
-     * audio (ERMAIN-334). Clicking still stops/cancels audio mode.
+     * audio. Clicking still stops/cancels audio mode.
      */
     isStarting?: boolean;
   };

--- a/frontend/src/components/ui/Controls/UserProfileDropdown.tsx
+++ b/frontend/src/components/ui/Controls/UserProfileDropdown.tsx
@@ -92,10 +92,6 @@ export const UserProfileDropdown = memo<UserProfileDropdownProps>(
         <DropdownMenu
           items={dropdownItems}
           align="left"
-          // preferredOrientation={{
-          //   vertical: 'top',
-          //   horizontal: 'left'
-          // }}
           data-testid="user-profile-dropdown"
           triggerIcon={
             <Avatar

--- a/frontend/src/components/ui/Feedback/Avatar.tsx
+++ b/frontend/src/components/ui/Feedback/Avatar.tsx
@@ -1,6 +1,5 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
-// import Image from "next/image"; // Removed Next.js Image import
 import React, { useMemo, useState } from "react";
 
 import { defaultThemeConfig } from "@/config/themeConfig";
@@ -42,12 +41,6 @@ export const Avatar = React.memo<AvatarProps>(
         const nameParts = uiProfile.name.split(" ");
         return `${nameParts[0][0]}${nameParts[1] ? nameParts[1][0] : ""}`.toUpperCase();
       }
-      // if (userProfile?.firstName && userProfile.lastName) {
-      //   return `${userProfile.firstName[0]}${userProfile.lastName[0]}`.toUpperCase();
-      // }
-      // if (userProfile?.username) {
-      //   return userProfile.username[0].toUpperCase();
-      // }
       return "E"; // Default to 'E' for Erato
     };
 

--- a/frontend/src/components/ui/FileUpload/FileSourceSelector.tsx
+++ b/frontend/src/components/ui/FileUpload/FileSourceSelector.tsx
@@ -77,19 +77,6 @@ export const FileSourceSelector = memo<FileSourceSelectorProps>(
       });
     }
 
-    // Future: Add Google Drive
-    // if (availableProviders.includes("googledrive")) {
-    //   menuItems.push({
-    //     label: t({
-    //       id: "fileSourceSelector.uploadFromGoogleDrive",
-    //       message: "Upload from Google Drive",
-    //     }),
-    //     icon: <Cloud className="size-4" />,
-    //     onClick: () => onSelectCloud("googledrive"),
-    //     disabled,
-    //   });
-    // }
-
     return (
       <DropdownMenu
         items={menuItems}

--- a/frontend/src/components/ui/Logo.tsx
+++ b/frontend/src/components/ui/Logo.tsx
@@ -1,6 +1,5 @@
 // "use client"; // Removed
 
-// import Image from "next/image"; // Removed Next.js Image import
 import { t } from "@lingui/core/macro";
 import { useState, useEffect } from "react";
 
@@ -45,9 +44,7 @@ export function Logo({
       width={width}
       height={height}
       className={className}
-      onError={() => {
-        // console.error("Failed to load logo:", logoPath); // Removed
-      }}
+      onError={() => {}}
     />
   );
 }

--- a/frontend/src/components/ui/Message/DefaultMessageControls.tsx
+++ b/frontend/src/components/ui/Message/DefaultMessageControls.tsx
@@ -52,7 +52,6 @@ export const DefaultMessageControls = memo(function DefaultMessageControls({
 
   // Chat-level edit permission from context; default true if unspecified
   const canEditChat = context.canEdit !== false; // default to true if unspecified
-  // const isDialogOwner = context.dialogOwnerId === profile.profile?.id;
 
   // Derive feedback state from initialFeedback prop
   // This avoids unnecessary re-renders from useEffect + useState combination

--- a/frontend/src/components/ui/MessageList/MessageItem.tsx
+++ b/frontend/src/components/ui/MessageList/MessageItem.tsx
@@ -59,35 +59,6 @@ export const MessageItem = memo<MessageItemProps>(
     onViewFeedback,
     allFilesById,
   }) => {
-    // Debug message loading state
-    // useEffect(() => {
-    //   if (message.sender === "assistant" && message.loading) {
-    //     debugLog("RENDER", `Assistant message ${messageId} is loading`, {
-    //       loadingState: message.loading.state,
-    //       content:
-    //         message.content.substring(0, 30) +
-    //         (message.content.length > 30 ? "..." : ""),
-    //     });
-    //   }
-    // }, [messageId, message]);
-
-    // Log rendering for assistant messages
-    // if (message.sender === "assistant") {
-    //   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    //   if (ENABLE_VERBOSE_DEBUG) {
-    //     console.log(
-    //       `%c🔄 RENDERING MESSAGE ${messageId}`,
-    //       "background: #121; color: #4af; font-size: 12px; padding: 2px 6px; border-radius: 3px;",
-    //       {
-    //         isLoading: !!message.loading,
-    //         loadingState: message.loading?.state,
-    //         contentLength: message.content.length,
-    //         hasError: !!message.error,
-    //       },
-    //     );
-    //   }
-    // }
-
     return (
       <div className={className}>
         <Renderer

--- a/frontend/src/components/ui/MessageList/MessageList.tsx
+++ b/frontend/src/components/ui/MessageList/MessageList.tsx
@@ -14,7 +14,6 @@ import {
 } from "./MessageListUtils";
 import { StandardMessageList } from "./StandardMessageList";
 import { VirtualizedMessageList } from "./VirtualizedMessageList";
-// import { ConversationIndicator } from "../Message/ConversationIndicator";
 
 import type { ChatMessageProps } from "../Chat/ChatMessage";
 import type {
@@ -461,13 +460,6 @@ export const MessageList = memo<MessageListProps>(
     isTransitioning,
     emptyStateComponent,
   }) => {
-    // Debug logging for rendering
-    // debugLog("RENDER", "MessageList rendering", {
-    //   messageCount: messageOrder.length,
-    //   hasLoadingMessage: messageOrder.some((id) => !!messages[id].loading),
-    //   loadingMessageIds: messageOrder.filter((id) => !!messages[id].loading),
-    // });
-
     const lastMessageLoadingContent = useMemo(() => {
       const result =
         messageOrder.length > 0 &&

--- a/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
@@ -66,8 +66,14 @@ vi.mock("@/lib/voice-runtime", () => ({
   createRicky0123VadEngine: vadMock.createRicky0123VadEngine,
 }));
 
-class MockMediaStreamTrack {
-  stop = vi.fn();
+class MockMediaStreamTrack extends EventTarget {
+  // Extends EventTarget so the ERMAIN-390 device-loss watchdog can attach
+  // its `ended`/`mute`/`unmute` listeners.
+  readyState: MediaStreamTrackState = "live";
+  muted = false;
+  stop = vi.fn(() => {
+    this.readyState = "ended";
+  });
 
   getSettings() {
     return {

--- a/frontend/src/hooks/audio/__tests__/useAudioTranscriptionRecorder.test.tsx
+++ b/frontend/src/hooks/audio/__tests__/useAudioTranscriptionRecorder.test.tsx
@@ -94,8 +94,14 @@ function readCanonicalWavSamples(): Float32Array {
   return samples;
 }
 
-class MockMediaStreamTrack {
-  stop = vi.fn();
+class MockMediaStreamTrack extends EventTarget {
+  // Extends EventTarget so the ERMAIN-390 device-loss watchdog can attach
+  // its `ended`/`mute`/`unmute` listeners.
+  readyState: MediaStreamTrackState = "live";
+  muted = false;
+  stop = vi.fn(() => {
+    this.readyState = "ended";
+  });
 
   getSettings() {
     return {

--- a/frontend/src/hooks/audio/__tests__/useMediaStreamTrackWatchdog.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useMediaStreamTrackWatchdog.test.ts
@@ -1,0 +1,187 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MUTE_GRACE_MS } from "../audioTuning";
+import {
+  useMediaStreamTrackWatchdog,
+  type TrackLossReason,
+} from "../useMediaStreamTrackWatchdog";
+
+/**
+ * Minimal MediaStreamTrack stand-in: a real EventTarget (so add/remove +
+ * dispatch behave like the browser) plus the mutable `readyState` / `muted`
+ * the watchdog reads. `stop()` flips `readyState` WITHOUT dispatching
+ * `ended`, matching the spec — that's why an intentional teardown never
+ * trips the watchdog.
+ */
+class FakeTrack extends EventTarget {
+  readyState: MediaStreamTrackState = "live";
+  muted = false;
+
+  stop() {
+    this.readyState = "ended";
+  }
+
+  end() {
+    this.readyState = "ended";
+    this.dispatchEvent(new Event("ended"));
+  }
+
+  mute() {
+    this.muted = true;
+    this.dispatchEvent(new Event("mute"));
+  }
+
+  unmute() {
+    this.muted = false;
+    this.dispatchEvent(new Event("unmute"));
+  }
+}
+
+function renderWatchdog() {
+  const onTrackLost = vi.fn<(reason: TrackLossReason) => void>();
+  const hook = renderHook(() => useMediaStreamTrackWatchdog({ onTrackLost }));
+  return { hook, onTrackLost };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useMediaStreamTrackWatchdog", () => {
+  it("reports `ended` immediately as the authoritative dead signal", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.end();
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("ended");
+  });
+
+  it("does NOT report a transient mute that recovers within the grace window", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    vi.advanceTimersByTime(MUTE_GRACE_MS - 1);
+    track.unmute();
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+
+    expect(onTrackLost).not.toHaveBeenCalled();
+  });
+
+  it("reports `muted` only once the mute outlives the grace window", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    vi.advanceTimersByTime(MUTE_GRACE_MS - 1);
+    expect(onTrackLost).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("muted");
+  });
+
+  it("does not escalate a mute that has already unmuted by the time the timer fires", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    // Clear `muted` without dispatching `unmute` (defensive: the timer
+    // re-reads live track state, not just the cancelled-timer path).
+    track.muted = false;
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+
+    expect(onTrackLost).not.toHaveBeenCalled();
+  });
+
+  it("escalates a mute that progressed to `ended` during the window as `ended`", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    // Track fully dies during the grace window without us hearing `ended`
+    // (readyState flips, no event dispatched). The decision-time re-read
+    // should report the authoritative `ended`, not a soft `muted`.
+    track.readyState = "ended";
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("ended");
+  });
+
+  it("fires at most once when `ended` follows a grace-window mute", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("muted");
+
+    // A late `ended` on the same (now detached) track must not re-fire.
+    track.end();
+    expect(onTrackLost).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a track that is already `ended` at attach time (async, no re-entrancy)", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    track.stop(); // ended before we attach; `ended` will never dispatch
+
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+    // Deferred onto a fresh task so it can't re-enter the caller's start.
+    expect(onTrackLost).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(0);
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("ended");
+  });
+
+  it("does not fire after unwatchTrack, including a pending mute timer", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    track.mute();
+    hook.result.current.unwatchTrack();
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+    track.end();
+
+    expect(onTrackLost).not.toHaveBeenCalled();
+  });
+
+  it("detaches the previous track when a new one is watched", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const first = new FakeTrack();
+    const second = new FakeTrack();
+    hook.result.current.watchTrack(first as unknown as MediaStreamTrack);
+    hook.result.current.watchTrack(second as unknown as MediaStreamTrack);
+
+    first.end();
+    expect(onTrackLost).not.toHaveBeenCalled();
+
+    second.end();
+    expect(onTrackLost).toHaveBeenCalledExactlyOnceWith("ended");
+  });
+
+  it("stops reporting once the host unmounts", () => {
+    const { hook, onTrackLost } = renderWatchdog();
+    const track = new FakeTrack();
+    hook.result.current.watchTrack(track as unknown as MediaStreamTrack);
+
+    hook.unmount();
+    track.mute();
+    vi.advanceTimersByTime(MUTE_GRACE_MS);
+    track.end();
+
+    expect(onTrackLost).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/audio/audioTuning.ts
+++ b/frontend/src/hooks/audio/audioTuning.ts
@@ -3,24 +3,19 @@
  * pipeline. These are properties of the browser onset-detection
  * algorithm — identical across every deployment — not cost/policy
  * levers, so they live here as frontend constants rather than being
- * plumbed through `erato.toml`. (Investigated on ERMAIN-379: the backend
- * `AudioTranscriptionConfig` carries only server-side STT/LLM tuning; no
- * onset/VAD/calibration field exists, and only `enabled` +
- * `max_recording_duration_seconds` ever reach the frontend.)
+ * plumbed through `erato.toml`.
  *
  * Pure data — no React, no DOM — shared by both recorder hooks and the
- * pure `onsetDetector` state machine. ERMAIN-380 (mic-quality probe)
- * reuses the same RMS/onset math, so keep the knobs in one place.
+ * pure `onsetDetector` state machine; the mic-quality probe reuses the
+ * same RMS/onset math, so keep the knobs in one place.
  */
 
 /**
  * Synthetic silence prefix prepended to every session before captured
- * audio. Mirrors what production streaming-STT VADs require for
- * speech-onset calibration (OpenAI Realtime `prefix_padding_ms` defaults
- * to 300 ms; Silero `speech_pad_ms` / sherpa-onnx pre-speech padding land
- * in the same range). Without it, a back-to-back second dictation finds
- * the OS audio device still hot, ships near-zero leading silence, and the
- * server's VAD trims the first word (ERMAIN-334).
+ * audio. Production streaming-STT VADs need ~300 ms of leading silence for
+ * speech-onset calibration. Without it, a back-to-back second dictation
+ * finds the OS audio device still hot, ships near-zero leading silence, and
+ * the server's VAD trims the first word.
  */
 export const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
 
@@ -36,28 +31,22 @@ export const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
 
 /**
  * Grace window before a sustained `mute` on the capture `MediaStreamTrack`
- * is escalated to a device-loss (ERMAIN-390). `mute`/`unmute` fire
- * (browser-controlled, distinct from the app-controlled `enabled`) when a
- * source temporarily can't produce data — on iOS/WebKit this happens during
- * route changes and interruptions (AirPods connect/disconnect, an incoming
- * call, Siri), so a naive "mute → error" false-positives on a transient
- * that recovers. An `unmute` inside this window cancels the escalation;
- * only a mute that outlives it is treated as lost (`ended` remains the
- * authoritative, immediate "dead" signal). Note `unmute` is NOT guaranteed
- * to arrive — WebKit fires it only "sometimes" after an interruption, and
- * a route change can mute with no unmute at all (WebKit bug 212040) — so
- * grace-expiry escalation is the intended fallback, not an edge case.
+ * is escalated to a device-loss. `mute`/`unmute` fire (browser-controlled,
+ * distinct from the app-controlled `enabled`) when a source temporarily
+ * can't produce data — on iOS/WebKit this happens during route changes and
+ * interruptions (AirPods connect/disconnect, an incoming call, Siri), so a
+ * naive "mute → error" false-positives on a transient that recovers. An
+ * `unmute` inside this window cancels the escalation; only a mute that
+ * outlives it is treated as lost (`ended` remains the authoritative,
+ * immediate "dead" signal). `unmute` is not guaranteed to arrive — a route
+ * change can mute with no unmute at all — so grace-expiry escalation is the
+ * intended fallback, not an edge case.
  *
- * 5 s, not a sub-second value: WebKit's own capture pipeline budgets up to
- * ~5 s for a Bluetooth reconfiguration to complete (WebKit commit 24cb5e2
- * raised an internal capture-failure guard precisely because "Bluetooth
- * reconfiguration sometimes took up to 5 seconds"), and the mature WebRTC
- * SDKs debounce mute in the same band (LiveKit 5 s before pausing upstream,
- * Jitsi 4 s of zero-signal before NO_AUDIO_INPUT). A shorter window risks
- * declaring "lost" mid-handoff on a slow AirPods connect — one of this
- * ticket's own acceptance scenarios. Tradeoff: answering an incoming call
- * holds the mic past 5 s, so this surfaces a clean "interrupted" stop — the
- * correct outcome, since dictation can't continue mid-call.
+ * 5 s, not sub-second: a Bluetooth/AirPods reconfiguration can take up to
+ * ~5 s, so a shorter window risks declaring "lost" mid-handoff on a slow
+ * connect. Tradeoff: answering an incoming call holds the mic past 5 s, so
+ * this surfaces a clean "interrupted" stop — the correct outcome, since
+ * dictation can't continue mid-call.
  */
 export const MUTE_GRACE_MS = 5_000;
 
@@ -104,7 +93,7 @@ export const ONSET_TUNING = {
 
   /**
    * Upper clamp on epsilon (~−34 dBFS) — a very noisy room still flips.
-   * Tradeoff (G6): in a room whose noise floor exceeds ~0.02 RMS, the cue
+   * Tradeoff: in a room whose noise floor exceeds ~0.02 RMS, the cue
    * can early-fire on background noise (epsilon is capped below the floor).
    * Bounded and no worse than the old Chromium behaviour; revisit only if
    * UX flags false-positive onsets in loud environments.
@@ -138,7 +127,7 @@ export const ONSET_TUNING = {
   maxHoldMs: 800,
 
   /**
-   * Frame-independent wall-clock backstop for the "speak now" cue (G1).
+   * Frame-independent wall-clock backstop for the "speak now" cue.
    * `maxHoldMs` lives in audio time and freezes if frames stop arriving,
    * so a stalled capture would hang the spinner forever. This timer is
    * armed once at controller construction and force-flips the cue if
@@ -148,7 +137,7 @@ export const ONSET_TUNING = {
    *
    * Caveat: this only resolves the *cue*; it cannot tell a dead capture
    * from a flowing-but-quiet one — that needs track-health handling
-   * (tracked separately as the device-loss follow-up).
+   * (the capture-track device-loss watchdog).
    */
   wallClockBackstopMs: 1_200,
 } as const;

--- a/frontend/src/hooks/audio/audioTuning.ts
+++ b/frontend/src/hooks/audio/audioTuning.ts
@@ -35,6 +35,33 @@ export const PRE_SPEECH_SILENCE_PRIMER_MS = 300;
 export const MIN_AUDIO_CAPTURE_DELAY_MS = 150;
 
 /**
+ * Grace window before a sustained `mute` on the capture `MediaStreamTrack`
+ * is escalated to a device-loss (ERMAIN-390). `mute`/`unmute` fire
+ * (browser-controlled, distinct from the app-controlled `enabled`) when a
+ * source temporarily can't produce data — on iOS/WebKit this happens during
+ * route changes and interruptions (AirPods connect/disconnect, an incoming
+ * call, Siri), so a naive "mute → error" false-positives on a transient
+ * that recovers. An `unmute` inside this window cancels the escalation;
+ * only a mute that outlives it is treated as lost (`ended` remains the
+ * authoritative, immediate "dead" signal). Note `unmute` is NOT guaranteed
+ * to arrive — WebKit fires it only "sometimes" after an interruption, and
+ * a route change can mute with no unmute at all (WebKit bug 212040) — so
+ * grace-expiry escalation is the intended fallback, not an edge case.
+ *
+ * 5 s, not a sub-second value: WebKit's own capture pipeline budgets up to
+ * ~5 s for a Bluetooth reconfiguration to complete (WebKit commit 24cb5e2
+ * raised an internal capture-failure guard precisely because "Bluetooth
+ * reconfiguration sometimes took up to 5 seconds"), and the mature WebRTC
+ * SDKs debounce mute in the same band (LiveKit 5 s before pausing upstream,
+ * Jitsi 4 s of zero-signal before NO_AUDIO_INPUT). A shorter window risks
+ * declaring "lost" mid-handoff on a slow AirPods connect — one of this
+ * ticket's own acceptance scenarios. Tradeoff: answering an incoming call
+ * holds the mic past 5 s, so this surfaces a clean "interrupted" stop — the
+ * correct outcome, since dictation can't continue mid-call.
+ */
+export const MUTE_GRACE_MS = 5_000;
+
+/**
  * Tunables for the RMS-based speech-onset detector (ERMAIN-379). The
  * detector replaced an exact-zero predicate (`sample !== 0`) that
  * mistimed on WebKit/Safari, whose raw-capture path emits a low-level

--- a/frontend/src/hooks/audio/onsetDetector.ts
+++ b/frontend/src/hooks/audio/onsetDetector.ts
@@ -1,5 +1,5 @@
 /**
- * Pure speech-onset state machine (ERMAIN-379). Replaces the exact-zero
+ * Pure speech-onset state machine. Replaces the exact-zero
  * predicate (`sample !== 0`) that gated the UI "speak now" cue
  * (`isCapturingAudio`). Exact-zero detection assumes silence == digital
  * zero — true on Chromium's capture pipeline, but FALSE on WebKit/Safari

--- a/frontend/src/hooks/audio/onsetFlipController.ts
+++ b/frontend/src/hooks/audio/onsetFlipController.ts
@@ -2,7 +2,7 @@
  * Wires the pure `onsetDetector` to the UI "speak now" cue with the
  * `MIN_AUDIO_CAPTURE_DELAY_MS` deferral floor, so both recorder hooks
  * share one onset implementation instead of a copy-pasted message-handler
- * block (ERMAIN-379). The hook supplies the guarded `onFlip` (it knows
+ * block. The hook supplies the guarded `onFlip` (it knows
  * about `isMounted` / the live processor ref) and an optional diagnostics
  * sink; everything else — detection, debounce, the deferral timer, and
  * fire-once semantics — lives here.
@@ -44,7 +44,7 @@ export function createSpeechOnsetController(options: {
     }
   };
 
-  // Wall-clock backstop (G1): the detector's max-hold is measured in audio
+  // Wall-clock backstop: the detector's max-hold is measured in audio
   // time and only advances while frames arrive, so a capture that stalls
   // before onset would hang the cue forever. This frame-independent timer
   // guarantees the cue resolves regardless of frame delivery. It normally
@@ -75,8 +75,8 @@ export function createSpeechOnsetController(options: {
       // Onset reached on its own — the backstop is no longer needed.
       clearBackstop();
 
-      // Honor the MIN_AUDIO_CAPTURE_DELAY_MS floor (ERMAIN-379 invariant):
-      // hold the cue at least this long after pipeline-ready so a warm
+      // Honor the MIN_AUDIO_CAPTURE_DELAY_MS floor: hold the cue at least
+      // this long after pipeline-ready so a warm
       // device doesn't blink the spinner. In real-time delivery onset
       // already trails calibration past this floor; the deferral remains
       // for buffered-burst delivery and to keep the invariant intact.

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -52,10 +52,9 @@ import type { VoiceVadEngine } from "@/lib/voice-runtime";
 
 const AUDIO_DICTATION_WORKLET_PROCESSOR_NAME = "audio-dictation-processor";
 
-// Dev-gated diagnostics (enable with `localStorage.DEBUG = "true"`). Used
-// for the ERMAIN-379 `[AUDIO_DICT]` validation pass (per-frame RMS + chosen
-// epsilon on Chrome / desktop Safari / a physical iPhone); strip once the
-// onset timing is signed off on real devices.
+// Dev-gated diagnostics (enable with `localStorage.DEBUG = "true"`):
+// per-frame `[AUDIO_DICT]` RMS + chosen epsilon. Strip once the onset
+// timing is signed off on real devices.
 const logger = createLogger("HOOK", "useAudioDictationRecorder");
 
 const DEFAULT_AUDIO_DICTATION_CHUNK_DURATION_MS = 30_000;
@@ -218,8 +217,7 @@ export function useAudioDictationRecorder({
    * state can't leak), but the context itself, its audio rendering
    * thread, and the registered worklet processor stay warm. Closing and
    * re-creating the context on every stop pays an audio-thread spin-up
-   * cost on every restart — which is most likely what was eating the
-   * first word on a "warm" second dictation.
+   * cost on every restart.
    */
   const audioContextRef = useRef<AudioContext | null>(null);
   /**
@@ -353,9 +351,8 @@ export function useAudioDictationRecorder({
       // Suspend rather than close: each dictation gets fresh source /
       // analyser / worklet nodes (so per-session state can't leak), but
       // the AudioContext itself stays warm. Closing + re-creating pays an
-      // audio-thread spin-up cost on every restart which is most likely
-      // what was eating the first word on a warm second session. Close
-      // only happens on the hook's unmount cleanup.
+      // audio-thread spin-up cost on every restart. Close only happens on
+      // the hook's unmount cleanup.
       if (audioContextRef.current?.state === "running") {
         void audioContextRef.current.suspend();
       }
@@ -524,7 +521,7 @@ export function useAudioDictationRecorder({
       // matters when we're reusing a session-2 context that was
       // suspended at the end of session 1, and on browsers where a
       // freshly-created context starts suspended after user activation
-      // has lapsed across the preceding awaits (Mozilla bug 1629478).
+      // has lapsed across the preceding awaits.
       try {
         await audioContext.resume();
       } catch {
@@ -883,14 +880,13 @@ export function useAudioDictationRecorder({
         // The worklet posts every render quantum, including zero-filled
         // OS warm-up frames — we want those in the stream sent to the
         // server too (it stays dumb; server-side prefix padding handles
-        // onset — https://developers.openai.com/api/docs/guides/realtime-vad,
-        // `prefix_padding_ms` default 300 ms). The "speak now" UI cue is a
-        // separate, UI-only concern: an RMS onset detector flips
-        // `isCapturingAudio` on real speech-level energy. It replaced an
-        // exact-zero predicate (`sample !== 0`) that mistimed on WebKit,
-        // whose raw-capture warm-up emits a noise floor instead of bit-exact
-        // zeros (ERMAIN-379). The detector gates ONLY the cue; it never sees
-        // or alters streamed bytes.
+        // onset). The "speak now" UI cue is a separate, UI-only concern:
+        // an RMS onset detector flips `isCapturingAudio` on real
+        // speech-level energy. It replaced an exact-zero predicate
+        // (`sample !== 0`) that mistimed on WebKit, whose raw-capture
+        // warm-up emits a noise floor instead of bit-exact zeros. The
+        // detector gates ONLY the cue; it never sees or alters streamed
+        // bytes.
         const flipCapturingAudio = () => {
           // Guard against late firings: if the pipeline was torn down
           // between scheduling and execution, the processor ref will be

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -43,6 +43,10 @@ import {
 } from "./onsetFlipController";
 import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
+import {
+  useMediaStreamTrackWatchdog,
+  type TrackLossReason,
+} from "./useMediaStreamTrackWatchdog";
 
 import type { VoiceVadEngine } from "@/lib/voice-runtime";
 
@@ -275,6 +279,22 @@ export function useAudioDictationRecorder({
       enabled,
     });
 
+  /**
+   * Capture-track device-loss watchdog (ERMAIN-390). Delegated through a
+   * ref because the real handler stops dictation, which is defined further
+   * down — the ref keeps `watchTrack`/`unwatchTrack` available to the early
+   * teardown helpers while the handler is wired in an effect below.
+   */
+  const captureTrackLostHandlerRef = useRef<(reason: TrackLossReason) => void>(
+    () => {},
+  );
+  const { watchTrack: watchCaptureTrack, unwatchTrack: unwatchCaptureTrack } =
+    useMediaStreamTrackWatchdog({
+      onTrackLost: useCallback((reason: TrackLossReason) => {
+        captureTrackLostHandlerRef.current(reason);
+      }, []),
+    });
+
   useEffect(() => {
     onTranscriptChunkRef.current = onTranscriptChunk;
   }, [onTranscriptChunk]);
@@ -353,13 +373,23 @@ export function useAudioDictationRecorder({
   const tearDownCaptureGraph = useCallback(() => {
     clearRecordingDurationTimer();
     stopVadEngine();
+    // Detach the device-loss listeners before stopping the track. Our own
+    // `track.stop()` does not fire `ended`, but a `mute` grace timer may be
+    // pending — cancel it so an intentional teardown can't surface a
+    // spurious post-stop "muted" loss.
+    unwatchCaptureTrack();
 
     if (mediaStreamRef.current) {
       mediaStreamRef.current.getTracks().forEach((track) => track.stop());
       mediaStreamRef.current = null;
     }
     stopRecordingVisualizer();
-  }, [clearRecordingDurationTimer, stopRecordingVisualizer, stopVadEngine]);
+  }, [
+    clearRecordingDurationTimer,
+    stopRecordingVisualizer,
+    stopVadEngine,
+    unwatchCaptureTrack,
+  ]);
 
   const sendLivePcmChunk = useCallback((pcmBytes: Uint8Array) => {
     const session = liveSessionRef.current;
@@ -693,6 +723,25 @@ export function useAudioDictationRecorder({
     tearDownCaptureGraph,
   ]);
 
+  // Wire the watchdog to a clean stop. A genuinely dead capture (`ended`,
+  // or a mute outliving the grace window) surfaces an actionable error and
+  // completes the session on whatever was captured before the mic died —
+  // no silent dead capture (ERMAIN-390). Defined here so it can reference
+  // `stopDictation`; the watchdog reads it through the delegating ref.
+  useEffect(() => {
+    captureTrackLostHandlerRef.current = (reason: TrackLossReason) => {
+      if (!isMounted()) {
+        return;
+      }
+      setDictationError(
+        reason === "ended"
+          ? t`The microphone was disconnected. Please check your microphone and start dictation again.`
+          : t`The microphone stopped sending audio. Please check your microphone and start dictation again.`,
+      );
+      stopDictation();
+    };
+  }, [isMounted, stopDictation]);
+
   const startDictation = useCallback(async () => {
     if (
       startInFlightRef.current ||
@@ -775,6 +824,9 @@ export function useAudioDictationRecorder({
 
       mediaStreamRef.current = stream;
       const audioTrack = stream.getAudioTracks()[0];
+      // Start watching for mid-session device-loss (AirPods route change,
+      // incoming call, unplug) as soon as the track exists (ERMAIN-390).
+      watchCaptureTrack(audioTrack);
       const trackSettings = audioTrack.getSettings();
       setDictationDiagnostics(mediaTrackSettingsToDiagnostics(trackSettings));
 
@@ -1087,6 +1139,7 @@ export function useAudioDictationRecorder({
     stopVadEngine,
     tearDownCaptureGraph,
     vadAutoStopEnabled,
+    watchCaptureTrack,
   ]);
 
   const toggleDictation = useCallback(() => {

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -33,6 +33,10 @@ import {
 } from "./onsetFlipController";
 import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
 import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
+import {
+  useMediaStreamTrackWatchdog,
+  type TrackLossReason,
+} from "./useMediaStreamTrackWatchdog";
 
 import type {
   AudioTranscriptionMetadata,
@@ -453,6 +457,22 @@ export function useAudioTranscriptionRecorder({
   const { selectedAudioInputDeviceId, setSelectedAudioInputDeviceId } =
     useAudioInputDevicePreference();
 
+  /**
+   * Capture-track device-loss watchdog (ERMAIN-390). Delegated through a
+   * ref because the real handler stops recording, which is defined further
+   * down — the ref keeps `watchTrack`/`unwatchTrack` available to the early
+   * teardown helpers while the handler is wired in an effect below.
+   */
+  const captureTrackLostHandlerRef = useRef<(reason: TrackLossReason) => void>(
+    () => {},
+  );
+  const { watchTrack: watchCaptureTrack, unwatchTrack: unwatchCaptureTrack } =
+    useMediaStreamTrackWatchdog({
+      onTrackLost: useCallback((reason: TrackLossReason) => {
+        captureTrackLostHandlerRef.current(reason);
+      }, []),
+    });
+
   useEffect(() => {
     fileFetchOptionsRef.current = fileFetchOptions;
   }, [fileFetchOptions]);
@@ -576,13 +596,23 @@ export function useAudioTranscriptionRecorder({
   const stopMediaRecordingStream = useCallback(() => {
     clearRecordingDurationTimer();
     stopVadEngine();
+    // Detach the device-loss listeners before stopping the track. Our own
+    // `track.stop()` does not fire `ended`, but a `mute` grace timer may be
+    // pending — cancel it so an intentional teardown can't surface a
+    // spurious post-stop "muted" loss.
+    unwatchCaptureTrack();
 
     if (mediaStreamRef.current) {
       mediaStreamRef.current.getTracks().forEach((track) => track.stop());
       mediaStreamRef.current = null;
     }
     stopRecordingVisualizer();
-  }, [clearRecordingDurationTimer, stopRecordingVisualizer, stopVadEngine]);
+  }, [
+    clearRecordingDurationTimer,
+    stopRecordingVisualizer,
+    stopVadEngine,
+    unwatchCaptureTrack,
+  ]);
 
   const { attachStateChangeListener } = useAudioContextInterruptionRecovery({
     audioContextRef,
@@ -1208,6 +1238,25 @@ export function useAudioTranscriptionRecorder({
     void finalizeLiveTranscriptionSession(session);
   }, [finalizeLiveTranscriptionSession, stopMediaRecordingStream]);
 
+  // Wire the watchdog to a clean stop. A genuinely dead capture (`ended`,
+  // or a mute outliving the grace window) surfaces an actionable error and
+  // finalizes the session on whatever was captured before the mic died —
+  // no silent dead capture (ERMAIN-390). Defined here so it can reference
+  // `stopAudioRecording`; the watchdog reads it through the delegating ref.
+  useEffect(() => {
+    captureTrackLostHandlerRef.current = (reason: TrackLossReason) => {
+      if (!isMounted()) {
+        return;
+      }
+      setRecordingError(
+        reason === "ended"
+          ? t`The microphone was disconnected. Please check your microphone and start recording again.`
+          : t`The microphone stopped sending audio. Please check your microphone and start recording again.`,
+      );
+      stopAudioRecording();
+    };
+  }, [isMounted, stopAudioRecording]);
+
   const startAudioRecording = useCallback(async () => {
     if (!audioTranscriptionEnabled || !uploadEnabled) {
       setRecordingError(
@@ -1279,6 +1328,9 @@ export function useAudioTranscriptionRecorder({
 
       mediaStreamRef.current = stream;
       const audioTrack = stream.getAudioTracks()[0];
+      // Start watching for mid-session device-loss (AirPods route change,
+      // incoming call, unplug) as soon as the track exists (ERMAIN-390).
+      watchCaptureTrack(audioTrack);
       const trackSettings = audioTrack.getSettings();
       setRecordingDiagnostics(mediaTrackSettingsToDiagnostics(trackSettings));
 
@@ -1614,6 +1666,7 @@ export function useAudioTranscriptionRecorder({
     setRecordingBarsThrottled,
     stopVadEngine,
     vadAutoStopEnabled,
+    watchCaptureTrack,
   ]);
 
   const toggleAudioRecording = useCallback(() => {

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -662,9 +662,7 @@ export function useAudioTranscriptionRecorder({
       // resume() is a no-op when already running; it matters when
       // reusing a context suspended at the end of the prior recording,
       // and on hosts where a fresh context starts suspended (embedded
-      // webviews / lapsed user activation). The transcription recorder
-      // previously never resumed, which silently produced zero capture
-      // on suspended-start hosts (ERMAIN-334).
+      // webviews / lapsed user activation).
       try {
         await audioContext.resume();
       } catch {
@@ -1364,10 +1362,9 @@ export function useAudioTranscriptionRecorder({
           audioContext,
           AUDIO_TRANSCRIPTION_WORKLET_PROCESSOR_NAME,
         );
-        // Match the dictation recorder: time-domain sampling with a
-        // 256-sample FFT and a touch of smoothing reads voice energy
-        // across the whole window instead of bucketing it into one
-        // low-frequency bin, so all five bars react to speech.
+        // 256-sample FFT + light smoothing reads voice energy across the
+        // whole window so all five bars track speech (matches the
+        // dictation recorder).
         analyser.fftSize = 256;
         analyser.smoothingTimeConstant = 0.65;
         sourceSampleRate = audioContext.sampleRate;
@@ -1392,10 +1389,8 @@ export function useAudioTranscriptionRecorder({
         // The worklet posts every render quantum, including zero-filled
         // OS warm-up frames — those belong in the stream sent to the
         // server (it stays dumb). The "speak now" UI cue is separate and
-        // UI-only: an RMS onset detector flips isCapturingAudio on real
-        // speech-level energy. It replaced an exact-zero predicate that
-        // mistimed on WebKit's noise-floor warm-up — see
-        // useAudioDictationRecorder and onsetDetector (ERMAIN-379).
+        // UI-only (RMS onset detector) — see useAudioDictationRecorder and
+        // onsetDetector.
         const flipCapturingAudio = () => {
           // Guard against late firings after teardown or unmount: the
           // processor ref will be null or point at a different node.

--- a/frontend/src/hooks/audio/useMediaStreamTrackWatchdog.ts
+++ b/frontend/src/hooks/audio/useMediaStreamTrackWatchdog.ts
@@ -5,38 +5,26 @@ import { MUTE_GRACE_MS } from "./audioTuning";
 export type TrackLossReason = "ended" | "muted";
 
 /**
- * Watches the live capture `MediaStreamTrack` for device-loss mid-session
- * (ERMAIN-390) — the failure surface the ERMAIN-379 AudioContext
- * interruption recovery (`useAudioContextInterruptionRecovery`) does NOT
- * cover. On iOS/WebKit a Bluetooth route change (AirPods connect /
- * disconnect), an incoming call, or an unplugged device can end or mute
- * the capture track, after which the audio graph silently produces nothing
- * — no frames, no error, no recovery. The G1 wall-clock backstop landed in
- * ERMAIN-379 guarantees the "speak now" cue still resolves, but it can't
- * tell a dead mic from a flowing-but-quiet one; this watchdog is that
- * missing signal.
+ * Watches the live capture `MediaStreamTrack` for mid-session device-loss:
+ * a Bluetooth route change (AirPods connect/disconnect), an incoming call,
+ * or an unplugged device can end or mute the track, after which the audio
+ * graph silently produces nothing — no frames, no error, no recovery. This
+ * is the signal the AudioContext interruption recovery
+ * (`useAudioContextInterruptionRecovery`) does not cover.
  *
- * Signal handling, per the ERMAIN-390 caveats:
- *   - `ended` is the AUTHORITATIVE "dead" signal → reported immediately.
+ *   - `ended` is the authoritative "dead" signal → reported immediately.
  *   - `mute`/`unmute` are browser-controlled (distinct from the
- *     app-controlled `enabled`) and fire TRANSIENTLY on iOS during route
- *     changes and interruptions, so "mute → lost" would false-positive. A
- *     `mute` arms a grace timer (`MUTE_GRACE_MS`); an `unmute` inside the
- *     window cancels it (benign transient). Only a mute that outlives the
- *     window escalates to a loss — a track still muted that long is, in
- *     practice, the same silent-dead capture this ticket removes. `unmute`
- *     is not guaranteed to arrive (WebKit fires it only "sometimes" after
- *     an interruption), so this expiry path is the intended fallback. The
- *     timer re-reads live track state rather than trusting the stale event.
+ *     app-controlled `enabled`) and fire transiently on iOS during route
+ *     changes, so "mute → lost" would false-positive. A `mute` arms a grace
+ *     timer (`MUTE_GRACE_MS`); an `unmute` cancels it. Only a mute that
+ *     outlives the window is treated as lost. `unmute` is not guaranteed to
+ *     arrive, so grace-expiry escalation is the intended fallback; the timer
+ *     re-reads live track state rather than trusting the stale event.
  *
- * Re-acquire is intentionally NOT attempted here: re-running getUserMedia
- * can hand back a different sample rate that collides with the
- * rate-coupled `new AudioContext({ sampleRate })` and risks re-triggering
- * the ERMAIN-334 first-word truncation, so the safe baseline is a clean
- * stop with a surfaced error (ERMAIN-390 caveat 2). Engine-agnostic:
- * `ended` is reliable everywhere (a USB unplug ends the track on desktop
- * too) and the grace window is harmless off-WebKit, so — unlike
- * `useAudioContextInterruptionRecovery` — this is not gated to WebKit.
+ * No re-acquire: re-running getUserMedia can return a different sample rate
+ * that collides with the rate-coupled `new AudioContext({ sampleRate })`, so
+ * the safe baseline is a clean stop with a surfaced error. Engine-agnostic —
+ * `ended` is reliable everywhere and the grace window is harmless off-WebKit.
  *
  * `onTrackLost` is read through an internal ref, so the returned
  * `watchTrack` / `unwatchTrack` are stable and the consumer can pass a

--- a/frontend/src/hooks/audio/useMediaStreamTrackWatchdog.ts
+++ b/frontend/src/hooks/audio/useMediaStreamTrackWatchdog.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { MUTE_GRACE_MS } from "./audioTuning";
+
+export type TrackLossReason = "ended" | "muted";
+
+/**
+ * Watches the live capture `MediaStreamTrack` for device-loss mid-session
+ * (ERMAIN-390) — the failure surface the ERMAIN-379 AudioContext
+ * interruption recovery (`useAudioContextInterruptionRecovery`) does NOT
+ * cover. On iOS/WebKit a Bluetooth route change (AirPods connect /
+ * disconnect), an incoming call, or an unplugged device can end or mute
+ * the capture track, after which the audio graph silently produces nothing
+ * — no frames, no error, no recovery. The G1 wall-clock backstop landed in
+ * ERMAIN-379 guarantees the "speak now" cue still resolves, but it can't
+ * tell a dead mic from a flowing-but-quiet one; this watchdog is that
+ * missing signal.
+ *
+ * Signal handling, per the ERMAIN-390 caveats:
+ *   - `ended` is the AUTHORITATIVE "dead" signal → reported immediately.
+ *   - `mute`/`unmute` are browser-controlled (distinct from the
+ *     app-controlled `enabled`) and fire TRANSIENTLY on iOS during route
+ *     changes and interruptions, so "mute → lost" would false-positive. A
+ *     `mute` arms a grace timer (`MUTE_GRACE_MS`); an `unmute` inside the
+ *     window cancels it (benign transient). Only a mute that outlives the
+ *     window escalates to a loss — a track still muted that long is, in
+ *     practice, the same silent-dead capture this ticket removes. `unmute`
+ *     is not guaranteed to arrive (WebKit fires it only "sometimes" after
+ *     an interruption), so this expiry path is the intended fallback. The
+ *     timer re-reads live track state rather than trusting the stale event.
+ *
+ * Re-acquire is intentionally NOT attempted here: re-running getUserMedia
+ * can hand back a different sample rate that collides with the
+ * rate-coupled `new AudioContext({ sampleRate })` and risks re-triggering
+ * the ERMAIN-334 first-word truncation, so the safe baseline is a clean
+ * stop with a surfaced error (ERMAIN-390 caveat 2). Engine-agnostic:
+ * `ended` is reliable everywhere (a USB unplug ends the track on desktop
+ * too) and the grace window is harmless off-WebKit, so — unlike
+ * `useAudioContextInterruptionRecovery` — this is not gated to WebKit.
+ *
+ * `onTrackLost` is read through an internal ref, so the returned
+ * `watchTrack` / `unwatchTrack` are stable and the consumer can pass a
+ * freshly-bound handler each render without re-attaching listeners.
+ */
+export function useMediaStreamTrackWatchdog({
+  onTrackLost,
+}: {
+  onTrackLost: (reason: TrackLossReason) => void;
+}): {
+  watchTrack: (track: MediaStreamTrack) => void;
+  unwatchTrack: () => void;
+} {
+  const watchedTrackRef = useRef<MediaStreamTrack | null>(null);
+  // Detaches the listeners from the currently-watched track. Held in a ref
+  // (rather than re-derived) so watchTrack/unwatchTrack stay stable and the
+  // closed-over handlers are released exactly once.
+  const detachRef = useRef<(() => void) | null>(null);
+  // Backs both the mute grace timer and the deferred already-ended report,
+  // so a teardown that lands first can cancel either via unwatchTrack.
+  const pendingLossTimerRef = useRef<number | null>(null);
+  const onTrackLostRef = useRef(onTrackLost);
+
+  useEffect(() => {
+    onTrackLostRef.current = onTrackLost;
+  }, [onTrackLost]);
+
+  const clearPendingLossTimer = useCallback(() => {
+    if (pendingLossTimerRef.current !== null) {
+      window.clearTimeout(pendingLossTimerRef.current);
+      pendingLossTimerRef.current = null;
+    }
+  }, []);
+
+  const unwatchTrack = useCallback(() => {
+    clearPendingLossTimer();
+    detachRef.current?.();
+    detachRef.current = null;
+    watchedTrackRef.current = null;
+  }, [clearPendingLossTimer]);
+
+  const reportLost = useCallback(
+    (reason: TrackLossReason) => {
+      // Detach FIRST so a follow-up event on the same track (e.g. `ended`
+      // arriving after a grace-window `muted`) can't fire onTrackLost twice.
+      unwatchTrack();
+      onTrackLostRef.current(reason);
+    },
+    [unwatchTrack],
+  );
+
+  const watchTrack = useCallback(
+    (track: MediaStreamTrack) => {
+      if (watchedTrackRef.current === track) {
+        return;
+      }
+      unwatchTrack();
+
+      const handleEnded = () => reportLost("ended");
+      const handleMute = () => {
+        clearPendingLossTimer();
+        pendingLossTimerRef.current = window.setTimeout(() => {
+          pendingLossTimerRef.current = null;
+          if (watchedTrackRef.current !== track) {
+            return;
+          }
+          // Re-read live state at decision time rather than trusting the
+          // stale `mute` event. If the track fully died during the window
+          // (a mute that progressed to `ended` without us hearing the
+          // event), report the authoritative `ended` reason, not a soft
+          // `muted`. A recovered (unmuted) track is a benign transient.
+          if (track.readyState === "ended") {
+            reportLost("ended");
+            return;
+          }
+          if (!track.muted) {
+            return;
+          }
+          reportLost("muted");
+        }, MUTE_GRACE_MS);
+      };
+      const handleUnmute = () => clearPendingLossTimer();
+
+      track.addEventListener("ended", handleEnded);
+      track.addEventListener("mute", handleMute);
+      track.addEventListener("unmute", handleUnmute);
+      detachRef.current = () => {
+        track.removeEventListener("ended", handleEnded);
+        track.removeEventListener("mute", handleMute);
+        track.removeEventListener("unmute", handleUnmute);
+      };
+      watchedTrackRef.current = track;
+
+      // A device change can race between getUserMedia resolving and this
+      // attach, so the track may already be dead — and a track that's
+      // already `ended` will never dispatch the event we just bound. Report
+      // it, but on a fresh task so we never re-enter the still-running start
+      // path synchronously (the caller wires onTrackLost to a full stop).
+      if (track.readyState === "ended") {
+        pendingLossTimerRef.current = window.setTimeout(() => {
+          pendingLossTimerRef.current = null;
+          if (watchedTrackRef.current === track) {
+            reportLost("ended");
+          }
+        }, 0);
+      }
+    },
+    [clearPendingLossTimer, reportLost, unwatchTrack],
+  );
+
+  useEffect(() => {
+    return () => {
+      unwatchTrack();
+    };
+  }, [unwatchTrack]);
+
+  return { watchTrack, unwatchTrack };
+}

--- a/frontend/src/hooks/chat/handlers/handleMessageComplete.ts
+++ b/frontend/src/hooks/chat/handlers/handleMessageComplete.ts
@@ -57,15 +57,6 @@ export const handleMessageComplete = (
   // Extract text for logging
   const finalTextContent = extractTextFromContent(finalContent);
 
-  if (process.env.NODE_ENV === "development") {
-    // logger.log(
-    //   "Assistant message completed. Real ID:",
-    //   realMessageId,
-    //   "Final content snippet:",
-    //   finalTextContent.substring(0, 50),
-    // );
-  }
-
   // Update streaming state to indicate completion
   // Set isFinalizing to true while refetch/cleanup happens
   logger.log(

--- a/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
+++ b/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
@@ -134,7 +134,7 @@ export function handleUserMessageSaved(
               currentMessageId.startsWith("temp-user-"))) ||
           currentAnchoredMessage?.role === "user";
 
-        // ERMAIN-88 FIX: Only create optimistic assistant if one doesn't already exist
+        // Only create optimistic assistant if one doesn't already exist
         // The optimistic assistant is now created immediately in sendMessage()
         const hasOptimisticAssistant =
           currentMessageId?.startsWith("temp-assistant-") &&

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -5,7 +5,6 @@
  */
 /* eslint-disable lingui/no-unlocalized-strings */
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-// import { useRouter } from "next/navigation"; // Removed Next.js router
 import { useCallback, useMemo } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom"; // Added React Router hooks
 import { create } from "zustand";

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -71,7 +71,6 @@ const getAuthHeaders = (): Record<string, string> => {
 // Remove onChatCreated from parameters
 interface UseChatMessagingParams {
   chatId: string | null;
-  // onChatCreated?: (newChatId: string) => void;
   silentChatId?: string | null;
   /** Platform identifier sent via X-Erato-Platform header. Defaults to "web". */
   platform?: string;
@@ -153,17 +152,12 @@ function handleNullChatIdScenario(
 
 export function useChatMessaging(
   chatIdOrParams: string | null | UseChatMessagingParams,
-  // legacyOnChatCreated?: (newChatId: string) => void, // Remove legacy param
 ) {
   // Support both old and new function signatures for backward compatibility
   const chatId =
     typeof chatIdOrParams === "string" || chatIdOrParams === null
       ? chatIdOrParams
       : chatIdOrParams.chatId;
-
-  // Remove onChatCreated extraction
-  // const onChatCreated =
-  //   ...
 
   const silentChatId =
     typeof chatIdOrParams === "string" || chatIdOrParams === null
@@ -234,8 +228,6 @@ export function useChatMessaging(
   const resumeAttemptsByKeyRef = useRef<Record<string, number>>({});
   const lastResumeAttemptedChatIdRef = useRef<string | null>(null);
   const isUnmountingRef = useRef(false); // Track if we're unmounting to skip unnecessary refetch
-  // Remove pendingChatIdRef, use state instead
-  // const pendingChatIdRef = useRef<string | null>(null);
   const [newlyCreatedChatId, setNewlyCreatedChatId] = useState<string | null>(
     null,
   );
@@ -268,7 +260,6 @@ export function useChatMessaging(
   // Add explicit navigation hook
   const explicitNav = useExplicitNavigation();
 
-  // Log hook mounting and unmounting - keep this for debugging chat lifecycle
   useEffect(() => {
     const currentChatId = chatId; // Capture chatId for cleanup
     const isInTransition =
@@ -707,9 +698,6 @@ export function useChatMessaging(
 
   // Clean up any existing SSE connection on unmount or chatId change
   useEffect(() => {
-    // logger.log(
-    //   `[CHAT_FLOW_LIFECYCLE_DEBUG] Setting up cleanup effect for chatId: ${chatId ?? "null"}`,
-    // );
     const capturedChatIdForCleanup = chatId; // Capture chatId for the cleanup function
 
     return () => {
@@ -923,7 +911,6 @@ export function useChatMessaging(
             break;
 
           case "text_delta":
-            // logger.log("processStreamEvent: text_delta event. Delta:", responseData.delta); // Can be too noisy
             handleTextDelta(responseData, activeStreamKey);
             break;
 
@@ -1277,16 +1264,6 @@ export function useChatMessaging(
         "[DEBUG_STREAMING] sendMessage: isSubmittingRef.current set to true.",
       );
 
-      if (process.env.NODE_ENV === "development") {
-        // logger.log(
-        //   "[CHAT_FLOW] Added temporary user message:",
-        //   userMessage.id,
-        // );
-        // logger.log(
-        //   `[CHAT_FLOW_LIFECYCLE_DEBUG] sendMessage called with chatId: ${chatId ?? "null"}, silentChatId: ${silentChatId ?? "null"}`,
-        // );
-      }
-
       try {
         // Reset any previous streaming state FIRST
         logger.log(
@@ -1294,7 +1271,7 @@ export function useChatMessaging(
         );
         resetStreaming(streamKey);
 
-        // ERMAIN-88 FIX: Create optimistic assistant placeholder immediately
+        // Create optimistic assistant placeholder immediately
         // This provides instant UI feedback while the POST request is being processed
         const optimisticAssistantId = `temp-assistant-${Date.now()}`;
         const now = new Date().toISOString();
@@ -1319,9 +1296,6 @@ export function useChatMessaging(
           logger.log(
             "[DEBUG_STREAMING] sendMessage: Closing previous SSE connection before creating a new one.",
           );
-          // logger.log(
-          //   `[CHAT_FLOW_LIFECYCLE_DEBUG] sendMessage: Cleaning up existing sseCleanupRef for chatId: ${chatId ?? "null"} before new connection.`,
-          // );
           existingCleanup();
           setSSECleanupForKey(streamKey, null);
 
@@ -1371,9 +1345,6 @@ export function useChatMessaging(
         const sseUrl = `/api/v1beta/me/messages/submitstream`;
 
         // The SSE client will handle the POST request format
-        // logger.log(
-        //   `[CHAT_FLOW_LIFECYCLE_DEBUG] sendMessage: About to call createSSEConnection for chatId: ${chatId ?? "null"}. sseCleanupRef.current is currently ${sseCleanupRef.current ? "set" : "null"}.`,
-        // );
         logger.log(
           `[DEBUG_STREAMING] sendMessage: Calling createSSEConnection. Current stream-keyed cleanup is ${getSSECleanupForKey(streamKey) ? "set" : "null"}.`,
         );
@@ -1520,9 +1491,6 @@ export function useChatMessaging(
         setSSECleanupForKey(streamKey, cleanup);
         setSSEAbortCallback(cleanup, streamKey);
 
-        // logger.log(
-        //   `[CHAT_FLOW_LIFECYCLE_DEBUG] sendMessage: Assigned new cleanup to sseCleanupRef.current for chatId: ${chatId ?? "null"}.`,
-        // );
         logger.log(
           `[DEBUG_STREAMING] sendMessage: Assigned new cleanup to sseCleanupRef.current.`,
         );

--- a/frontend/src/hooks/files/errors.ts
+++ b/frontend/src/hooks/files/errors.ts
@@ -90,7 +90,7 @@ export function isUploadTooLarge(error: unknown): error is ApiUploadFileError {
     error !== null &&
     "message" in error &&
     // eslint-disable-next-line @typescript-eslint/no-explicit-any,lingui/no-unlocalized-strings
-    (error.message as any).includes("NetworkError") // More robust check
+    (error.message as any).includes("NetworkError")
   ) {
     console.warn(
       "A generic NetworkError was caught in a Firefox environment. This is likely due to the file size exceeding browser or server limits. Treating as UploadTooLargeError.",

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2908,6 +2908,22 @@ msgstr "Das Mikrofon wird bereits von einer anderen Anwendung oder Aufnahme verw
 msgid "The microphone is already in use by another application."
 msgstr ""
 
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start dictation again."
+msgstr "Das Mikrofon sendet kein Audio mehr. Bitte überprüfen Sie Ihr Mikrofon und starten Sie das Diktat erneut."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start recording again."
+msgstr "Das Mikrofon sendet kein Audio mehr. Bitte überprüfen Sie Ihr Mikrofon und starten Sie die Aufnahme erneut."
+
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start dictation again."
+msgstr "Das Mikrofon wurde getrennt. Bitte überprüfen Sie Ihr Mikrofon und starten Sie das Diktat erneut."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start recording again."
+msgstr "Das Mikrofon wurde getrennt. Bitte überprüfen Sie Ihr Mikrofon und starten Sie die Aufnahme erneut."
+
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "The selected microphone is not available. Refresh the device list and try again."
 msgstr "Das ausgewählte Mikrofon ist nicht verfügbar. Aktualisieren Sie die Geräteliste und versuchen Sie es erneut."

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2908,6 +2908,22 @@ msgstr "The microphone is already in use by another application or recording."
 msgid "The microphone is already in use by another application."
 msgstr "The microphone is already in use by another application."
 
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start dictation again."
+msgstr "The microphone stopped sending audio. Please check your microphone and start dictation again."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start recording again."
+msgstr "The microphone stopped sending audio. Please check your microphone and start recording again."
+
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start dictation again."
+msgstr "The microphone was disconnected. Please check your microphone and start dictation again."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start recording again."
+msgstr "The microphone was disconnected. Please check your microphone and start recording again."
+
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "The selected microphone is not available. Refresh the device list and try again."
 msgstr "The selected microphone is not available. Refresh the device list and try again."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2908,6 +2908,22 @@ msgstr "El micrófono ya está siendo usado por otra aplicación o grabación."
 msgid "The microphone is already in use by another application."
 msgstr ""
 
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start dictation again."
+msgstr "El micrófono dejó de enviar audio. Comprueba el micrófono y vuelve a iniciar el dictado."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start recording again."
+msgstr "El micrófono dejó de enviar audio. Comprueba el micrófono y vuelve a iniciar la grabación."
+
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start dictation again."
+msgstr "El micrófono se desconectó. Comprueba el micrófono y vuelve a iniciar el dictado."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start recording again."
+msgstr "El micrófono se desconectó. Comprueba el micrófono y vuelve a iniciar la grabación."
+
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "The selected microphone is not available. Refresh the device list and try again."
 msgstr "El micrófono seleccionado no está disponible. Actualiza la lista de dispositivos e inténtalo de nuevo."

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2908,6 +2908,22 @@ msgstr "Le microphone est déjà utilisé par une autre application ou un autre 
 msgid "The microphone is already in use by another application."
 msgstr ""
 
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start dictation again."
+msgstr "Le microphone n'envoie plus de son. Veuillez vérifier votre microphone et relancer la dictée."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start recording again."
+msgstr "Le microphone n'envoie plus de son. Veuillez vérifier votre microphone et relancer l'enregistrement."
+
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start dictation again."
+msgstr "Le microphone a été déconnecté. Veuillez vérifier votre microphone et relancer la dictée."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start recording again."
+msgstr "Le microphone a été déconnecté. Veuillez vérifier votre microphone et relancer l'enregistrement."
+
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "The selected microphone is not available. Refresh the device list and try again."
 msgstr "Le microphone sélectionné n'est pas disponible. Actualisez la liste des appareils et réessayez."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2908,6 +2908,22 @@ msgstr "Mikrofon jest już używany przez inną aplikację lub nagranie."
 msgid "The microphone is already in use by another application."
 msgstr ""
 
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start dictation again."
+msgstr "Mikrofon przestał przesyłać dźwięk. Sprawdź mikrofon i ponownie rozpocznij dyktowanie."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone stopped sending audio. Please check your microphone and start recording again."
+msgstr "Mikrofon przestał przesyłać dźwięk. Sprawdź mikrofon i ponownie rozpocznij nagrywanie."
+
+#: src/hooks/audio/useAudioDictationRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start dictation again."
+msgstr "Mikrofon został odłączony. Sprawdź mikrofon i ponownie rozpocznij dyktowanie."
+
+#: src/hooks/audio/useAudioTranscriptionRecorder.ts
+msgid "The microphone was disconnected. Please check your microphone and start recording again."
+msgstr "Mikrofon został odłączony. Sprawdź mikrofon i ponownie rozpocznij nagrywanie."
+
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 msgid "The selected microphone is not available. Refresh the device list and try again."
 msgstr "Wybrany mikrofon jest niedostępny. Odśwież listę urządzeń i spróbuj ponownie."

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,6 +1,5 @@
 /**
- * Basic types for chat functionality
- * These are placeholder types for the new implementation
+ * Types for chat functionality.
  */
 
 import type { ContentPart } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
@@ -80,17 +79,9 @@ export interface OutlookArtifact {
   proposedClientAction?: string;
   /**
    * Producer-computed verdict (add-in only) for whether an UNFENCED whole
-   * `"body"`-mode response should render as the insertable email card. Computed
-   * once in AddinChat as `!isClientActionFacet || proposedClientAction != null`,
-   * where `isClientActionFacet` is keyed off the OFFERABLE actions (the backend
-   * `allowedClientActions` intersected with the actions the add-in actually
-   * implements) — so an ambient reply facet that produced a plain answer (no
-   * proposal) suppresses the card, while a compose/rewrite facet (no offerable
-   * actions) always cards. Stamped only when it SUPPRESSES (`false`); absent is
-   * treated as `true`. Undefined on the web app (the producer runs only in the
-   * add-in), which leaves web rendering unchanged. Single source of truth for
-   * carding so the gate and the add-in renderer cannot drift; a future
-   * backend draft-intent signal folds into this one field.
+   * `"body"`-mode response should render as the insertable email card. Stamped
+   * only when it SUPPRESSES (`false`); absent is treated as `true`. Undefined on
+   * the web app.
    */
   shouldRenderEmailCard?: boolean;
   /**

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -68,12 +68,8 @@ export function mergeDisplayMessages(
     const content = extractTextFromContent(msg.content);
     const apiMessageTime = recentApiUserMessages.get(content);
 
-    // Check if this looks like a duplicate of a very recent API message
-    // A message is a duplicate if:
-    // 1. It has the same content as an API message
-    // 2. The API message is very recent (within 5 seconds)
-    // 3. The local message timestamp is very close to the API message (within 3 seconds)
-    // This tight window catches temp→confirmed transitions without blocking rapid re-sends
+    // A local user message is a duplicate when its content matches a recent API
+    // message (within the 5s window above) and their timestamps are within 3s.
     const isDuplicateOfRecentMessage =
       msg.role === "user" &&
       apiMessageTime &&
@@ -90,8 +86,6 @@ export function mergeDisplayMessages(
   return Object.fromEntries(messageMap.entries());
 }
 
-// Define a more specific type for the request body if available from your API schemas
-// For now, using a general structure.
 export interface SubmitStreamRequestBody {
   user_message: string;
   previous_message_id?: string;

--- a/frontend/src/utils/sse/sseClient.ts
+++ b/frontend/src/utils/sse/sseClient.ts
@@ -5,8 +5,6 @@
  * with support for custom headers and event handling.
  *
  * Note: The native EventSource API doesn't support custom headers.
- * For production, consider using a polyfill like 'event-source-polyfill' or
- * a custom implementation for more advanced features.
  */
 
 import { mergeApiAuthHeaders } from "@/auth/apiRequestAuth";
@@ -122,20 +120,18 @@ export function createSSEConnection(url: string, options: SSEOptions = {}) {
   abortController = new AbortController();
   const { signal } = abortController;
 
-  // Helper async generator to iterate over stream reader (alternative structure)
+  // Async generator over the stream reader
   async function* streamAsyncIterator(
     reader: ReadableStreamDefaultReader<Uint8Array>,
   ) {
     try {
-      let result = await reader.read(); // Initial read before the loop
+      let result = await reader.read();
       while (!result.done) {
-        // Loop condition based on 'done'
-        yield result.value; // Yield the current chunk
-        result = await reader.read(); // Read the next chunk at the end
+        yield result.value;
+        result = await reader.read();
       }
-      // Loop naturally terminates when result.done is true
     } finally {
-      reader.releaseLock(); // Ensure the lock is always released
+      reader.releaseLock();
     }
   }
 
@@ -143,16 +139,14 @@ export function createSSEConnection(url: string, options: SSEOptions = {}) {
   const readSSEStream = async (stream: ReadableStream<Uint8Array>) => {
     let buffer = "";
     const decoder = new TextDecoder();
-    const reader = stream.getReader(); // Get the reader
+    const reader = stream.getReader();
 
     try {
       logger.log("Stream connected, starting to read using async generator");
       isConnected = true;
       onOpen?.();
 
-      // Use for await...of on the async generator helper
       for await (const value of streamAsyncIterator(reader)) {
-        // Decode chunk and add to buffer
         const chunk = decoder.decode(value, { stream: true });
         buffer += chunk;
 

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -67,15 +67,11 @@ export function deepMerge<T extends Record<string, unknown>>(
   target: T,
   source?: Partial<T>,
 ): T {
-  // If source is undefined or null, return the target
   if (!source) return target;
 
-  // Create a new object to avoid mutating the target
   const result = { ...target };
 
-  // Iterate through all source properties
   Object.keys(source).forEach((key) => {
-    // Get the key as a proper key of T
     const typedKey = key as keyof T;
     const sourceValue = source[typedKey];
     const targetValue = target[typedKey];
@@ -94,7 +90,6 @@ export function deepMerge<T extends Record<string, unknown>>(
         sourceValue as Record<string, unknown>,
       ) as T[keyof T];
     } else {
-      // Otherwise, use the source value directly
       result[typedKey] = sourceValue as T[keyof T];
     }
   });

--- a/office-addin/src/hooks/useCurrentThread.ts
+++ b/office-addin/src/hooks/useCurrentThread.ts
@@ -19,7 +19,7 @@ export interface UseCurrentThreadResult {
    * True when the conversation fetch failed outright (first page errored, so
    * nothing was retrieved). Consumers surface this rather than silently
    * showing "no thread" — distinct from a genuinely empty conversation, which
-   * leaves `thread === null` with `error === false` (INV-7).
+   * leaves `thread === null` with `error === false`.
    */
   error: boolean;
 }

--- a/office-addin/src/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/providers/OutlookEmailSourceProvider.tsx
@@ -123,7 +123,7 @@ interface OutlookEmailSourceContextValue {
   /**
    * True when the open conversation failed to load entirely (Graph fetch
    * errored on the first page). Surfaced so the UI can warn the user rather
-   * than silently presenting an empty thread (INV-7).
+   * than silently presenting an empty thread.
    */
   emailThreadLoadError: boolean;
   currentThread: ParsedThread | null;

--- a/office-addin/src/utils/buildThreadSynthInputs.ts
+++ b/office-addin/src/utils/buildThreadSynthInputs.ts
@@ -14,11 +14,10 @@
  *     provenance marker naming where the full copy lives. Three different
  *     versions of `Lastenheft.pdf` = three byte streams = all kept.
  *   - Attachments with no retrievable bytes (cloud references, un-fetchable
- *     items) are disclosed as markers, never silently dropped (INV-9).
+ *     items) are disclosed as markers, never silently dropped.
  *   - An image-only message (no body text, only inline images) gets a marker
  *     so it isn't invisibly empty.
- *   - A partial thread appends a synthetic note disclosing incompleteness
- *     (INV-7).
+ *   - A partial thread appends a synthetic note disclosing incompleteness.
  *
  * Bodies are never mutated for dedup — markers are appended, respecting the
  * message's html-vs-text body type.

--- a/office-addin/src/utils/fetchOutlookMessage.ts
+++ b/office-addin/src/utils/fetchOutlookMessage.ts
@@ -35,7 +35,7 @@ export type {
 } from "./fetchOutlookMessageGraph";
 
 /**
- * Environment dispatcher for Outlook message fetching (ERMAIN-353).
+ * Environment dispatcher for Outlook message fetching.
  *
  * The add-in talks to exactly one of two mutually exclusive mail backends,
  * selected by where the mailbox lives (NOT by auth mode — SE and EXO both

--- a/office-addin/src/utils/fetchOutlookMessageGraph.ts
+++ b/office-addin/src/utils/fetchOutlookMessageGraph.ts
@@ -109,8 +109,7 @@ export async function fetchParentMessageInConversationViaGraph(
     // `and isDraft eq false` plus `$orderby=receivedDateTime desc` trips
     // Graph's `InefficientFilter` constraint: properties in `$orderby` must
     // also appear in `$filter`, in the same order, before non-orderby
-    // properties — see the rule at
-    // https://learn.microsoft.com/en-us/graph/api/user-list-messages.
+    // properties.
     // We instead pull the most recent ~thread-worth of messages and pick
     // the latest non-draft client-side.
     const filter = `conversationId eq '${escapeODataString(conversationId)}'`;
@@ -238,7 +237,7 @@ export interface FetchConversationOptions {
  *   - `ok`      — every page fetched successfully.
  *   - `partial` — at least one page succeeded but a later page failed or the
  *                 hard page cap was hit. Some messages may be missing; the
- *                 caller should mark the thread incomplete (INV-7).
+ *                 caller should mark the thread incomplete.
  *   - `error`   — the very first page failed; `messages` is empty and the
  *                 caller must surface a load error rather than silently
  *                 producing "no thread".
@@ -293,7 +292,6 @@ export async function fetchConversationMessagesViaGraph(
   // the row materializes as that subtype; itemAttachment and
   // referenceAttachment items still come back (without those fields), so
   // callers can discriminate on `@odata.type` and skip non-file rows.
-  // See microsoftgraph/microsoft-graph-explorer-v4#3916.
   const attachmentSelect = [
     "id",
     "name",

--- a/office-addin/src/utils/officeTheme/detectTheme.ts
+++ b/office-addin/src/utils/officeTheme/detectTheme.ts
@@ -17,14 +17,13 @@ export type OfficeThemeSnapshot = {
  * Microsoft documents `isDarkTheme`, `themeId`, and `fluentThemeData` as
  * "not supported in Outlook" — the host bridges them through as sentinel
  * strings (`"#000001"`, `"#NaN"`, etc.) that look usable but aren't part of
- * the contract. See https://learn.microsoft.com/en-us/javascript/api/office/office.officetheme
+ * the contract.
  *
  * Other hosts (Excel, Word, PowerPoint) read `isDarkTheme` directly.
  *
  * Known Outlook-on-Windows bug: theme changes don't propagate until the user
  * fully restarts Outlook — the values cached here stay stale and
  * `OfficeThemeChanged` either doesn't fire or fires with the previous value.
- * Open issue: https://github.com/OfficeDev/office-js/issues/6348
  *
  * The caller passes `host` — this module deliberately does not read
  * `Office.context.host` itself, so it stays pure and easy to test.

--- a/office-addin/src/utils/officeTheme/subscribeThemeChanges.ts
+++ b/office-addin/src/utils/officeTheme/subscribeThemeChanges.ts
@@ -8,8 +8,7 @@ import { detectTheme, type OfficeThemeSnapshot } from "./detectTheme";
  *
  * 1. `Office.EventType.OfficeThemeChanged` on the Outlook mailbox (Mailbox
  *    requirement set 1.14). Fires reliably on OWA. Fires unreliably with
- *    stale payload on Outlook for Windows / Mac — see
- *    https://github.com/OfficeDev/office-js/issues/6348.
+ *    stale payload on Outlook for Windows / Mac.
  *
  * 2. `prefers-color-scheme` media query. Reflects the OS dark-mode preference
  *    and fires immediately even when Outlook's `officeTheme` cache is stale

--- a/office-addin/src/utils/parseEmlFile.ts
+++ b/office-addin/src/utils/parseEmlFile.ts
@@ -18,7 +18,7 @@ export function isEmlFile(file: File): boolean {
  * Phase 1 transitional adapter — flattens a dropped `.eml` into the raw
  * RFC822 file plus one sibling `File` per non-inline, non-related attachment.
  *
- * Branch A (ERMAIN-273) replaces this output with a trimmed single `.eml`
+ * Branch A replaces this output with a trimmed single `.eml`
  * via surgical MIME removal — that swap lands in Phase 2. Until then we
  * keep the sibling-upload shape so the existing pipeline keeps working
  * while the selection UI / pre-upload validation is built on top of the

--- a/office-addin/src/utils/parsedThread.ts
+++ b/office-addin/src/utils/parsedThread.ts
@@ -38,7 +38,7 @@ export interface ThreadAttachment {
    * When `contentBytes` is null, a human-readable reason the bytes are
    * unavailable (cloud reference, un-retrievable item, unsupported subtype).
    * Surfaced to the LLM as a disclosure marker so the attachment's existence
-   * is never silently dropped (INV-9). Null when bytes are present.
+   * is never silently dropped. Null when bytes are present.
    */
   unavailableReason: string | null;
 }
@@ -67,7 +67,7 @@ export interface ParsedThread {
   /**
    * True when the conversation could not be fully fetched (a later page
    * failed or the page cap was hit). Consumers disclose this to the LLM
-   * (INV-7), and `chooseBody` suppresses the plaintext-body collapse so
+   * and `chooseBody` suppresses the plaintext-body collapse so
    * quoted history that may live only in an unfetched earlier message is
    * retained. (Attachment dedup stays safe even when incomplete: the
    * canonical copy a marker points to is always the first occurrence within
@@ -79,7 +79,7 @@ export interface ParsedThread {
 /**
  * Thrown when the conversation fetch fails on its very first page — i.e. we
  * have nothing, as opposed to a genuinely empty conversation. Callers must
- * surface this loudly rather than rendering "no thread" (INV-7).
+ * surface this loudly rather than rendering "no thread".
  */
 export class ThreadFetchError extends Error {
   constructor(conversationId: string) {
@@ -193,7 +193,7 @@ function chooseBody(
   let chosenContent: string | null;
   let chosenIsHtml: boolean;
   if (fullContent === null) {
-    // Full body empty → fall back to uniqueBody, reading its OWN type (INV-4).
+    // Full body empty → fall back to uniqueBody, reading its OWN type.
     chosenContent = uniqContent;
     chosenIsHtml = uniqContent !== null ? uniqIsHtml : false;
   } else if (uniqContent === null) {
@@ -270,7 +270,7 @@ function transformAttachment(
   }
 
   // No bytes available. Rather than the old silent `return null`, disclose the
-  // attachment's existence so its content is never invisibly dropped (INV-9).
+  // attachment's existence so its content is never invisibly dropped.
   const named = name ? `: ${name}` : "";
   let unavailableReason: string;
   switch (attachment["@odata.type"]) {

--- a/office-addin/src/utils/synthesizeThreadEml.ts
+++ b/office-addin/src/utils/synthesizeThreadEml.ts
@@ -12,7 +12,7 @@
  *     three replies — MIME structure preserves which version came from
  *     which message).
  *   - The frontend's EmlPreview already recurses into nested message
- *     attachments via FilePreviewContent (see commit a25a5966).
+ *     attachments via FilePreviewContent.
  *
  * Encoding choices kept deliberately simple:
  *   - Bodies: HTML when present, else plain text. UTF-8 + base64, line-


### PR DESCRIPTION
## What & why

Adds a **capture-track device-loss watchdog** (ERMAIN-390) — the **G2 follow-up** from the ERMAIN-379 resiliency review (#753). Neither recorder hook listened to `MediaStreamTrack` lifecycle events, so on iOS/WebKit a Bluetooth route change (AirPods connect/disconnect), an incoming call, or an unplugged device could **end or mute the capture track**, after which the audio graph silently produced nothing — no feedback, no recovery. This is a *different failure surface* than the AudioContext `interrupted`/`suspended` recovery that #753 shipped (`useAudioContextInterruptionRecovery`), and was explicitly left as the "device-loss follow-up" (`audioTuning.ts` G1 backstop note: the backstop resolves the cue but "can't tell a dead capture from a flowing-but-quiet one").

## What it does

New shared hook **`useMediaStreamTrackWatchdog`** (mirrors the `useAudioContextInterruptionRecovery` precedent), wired into both `useAudioDictationRecorder` and `useAudioTranscriptionRecorder`:

- **`ended` → authoritative "dead" signal**: immediately surfaces an actionable error and cleanly stops the session, **finalizing whatever audio was captured before the mic died** (no silent dead capture).
- **`mute`/`unmute` → debounced**: a `mute` arms a grace timer; an `unmute` within the window cancels it (benign iOS transient). Only a mute that *outlives* the window escalates to a loss. The timer **re-reads live track state** at decision time (a mute that progressed to `ended` reports the authoritative `ended` reason).
- **Already-ended-at-attach race** handled (device change racing `getUserMedia`): reported on a deferred task so it can't re-enter the still-running start path.
- **No auto re-acquire** — re-running `getUserMedia` can return a different sample rate that collides with our rate-coupled `AudioContext` and risks re-triggering the ERMAIN-334 first-word truncation. Safe baseline = clean stop + error; re-acquire stays a descoped stretch goal.
- Engine-agnostic, idempotent, cleaned up on teardown/unmount (unwatch happens before our own `track.stop()`, which per spec does not fire `ended`).

## Grace window = 5 s (validated)

The design was cross-checked against mature WebRTC SDKs and primary sources. Findings shifted the grace window from an initial 3 s to **5 s**:

- WebKit's own capture pipeline budgets ~5 s for a Bluetooth reconfiguration (commit `24cb5e2` raised an internal guard because "Bluetooth reconfiguration sometimes took up to 5 seconds"). A 3 s window would false-kill a session mid-handoff on a slow **AirPods connect — one of this ticket's own acceptance scenarios**.
- Matches the band used by LiveKit (debounces mute 5 s) and Jitsi (4 s of zero-signal).
- Confirmed correct: `stop()` does not fire `ended` (spec/MDN); transient iOS mute/unmute on route change is vendor-documented (WebKit commits `616d47c`/`e32bbc1`, bug 208516); `unmute` is **not** guaranteed to arrive, so grace-expiry escalation is the intended fallback.

## i18n

Four new strings (ended/muted × dictation/recording), translated in all catalogs (de/es/fr/pl) matching each catalog's established voice and terminology. Extraction is idempotent; catalogs compile.

## Tests

New `useMediaStreamTrackWatchdog.test.ts` (10 cases: ended-immediate, transient-mute-recovers, grace-window escalation, mute→ended re-read, already-ended-at-attach, single-fire guard, unwatch, track replacement, unmount). Updated both recorder test mocks (`MockMediaStreamTrack` now extends `EventTarget`). **Full audio suite 55/55**, `tsc` clean, `eslint --max-warnings=0` clean, prettier clean.

## Not in this PR (follow-ups surfaced by the validation)

Both are out of ERMAIN-390's stated scope and warrant their own tickets:
- `navigator.mediaDevices` **`devicechange`** cross-check keyed on the captured `deviceId` (LiveKit + Jitsi both do this; track events aren't guaranteed on every removal).
- **Silence / no-data RMS backstop** (~4 s, like Jitsi's `NoAudioSignalDetection`) for the live-but-silent capture-failure path that events can't catch — would reuse the ERMAIN-379 RMS infra.

## Verification status

- [x] Automated: unit tests, typecheck, lint, i18n compile.
- [x] **Physical iPhone** (AirPods connect/disconnect mid-dictation; incoming call) — the remaining acceptance item, can't be reproduced in the simulator.
