### PR TITLE
Add https://outlook.cloud.microsoft as default frame-ancestor

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -187,8 +187,8 @@ chat_provider_ids = ["test-token-limit"]
 # # Example: message_feedback_edit_time_limit_seconds = 300  # 5 minutes
 # message_feedback_edit_time_limit_seconds = 300
 # # Additional Content-Security-Policy frame-ancestors sources for embedding the frontend.
-# # 'self' is always included. When the Office add-in is enabled, https://outlook.office.com is included.
-# extra_frame_ancestors = ["https://outlook.cloud.microsoft"]
+# # 'self' is always included. When the Office add-in is enabled, https://outlook.office.com and https://outlook.cloud.microsoft are included.
+# extra_frame_ancestors = ["https://example.com"]
 # # Whether to omit the frame-ancestors directive entirely (default: false)
 # allow_any_frame_ancestor = false
 #

--- a/backend/erato/src/frontend_environment.rs
+++ b/backend/erato/src/frontend_environment.rs
@@ -73,7 +73,10 @@ const FRONTEND_ENV_KEY_MASK_REASONING_TRACE_TEXT: &str = "MASK_REASONING_TRACE_T
 const COMPONENT_KITS_PUBLIC_MOUNT_BASE: &str = "/public/component-kits";
 const COMPONENT_KIT_REACT_RUNTIME_SCRIPT_PATH: &str =
     "/public/common/assets/component-kit-react-runtime.js";
-const OUTLOOK_OFFICE_FRAME_ANCESTOR: &str = "https://outlook.office.com";
+const OUTLOOK_OFFICE_FRAME_ANCESTORS: &[&str] = &[
+    "https://outlook.office.com",
+    "https://outlook.cloud.microsoft",
+];
 
 #[derive(Debug, Clone, Default)]
 /// Map of values that will be provided as environment-variable-like global variables to the frontend.
@@ -211,7 +214,11 @@ fn build_content_security_policy(config: &AppConfig) -> Option<HeaderValue> {
 
     let mut frame_ancestors = vec!["'self'".to_string()];
     if config.integrations.ms_office.addin.enabled {
-        frame_ancestors.push(OUTLOOK_OFFICE_FRAME_ANCESTOR.to_string());
+        frame_ancestors.extend(
+            OUTLOOK_OFFICE_FRAME_ANCESTORS
+                .iter()
+                .map(ToString::to_string),
+        );
     }
     frame_ancestors.extend(
         config
@@ -1213,7 +1220,9 @@ mod tests {
 
         assert_eq!(
             content_security_policy_str(&config).as_deref(),
-            Some("frame-ancestors 'self' https://outlook.office.com")
+            Some(
+                "frame-ancestors 'self' https://outlook.office.com https://outlook.cloud.microsoft"
+            )
         );
     }
 

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -429,7 +429,7 @@ window.FOO = "bar";
 
 Additional `Content-Security-Policy` `frame-ancestors` sources that may embed the frontend.
 
-Erato always includes `'self'`. When the Microsoft Office add-in is enabled, Erato also includes `https://outlook.office.com`.
+Erato always includes `'self'`. When the Microsoft Office add-in is enabled, Erato also includes `https://outlook.office.com` and `https://outlook.cloud.microsoft`.
 
 **Default value:** `[]`
 


### PR DESCRIPTION
When the Office add-in is enabled, the `frame-ancestors` CSP directive now includes `https://outlook.cloud.microsoft` in addition to the existing `https://outlook.office.com`, so the frontend can be embedded from the newer Outlook domain out of the box.

Also updated the config docs and `erato.template.toml` comment to reflect both defaults.