### PR TITLE
Client tools: portable-name hygiene + offering-loop hardening

### DIFF
--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -882,6 +882,28 @@ impl AppConfig {
             if !seen_qualified_names.insert(qualified.clone()) {
                 panic!("Duplicate client tool '{}'.", qualified);
             }
+            // Portable-name check is a WARNING, not an error: the pattern is
+            // the OpenAI/Azure + Anthropic intersection, but Gemini accepts
+            // more (dots, colons, 128 chars), so a laxer name may be
+            // deliberate in a Gemini-only deployment. tracing is not
+            // initialized yet at config load, hence startup_log.
+            if !(name.len() <= 64
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+            {
+                crate::startup_log::warn_preinit(format!(
+                    "Client tool name '{}' does not match ^[a-zA-Z0-9_-]{{1,64}}$; \
+                     OpenAI/Azure and Anthropic reject such tool names at request time.",
+                    name
+                ));
+            }
+            if tool.timeout_ms == Some(0) {
+                panic!(
+                    "Client tool '{}' has timeout_ms = 0; every call would time out before the client can respond.",
+                    qualified
+                );
+            }
             match serde_json::from_str::<serde_json::Value>(&tool.parameters) {
                 Ok(value) if value.is_object() => {}
                 Ok(_) => panic!(
@@ -2807,9 +2829,15 @@ pub struct ClientToolsConfig {
 /// must use the terminal `client_actions` (`propose_client_action`) path.
 #[derive(Debug, Deserialize, PartialEq, Eq, Clone, Default, Facet)]
 pub struct ClientToolConfig {
-    /// Tool name exposed to the model (e.g. "outlook.fetch_availability").
-    /// Must be non-empty and must not collide with the reserved
+    /// Tool name exposed to the model (e.g. "fetch_availability", selected in
+    /// allowlists as "outlook/fetch_availability" via its namespace). Must be
+    /// non-empty and must not collide with the reserved
     /// `propose_client_action` name; the `namespace/name` pair must be unique.
+    /// Portable names match `^[a-zA-Z0-9_-]{1,64}$` — that is the
+    /// cross-provider intersection (OpenAI/Azure and Anthropic reject
+    /// anything else at request time; Gemini additionally accepts dots,
+    /// colons, and up to 128 chars). Names outside the portable set load with
+    /// a startup warning, not an error.
     pub name: String,
 
     /// Namespace used for `tool_call_allowlist` selection (e.g. `outlook` →

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1457,6 +1457,11 @@ pub struct PreparedChatRequest {
     mcp_servers_unavailable: Vec<String>,
     // Filtered MCP tools available to this request, including server routing info.
     available_mcp_tools: Vec<crate::services::mcp_session_manager::ManagedTool>,
+    // Park budgets of the client tools OFFERED to this request, keyed by the
+    // model-facing name (unique post-dedup). The dispatch/park site resolves
+    // timeouts from here instead of re-finding config entries by bare name,
+    // which is ambiguous when namespaces reuse a name.
+    offered_client_tool_timeouts: HashMap<String, Option<u64>>,
     // Prepared `genai` `ChatRequest` (messages + available tools)
     chat_request: ChatRequest,
     // Prepared `genai` `ChatOptions` (e.g. reasoning effort)
@@ -2043,25 +2048,61 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         &effective_selected_facet_ids,
         user_input.action_facet.as_ref().map(|af| af.id.as_str()),
     );
+    // Park budgets of the client tools OFFERED to this request, keyed by the
+    // model-facing name (unique post-dedup). The dispatch/park site resolves
+    // timeouts from here instead of re-finding config entries by bare name.
+    let mut offered_client_tool_timeouts: std::collections::HashMap<String, Option<u64>> =
+        std::collections::HashMap::new();
     if !client_tool_allowlist.is_empty() {
-        for client_tool in app_state.config.client_tools.tools.values() {
-            if !is_qualified_tool_allowed(
-                client_tool.namespace_or_default(),
-                &client_tool.name,
-                &client_tool_allowlist,
-            ) {
-                continue;
+        let allowlist_matched: Vec<&crate::config::ClientToolConfig> = app_state
+            .config
+            .client_tools
+            .tools
+            .values()
+            .filter(|client_tool| {
+                is_qualified_tool_allowed(
+                    client_tool.namespace_or_default(),
+                    &client_tool.name,
+                    &client_tool_allowlist,
+                )
+            })
+            .collect();
+        let selection = crate::services::client_tools::select_client_tools(
+            allowlist_matched,
+            &client_tool_allowlist,
+            |name| generation_mcp_tools.iter().any(|mcp| mcp.tool.name == name),
+        );
+        for (skipped_tool, skip) in &selection.skipped {
+            use crate::services::client_tools::ClientToolSkip;
+            match skip {
+                ClientToolSkip::ReservedName => tracing::warn!(
+                    "Not offering client tool '{}': the name is reserved",
+                    skipped_tool.qualified_name()
+                ),
+                // An exact allowlist entry naming a tool that then cannot be
+                // offered is always a config bug — surface it loudly.
+                ClientToolSkip::McpCollision {
+                    explicitly_selected: true,
+                } => tracing::error!(
+                    "Not offering client tool '{}' although the allowlist selects it EXACTLY: an MCP tool already uses the model-facing name '{}' — fix the config",
+                    skipped_tool.qualified_name(),
+                    skipped_tool.name
+                ),
+                ClientToolSkip::McpCollision { .. } => tracing::warn!(
+                    "Not offering client tool '{}': an MCP tool already uses the model-facing name '{}'",
+                    skipped_tool.qualified_name(),
+                    skipped_tool.name
+                ),
+                ClientToolSkip::DuplicateBareName { winner_qualified } => tracing::warn!(
+                    "Not offering client tool '{}': '{}' already offers the model-facing name '{}' (providers require unique tool names)",
+                    skipped_tool.qualified_name(),
+                    winner_qualified,
+                    skipped_tool.name
+                ),
             }
+        }
+        for client_tool in selection.offered {
             let name = client_tool.name.as_str();
-            if name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
-                || generation_mcp_tools.iter().any(|mcp| mcp.tool.name == name)
-            {
-                tracing::warn!(
-                    "Not offering client tool '{}': the name is reserved or already used by an MCP tool",
-                    name
-                );
-                continue;
-            }
             let schema = match serde_json::from_str::<serde_json::Value>(&client_tool.parameters) {
                 Ok(schema) => schema,
                 Err(error) => {
@@ -2073,6 +2114,10 @@ pub(crate) async fn prepare_chat_request_with_adapters(
                     continue;
                 }
             };
+            // Remember the OFFERED entry's park budget by model-facing name
+            // (unique post-dedup) — the dispatch site must not re-find the
+            // config by bare name, which is ambiguous across namespaces.
+            offered_client_tool_timeouts.insert(name.to_string(), client_tool.timeout_ms);
             chat_request_tools.push(crate::services::client_tools::build_client_tool(
                 name,
                 &client_tool.description,
@@ -2131,6 +2176,7 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         generation_request_context,
         mcp_servers_unavailable: tool_discovery.unavailable_server_ids,
         available_mcp_tools: generation_mcp_tools.clone(),
+        offered_client_tool_timeouts,
         chat_request,
         chat_options,
     })
@@ -2246,6 +2292,7 @@ async fn stream_generate_chat_completion<
     mcp_servers_unavailable: Vec<String>,
     allowed_tool_names: HashSet<String>,
     available_mcp_tools: Vec<crate::services::mcp_session_manager::ManagedTool>,
+    offered_client_tool_timeouts: HashMap<String, Option<u64>>,
     chat_provider_headers_context: &'a ChatProviderHeadersContext<'a>,
     streaming_task: Option<&Arc<StreamingTask>>,
     assistant_id: Option<Uuid>,
@@ -2659,15 +2706,13 @@ async fn stream_generate_chat_completion<
                 // durable signal path.
                 let _ = call_message.send_event(tx.clone()).await;
 
-                // Resolve this tool's park budget: the top-level client tool's
-                // `timeout_ms` override if set, else the default.
-                let park_timeout_ms = app_state
-                    .config
-                    .client_tools
-                    .tools
-                    .values()
-                    .find(|tool| tool.name == tool_name)
-                    .and_then(|tool| tool.timeout_ms)
+                // Resolve this tool's park budget from the entry that was
+                // OFFERED to this request (a bare-name config scan would be
+                // ambiguous when namespaces reuse a name), else the default.
+                let park_timeout_ms = offered_client_tool_timeouts
+                    .get(tool_name.as_str())
+                    .copied()
+                    .flatten()
                     .unwrap_or(DEFAULT_CLIENT_TOOL_PARK_TIMEOUT_MS);
 
                 // Park until the client POSTs a result, an abort arrives, or the
@@ -6397,6 +6442,7 @@ async fn run_message_submit_task(
         generation_request_context,
         mcp_servers_unavailable,
         available_mcp_tools,
+        offered_client_tool_timeouts,
     } = prepare_chat_request(
         app_state,
         policy,
@@ -6677,6 +6723,7 @@ async fn run_message_submit_task(
         mcp_servers_unavailable,
         allowed_tool_names,
         available_mcp_tools,
+        offered_client_tool_timeouts,
         &chat_provider_headers_context,
         Some(task),
         chat.assistant_id,
@@ -6902,6 +6949,7 @@ pub async fn regenerate_message_sse(
                 generation_request_context,
                 mcp_servers_unavailable,
                 available_mcp_tools,
+                offered_client_tool_timeouts,
             } = prepare_chat_request_res.unwrap();
 
             let langfuse_trace_enrichment = match build_langfuse_trace_enrichment(
@@ -7001,6 +7049,7 @@ pub async fn regenerate_message_sse(
                     mcp_servers_unavailable,
                     allowed_tool_names,
                     available_mcp_tools,
+                    offered_client_tool_timeouts,
                     &chat_provider_headers_context,
                     Some(&task_for_stream),
                     chat.assistant_id,
@@ -7251,6 +7300,7 @@ pub async fn edit_message_sse(
                 generation_request_context,
                 mcp_servers_unavailable,
                 available_mcp_tools,
+                offered_client_tool_timeouts,
             } = prepare_chat_request_res.unwrap();
 
             let langfuse_trace_enrichment = match build_langfuse_trace_enrichment(
@@ -7350,6 +7400,7 @@ pub async fn edit_message_sse(
                     mcp_servers_unavailable,
                     allowed_tool_names,
                     available_mcp_tools,
+                    offered_client_tool_timeouts,
                     &chat_provider_headers_context,
                     Some(&task_for_stream),
                     chat.assistant_id,

--- a/backend/erato/src/services/client_tools.rs
+++ b/backend/erato/src/services/client_tools.rs
@@ -11,9 +11,13 @@
 //! drops the parked turn, so a client may re-execute on recovery. Mutations
 //! must use the terminal `client_actions` path.
 
+use std::collections::HashMap;
+
 use genai::chat::Tool as GenaiTool;
 use genai::chat::ToolName as GenaiToolName;
 use serde_json::Value;
+
+use crate::config::ClientToolConfig;
 
 /// Build a genai tool for a facet-declared client tool. `schema` is the parsed
 /// JSON-Schema object for the tool's input parameters (validated as a JSON
@@ -32,6 +36,81 @@ pub fn build_client_tool(
         strict: if omit_tool_strict { None } else { Some(false) },
         config: None,
     }
+}
+
+/// Why an allowlist-selected client tool was NOT offered to the model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientToolSkip {
+    /// The bare name collides with the reserved `propose_client_action` tool.
+    ReservedName,
+    /// An MCP tool already uses the same model-facing name; the MCP tool wins.
+    /// `explicitly_selected` is true when the allowlist named this client tool
+    /// EXACTLY (`namespace/name`, not via a wildcard) — that combination is
+    /// always a config bug and is logged at error level.
+    McpCollision { explicitly_selected: bool },
+    /// An earlier client tool (in deterministic qualified-name order) already
+    /// exposes the same model-facing name. Cross-namespace bare-name reuse is
+    /// valid config (platform-disjoint packages), but providers require unique
+    /// tool names within one request, so only the first is offered.
+    DuplicateBareName { winner_qualified: String },
+}
+
+/// The client tools to offer for one request, plus per-tool skip diagnostics.
+pub struct ClientToolSelection<'a> {
+    pub offered: Vec<&'a ClientToolConfig>,
+    pub skipped: Vec<(&'a ClientToolConfig, ClientToolSkip)>,
+}
+
+/// Select the client tools to offer: the allowlist-matched tools in
+/// DETERMINISTIC qualified-name order (config holds them in a `HashMap`, whose
+/// iteration order would otherwise churn provider prompt-cache prefixes and
+/// make collision winners arbitrary across restarts), minus reserved-name,
+/// MCP-collision, and duplicate-bare-name entries. Pure — the caller does the
+/// allowlist matching and the logging.
+pub fn select_client_tools<'a>(
+    allowlist_matched: Vec<&'a ClientToolConfig>,
+    allowlist: &[String],
+    mcp_has_tool: impl Fn(&str) -> bool,
+) -> ClientToolSelection<'a> {
+    let mut matched = allowlist_matched;
+    matched.sort_by_key(|tool| tool.qualified_name());
+
+    let mut offered: Vec<&ClientToolConfig> = Vec::new();
+    let mut winner_by_bare_name: HashMap<&str, String> = HashMap::new();
+    let mut skipped: Vec<(&ClientToolConfig, ClientToolSkip)> = Vec::new();
+
+    for tool in matched {
+        let name = tool.name.as_str();
+        if name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME {
+            skipped.push((tool, ClientToolSkip::ReservedName));
+            continue;
+        }
+        if mcp_has_tool(name) {
+            let explicitly_selected = allowlist
+                .iter()
+                .any(|pattern| *pattern == tool.qualified_name());
+            skipped.push((
+                tool,
+                ClientToolSkip::McpCollision {
+                    explicitly_selected,
+                },
+            ));
+            continue;
+        }
+        if let Some(winner) = winner_by_bare_name.get(name) {
+            skipped.push((
+                tool,
+                ClientToolSkip::DuplicateBareName {
+                    winner_qualified: winner.clone(),
+                },
+            ));
+            continue;
+        }
+        winner_by_bare_name.insert(name, tool.qualified_name());
+        offered.push(tool);
+    }
+
+    ClientToolSelection { offered, skipped }
 }
 
 /// The result of a client-executed tool, delivered back to the suspended
@@ -69,13 +148,13 @@ mod tests {
     fn build_client_tool_sets_name_description_and_schema() {
         let schema = json!({ "type": "object", "properties": {} });
         let tool = build_client_tool(
-            "outlook.fetch_availability",
+            "fetch_availability",
             "Fetch the user's free/busy.",
             schema.clone(),
             false,
         );
         match &tool.name {
-            GenaiToolName::Custom(name) => assert_eq!(name, "outlook.fetch_availability"),
+            GenaiToolName::Custom(name) => assert_eq!(name, "fetch_availability"),
             other => panic!("expected a custom tool name, got {other:?}"),
         }
         assert_eq!(
@@ -90,5 +169,87 @@ mod tests {
     fn build_client_tool_omits_strict_when_requested() {
         let tool = build_client_tool("t", "d", json!({ "type": "object" }), true);
         assert_eq!(tool.strict, None);
+    }
+
+    fn tool(namespace: &str, name: &str) -> ClientToolConfig {
+        ClientToolConfig {
+            name: name.to_string(),
+            namespace: Some(namespace.to_string()),
+            description: "d".to_string(),
+            parameters: r#"{ "type": "object" }"#.to_string(),
+            timeout_ms: None,
+        }
+    }
+
+    #[test]
+    fn select_orders_deterministically_by_qualified_name() {
+        let (b, a) = (tool("teams", "ping"), tool("outlook", "ping2"));
+        let selection = select_client_tools(vec![&b, &a], &[], |_| false);
+        let offered: Vec<_> = selection
+            .offered
+            .iter()
+            .map(|t| t.qualified_name())
+            .collect();
+        assert_eq!(offered, vec!["outlook/ping2", "teams/ping"]);
+        assert!(selection.skipped.is_empty());
+    }
+
+    #[test]
+    fn select_dedups_bare_names_first_in_order_wins() {
+        let (teams, outlook) = (
+            tool("teams", "fetch_availability"),
+            tool("outlook", "fetch_availability"),
+        );
+        let selection = select_client_tools(vec![&teams, &outlook], &[], |_| false);
+        assert_eq!(selection.offered.len(), 1);
+        assert_eq!(
+            selection.offered[0].qualified_name(),
+            "outlook/fetch_availability"
+        );
+        assert_eq!(
+            selection.skipped,
+            vec![(
+                &teams,
+                ClientToolSkip::DuplicateBareName {
+                    winner_qualified: "outlook/fetch_availability".to_string(),
+                }
+            )]
+        );
+    }
+
+    #[test]
+    fn select_skips_mcp_collisions_and_flags_exact_selection() {
+        let (colliding, wildcard_selected) = (tool("outlook", "search"), tool("teams", "search2"));
+        let allowlist = vec!["outlook/search".to_string(), "teams/*".to_string()];
+        let selection =
+            select_client_tools(vec![&colliding, &wildcard_selected], &allowlist, |name| {
+                name == "search" || name == "search2"
+            });
+        assert!(selection.offered.is_empty());
+        assert_eq!(
+            selection.skipped,
+            vec![
+                (
+                    &colliding,
+                    ClientToolSkip::McpCollision {
+                        explicitly_selected: true,
+                    }
+                ),
+                (
+                    &wildcard_selected,
+                    ClientToolSkip::McpCollision {
+                        explicitly_selected: false,
+                    }
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn select_skips_the_reserved_name() {
+        let reserved = tool("client", "propose_client_action");
+        let selection = select_client_tools(vec![&reserved], &[], |_| false);
+        assert!(selection.offered.is_empty());
+        assert_eq!(selection.skipped[0].1, ClientToolSkip::ReservedName);
     }
 }

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -2928,7 +2928,7 @@ fn test_top_level_client_tools_load_with_namespace() {
     let config = migrate_config_with_action_facets(
         r#"
 [client_tools.tools.fetch_availability]
-name = "outlook.fetch_availability"
+name = "fetch_availability"
 namespace = "outlook"
 description = "Fetch the user's calendar free/busy in a window."
 parameters = '{ "type": "object", "properties": {}, "additionalProperties": false }'
@@ -2943,9 +2943,9 @@ parameters = '{ "type": "object" }'
 
     assert_eq!(config.client_tools.tools.len(), 2);
     let tool = &config.client_tools.tools["fetch_availability"];
-    assert_eq!(tool.name, "outlook.fetch_availability");
+    assert_eq!(tool.name, "fetch_availability");
     assert_eq!(tool.namespace_or_default(), "outlook");
-    assert_eq!(tool.qualified_name(), "outlook/outlook.fetch_availability");
+    assert_eq!(tool.qualified_name(), "outlook/fetch_availability");
     assert_eq!(tool.timeout_ms, Some(30000));
     assert!(tool.parameters.contains("\"type\": \"object\""));
     // Defaults to the `client` namespace when unset.
@@ -2963,6 +2963,37 @@ fn test_client_tool_reserved_name_rejected() {
 name = "propose_client_action"
 description = "collides with the reserved client-action tool name"
 parameters = '{ "type": "object" }'
+"#,
+    );
+}
+
+#[test]
+fn test_client_tool_nonportable_name_warns_but_loads() {
+    // Dots are outside the portable ^[a-zA-Z0-9_-]{1,64}$ intersection
+    // (OpenAI/Anthropic reject them at request time) but Gemini accepts them,
+    // so config load only WARNS — the tool must still load.
+    let config = migrate_config_with_action_facets(
+        r#"
+[client_tools.tools.dotted]
+name = "outlook.fetch"
+namespace = "outlook"
+description = "nonportable dotted name"
+parameters = '{ "type": "object" }'
+"#,
+    );
+    assert_eq!(config.client_tools.tools["dotted"].name, "outlook.fetch");
+}
+
+#[test]
+#[should_panic(expected = "timeout_ms = 0")]
+fn test_client_tool_zero_timeout_rejected() {
+    migrate_config_with_action_facets(
+        r#"
+[client_tools.tools.instant]
+name = "instant"
+description = "park would cancel immediately"
+parameters = '{ "type": "object" }'
+timeout_ms = 0
 "#,
     );
 }

--- a/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
+++ b/frontend/src/hooks/chat/handlers/handleClientToolCall.test.ts
@@ -22,7 +22,7 @@ function makeEvent(
     message_id: "msg-1",
     content_index: 0,
     tool_call_id: "call-1",
-    tool_name: "outlook.fetch_availability",
+    tool_name: "fetch_availability",
     input: { window_start: "x" },
     ...overrides,
   } as MessageSubmitStreamingResponseClientToolCall & {
@@ -50,7 +50,7 @@ describe("handleClientToolCall", () => {
   });
 
   it("runs the registered executor and POSTs its result", async () => {
-    registerClientToolExecutor("outlook.fetch_availability", async (input) => {
+    registerClientToolExecutor("fetch_availability", async (input) => {
       expect(input).toEqual({ window_start: "x" });
       return { ok: true, result: { slots: 3 } };
     });
@@ -73,7 +73,7 @@ describe("handleClientToolCall", () => {
   });
 
   it("POSTs an error when the executor returns a failure", async () => {
-    registerClientToolExecutor("outlook.fetch_availability", async () => ({
+    registerClientToolExecutor("fetch_availability", async () => ({
       ok: false,
       error: "boom",
     }));
@@ -84,7 +84,7 @@ describe("handleClientToolCall", () => {
   });
 
   it("POSTs an error when the executor throws", async () => {
-    registerClientToolExecutor("outlook.fetch_availability", async () => {
+    registerClientToolExecutor("fetch_availability", async () => {
       throw new Error("kaboom");
     });
 
@@ -101,7 +101,7 @@ describe("handleClientToolCall", () => {
 
   it("execute-once: a replayed event does not re-run or re-POST the tool", async () => {
     const executor = vi.fn(async () => ({ ok: true as const, result: 1 }));
-    registerClientToolExecutor("outlook.fetch_availability", executor);
+    registerClientToolExecutor("fetch_availability", executor);
 
     await handleClientToolCall(makeEvent(), deps);
     await handleClientToolCall(makeEvent(), deps); // replay, same tool_call_id
@@ -125,7 +125,7 @@ describe("handleClientToolCall", () => {
       await gate;
       return { ok: true as const, result: 1 };
     });
-    registerClientToolExecutor("outlook.fetch_availability", executor);
+    registerClientToolExecutor("fetch_availability", executor);
 
     // Fire both before the first resolves; the pre-await guard must block the
     // second (this would fail if the mark moved after the await).
@@ -140,7 +140,7 @@ describe("handleClientToolCall", () => {
 
   it("un-marks on a failed POST so a later replay retries", async () => {
     const executor = vi.fn(async () => ({ ok: true as const, result: 1 }));
-    registerClientToolExecutor("outlook.fetch_availability", executor);
+    registerClientToolExecutor("fetch_availability", executor);
     fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
 
     await handleClientToolCall(makeEvent(), deps);
@@ -153,7 +153,7 @@ describe("handleClientToolCall", () => {
   });
 
   it("delivers an empty success as an explicit null result", async () => {
-    registerClientToolExecutor("outlook.fetch_availability", async () => ({
+    registerClientToolExecutor("fetch_availability", async () => ({
       ok: true as const,
       result: undefined,
     }));


### PR DESCRIPTION
## Summary

Main-side follow-up from the adversarial design review of the appointment-scheduling seam (#801). Two concerns, one small PR:

**Name hygiene.** The dotted example name `outlook.fetch_availability` survived in docs and test fixtures although OpenAI/Azure and Anthropic reject `.` in tool names at request time — config validation would accept it and the first tool call would 400. Changes:
- `ClientToolConfig.name` doc now documents the portable contract `^[a-zA-Z0-9_-]{1,64}$` as the cross-provider intersection (Gemini is laxer: dots/colons, 128 chars).
- All fixture occurrences renamed dot-free (`client_tools.rs` unit test, `integration_tests/config.rs` — incl. the doubly-stale qualified `outlook/outlook.fetch_availability` assertion — and 8 in `handleClientToolCall.test.ts`).
- New startup **warning** (not panic — Gemini-only deployments may be deliberate) for non-portable names, via `startup_log::warn_preinit` since tracing isn't initialized at config load.
- `timeout_ms = 0` now fails validation (every park would time out before the client could respond).
- Deliberately untouched: dotted `client_actions` ids (`outlook.reply` …) — those are enum values inside `propose_client_action`'s input, never model-facing tool names.

**Offering-loop hardening.** Config uniqueness is qualified-name-only, so two tools may share a bare model-facing name (`outlook/x` + `teams/x` — a coherent composed deployment across platform-disjoint packages). Previously:
- both could be offered in one request → duplicate tool names → provider 400 from valid config;
- iteration over the config `HashMap` made the offering order (and any collision winner) nondeterministic across restarts, churning provider prompt-cache prefixes;
- the park-timeout lookup re-found the config entry by bare name, so a never-offered duplicate elsewhere in config could supply the wrong `timeout_ms`.

Changes: selection extracted into a pure, unit-tested `select_client_tools` (deterministic qualified-name order; first-in-order wins bare-name dedup with a warn; MCP-collision skip **escalated to error-level** when the allowlist selected the client tool exactly — that combination is always a config bug); the park timeout now resolves from the entries actually offered to the request, threaded through `PreparedChatRequest`.

## Verification

- 577/577 backend tests (6 new: selection ordering/dedup/collision/reserved + zero-timeout rejection + non-portable-name loads-with-warning), `clippy --all-targets -D warnings` clean, fmt clean.
- 9/9 frontend handler tests after the fixture rename.
- No config keys added → no config-reference regeneration needed (generator extracts field paths only).
