### PR TITLE
Add compat flag to make Anthropic + Bifrost + reasoning replay work

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -54,6 +54,7 @@ cost_output_tokens_per_1m = 0.0
 # top_p = 0.9              # Optional nucleus sampling parameter
 # reasoning_effort = "low" # Optional reasoning effort: "none" | "minimal" | "low" | "medium" | "high"
 # verbosity = "medium"     # Optional verbosity: "low" | "medium" | "high"
+# compat_no_replay_summary = false # Optional: do not replay plain reasoning summaries
 
 # Model permissions - allow test model for all users (low token limit makes it test-only anyway)
 [model_permissions.rules.allow-test-model-for-all]

--- a/backend/erato/src/config.rs
+++ b/backend/erato/src/config.rs
@@ -3684,6 +3684,10 @@ pub struct ModelSettings {
     // Defaults to `false`.
     #[serde(default)]
     pub compat_omit_strict: bool,
+    // Whether to skip replaying plain reasoning summaries as prior reasoning content.
+    // Defaults to `false`.
+    #[serde(default)]
+    pub compat_no_replay_summary: bool,
     // Optional sampling temperature for generation.
     pub temperature: Option<f64>,
     // Optional nucleus sampling parameter.

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -109,6 +109,7 @@ fn now_timestamp() -> String {
 
 fn build_openai_responses_reasoning_replay_parts(
     generation_metadata: GenerationMetadata,
+    compat_no_replay_summary: bool,
 ) -> Vec<GenAiContentPart> {
     let reasoning_summary = generation_metadata
         .reasoning_summary
@@ -147,10 +148,14 @@ fn build_openai_responses_reasoning_replay_parts(
             .collect();
     }
 
-    reasoning_summary
-        .map(GenAiContentPart::ReasoningContent)
-        .into_iter()
-        .collect()
+    if compat_no_replay_summary {
+        Vec::new()
+    } else {
+        reasoning_summary
+            .map(GenAiContentPart::ReasoningContent)
+            .into_iter()
+            .collect()
+    }
 }
 
 fn strip_persisted_reasoning_messages(chat_request: &mut ChatRequest) {
@@ -238,6 +243,7 @@ async fn collect_reasoning_replay_messages(
     subject: &Subject,
     just_submitted_user_message_id: &Uuid,
     current_chat_provider_id: &str,
+    compat_no_replay_summary: bool,
 ) -> Result<Vec<OpenAiResponsesReasoningReplayMessage>, Report> {
     let mut current_message = get_message_by_id(
         &app_state.db,
@@ -267,7 +273,10 @@ async fn collect_reasoning_replay_messages(
             continue;
         };
 
-        let replay_parts = build_openai_responses_reasoning_replay_parts(generation_metadata);
+        let replay_parts = build_openai_responses_reasoning_replay_parts(
+            generation_metadata,
+            compat_no_replay_summary,
+        );
         if !replay_parts.is_empty() {
             let generation_parameters =
                 current_message
@@ -2141,6 +2150,7 @@ pub(crate) async fn prepare_chat_request_with_adapters(
                 &me_profile_input.subject,
                 &user_input.just_submitted_user_message_id,
                 chat_provider_id.as_str(),
+                effective_model_settings.compat_no_replay_summary,
             )
             .await?;
             if !reasoning_replay_messages.is_empty() {
@@ -5930,16 +5940,19 @@ mod reasoning_replay_tests {
 
     #[test]
     fn openai_responses_reasoning_replay_deduplicates_encrypted_content() {
-        let parts = build_openai_responses_reasoning_replay_parts(generation_metadata(
-            Some("summary".to_string()),
-            Some(vec![ReasoningItem {
-                id: Some("rs_123".to_string()),
-                summary: vec![ReasoningSummaryText::new("summary")],
-                encrypted_content: Some("encrypted".to_string()),
-                ..Default::default()
-            }]),
-            Some(vec!["encrypted".to_string()]),
-        ));
+        let parts = build_openai_responses_reasoning_replay_parts(
+            generation_metadata(
+                Some("summary".to_string()),
+                Some(vec![ReasoningItem {
+                    id: Some("rs_123".to_string()),
+                    summary: vec![ReasoningSummaryText::new("summary")],
+                    encrypted_content: Some("encrypted".to_string()),
+                    ..Default::default()
+                }]),
+                Some(vec!["encrypted".to_string()]),
+            ),
+            false,
+        );
 
         assert_eq!(parts.len(), 1);
         let GenAiContentPart::ReasoningItem(reasoning_item) = &parts[0] else {
@@ -5955,11 +5968,50 @@ mod reasoning_replay_tests {
 
     #[test]
     fn openai_responses_reasoning_replay_synthesizes_summary_for_legacy_encrypted_content() {
-        let parts = build_openai_responses_reasoning_replay_parts(generation_metadata(
-            Some("summary".to_string()),
-            None,
-            Some(vec!["encrypted".to_string()]),
-        ));
+        let parts = build_openai_responses_reasoning_replay_parts(
+            generation_metadata(
+                Some("summary".to_string()),
+                None,
+                Some(vec!["encrypted".to_string()]),
+            ),
+            false,
+        );
+
+        assert_eq!(parts.len(), 1);
+        let GenAiContentPart::ReasoningItem(reasoning_item) = &parts[0] else {
+            panic!("expected reasoning item");
+        };
+        assert_eq!(
+            reasoning_item.encrypted_content.as_deref(),
+            Some("encrypted")
+        );
+        assert_eq!(reasoning_item.summary.len(), 1);
+        assert_eq!(reasoning_item.summary[0].text, "summary");
+    }
+
+    #[test]
+    fn openai_responses_reasoning_replay_can_skip_summary_only_replay() {
+        let parts = build_openai_responses_reasoning_replay_parts(
+            generation_metadata(Some("summary".to_string()), None, None),
+            true,
+        );
+
+        assert!(
+            parts.is_empty(),
+            "compat_no_replay_summary should not replay plain reasoning summaries"
+        );
+    }
+
+    #[test]
+    fn openai_responses_reasoning_replay_still_replays_encrypted_content_when_summary_disabled() {
+        let parts = build_openai_responses_reasoning_replay_parts(
+            generation_metadata(
+                Some("summary".to_string()),
+                None,
+                Some(vec!["encrypted".to_string()]),
+            ),
+            true,
+        );
 
         assert_eq!(parts.len(), 1);
         let GenAiContentPart::ReasoningItem(reasoning_item) = &parts[0] else {

--- a/backend/erato/src/services/prompt_composition/model_settings.rs
+++ b/backend/erato/src/services/prompt_composition/model_settings.rs
@@ -49,6 +49,9 @@ fn merge_model_settings(base: &ModelSettings, overrides: &ModelSettings) -> Mode
     if overrides.compat_omit_strict {
         merged.compat_omit_strict = true;
     }
+    if overrides.compat_no_replay_summary {
+        merged.compat_no_replay_summary = true;
+    }
     if let Some(temperature) = overrides.temperature {
         merged.temperature = Some(temperature);
     }
@@ -89,6 +92,7 @@ mod tests {
         let base = ModelSettings {
             generate_images: true,
             compat_omit_strict: false,
+            compat_no_replay_summary: false,
             temperature: Some(0.2),
             top_p: None,
             reasoning_effort: None,
@@ -197,5 +201,26 @@ mod tests {
 
         let merged = build_model_settings_for_facets(&base, &config, &["facet".to_string()]);
         assert!(merged.generate_images);
+    }
+
+    #[test]
+    fn applies_compat_no_replay_summary() {
+        let base = ModelSettings::default();
+        let config = ExperimentalFacetsConfig {
+            facets: HashMap::from([(
+                "facet".to_string(),
+                facet(
+                    "Facet",
+                    ModelSettings {
+                        compat_no_replay_summary: true,
+                        ..Default::default()
+                    },
+                ),
+            )]),
+            ..Default::default()
+        };
+
+        let merged = build_model_settings_for_facets(&base, &config, &["facet".to_string()]);
+        assert!(merged.compat_no_replay_summary);
     }
 }

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -2224,6 +2224,7 @@ top_p = 0.9
 reasoning_effort = "minimal"
 verbosity = "high"
 compat_omit_strict = true
+compat_no_replay_summary = true
 
 [file_storage_providers.test]
 provider_kind = "s3"
@@ -2257,6 +2258,7 @@ config = { bucket = "test-bucket", endpoint = "http://localhost:8333", region = 
         Some(ModelReasoningEffort::Minimal)
     );
     assert!(provider.model_settings.compat_omit_strict);
+    assert!(provider.model_settings.compat_no_replay_summary);
     assert_eq!(
         provider.model_settings.verbosity,
         Some(ModelVerbosity::High)
@@ -2314,6 +2316,7 @@ config = { bucket = "test-bucket", endpoint = "http://localhost:8333", region = 
     assert_eq!(provider.model_settings.top_p, None);
     assert_eq!(provider.model_settings.reasoning_effort, None);
     assert!(!provider.model_settings.compat_omit_strict);
+    assert!(!provider.model_settings.compat_no_replay_summary);
     assert_eq!(provider.model_settings.verbosity, None);
 }
 

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -155,6 +155,9 @@
   "chat_provider.model_name_langfuse": {
     "hide_in_docs": true
   },
+  "chat_provider.model_settings.compat_no_replay_summary": {
+    "hide_in_docs": true
+  },
   "chat_provider.model_settings.compat_omit_strict": {
     "hide_in_docs": true
   },
@@ -230,6 +233,7 @@
   "chat_providers.providers.<provider-id>.model_icon": {},
   "chat_providers.providers.<provider-id>.model_name": {},
   "chat_providers.providers.<provider-id>.model_name_langfuse": {},
+  "chat_providers.providers.<provider-id>.model_settings.compat_no_replay_summary": {},
   "chat_providers.providers.<provider-id>.model_settings.compat_omit_strict": {},
   "chat_providers.providers.<provider-id>.model_settings.generate_images": {},
   "chat_providers.providers.<provider-id>.model_settings.reasoning_effort": {},
@@ -286,6 +290,7 @@
   "experimental_facets.facets.<facet-id>.disable_facet_prompt_template": {},
   "experimental_facets.facets.<facet-id>.display_name": {},
   "experimental_facets.facets.<facet-id>.icon": {},
+  "experimental_facets.facets.<facet-id>.model_settings.compat_no_replay_summary": {},
   "experimental_facets.facets.<facet-id>.model_settings.compat_omit_strict": {},
   "experimental_facets.facets.<facet-id>.model_settings.generate_images": {},
   "experimental_facets.facets.<facet-id>.model_settings.reasoning_effort": {},

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -980,12 +980,16 @@ top_p = 0.9
 reasoning_effort = "minimal"
 verbosity = "high"
 compat_omit_strict = false
+compat_no_replay_summary = false
 ```
 
 **Fields:**
 
 - **`generate_images`** _(default: false)_ - When set to `true`, the model will generate images instead of text. This is useful for image generation models like DALL-E. The user's message text will be used as the prompt for image generation. The generated image is automatically downloaded, stored as a file upload, and added to the chat history as an image file pointer.
 - **`compat_omit_strict`** _(default: false)_ - When set to `true`, requests will omit explicit tool schema `strict` fields for MCP tools. This can help when provider gateways reject strict-mode tool metadata.
+{/* erato_toml_config_key: chat_providers.providers.<provider-id>.model_settings.compat_no_replay_summary */}
+{/* erato_toml_config_key: experimental_facets.facets.<facet-id>.model_settings.compat_no_replay_summary */}
+- **`compat_no_replay_summary`** _(default: false)_ - When set to `true`, plain reasoning summaries from prior turns are not replayed as reasoning content. Use this for provider gateways that require signed or encrypted reasoning replay data and reject unsigned summary-only reasoning blocks.
 - **`temperature`** _(default: None)_ - Optional sampling temperature for generation (higher values increase randomness).
 - **`top_p`** _(default: None)_ - Optional nucleus sampling parameter to control diversity.
 - **`reasoning_effort`** _(default: None)_ - Optional reasoning effort for supported models. Values: `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`.


### PR DESCRIPTION
Adds `chat_providers.providers.<provider-id>.model_settings.compat_no_replay_summary`

Related Linear issue: ERMAIN-444