### PR TITLE
Client-tool round-trip — frontend (executor registry + result handler)

### DIFF
--- a/frontend/src/hooks/chat/clientToolExecutors.ts
+++ b/frontend/src/hooks/chat/clientToolExecutors.ts
@@ -1,0 +1,52 @@
+/**
+ * Registry for client-executed tools. The host (e.g. the Outlook add-in)
+ * registers executors by tool name; the shared streaming loop looks them up when
+ * the backend emits a `client_tool_call`. Executors MUST be read-only /
+ * idempotent — a backend restart drops the parked turn and the client may
+ * re-execute on recovery; mutations belong on `propose_client_action`.
+ */
+
+export type ClientToolExecutionResult =
+  | { ok: true; result: unknown }
+  | { ok: false; error: string };
+
+export type ClientToolExecutor = (
+  input: unknown,
+) => Promise<ClientToolExecutionResult>;
+
+const executors = new Map<string, ClientToolExecutor>();
+
+/** Register an executor by tool name; returns an unregister function. */
+export function registerClientToolExecutor(
+  name: string,
+  executor: ClientToolExecutor,
+): () => void {
+  executors.set(name, executor);
+  return () => {
+    if (executors.get(name) === executor) {
+      executors.delete(name);
+    }
+  };
+}
+
+export function getClientToolExecutor(
+  name: string,
+): ClientToolExecutor | undefined {
+  return executors.get(name);
+}
+
+// tool_call_ids handled this session, so a resumestream replay never re-runs a tool.
+const answeredToolCallIds = new Set<string>();
+
+export function markClientToolCallAnswered(toolCallId: string): void {
+  answeredToolCallIds.add(toolCallId);
+}
+
+export function hasClientToolCallBeenAnswered(toolCallId: string): boolean {
+  return answeredToolCallIds.has(toolCallId);
+}
+
+export function resetClientToolRegistryForTests(): void {
+  executors.clear();
+  answeredToolCallIds.clear();
+}

--- a/frontend/src/hooks/chat/clientToolExecutors.ts
+++ b/frontend/src/hooks/chat/clientToolExecutors.ts
@@ -35,11 +35,22 @@ export function getClientToolExecutor(
   return executors.get(name);
 }
 
