### PR TITLE
fix(office-addin): fix audio worklet 404 in production (ERMAIN-399)

### DIFF
--- a/office-addin/vite.config.ts
+++ b/office-addin/vite.config.ts
@@ -270,7 +270,8 @@ const rewriteLibraryWorkerUrlsPlugin = (isDevServer: boolean): Plugin => {
       }
       const updated = code.replace(
         /(['"])(\/assets\/audio-dictation-worklet-[^'"]+\.js)\1/g,
-        (_, quote, assetPath) => `${quote}${PRODUCTION_BASE}${assetPath}${quote}`,
+        (_, quote, assetPath) =>
+          `${quote}${PRODUCTION_BASE}${assetPath}${quote}`,
       );
       return updated !== code ? updated : null;
     },

--- a/office-addin/vite.config.ts
+++ b/office-addin/vite.config.ts
@@ -244,6 +244,39 @@ const sendFrontendLibraryAssetFile = (
   return true;
 };
 
+/**
+ * The @erato/frontend library bakes the audio worklet URL as "/assets/…"
+ * (its Vite build uses the default base "/"). In the office add-in production
+ * build, assets are served under "/public/platform-office-addin/", so the
+ * worklet lands at "/public/platform-office-addin/assets/…". The baked
+ * "/assets/…" URL therefore 404s at runtime.
+ *
+ * In dev mode the stageFrontendLibraryAssetsPlugin middleware intercepts
+ * "/assets/…" requests and serves the files correctly, so no rewrite is
+ * needed there.
+ */
+const rewriteLibraryWorkerUrlsPlugin = (isDevServer: boolean): Plugin => {
+  if (isDevServer) {
+    return { name: "rewrite-library-worker-urls" };
+  }
+
+  const PRODUCTION_BASE = "/public/platform-office-addin";
+
+  return {
+    name: "rewrite-library-worker-urls",
+    renderChunk(code) {
+      if (!code.includes("/assets/audio-dictation-worklet-")) {
+        return null;
+      }
+      const updated = code.replace(
+        /(['"])(\/assets\/audio-dictation-worklet-[^'"]+\.js)\1/g,
+        (_, quote, assetPath) => `${quote}${PRODUCTION_BASE}${assetPath}${quote}`,
+      );
+      return updated !== code ? updated : null;
+    },
+  };
+};
+
 const stageFrontendLibraryAssetsPlugin = (): Plugin => {
   return {
     name: "stage-frontend-library-assets",
@@ -537,6 +570,7 @@ export default defineConfig(({ mode }) => {
       stageFrontendLibraryAssetsPlugin(),
       stagePlatformLocalesPlugin(),
       stageFrontendVoiceRuntimeAssetsPlugin(),
+      rewriteLibraryWorkerUrlsPlugin(isDevServer),
       watchLinkedFrontendPublicOutputPlugin(linkedFrontend),
       copy404Plugin(),
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When using the office add-in in production, calling `audioContext.audioWorklet.addModule()` triggers a 404 for the audio-dictation-worklet file. This breaks dictation mode, conversational mode, and the microphone quality check.

**Root cause:** The `@erato/frontend` library is built with Vite's default `base: "/"`, which bakes the worklet URL as `/assets/audio-dictation-worklet-<hash>.js`. In production, the office add-in is served under `/public/platform-office-addin/`, so the worklet file actually lives at `/public/platform-office-addin/assets/audio-dictation-worklet-<hash>.js`. The root-relative `/assets/…` URL is never served in production, resulting in a 404.

The three hooks affected — `useAudioDictationRecorder`, `useAudioTranscriptionRecorder`, and `useGuidedAudioCapture` — all import `audio-dictation-worklet.ts?worker&url` which resolves to this baked URL.

In dev mode the problem does not appear because `stageFrontendLibraryAssetsPlugin` registers a middleware that intercepts `/assets/…` requests and serves the library assets directly from disk.

## Fix

Add a `rewriteLibraryWorkerUrlsPlugin` Vite plugin to `office-addin/vite.config.ts` that post-processes each output chunk during the **production** build. It rewrites the pattern:

```
"/assets/audio-dictation-worklet-<hash>.js"
```

to:

```
"/public/platform-office-addin/assets/audio-dictation-worklet-<hash>.js"
```

The plugin is a no-op in dev mode (`isDevServer === true`), preserving the existing dev behaviour.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-399](https://linear.app/erato-labs/issue/ERMAIN-399/audio-worklet-not-loading-404-wrong-path)

<div><a href="https://cursor.com/agents/bc-c8e06581-a020-4def-838d-8cad3db01512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8e06581-a020-4def-838d-8cad3db01512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

