### PR TITLE
fix(edit): mirror regenerate action-facet fallback in edit_message_sse

### DIFF
--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -641,6 +641,28 @@ pub fn get_generation_action_facet_from_message(
     Ok(None)
 }
 
+/// The action facet (id + args) stored in a user message's input parameters,
+/// if any. Used by edit to re-apply the facet the original user message
+/// carried when the edit request doesn't re-send one.
+pub fn get_input_action_facet_from_message(
+    message: &messages::Model,
+) -> Result<Option<StoredActionFacet>, Report> {
+    if let Some(input_params_json) = &message.input_parameters {
+        let input_params: InputParameters = serde_json::from_value(input_params_json.clone())
+            .map_err(|e| {
+                eyre!(
+                    "Failed to parse input parameters for message {}: {}",
+                    message.id,
+                    e
+                )
+            })?;
+        return Ok(input_params
+            .action_facet_id
+            .map(|id| (id, input_params.action_facet_args.unwrap_or_default())));
+    }
+    Ok(None)
+}
+
 /// Resolve a provider for a user message branch by checking the assistant response that follows
 /// the user message. Prefer the active-thread assistant sibling; fall back to newest sibling.
 pub async fn get_generation_chat_provider_id_for_replaced_user_message(

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -7182,9 +7182,38 @@ pub async fn edit_message_sse(
     // Move request data into the task
     let replace_user_message = request.replace_user_message;
     let replace_input_files_ids = request.replace_input_files_ids;
+    // Resolve the effective action facet for this edit. When the edit request
+    // carries no explicit facet, fall back to the one the original user
+    // message stored — re-validated against the CURRENT config so a facet
+    // removed/changed since is dropped (edit proceeds without it) rather than
+    // failing the request. Mirrors the regenerate precedent: the user edits
+    // their instruction, but the context it referred to (selected text, draft,
+    // etc.) persists. Unlike regenerate — which reuses the existing user
+    // message row — edit creates a NEW sibling message, so the resolved facet
+    // must be persisted onto it (below) as well as fed to the generation, or
+    // the UI and any subsequent edit would lose the context.
+    let resolved_action_facet: Option<ActionFacetRequest> = match request.action_facet.clone() {
+        Some(af) => Some(af),
+        None => crate::models::message::get_input_action_facet_from_message(&message_to_edit)
+            .ok()
+            .flatten()
+            .map(|(id, args)| ActionFacetRequest { id, args })
+            .filter(
+                |af| match validate_action_facet(&app_state.config, Some(af), platform) {
+                    Ok(()) => true,
+                    Err((_, reason)) => {
+                        tracing::warn!(
+                            "Dropping stored action facet '{}' on edit: {}",
+                            af.id,
+                            reason
+                        );
+                        false
+                    }
+                },
+            ),
+    };
     let edit_input_parameters =
-        request
-            .action_facet
+        resolved_action_facet
             .as_ref()
             .map(|af| crate::models::message::InputParameters {
                 action_facet_id: Some(af.id.clone()),
@@ -7264,39 +7293,6 @@ pub async fn edit_message_sse(
             } else {
                 None
             };
-            // Mirror the regenerate fallback for the action facet: an edit
-            // without an explicit facet re-applies the one the original
-            // generation ran under.  The user edits their instruction; the
-            // context it referred to (selected text, draft, etc.) should
-            // persist — matching the regenerate precedent.  Re-validated
-            // against the CURRENT config — a facet that was removed or
-            // changed since is dropped (edit proceeds without it) rather
-            // than failing the request.
-            let fallback_action_facet = if request.action_facet.is_none() {
-                crate::models::message::get_input_action_facet_from_message(&message_to_edit)
-                    .ok()
-                    .flatten()
-                    .map(|(id, args)| ActionFacetRequest { id, args })
-                    .filter(|af| {
-                        let platform = generation_request_context
-                            .platform
-                            .as_deref()
-                            .unwrap_or(DEFAULT_ERATO_PLATFORM);
-                        match validate_action_facet(&app_state.config, Some(af), platform) {
-                            Ok(()) => true,
-                            Err((_, reason)) => {
-                                tracing::warn!(
-                                    "Dropping stored action facet '{}' on edit: {}",
-                                    af.id,
-                                    reason
-                                );
-                                false
-                            }
-                        }
-                    })
-            } else {
-                None
-            };
             let user_input = PromptCompositionUserInput {
                 just_submitted_user_message_id: saved_user_message.id,
                 requested_chat_provider_id: request
@@ -7305,16 +7301,14 @@ pub async fn edit_message_sse(
                     .or(fallback_chat_provider_id),
                 new_input_file_ids: replace_input_files_ids,
                 selected_facet_ids: request.selected_facet_ids.clone(),
-                action_facet: request
-                    .action_facet
-                    .as_ref()
-                    .or(fallback_action_facet.as_ref())
-                    .map(
-                        |af| crate::services::prompt_composition::types::ActionFacetUserInput {
-                            id: af.id.clone(),
-                            args: af.args.clone(),
-                        },
-                    ),
+                // Resolved above (request facet, else the validated stored
+                // fallback); the same value is persisted via edit_input_parameters.
+                action_facet: resolved_action_facet.as_ref().map(|af| {
+                    crate::services::prompt_composition::types::ActionFacetUserInput {
+                        id: af.id.clone(),
+                        args: af.args.clone(),
+                    }
+                }),
             };
             let prepare_chat_request_res = prepare_chat_request(
                 &app_state,

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -7273,7 +7273,7 @@ pub async fn edit_message_sse(
             // changed since is dropped (edit proceeds without it) rather
             // than failing the request.
             let fallback_action_facet = if request.action_facet.is_none() {
-                crate::models::message::get_generation_action_facet_from_message(&message_to_edit)
+                crate::models::message::get_input_action_facet_from_message(&message_to_edit)
                     .ok()
                     .flatten()
                     .map(|(id, args)| ActionFacetRequest { id, args })
@@ -7309,12 +7309,12 @@ pub async fn edit_message_sse(
                     .action_facet
                     .as_ref()
                     .or(fallback_action_facet.as_ref())
-                    .map(|af| {
-                        crate::services::prompt_composition::types::ActionFacetUserInput {
+                    .map(
+                        |af| crate::services::prompt_composition::types::ActionFacetUserInput {
                             id: af.id.clone(),
                             args: af.args.clone(),
-                        }
-                    }),
+                        },
+                    ),
             };
             let prepare_chat_request_res = prepare_chat_request(
                 &app_state,

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -7264,6 +7264,39 @@ pub async fn edit_message_sse(
             } else {
                 None
             };
+            // Mirror the regenerate fallback for the action facet: an edit
+            // without an explicit facet re-applies the one the original
+            // generation ran under.  The user edits their instruction; the
+            // context it referred to (selected text, draft, etc.) should
+            // persist — matching the regenerate precedent.  Re-validated
+            // against the CURRENT config — a facet that was removed or
+            // changed since is dropped (edit proceeds without it) rather
+            // than failing the request.
+            let fallback_action_facet = if request.action_facet.is_none() {
+                crate::models::message::get_generation_action_facet_from_message(&message_to_edit)
+                    .ok()
+                    .flatten()
+                    .map(|(id, args)| ActionFacetRequest { id, args })
+                    .filter(|af| {
+                        let platform = generation_request_context
+                            .platform
+                            .as_deref()
+                            .unwrap_or(DEFAULT_ERATO_PLATFORM);
+                        match validate_action_facet(&app_state.config, Some(af), platform) {
+                            Ok(()) => true,
+                            Err((_, reason)) => {
+                                tracing::warn!(
+                                    "Dropping stored action facet '{}' on edit: {}",
+                                    af.id,
+                                    reason
+                                );
+                                false
+                            }
+                        }
+                    })
+            } else {
+                None
+            };
             let user_input = PromptCompositionUserInput {
                 just_submitted_user_message_id: saved_user_message.id,
                 requested_chat_provider_id: request
@@ -7272,12 +7305,16 @@ pub async fn edit_message_sse(
                     .or(fallback_chat_provider_id),
                 new_input_file_ids: replace_input_files_ids,
                 selected_facet_ids: request.selected_facet_ids.clone(),
-                action_facet: request.action_facet.as_ref().map(|af| {
-                    crate::services::prompt_composition::types::ActionFacetUserInput {
-                        id: af.id.clone(),
-                        args: af.args.clone(),
-                    }
-                }),
+                action_facet: request
+                    .action_facet
+                    .as_ref()
+                    .or(fallback_action_facet.as_ref())
+                    .map(|af| {
+                        crate::services::prompt_composition::types::ActionFacetUserInput {
+                            id: af.id.clone(),
+                            args: af.args.clone(),
+                        }
+                    }),
             };
             let prepare_chat_request_res = prepare_chat_request(
                 &app_state,

--- a/backend/erato/tests/integration_tests/api/edit.rs
+++ b/backend/erato/tests/integration_tests/api/edit.rs
@@ -3,13 +3,50 @@
 use axum::Router;
 use axum::http;
 use axum_test::TestServer;
+use erato::config::ActionFacetConfig;
+use erato::models::message::GenerationParameters;
+use erato::models::user::get_or_create_user;
 use erato::server::router::router;
+use mocktail::MockSet;
+use mocktail::body::BodyAction;
+use mocktail::mock_builder::Then;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 use serde_json::{Value, json};
 use sqlx::Pool;
 use sqlx::postgres::Postgres;
 
 use crate::test_app_state;
-use crate::test_utils::{TEST_JWT_TOKEN, TestRequestAuthExt, setup_mock_llm_server};
+use crate::test_utils::{
+    RequestBodyRecorder, TEST_JWT_TOKEN, TEST_USER_ISSUER, TEST_USER_SUBJECT, TestRequestAuthExt,
+    build_openai_text_streaming_response, hermetic_app_config, parse_sse_events,
+    setup_mock_llm_server, setup_mock_llm_server_with_mocks,
+};
+
+fn mock_llm_sse_response(then: Then, actions: Vec<BodyAction>) {
+    then.status(http::StatusCode::OK)
+        .headers([
+            ("Content-Type", "text/event-stream"),
+            ("Cache-Control", "no-cache"),
+            ("Connection", "keep-alive"),
+        ])
+        .bytes_stream_with_delays(actions);
+}
+
+fn add_action_facets(app_config: &mut erato::config::AppConfig) {
+    app_config.action_facets.facets.insert(
+        "rewrite".to_string(),
+        ActionFacetConfig {
+            display_name: "Rewrite".to_string(),
+            platform: None,
+            template: "Rewrite the following in a {{tone}} tone:\n\n{{content}}".to_string(),
+            allowed_args: vec!["tone".to_string(), "content".to_string()],
+            client_actions: vec![],
+            presentation: None,
+            client_actions_always_ask: vec![],
+            tool_call_allowlist: vec![],
+        },
+    );
+}
 
 // Helper structure for SSE events
 #[derive(Debug, Clone)]
@@ -533,4 +570,243 @@ async fn test_edit_assistant_message_fails(pool: Pool<Postgres>) {
         "Expected error message about wrong message role, got: {}",
         error_text
     );
+}
+
+/// Editing a message that was originally sent with an action facet re-applies
+/// the stored facet when the edit request omits it — the user is refining
+/// their instruction, not stripping the context.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_edit_falls_back_to_stored_action_facet(pool: Pool<Postgres>) {
+    let llm_request_recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    {
+        let recorder = llm_request_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post().path("/v1/chat/completions").matcher(recorder);
+            mock_llm_sse_response(then, build_openai_text_streaming_response(&["Rewritten."]));
+        });
+    }
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+    let db = app_state.db.clone();
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // Submit the original message WITH an action facet.
+    let submit_response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+
+    let submit_events = parse_sse_events(&submit_response);
+    let original_user_message_id = submit_events
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "user_message_saved"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected user_message_saved event with message_id");
+
+    // Edit the message WITHOUT re-sending the action facet.
+    let edit_response = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_message_id,
+            "replace_user_message": "Rewrite this (refined instruction)",
+            "replace_input_files_ids": []
+        }))
+        .await;
+    edit_response.assert_status_ok();
+
+    // Verify the edit assistant message has the facet in its generation params.
+    let assistant_messages = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::GenerationParameters.is_not_null())
+        .order_by_asc(erato::db::entity::messages::Column::CreatedAt)
+        .all(&db)
+        .await
+        .expect("Failed to fetch assistant messages");
+    assert_eq!(
+        assistant_messages.len(),
+        2,
+        "Expected original and edited assistant messages"
+    );
+
+    let edit_params: GenerationParameters = serde_json::from_value(
+        assistant_messages[1]
+            .generation_parameters
+            .clone()
+            .expect("Missing edit generation_parameters"),
+    )
+    .expect("Failed to deserialize edit generation parameters");
+    assert_eq!(
+        edit_params.action_facet_id.as_deref(),
+        Some("rewrite"),
+        "Edit must re-apply the facet stored on the original generation",
+    );
+    assert_eq!(
+        edit_params
+            .action_facet_args
+            .as_ref()
+            .and_then(|args| args.get("tone"))
+            .map(String::as_str),
+        Some("professional"),
+    );
+
+    // The rendered directive must have reached the LLM on both the original
+    // submit and the edit.  The recorder also sees the chat-title summary
+    // request, which only carries the raw user message.
+    let llm_request_bodies = llm_request_recorder.bodies();
+    let directive_body_count = llm_request_bodies
+        .iter()
+        .filter(|body| {
+            body.contains("Rewrite the following in a professional tone:")
+                && body.contains("yo whats up")
+        })
+        .count();
+    assert_eq!(
+        directive_body_count, 2,
+        "Expected the rendered facet directive in both generation request bodies (submit + edit): {llm_request_bodies:?}"
+    );
+}
+
+/// Editing after the stored action facet stopped validating drops the facet
+/// instead of failing the request — parity with the regenerate lane.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_edit_drops_stored_action_facet_that_no_longer_validates(pool: Pool<Postgres>) {
+    let (mut app_config, server) = setup_mock_llm_server(None).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool.clone()).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let test_server =
+        TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // Submit WITH the facet.
+    let submit_response = test_server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+
+    let submit_events = parse_sse_events(&submit_response);
+    let original_user_message_id = submit_events
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "user_message_saved"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected user_message_saved event with message_id");
+
+    // Replace the config with one that no longer knows the stored facet.
+    let replacement_config = hermetic_app_config(None, Some(server.url("/v1/").to_string()));
+    assert!(
+        !replacement_config
+            .action_facets
+            .facets
+            .contains_key("rewrite"),
+        "Replacement config must not declare the stored facet"
+    );
+    let replacement_app_state = test_app_state(replacement_config, pool).await;
+    let db = replacement_app_state.db.clone();
+    let replacement_app: Router = router(replacement_app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(replacement_app_state);
+    let replacement_server =
+        TestServer::new(replacement_app.into_make_service()).expect("Failed to create test server");
+
+    // Edit WITHOUT re-sending the facet, using the config that no longer has it.
+    let edit_response = replacement_server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_message_id,
+            "replace_user_message": "Rewrite this (refined)",
+            "replace_input_files_ids": []
+        }))
+        .await;
+    edit_response.assert_status_ok();
+
+    let edit_events = parse_sse_events(&edit_response);
+    assert!(
+        edit_events
+            .iter()
+            .any(|e| { serde_json::from_str::<Value>(&e.data)
+                .map(|j| j["message_type"] == "assistant_message_completed")
+                .unwrap_or(false) }),
+        "Edit must complete a generation even when the stored facet is gone"
+    );
+
+    let assistant_messages = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::GenerationParameters.is_not_null())
+        .order_by_asc(erato::db::entity::messages::Column::CreatedAt)
+        .all(&db)
+        .await
+        .expect("Failed to fetch assistant messages");
+    assert_eq!(assistant_messages.len(), 2);
+
+    let edit_params: GenerationParameters = serde_json::from_value(
+        assistant_messages[1]
+            .generation_parameters
+            .clone()
+            .expect("Missing edit generation_parameters"),
+    )
+    .expect("Failed to deserialize edit generation parameters");
+    assert_eq!(
+        edit_params.action_facet_id, None,
+        "A stored facet that no longer validates must be dropped on edit",
+    );
+    assert_eq!(edit_params.action_facet_args, None);
 }