-// tool_call_ids handled this session, so a resumestream replay never re-runs a tool.
+// tool_call_ids handled this session, so a resumestream replay never re-runs a
+// tool. Capped — idempotent executors make evicting the oldest safe.
+const MAX_ANSWERED_TOOL_CALLS = 500;
 const answeredToolCallIds = new Set<string>();
 
 export function markClientToolCallAnswered(toolCallId: string): void {
   answeredToolCallIds.add(toolCallId);
+  if (answeredToolCallIds.size > MAX_ANSWERED_TOOL_CALLS) {
+    const oldest = answeredToolCallIds.values().next().value;
+    if (oldest !== undefined) answeredToolCallIds.delete(oldest);
+  }
+}
+
+/** Un-mark after a failed delivery so a resumestream replay can retry. */
+export function unmarkClientToolCallAnswered(toolCallId: string): void {
+  answeredToolCallIds.delete(toolCallId);
 }
 
 export function hasClientToolCallBeenAnswered(toolCallId: string): boolean {

--- a/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
+++ b/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { handleClientToolCall } from "./handleClientToolCall";
+import {
+  registerClientToolExecutor,
+  resetClientToolRegistryForTests,
+} from "../clientToolExecutors";
+
+import type { MessageSubmitStreamingResponseClientToolCall } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+const deps = {
+  chatId: "chat-1",
+  getAuthHeaders: () => ({ Authorization: "Bearer tok" }),
+  extraHeaders: { "X-Erato-Platform": "outlook" },
+};
+
+function makeEvent(
+  overrides: Partial<MessageSubmitStreamingResponseClientToolCall> = {},
+) {
+  return {
+    message_type: "client_tool_call",
+    message_id: "msg-1",
+    content_index: 0,
+    tool_call_id: "call-1",
+    tool_name: "outlook.fetch_availability",
+    input: { window_start: "x" },
+    ...overrides,
+  } as MessageSubmitStreamingResponseClientToolCall & {
+    message_type: "client_tool_call";
+  };
+}
+
+function lastPostBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.at(-1);
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+describe("handleClientToolCall", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resetClientToolRegistryForTests();
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetClientToolRegistryForTests();
+  });
+
+  it("runs the registered executor and POSTs its result", async () => {
+    registerClientToolExecutor("outlook.fetch_availability", async (input) => {
+      expect(input).toEqual({ window_start: "x" });
+      return { ok: true, result: { slots: 3 } };
+    });
+
+    await handleClientToolCall(makeEvent(), deps);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/v1beta/me/messages/clienttoolresult");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer tok",
+    );
+    expect(lastPostBody(fetchMock)).toEqual({
+      chat_id: "chat-1",
+      message_id: "msg-1",
+      tool_call_id: "call-1",
+      result: { slots: 3 },
+    });
+  });
+
+  it("POSTs an error when the executor returns a failure", async () => {
+    registerClientToolExecutor("outlook.fetch_availability", async () => ({
+      ok: false,
+      error: "boom",
+    }));
+
+    await handleClientToolCall(makeEvent(), deps);
+
+    expect(lastPostBody(fetchMock)).toMatchObject({ error: "boom" });
+  });
+
+  it("POSTs an error when the executor throws", async () => {
+    registerClientToolExecutor("outlook.fetch_availability", async () => {
+      throw new Error("kaboom");
+    });
+
+    await handleClientToolCall(makeEvent(), deps);
+
+    expect(lastPostBody(fetchMock)).toMatchObject({ error: "kaboom" });
+  });
+
+  it("POSTs an error when no executor is registered", async () => {
+    await handleClientToolCall(makeEvent(), deps);
+
+    expect(lastPostBody(fetchMock).error).toContain("No client-tool executor");
+  });
+
+  it("execute-once: a replayed event does not re-run or re-POST the tool", async () => {
+    const executor = vi.fn(async () => ({ ok: true as const, result: 1 }));
+    registerClientToolExecutor("outlook.fetch_availability", executor);
+
+    await handleClientToolCall(makeEvent(), deps);
+    await handleClientToolCall(makeEvent(), deps); // replay, same tool_call_id
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when the chat id is missing", async () => {
+    await handleClientToolCall(makeEvent(), { ...deps, chatId: null });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
+++ b/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
@@ -115,4 +115,53 @@ describe("handleClientToolCall", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("execute-once holds under a concurrent (unawaited) double-fire", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const executor = vi.fn(async () => {
+      await gate;
+      return { ok: true as const, result: 1 };
+    });
+    registerClientToolExecutor("outlook.fetch_availability", executor);
+
+    // Fire both before the first resolves; the pre-await guard must block the
+    // second (this would fail if the mark moved after the await).
+    const p1 = handleClientToolCall(makeEvent(), deps);
+    const p2 = handleClientToolCall(makeEvent(), deps);
+    release();
+    await Promise.all([p1, p2]);
+
+    expect(executor).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("un-marks on a failed POST so a later replay retries", async () => {
+    const executor = vi.fn(async () => ({ ok: true as const, result: 1 }));
+    registerClientToolExecutor("outlook.fetch_availability", executor);
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+
+    await handleClientToolCall(makeEvent(), deps);
+    expect(executor).toHaveBeenCalledTimes(1);
+
+    // The failed delivery un-marked the id, so the replay runs + POSTs again.
+    await handleClientToolCall(makeEvent(), deps);
+    expect(executor).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("delivers an empty success as an explicit null result", async () => {
+    registerClientToolExecutor("outlook.fetch_availability", async () => ({
+      ok: true as const,
+      result: undefined,
+    }));
+
+    await handleClientToolCall(makeEvent(), deps);
+
+    const body = lastPostBody(fetchMock);
+    expect(body).toHaveProperty("result", null);
+    expect(body).not.toHaveProperty("error");
+  });
 });

--- a/frontend/src/hooks/chat/handlers/handleClientToolCall.ts
+++ b/frontend/src/hooks/chat/handlers/handleClientToolCall.ts
@@ -2,6 +2,7 @@ import {
   getClientToolExecutor,
   hasClientToolCallBeenAnswered,
   markClientToolCallAnswered,
+  unmarkClientToolCallAnswered,
 } from "../clientToolExecutors";
 
 import type {
@@ -55,7 +56,9 @@ export async function handleClientToolCall(
     try {
       const outcome = await executor(input ?? null);
       body = outcome.ok
-        ? { ...base, result: outcome.result as Value }
+        ? // Coalesce to explicit null so an empty success is delivered as a
+          // result, not treated by the backend as "no result → tool error".
+          { ...base, result: (outcome.result ?? null) as unknown as Value }
         : { ...base, error: outcome.error };
     } catch (error) {
       body = {
@@ -76,11 +79,14 @@ export async function handleClientToolCall(
       body: JSON.stringify(body),
     });
     if (!response.ok) {
+      // Un-mark so a resumestream replay can retry (executors are idempotent).
+      unmarkClientToolCallAnswered(tool_call_id);
       console.warn(
         `[client_tool_call] result POST returned ${response.status}`,
       );
     }
   } catch (error) {
+    unmarkClientToolCallAnswered(tool_call_id);
     console.warn("[client_tool_call] result POST failed", error);
   }
 }

--- a/frontend/src/hooks/chat/handlers/handleClientToolCall.ts
+++ b/frontend/src/hooks/chat/handlers/handleClientToolCall.ts
@@ -1,0 +1,86 @@
+import {
+  getClientToolExecutor,
+  hasClientToolCallBeenAnswered,
+  markClientToolCallAnswered,
+} from "../clientToolExecutors";
+
+import type {
+  ClientToolResultRequest,
+  MessageSubmitStreamingResponseClientToolCall,
+  Value,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+interface HandleClientToolCallDeps {
+  chatId: string | null;
+  getAuthHeaders: () => Record<string, string>;
+  extraHeaders?: Record<string, string>;
+}
+
+/**
+ * Runs the registered executor for a `client_tool_call` and POSTs the outcome to
+ * resume the suspended turn. Execute-once by `tool_call_id` (a resumestream
+ * replay re-emits the event); a missing/throwing executor still POSTs an error
+ * so the backend recovers instead of parking to timeout.
+ */
+export async function handleClientToolCall(
+  responseData: MessageSubmitStreamingResponseClientToolCall & {
+    message_type: "client_tool_call";
+  },
+  deps: HandleClientToolCallDeps,
+): Promise<void> {
+  const { message_id, tool_call_id, tool_name, input } = responseData;
+  const { chatId } = deps;
+
+  if (!chatId || !message_id || !tool_call_id || !tool_name) {
+    console.warn("[client_tool_call] missing required fields", responseData);
+    return;
+  }
+
+  // Guard before any await so a live event and its replay can't both run it.
+  if (hasClientToolCallBeenAnswered(tool_call_id)) {
+    return;
+  }
+  markClientToolCallAnswered(tool_call_id);
+
+  const base = { chat_id: chatId, message_id, tool_call_id };
+  let body: ClientToolResultRequest;
+
+  const executor = getClientToolExecutor(tool_name);
+  if (!executor) {
+    body = {
+      ...base,
+      error: `No client-tool executor registered for "${tool_name}"`,
+    };
+  } else {
+    try {
+      const outcome = await executor(input ?? null);
+      body = outcome.ok
+        ? { ...base, result: outcome.result as Value }
+        : { ...base, error: outcome.error };
+    } catch (error) {
+      body = {
+        ...base,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  try {
+    const response = await fetch("/api/v1beta/me/messages/clienttoolresult", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...deps.getAuthHeaders(),
+        ...(deps.extraHeaders ?? {}),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      console.warn(
+        `[client_tool_call] result POST returned ${response.status}`,
+      );
+    }
+  } catch (error) {
+    console.warn("[client_tool_call] result POST failed", error);
+  }
+}

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -966,12 +966,17 @@ export function useChatMessaging(
 
           case "client_tool_call":
             // Run the registered executor and POST the result to resume the
-            // backend's parked turn.
+            // backend's parked turn. Route by this stream's own key (rebound to
+            // the real chat id on chat_created) like every sibling handler — NOT
+            // the global newlyCreatedChatId slot, which a concurrent new chat
+            // would clobber and mis-route the result.
             void handleClientToolCall(responseData, {
               chatId:
-                chatId ??
-                useMessagingStore.getState().newlyCreatedChatId ??
-                null,
+                activeStreamKey !== NEW_CHAT_STREAM_KEY
+                  ? activeStreamKey
+                  : (chatId ??
+                    useMessagingStore.getState().newlyCreatedChatId ??
+                    null),
               getAuthHeaders,
               extraHeaders: { [X_ERATO_PLATFORM_HEADER]: platform },
             });

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -37,6 +37,7 @@ import { createSSEConnection, type SSEEvent } from "@/utils/sse/sseClient";
 
 import { handleAssistantMessageStarted } from "./handlers/handleAssistantMessageStarted";
 import { handleChatCreated } from "./handlers/handleChatCreated";
+import { handleClientToolCall } from "./handlers/handleClientToolCall";
 import { handleMessageComplete as externalHandleMessageComplete } from "./handlers/handleMessageComplete";
 import { handleReasoningDelta } from "./handlers/handleReasoningDelta";
 import { handleTextDelta } from "./handlers/handleTextDelta";
@@ -961,6 +962,19 @@ export function useChatMessaging(
               responseData,
             );
             handleToolCallUpdate(responseData, activeStreamKey);
+            break;
+
+          case "client_tool_call":
+            // Run the registered executor and POST the result to resume the
+            // backend's parked turn.
+            void handleClientToolCall(responseData, {
+              chatId:
+                chatId ??
+                useMessagingStore.getState().newlyCreatedChatId ??
+                null,
+              getAuthHeaders,
+              extraHeaders: { [X_ERATO_PLATFORM_HEADER]: platform },
+            });
             break;
 
           case "error": {

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -3640,6 +3640,52 @@ export const useAbortMessageStream = (
   });
 };
 
+export type ClientToolResultError = Fetcher.ErrorWrapper<undefined>;
+
+export type ClientToolResultVariables = {
+  body: Schemas.ClientToolResultRequest;
+} & V1betaApiContext["fetcherOptions"];
+
+export const fetchClientToolResult = (
+  variables: ClientToolResultVariables,
+  signal?: AbortSignal,
+) =>
+  v1betaApiFetch<
+    Schemas.ClientToolResultResponse,
+    ClientToolResultError,
+    Schemas.ClientToolResultRequest,
+    {},
+    {},
+    {}
+  >({
+    url: "/api/v1beta/me/messages/clienttoolresult",
+    method: "post",
+    ...variables,
+    signal,
+  });
+
+export const useClientToolResult = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      Schemas.ClientToolResultResponse,
+      ClientToolResultError,
+      ClientToolResultVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useV1betaApiContext();
+  return reactQuery.useMutation<
+    Schemas.ClientToolResultResponse,
+    ClientToolResultError,
+    ClientToolResultVariables
+  >({
+    mutationFn: (variables: ClientToolResultVariables) =>
+      fetchClientToolResult(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
 export type EditMessageSseError = Fetcher.ErrorWrapper<undefined>;
 
 export type EditMessageSseVariables = {

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -704,6 +704,43 @@ export type ChatModel = {
   model_icon?: string | null | undefined;
 };
 
+export type ClientToolResultRequest = {
+  /**
+   * The chat whose suspended generation is awaiting this result.
+   *
+   * @format uuid
+   * @example 00000000-0000-0000-0000-000000000000
+   */
+  chat_id: string;
+  /**
+   * An error message if the client could not execute the tool. Provide this
+   * OR `result`.
+   */
+  error?: string;
+  /**
+   * The id of the assistant message whose generation emitted the client
+   * tool call. Disambiguates a result from a task that has since been
+   * replaced by a concurrent generation on the same chat.
+   *
+   * @format uuid
+   * @example 00000000-0000-0000-0000-000000000000
+   */
+  message_id: string;
+  result?: Value;
+  /**
+   * The `tool_call_id` from the `client_tool_call` event being answered.
+   */
+  tool_call_id: string;
+};
+
+export type ClientToolResultResponse = {
+  /**
+   * True if a suspended generation received this result; false if it was a
+   * benign no-op (already delivered, timed out, aborted, or unknown id).
+   */
+  delivered: boolean;
+};
+
 export type CompleteMcpServerOauthResponse = {
   connection_status: McpServerStatusValue;
 };
@@ -1045,6 +1082,9 @@ export type EditMessageStreamingResponseMessage =
     })
   | (MessageSubmitStreamingResponseToolCallUpdate & {
       message_type: "tool_call_update";
+    })
+  | (MessageSubmitStreamingResponseClientToolCall & {
+      message_type: "client_tool_call";
     })
   | (MessageSubmitStreamingResponseError & {
       message_type: "error";
@@ -1407,6 +1447,26 @@ export type MessageSubmitStreamingResponseChatCreated = {
 };
 
 /**
+ * Sent when the model calls a facet `client_tool`: the generation is suspended
+ * until the client executes the tool and POSTs the result back to the
+ * continuation endpoint. Distinct from `tool_call_proposed` (which fires for
+ * every proposed tool call) — this is the signal to execute on the client.
+ */
+export type MessageSubmitStreamingResponseClientToolCall = {
+  /**
+   * @minimum 0
+   */
+  content_index: number;
+  input?: null | Value;
+  /**
+   * @format uuid
+   */
+  message_id: string;
+  tool_call_id: string;
+  tool_name: string;
+};
+
+/**
  * Represents different types of errors that can occur during message generation.
  */
 export type MessageSubmitStreamingResponseError = GenerationErrorType & {
@@ -1442,6 +1502,9 @@ export type MessageSubmitStreamingResponseMessage =
     })
   | (MessageSubmitStreamingResponseToolCallUpdate & {
       message_type: "tool_call_update";
+    })
+  | (MessageSubmitStreamingResponseClientToolCall & {
+      message_type: "client_tool_call";
     })
   | (MessageSubmitStreamingResponseError & {
       message_type: "error";
@@ -1746,6 +1809,9 @@ export type RegenerateMessageStreamingResponseMessage =
     })
   | (MessageSubmitStreamingResponseToolCallUpdate & {
       message_type: "tool_call_update";
+    })
+  | (MessageSubmitStreamingResponseClientToolCall & {
+      message_type: "client_tool_call";
     })
   | (MessageSubmitStreamingResponseError & {
       message_type: "error";

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -212,6 +212,11 @@ export {
   type EratoEmailCodeBlockProps,
   type ChatAddMenuExtraContentProps,
 } from "@/config/componentRegistry";
+export {
+  registerClientToolExecutor,
+  type ClientToolExecutor,
+  type ClientToolExecutionResult,
+} from "@/hooks/chat/clientToolExecutors";
 export { createLogger } from "@/utils/debugLogger";
 export { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 export {


### PR DESCRIPTION
The **client side** of the client-tool round-trip. When the backend (#786) suspends a turn and emits a `client_tool_call`, the shared streaming loop runs the registered executor and POSTs the result to `/me/messages/clienttoolresult`, resuming the turn.

**Host-agnostic** — no Outlook specifics. Hosts (the add-in) register their own executors; the `outlook.fetch_availability` executor is a follow-up (needs the calendar layer, #798).

## What

- **Regenerated API types** — `client_tool_call` event, `ClientToolResultRequest`/`Response`, and the result fetcher, from the backend OpenAPI spec (`pnpm codegen`).
- **Executor registry** (`registerClientToolExecutor`, exported from `@erato/frontend/library`) — a host registers an executor by tool name (e.g. `outlook.fetch_availability`); the shared loop, which can't import host code, looks it up.
- **`handleClientToolCall`** — looks up the executor, runs it, POSTs the outcome (routed by `chat_id` + `message_id`). If none is registered or it throws, POSTs an error so the backend recovers instead of parking to timeout.
- **Execute-once** by `tool_call_id` — a `resumestream` replay re-emits the event; the guard (set synchronously, before any await) prevents re-running a tool.
- Wired as `case "client_tool_call"` in `useChatMessaging`.

## Notes

- Depends on **#786** (backend) for the endpoint/event to exist at runtime; the types come from its regenerated spec.
- 6 handler unit tests (executor success/error/throw, no-executor, execute-once, missing-chat guard); typecheck + eslint + prettier clean.
