### PR TITLE
Mobile model selector placement and alignment

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1747,6 +1747,14 @@ export const ChatInput = ({
   const hasTopLeftAccessoryOverride =
     componentRegistry.ChatTopLeftAccessory !== null;
 
+  // Whether the model selector should render at all. When the controls are
+  // collapsed into the unified "+" menu (mobile / add-in), the selector is
+  // rendered in the left control group so it left-aligns next to the "+";
+  // otherwise it stays in the right group, right-aligned next to Send.
+  const showModelSelector =
+    !hasTopLeftAccessoryOverride &&
+    !(isAudioMode && !showModelSelectorInAudioMode);
+
   const shellWrapperStyle = {
     maxWidth: "var(--theme-layout-chat-input-max-width)",
   } as const;
@@ -2064,6 +2072,16 @@ export const ChatInput = ({
                     )}
                   </>
                 ))}
+              {useUnifiedMobileMenu && showModelSelector && (
+                <ModelSelector
+                  availableModels={availableModels}
+                  selectedModel={selectedModel}
+                  onModelChange={setSelectedModel}
+                  disabled={!isSelectionReady}
+                  align="left"
+                  className="ms-[var(--theme-spacing-control-gap)]"
+                />
+              )}
             </div>
 
             <div className="flex min-w-0 flex-wrap items-center gap-[var(--theme-spacing-control-gap)]">
@@ -2091,15 +2109,14 @@ export const ChatInput = ({
                   {t`Exit audio mode`}
                 </Button>
               )}
-              {!hasTopLeftAccessoryOverride &&
-                !(isAudioMode && !showModelSelectorInAudioMode) && (
-                  <ModelSelector
-                    availableModels={availableModels}
-                    selectedModel={selectedModel}
-                    onModelChange={setSelectedModel}
-                    disabled={!isSelectionReady}
-                  />
-                )}
+              {!useUnifiedMobileMenu && showModelSelector && (
+                <ModelSelector
+                  availableModels={availableModels}
+                  selectedModel={selectedModel}
+                  onModelChange={setSelectedModel}
+                  disabled={!isSelectionReady}
+                />
+              )}
               {isAudioMode &&
                 isPendingResponse &&
                 isConversationalAudioActive &&

--- a/frontend/src/components/ui/Chat/ModelSelector.tsx
+++ b/frontend/src/components/ui/Chat/ModelSelector.tsx
@@ -28,6 +28,13 @@ interface ModelSelectorProps {
   disabled?: boolean;
   /** Additional CSS classes */
   className?: string;
+  /**
+   * Which edge the dropdown menu aligns to. Defaults to "right" (the selector
+   * normally sits at the right edge of the input toolbar). Set to "left" when
+   * the selector is rendered on the left (e.g. the collapsed mobile/add-in
+   * layout) so the menu opens flush-left instead of clipping.
+   */
+  align?: "left" | "right";
 }
 
 function resolveModelDescription(model: ChatModel): string | null {
@@ -98,6 +105,7 @@ export const ModelSelector = ({
   onClearSelection,
   disabled = false,
   className = "",
+  align = "right",
 }: ModelSelectorProps) => {
   // Keep this marker so Lingui extracts the dynamic model description keys.
   const _modelDescriptionMarker = t`chat_models.<chat-provider-id>.description`;
@@ -175,7 +183,7 @@ export const ModelSelector = ({
     <div className={`flex items-center ${className}`}>
       <DropdownMenu
         items={dropdownItems}
-        align="right"
+        align={align}
         onOpenChange={setIsDropdownOpen}
         matchContentWidth
         triggerButtonVariant="secondary"


### PR DESCRIPTION
This pull request updates the chat input UI to improve the placement and alignment of the `ModelSelector` component, particularly for mobile and add-in layouts where controls are collapsed. The changes ensure that the model selector appears in a consistent and intuitive location and that its dropdown menu aligns correctly depending on its position.

**UI improvements for model selector placement and alignment:**

* Added a `showModelSelector` variable to centralize logic for when the `ModelSelector` should be rendered, ensuring it appears in the correct control group depending on layout and mode (`ChatInput.tsx`).
* Updated rendering logic to place the `ModelSelector` in the left control group (with left alignment) when the unified mobile menu is used, and in the right group otherwise (`ChatInput.tsx`). [[1]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77R2075-R2084) [[2]](diffhunk://#diff-48572c04e85d4b038b7cdbac6eeb2d04f732dc119b308a24afd718795c5e2c77L2094-R2112)

**Component flexibility and alignment:**

* Added a new `align` prop to `ModelSelector` (defaulting to `"right"`), allowing its dropdown menu to align left or right based on context, and passed this prop through to the underlying `DropdownMenu` (`ModelSelector.tsx`). [[1]](diffhunk://#diff-2b4688f0b965df7d5f6d3cd8f2e4c5d1431f0b1e6f2da77835bd392b46e304f0R31-R37) [[2]](diffhunk://#diff-2b4688f0b965df7d5f6d3cd8f2e4c5d1431f0b1e6f2da77835bd392b46e304f0R108) [[3]](diffhunk://#diff-2b4688f0b965df7d5f6d3cd8f2e4c5d1431f0b1e6f2da77835bd392b46e304f0L178-R186)