--- a/backend/erato/tests/integration_tests/api/edit.rs
+++ b/backend/erato/tests/integration_tests/api/edit.rs
@@ -46,6 +46,19 @@ fn add_action_facets(app_config: &mut erato::config::AppConfig) {
             tool_call_allowlist: vec![],
         },
     );
+    app_config.action_facets.facets.insert(
+        "summarize".to_string(),
+        ActionFacetConfig {
+            display_name: "Summarize".to_string(),
+            platform: None,
+            template: "Summarize the following briefly:\n\n{{content}}".to_string(),
+            allowed_args: vec!["content".to_string()],
+            client_actions: vec![],
+            presentation: None,
+            client_actions_always_ask: vec![],
+            tool_call_allowlist: vec![],
+        },
+    );
 }
 
 // Helper structure for SSE events
@@ -695,6 +708,341 @@ async fn test_edit_falls_back_to_stored_action_facet(pool: Pool<Postgres>) {
         directive_body_count, 2,
         "Expected the rendered facet directive in both generation request bodies (submit + edit): {llm_request_bodies:?}"
     );
+
+    // Regression (ERMAIN edit fallback): the fallback facet must ALSO be
+    // persisted onto the edited user message's input_parameters — not only fed
+    // to the generation.  The add-in reads these back to render the facet chip
+    // and the selected text, and a subsequent edit falls back off them.  The
+    // edited user message is the sibling of the original.
+    let edited_user_message_id = parse_sse_events(&edit_response)
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "user_message_saved"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected user_message_saved event on edit");
+    let original_uuid = sea_orm::prelude::Uuid::parse_str(&original_user_message_id)
+        .expect("original user message id is a uuid");
+    let edited_user_message = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::SiblingMessageId.eq(original_uuid))
+        .one(&db)
+        .await
+        .expect("Failed to fetch edited user message")
+        .expect("Edited user message should exist");
+    // Guard the sibling query against ever silently picking a wrong row.
+    assert_eq!(
+        edited_user_message.id.to_string(),
+        edited_user_message_id,
+        "Sibling query must resolve to the message the edit's SSE reported",
+    );
+    let edited_input_params: erato::models::message::InputParameters = serde_json::from_value(
+        edited_user_message
+            .input_parameters
+            .clone()
+            .expect("Edited user message must persist input_parameters"),
+    )
+    .expect("Failed to deserialize edited input parameters");
+    assert_eq!(
+        edited_input_params.action_facet_id.as_deref(),
+        Some("rewrite"),
+        "Edited user message must persist the fallback facet id (UI chip + chained edits)",
+    );
+    assert_eq!(
+        edited_input_params
+            .action_facet_args
+            .as_ref()
+            .and_then(|args| args.get("content"))
+            .map(String::as_str),
+        Some("yo whats up"),
+        "Edited user message must persist the fallback facet args (e.g. the selected text)",
+    );
+}
+
+/// Editing an already-edited message keeps re-applying the original facet.
+/// This only works if each edit PERSISTS the fallback facet onto the new user
+/// message: the second edit reads its fallback off the first edit's message,
+/// so a fallback that fed generation but was never stored would break the
+/// chain on the second hop (the exact symptom of the reported regression).
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_edit_chained_fallback_persists_action_facet(pool: Pool<Postgres>) {
+    let llm_request_recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    {
+        let recorder = llm_request_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post().path("/v1/chat/completions").matcher(recorder);
+            mock_llm_sse_response(then, build_openai_text_streaming_response(&["Rewritten."]));
+        });
+    }
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+    let db = app_state.db.clone();
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // Extracts the newest `user_message_saved` message_id from an SSE response.
+    let saved_user_message_id = |response: &axum_test::TestResponse| {
+        parse_sse_events(response)
+            .iter()
+            .find_map(|event| {
+                if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                    && json["message_type"] == "user_message_saved"
+                {
+                    return json["message_id"].as_str().map(|s| s.to_string());
+                }
+                None
+            })
+            .expect("Expected user_message_saved event with message_id")
+    };
+
+    // Submit WITH the facet.
+    let submit_response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+    let original_user_message_id = saved_user_message_id(&submit_response);
+
+    // First edit WITHOUT a facet — falls back and persists.
+    let edit_one = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_message_id,
+            "replace_user_message": "Rewrite this (v2)",
+            "replace_input_files_ids": []
+        }))
+        .await;
+    edit_one.assert_status_ok();
+    let first_edit_user_message_id = saved_user_message_id(&edit_one);
+
+    // Second edit, now editing the FIRST edit's message, again WITHOUT a facet.
+    // The fallback must come from what the first edit persisted.
+    let edit_two = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": first_edit_user_message_id,
+            "replace_user_message": "Rewrite this (v3)",
+            "replace_input_files_ids": []
+        }))
+        .await;
+    edit_two.assert_status_ok();
+    let second_edit_user_message_id = saved_user_message_id(&edit_two);
+
+    // The rendered directive must have reached the LLM on all three
+    // generations (submit + edit1 + edit2). Title-summary requests only carry
+    // the raw user message, so they don't match.
+    let directive_body_count = llm_request_recorder
+        .bodies()
+        .iter()
+        .filter(|body| {
+            body.contains("Rewrite the following in a professional tone:")
+                && body.contains("yo whats up")
+        })
+        .count();
+    assert_eq!(
+        directive_body_count, 3,
+        "Facet directive must survive a chain of edits (submit + edit1 + edit2)",
+    );
+
+    // The twice-edited user message must still carry the persisted facet.
+    let second_edit_uuid = sea_orm::prelude::Uuid::parse_str(&second_edit_user_message_id)
+        .expect("second edit user message id is a uuid");
+    let twice_edited = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::Id.eq(second_edit_uuid))
+        .one(&db)
+        .await
+        .expect("Failed to fetch twice-edited user message")
+        .expect("Twice-edited user message should exist");
+    let params: erato::models::message::InputParameters = serde_json::from_value(
+        twice_edited
+            .input_parameters
+            .clone()
+            .expect("Twice-edited user message must persist input_parameters"),
+    )
+    .expect("Failed to deserialize twice-edited input parameters");
+    assert_eq!(params.action_facet_id.as_deref(), Some("rewrite"));
+    assert_eq!(
+        params
+            .action_facet_args
+            .as_ref()
+            .and_then(|args| args.get("content"))
+            .map(String::as_str),
+        Some("yo whats up"),
+    );
+}
+
+/// An edit that DOES send an explicit action facet must win over the stored
+/// one — for both the generation and the persisted input_parameters. Pins the
+/// precedence of the request facet over the fallback; a regression flipping it
+/// (fallback clobbering explicit) or dropping explicit-facet persistence would
+/// go uncaught by the fallback tests, which never send a facet on edit.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_edit_explicit_action_facet_overrides_stored_one(pool: Pool<Postgres>) {
+    let llm_request_recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    {
+        let recorder = llm_request_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post().path("/v1/chat/completions").matcher(recorder);
+            mock_llm_sse_response(then, build_openai_text_streaming_response(&["Done."]));
+        });
+    }
+    let (mut app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    add_action_facets(&mut app_config);
+    let app_state = test_app_state(app_config, pool).await;
+    let db = app_state.db.clone();
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // Submit with facet A ("rewrite").
+    let submit_response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "Rewrite this",
+            "action_facet": {
+                "id": "rewrite",
+                "args": { "tone": "professional", "content": "yo whats up" }
+            }
+        }))
+        .await;
+    submit_response.assert_status_ok();
+    let original_user_message_id = parse_sse_events(&submit_response)
+        .iter()
+        .find_map(|event| {
+            if let Ok(json) = serde_json::from_str::<Value>(&event.data)
+                && json["message_type"] == "user_message_saved"
+            {
+                return json["message_id"].as_str().map(|s| s.to_string());
+            }
+            None
+        })
+        .expect("Expected user_message_saved event with message_id");
+
+    // Edit WITH an explicit facet B ("summarize") — B must win over stored A.
+    let edit_response = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_message_id,
+            "replace_user_message": "Actually summarize it",
+            "replace_input_files_ids": [],
+            "action_facet": {
+                "id": "summarize",
+                "args": { "content": "different selection" }
+            }
+        }))
+        .await;
+    edit_response.assert_status_ok();
+
+    // Generation ran under B, not A.
+    let assistant_messages = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::GenerationParameters.is_not_null())
+        .order_by_asc(erato::db::entity::messages::Column::CreatedAt)
+        .all(&db)
+        .await
+        .expect("Failed to fetch assistant messages");
+    assert_eq!(assistant_messages.len(), 2);
+    let edit_params: GenerationParameters = serde_json::from_value(
+        assistant_messages[1]
+            .generation_parameters
+            .clone()
+            .expect("Missing edit generation_parameters"),
+    )
+    .expect("Failed to deserialize edit generation parameters");
+    assert_eq!(
+        edit_params.action_facet_id.as_deref(),
+        Some("summarize"),
+        "The explicit request facet must win over the stored fallback",
+    );
+
+    // Each directive reached the LLM exactly once: A on submit, B on the edit.
+    let llm_request_bodies = llm_request_recorder.bodies();
+    let facet_a_count = llm_request_bodies
+        .iter()
+        .filter(|body| body.contains("Rewrite the following in a professional tone:"))
+        .count();
+    let facet_b_count = llm_request_bodies
+        .iter()
+        .filter(|body| {
+            body.contains("Summarize the following briefly:")
+                && body.contains("different selection")
+        })
+        .count();
+    assert_eq!(facet_a_count, 1, "Stored facet A only in the submit body");
+    assert_eq!(facet_b_count, 1, "Explicit facet B only in the edit body");
+
+    // Persistence carries B, not A.
+    let original_uuid = sea_orm::prelude::Uuid::parse_str(&original_user_message_id)
+        .expect("original user message id is a uuid");
+    let edited_user_message = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::SiblingMessageId.eq(original_uuid))
+        .one(&db)
+        .await
+        .expect("Failed to fetch edited user message")
+        .expect("Edited user message should exist");
+    let edited_input_params: erato::models::message::InputParameters = serde_json::from_value(
+        edited_user_message
+            .input_parameters
+            .clone()
+            .expect("Edited user message must persist input_parameters"),
+    )
+    .expect("Failed to deserialize edited input parameters");
+    assert_eq!(
+        edited_input_params.action_facet_id.as_deref(),
+        Some("summarize"),
+        "The persisted facet must be the explicit one, not the stored fallback",
+    );
+    assert_eq!(
+        edited_input_params
+            .action_facet_args
+            .as_ref()
+            .and_then(|args| args.get("content"))
+            .map(String::as_str),
+        Some("different selection"),
+    );
 }
 
 /// Editing after the stored action facet stopped validating drops the facet
@@ -809,4 +1157,21 @@ async fn test_edit_drops_stored_action_facet_that_no_longer_validates(pool: Pool
         "A stored facet that no longer validates must be dropped on edit",
     );
     assert_eq!(edit_params.action_facet_args, None);
+
+    // The drop must also hold on the PERSISTENCE side: an implementation that
+    // stored the facet before validating would pass the generation asserts
+    // above, but the invalid facet would sit on the edited sibling — ready to
+    // be resurrected by a later edit under a config that re-adds it.
+    let original_uuid = sea_orm::prelude::Uuid::parse_str(&original_user_message_id)
+        .expect("original user message id is a uuid");
+    let edited_user_message = erato::db::entity::messages::Entity::find()
+        .filter(erato::db::entity::messages::Column::SiblingMessageId.eq(original_uuid))
+        .one(&db)
+        .await
+        .expect("Failed to fetch edited user message")
+        .expect("Edited user message should exist");
+    assert_eq!(
+        edited_user_message.input_parameters, None,
+        "A dropped facet must not be persisted onto the edited user message",
+    );
 }

--- a/backend/erato/tests/integration_tests/api/edit.rs
+++ b/backend/erato/tests/integration_tests/api/edit.rs
@@ -781,11 +781,11 @@ async fn test_edit_drops_stored_action_facet_that_no_longer_validates(pool: Pool
 
     let edit_events = parse_sse_events(&edit_response);
     assert!(
-        edit_events
-            .iter()
-            .any(|e| { serde_json::from_str::<Value>(&e.data)
+        edit_events.iter().any(|e| {
+            serde_json::from_str::<Value>(&e.data)
                 .map(|j| j["message_type"] == "assistant_message_completed")
-                .unwrap_or(false) }),
+                .unwrap_or(false)
+        }),
         "Edit must complete a generation even when the stored facet is gone"
     );
 


### PR DESCRIPTION
## Problem

Editing a message that was originally sent with an action facet (e.g. `outlook_rewrite_selection` with `selected_text` args) silently dropped the entire facet context on the re-generated turn. The model received zero facet context, so it behaved as if no selection existed.

Root cause: `edit_message_sse` mapped `request.action_facet` directly with no fallback — unlike the `regenerate` path which gained a `fallback_action_facet` block in commit b86276af. The `action_facet` field on `EditMessageRequest` was wired in commit bb50e351 but the matching backend fallback was never implemented.

## Solution

Mirror the regenerate fallback exactly inside `edit_message_sse`:

- When `request.action_facet` is `None`, read the edited message's stored facet from `generation_parameters` via `get_generation_action_facet_from_message(&message_to_edit)`.
- Re-validate against the **current** config and platform — a facet removed from config since the original send is dropped with `tracing::warn` rather than returning a 400.
- Apply via `.or(fallback_action_facet.as_ref())`, so an explicit `action_facet` in the edit request still takes precedence.

This is **option (a)** from the issue — a single backend location that fixes all clients (web, Outlook add-in, any future client) for free.

## Changes

- **`backend/erato/src/server/api/v1beta/message_streaming.rs`** — add `fallback_action_facet` block inside the spawned task in `edit_message_sse`, update `PromptCompositionUserInput.action_facet` to use `.or(fallback_action_facet.as_ref())`.

- **`backend/erato/tests/integration_tests/api/edit.rs`** — two new integration tests:
  - `test_edit_falls_back_to_stored_action_facet`: submits with a `rewrite` facet, edits without one, asserts the facet appears in the edit's `generation_parameters` **and** that the rendered directive reached the LLM in both the original and edit requests.
  - `test_edit_drops_stored_action_facet_that_no_longer_validates`: same setup but edit runs against a config that no longer declares the facet — asserts the edit succeeds (200) and the generation parameters contain no facet.

Closes ERMAIN-429
