### PR TITLE
Export message-rendering surface for component kits + stable i18n ids

### DIFF
--- a/frontend/src/componentKitReactRuntime.ts
+++ b/frontend/src/componentKitReactRuntime.ts
@@ -2,8 +2,14 @@ import { Trans, useLingui } from "@lingui/react";
 import React from "react";
 import { createPortal } from "react-dom";
 
+import { useTraceFeature } from "./providers/FeatureConfigProvider";
+
 type ComponentKitReactRuntime = typeof React & {
   createPortal: typeof createPortal;
+};
+
+type ComponentKitFeatureRuntime = {
+  useTraceFeature: typeof useTraceFeature;
 };
 
 const componentKitReactRuntime: ComponentKitReactRuntime = {
@@ -20,4 +26,12 @@ const componentKitReactRuntime: ComponentKitReactRuntime = {
 ).ERATO_LINGUI_REACT = {
   Trans,
   useLingui,
+};
+
+(
+  window as Window & {
+    ERATO_FEATURES?: ComponentKitFeatureRuntime;
+  }
+).ERATO_FEATURES = {
+  useTraceFeature,
 };

--- a/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
+++ b/frontend/src/components/ui/Message/EratoEmailSuggestion.tsx
@@ -50,7 +50,9 @@ export function DefaultEratoEmailCodeBlock({
           onClick={handleCopy}
           className="rounded-md border border-theme-border bg-theme-bg-primary px-3 py-1 text-xs hover:bg-theme-bg-tertiary"
         >
-          {copied ? t`Copied!` : t`Copy`}
+          {copied
+            ? t({ id: "chat.message.email.copied", message: "Copied!" })
+            : t({ id: "chat.message.email.copy", message: "Copy" })}
         </button>
       </div>
     </div>

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -253,8 +253,16 @@ function MarkdownPre({
       <button
         type="button"
         onClick={handleCopy}
-        aria-label={copied ? t`Copied` : t`Copy code`}
-        title={copied ? t`Copied` : t`Copy code`}
+        aria-label={
+          copied
+            ? t({ id: "chat.message.code.copied", message: "Copied" })
+            : t({ id: "chat.message.code.copy", message: "Copy code" })
+        }
+        title={
+          copied
+            ? t({ id: "chat.message.code.copied", message: "Copied" })
+            : t({ id: "chat.message.code.copy", message: "Copy code" })
+        }
         className="absolute right-2 top-2 z-10 flex items-center justify-center rounded border border-theme-border bg-theme-bg-secondary p-1 text-theme-fg-muted opacity-0 transition-opacity hover:bg-theme-bg-tertiary hover:text-theme-fg-primary focus:opacity-100 group-hover:opacity-100"
       >
         {copied ? (
@@ -353,7 +361,7 @@ const autolinkEratoFiles = (text: string): string => {
     if (prevChar === "(") {
       return match;
     }
-    return `[${t`Link`}](${match})`;
+    return `[${t({ id: "chat.message.link.fallback", message: "Link" })}](${match})`;
   });
 };
 
@@ -621,7 +629,12 @@ export const MessageContent = memo(function MessageContent({
                 onFileLinkPreview(resolvedEratoFile.previewFile);
               }}
             >
-              {typeof alt === "string" ? alt : t`Image`}
+              {typeof alt === "string"
+                ? alt
+                : t({
+                    id: "chat.message.image.fallback_alt",
+                    message: "Image",
+                  })}
             </a>
           );
         }
@@ -634,7 +647,12 @@ export const MessageContent = memo(function MessageContent({
               rel="noopener noreferrer"
               className="text-theme-fg-accent underline hover:opacity-80"
             >
-              {typeof alt === "string" ? alt : t`Image`}
+              {typeof alt === "string"
+                ? alt
+                : t({
+                    id: "chat.message.image.fallback_alt",
+                    message: "Image",
+                  })}
             </a>
           );
         }
@@ -868,7 +886,7 @@ export const MessageContent = memo(function MessageContent({
             data-footnotes="true"
           >
             <h2 className="mb-3 font-heading text-lg font-semibold text-theme-fg-primary">
-              {t`Footnotes`}
+              {t({ id: "chat.message.footnotes", message: "Footnotes" })}
             </h2>
             {/* Filter out the auto-generated h2 from children */}
             {React.Children.toArray(children).filter(

--- a/frontend/src/components/ui/ToolCall/ToolCallInput.tsx
+++ b/frontend/src/components/ui/ToolCall/ToolCallInput.tsx
@@ -19,7 +19,7 @@ export const ToolCallInput: React.FC<ToolCallInputProps> = ({
   return (
     <div className={className}>
       <div className="mb-2 text-xs font-medium text-theme-fg-secondary">
-        {t`Input Parameters`}
+        {t({ id: "toolcall.input.title", message: "Input Parameters" })}
       </div>
       <JsonDisplay data={input} />
     </div>

--- a/frontend/src/components/ui/ToolCall/ToolCallOutput.tsx
+++ b/frontend/src/components/ui/ToolCall/ToolCallOutput.tsx
@@ -27,7 +27,9 @@ export const ToolCallOutput: React.FC<ToolCallOutputProps> = ({
           isError ? "text-theme-error-fg" : "text-theme-fg-secondary",
         )}
       >
-        {isError ? t`Error Output` : t`Output`}
+        {isError
+          ? t({ id: "toolcall.output.error", message: "Error Output" })
+          : t({ id: "toolcall.output.title", message: "Output" })}
       </div>
       <div className={clsx({ "opacity-75": isError })}>
         <JsonDisplay data={output} />

--- a/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
+++ b/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
@@ -20,9 +20,19 @@ const buildLabel = (durationMs: number | null, hasError: boolean): string => {
   const formatted = formatThinkingDuration(durationMs);
 
   if (hasError) {
-    return formatted ? t`Stopped after ${formatted}` : t`Stopped`;
+    return formatted
+      ? t({
+          id: "trace.header.stopped_after",
+          message: `Stopped after ${formatted}`,
+        })
+      : t({ id: "trace.header.stopped", message: "Stopped" });
   }
-  return formatted ? t`Thought for ${formatted}` : t`Thought`;
+  return formatted
+    ? t({
+        id: "trace.header.thought_for",
+        message: `Thought for ${formatted}`,
+      })
+    : t({ id: "trace.header.thought", message: "Thought" });
 };
 
 /**

--- a/frontend/src/components/ui/Trace/TraceDoneMarker.tsx
+++ b/frontend/src/components/ui/Trace/TraceDoneMarker.tsx
@@ -16,7 +16,7 @@ export const TraceDoneMarker = () => (
       hasTrailingLine={false}
     />
     <div className="min-w-0 flex-1 pl-2.5 pt-0.5 text-sm text-theme-fg-secondary">
-      {t`Done`}
+      {t({ id: "trace.done", message: "Done" })}
     </div>
   </div>
 );

--- a/frontend/src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+++ b/frontend/src/components/ui/Trace/TraceThinkingPlaceholder.tsx
@@ -27,7 +27,9 @@ export const TraceThinkingPlaceholder = ({
       isActive
     />
     <div className="min-w-0 flex-1 pl-2.5 pt-0.5 text-sm italic text-theme-fg-muted">
-      <span className="animate-pulse">{t`Thinking…`}</span>
+      <span className="animate-pulse">
+        {t({ id: "trace.thinking.placeholder", message: "Thinking…" })}
+      </span>
     </div>
   </div>
 );

--- a/frontend/src/components/ui/Trace/hooks/useThinkingDuration.ts
+++ b/frontend/src/components/ui/Trace/hooks/useThinkingDuration.ts
@@ -18,7 +18,8 @@ const SECONDS_THRESHOLD_MS = 10 * MS_PER_MINUTE;
 export const formatThinkingDuration = (ms: number | null): string | null => {
   if (ms == null || !Number.isFinite(ms) || ms <= 0) return null;
 
-  if (ms < MS_PER_SECOND) return t`less than a second`;
+  if (ms < MS_PER_SECOND)
+    return t({ id: "trace.duration.subsecond", message: "less than a second" });
 
   const totalSeconds = Math.round(ms / MS_PER_SECOND);
 

--- a/frontend/src/components/ui/Trace/steps/ReasoningStep.tsx
+++ b/frontend/src/components/ui/Trace/steps/ReasoningStep.tsx
@@ -25,7 +25,7 @@ export const ReasoningStep = ({
   renderMarkdown,
   maskReasoningText = false,
 }: ReasoningStepProps) => {
-  const fallbackTitle = t`Thinking`;
+  const fallbackTitle = t({ id: "trace.reasoning.title", message: "Thinking" });
   const isRunning = status === "running" && isStreaming;
 
   if (maskReasoningText) {

--- a/frontend/src/components/ui/Trace/steps/ToolUseStep.tsx
+++ b/frontend/src/components/ui/Trace/steps/ToolUseStep.tsx
@@ -22,8 +22,8 @@ const STATUS_PILL_CLASS = {
 } as const;
 
 const STATUS_LABEL = {
-  running: () => t`Running`,
-  error: () => t`Failed`,
+  running: () => t({ id: "trace.tool.running", message: "Running" }),
+  error: () => t({ id: "trace.tool.failed", message: "Failed" }),
 } as const;
 
 type StatusWithPill = keyof typeof STATUS_PILL_CLASS;

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -24,7 +24,19 @@ export {
 export type { OutlookArtifact } from "@/types/chat";
 export { MessageTimestamp } from "@/components/ui/Message/MessageTimestamp";
 export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
-export { DefaultEratoEmailCodeBlock } from "@/components/ui/Message/EratoEmailSuggestion";
+export {
+  DefaultEratoEmailCodeBlock,
+  EratoEmailSuggestion,
+} from "@/components/ui/Message/EratoEmailSuggestion";
+export { ImageContentDisplay } from "@/components/ui/Message/ImageContentDisplay";
+export {
+  Trace,
+  groupIntoTraceClusters,
+  isTraceablePart,
+  durationFromTracePartsOrLegacyMessageTimestamps,
+  type TraceCluster,
+  type TraceablePart,
+} from "@/components/ui/Trace";
 export { FilePreviewModal } from "@/components/ui/Modal/FilePreviewModal";
 export { ModalBase } from "@/components/ui/Modal/ModalBase";
 export {
@@ -198,9 +210,11 @@ export {
   useAudioConversationalFeature,
   useFeatureConfig,
   useMessageFeedbackFeature,
+  useTraceFeature,
   useUploadFeature,
   type FeatureConfig,
   type MessageFeedbackFeatureConfig,
+  type TraceFeatureConfig,
 } from "@/providers/FeatureConfigProvider";
 export { EratoUiProvider, type EratoUiProviderProps } from "./EratoUiProvider";
 export {
@@ -228,6 +242,7 @@ export { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 export {
   extractTextFromContent,
   parseContent,
+  type UiImagePart,
 } from "@/utils/adapters/contentPartAdapter";
 export { getSupportedFileTypes } from "@/utils/capabilitiesToFileTypes";
 export {

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1294,6 +1294,26 @@ msgid "chat.message.aria"
 msgstr "Nachricht"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Feedback/CopyErrorButton.tsx
 msgid "chat.message.error.copy_report"
 msgstr "Fehlerbericht kopieren"
@@ -1392,6 +1412,21 @@ msgstr "Anfragelimit oder Kontingent überschritten. Das kann auch passieren, we
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.error.variant.rate_limit.cta"
 msgstr "Bitte versuche es in einer Minute erneut und reduziere die Länge oder Anzahl der Anhänge."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.footnotes"
+msgstr "Fußnoten"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.image.fallback_alt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.link.fallback"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
@@ -2757,6 +2792,51 @@ msgid "sharing.type.user"
 msgstr "Benutzer"
 
 #. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallInput.tsx
+msgid "toolcall.input.title"
+msgstr "Eingabeparameter"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.error"
+msgstr "Fehlerausgabe"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.title"
+msgstr "Ausgabe"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceDoneMarker.tsx
+msgid "trace.done"
+msgstr "Fertig"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "trace.duration.subsecond"
+msgstr "weniger als eine Sekunde"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped"
+msgstr "Abgebrochen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped_after"
+msgstr "Abgebrochen nach {formatted}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought"
+msgstr "Nachgedacht"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought_for"
+msgstr "Nachgedacht für {formatted}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked"
 msgstr "Denkt nach…"
@@ -2765,6 +2845,26 @@ msgstr "Denkt nach…"
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked.done"
 msgstr "Nachdenken abgeschlossen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ReasoningStep.tsx
+msgid "trace.reasoning.title"
+msgstr "Denkt nach"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "trace.thinking.placeholder"
+msgstr "Denkt nach…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.failed"
+msgstr "Fehlgeschlagen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.running"
+msgstr "Wird ausgeführt"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ImageLightbox.tsx
@@ -3225,20 +3325,20 @@ msgid "Conversational"
 msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copied"
-msgstr ""
+#~ msgid "Copied"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copied!"
-msgstr ""
+#~ msgid "Copied!"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copy"
-msgstr ""
+#~ msgid "Copy"
+#~ msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copy code"
-msgstr ""
+#~ msgid "Copy code"
+#~ msgstr ""
 
 #: src/hooks/audio/useGuidedAudioCapture.ts
 msgid "Could not capture audio from the microphone. Please try again."
@@ -3363,8 +3463,8 @@ msgid "Dismiss"
 msgstr "Schließen"
 
 #: src/components/ui/Trace/TraceDoneMarker.tsx
-msgid "Done"
-msgstr "Fertig"
+#~ msgid "Done"
+#~ msgstr "Fertig"
 
 #: src/components/ui/Modal/FilePreviewModal.tsx
 msgid "Download File"
@@ -3428,8 +3528,8 @@ msgstr "Fehler"
 #~ msgstr "Fehler beim Laden des Themes:"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Error Output"
-msgstr "Fehlerausgabe"
+#~ msgid "Error Output"
+#~ msgstr "Fehlerausgabe"
 
 #: src/components/ui/FileUpload/FileUploadStates.tsx
 msgid "Error:"
@@ -3464,7 +3564,6 @@ msgstr "facets.<facet-id>.displayName"
 #~ msgstr "fehlgeschlagen"
 
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Trace/steps/ToolUseStep.tsx
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
@@ -3510,8 +3609,8 @@ msgid "Finishing dictation"
 msgstr "Audiodiktat wird abgeschlossen"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Footnotes"
-msgstr "Fußnoten"
+#~ msgid "Footnotes"
+#~ msgstr "Fußnoten"
 
 #: src/pages/SearchPage.tsx
 msgid "Found {resultsCount} results"
@@ -3534,8 +3633,8 @@ msgid "How to Test:"
 msgstr "So testen Sie:"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Image"
-msgstr ""
+#~ msgid "Image"
+#~ msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "In Progress"
@@ -3550,8 +3649,8 @@ msgid "Include message"
 msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
-msgid "Input Parameters"
-msgstr "Eingabeparameter"
+#~ msgid "Input Parameters"
+#~ msgstr "Eingabeparameter"
 
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
@@ -3562,16 +3661,16 @@ msgid "Largest file context contributors:"
 msgstr "Größte Kontextbeiträge von Dateien:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
-msgid "less than a second"
-msgstr "weniger als eine Sekunde"
+#~ msgid "less than a second"
+#~ msgstr "weniger als eine Sekunde"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Heller Modus"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Link"
-msgstr ""
+#~ msgid "Link"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInputAudioModeButton.tsx
 msgid "Listening"
@@ -3735,8 +3834,8 @@ msgid "assistant.form.prompt-optimizer.tooltip"
 msgstr "Prompt optimieren"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Output"
-msgstr "Ausgabe"
+#~ msgid "Output"
+#~ msgstr "Ausgabe"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Please wait"
@@ -3856,8 +3955,8 @@ msgid "Retrying..."
 msgstr "Erneuter Versuch..."
 
 #: src/components/ui/Trace/steps/ToolUseStep.tsx
-msgid "Running"
-msgstr "Wird ausgeführt"
+#~ msgid "Running"
+#~ msgstr "Wird ausgeführt"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 #~ msgid "sample rate: {0} Hz"
@@ -4019,12 +4118,12 @@ msgstr "Audiodiktat stoppen"
 #~ msgstr "Aufnahme stoppen"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped"
-msgstr "Abgebrochen"
+#~ msgid "Stopped"
+#~ msgstr "Abgebrochen"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped after {formatted}"
-msgstr "Abgebrochen nach {formatted}"
+#~ msgid "Stopped after {formatted}"
+#~ msgstr "Abgebrochen nach {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Subject"
@@ -4098,13 +4197,12 @@ msgid "The selected microphone is not available. Refresh the device list and try
 msgstr "Das ausgewählte Mikrofon ist nicht verfügbar. Aktualisieren Sie die Geräteliste und versuchen Sie es erneut."
 
 #: src/components/ui/Feedback/LoadingIndicator.tsx
-#: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "Thinking"
 msgstr "Denkt nach"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
-msgid "Thinking…"
-msgstr "Denkt nach…"
+#~ msgid "Thinking…"
+#~ msgstr "Denkt nach…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -4115,12 +4213,12 @@ msgid "This message is using {percentUsed}% of the available token limit ({total
 msgstr "Diese Nachricht verwendet {percentUsed}% des verfügbaren Token-Limits ({totalTokensFormatted} von {maxTokensFormatted})."
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought"
-msgstr "Nachgedacht"
+#~ msgid "Thought"
+#~ msgstr "Nachgedacht"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought for {formatted}"
-msgstr "Nachgedacht für {formatted}"
+#~ msgid "Thought for {formatted}"
+#~ msgstr "Nachgedacht für {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "To"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1294,6 +1294,26 @@ msgid "chat.message.aria"
 msgstr "message"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copied"
+msgstr "Copied"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copy"
+msgstr "Copy code"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copied"
+msgstr "Copied!"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copy"
+msgstr "Copy"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Feedback/CopyErrorButton.tsx
 msgid "chat.message.error.copy_report"
 msgstr "Copy error report"
@@ -1392,6 +1412,21 @@ msgstr "Rate limit or quota exceeded. This can also happen if your input is too 
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.error.variant.rate_limit.cta"
 msgstr "Please try again in a minute, and reduce the length or number of attachments."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.footnotes"
+msgstr "Footnotes"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.image.fallback_alt"
+msgstr "Image"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.link.fallback"
+msgstr "Link"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
@@ -2757,6 +2792,51 @@ msgid "sharing.type.user"
 msgstr "User"
 
 #. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallInput.tsx
+msgid "toolcall.input.title"
+msgstr "Input Parameters"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.error"
+msgstr "Error Output"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.title"
+msgstr "Output"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceDoneMarker.tsx
+msgid "trace.done"
+msgstr "Done"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "trace.duration.subsecond"
+msgstr "less than a second"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped"
+msgstr "Stopped"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped_after"
+msgstr "Stopped after {formatted}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought"
+msgstr "Thought"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought_for"
+msgstr "Thought for {formatted}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked"
 msgstr "Thinking…"
@@ -2765,6 +2845,26 @@ msgstr "Thinking…"
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked.done"
 msgstr "Thinking complete"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ReasoningStep.tsx
+msgid "trace.reasoning.title"
+msgstr "Thinking"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "trace.thinking.placeholder"
+msgstr "Thinking…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.failed"
+msgstr "Failed"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.running"
+msgstr "Running"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ImageLightbox.tsx
@@ -3225,20 +3325,20 @@ msgid "Conversational"
 msgstr "Conversational"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copied"
-msgstr "Copied"
+#~ msgid "Copied"
+#~ msgstr "Copied"
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copied!"
-msgstr "Copied!"
+#~ msgid "Copied!"
+#~ msgstr "Copied!"
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copy"
-msgstr "Copy"
+#~ msgid "Copy"
+#~ msgstr "Copy"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copy code"
-msgstr "Copy code"
+#~ msgid "Copy code"
+#~ msgstr "Copy code"
 
 #: src/hooks/audio/useGuidedAudioCapture.ts
 msgid "Could not capture audio from the microphone. Please try again."
@@ -3363,8 +3463,8 @@ msgid "Dismiss"
 msgstr "Dismiss"
 
 #: src/components/ui/Trace/TraceDoneMarker.tsx
-msgid "Done"
-msgstr "Done"
+#~ msgid "Done"
+#~ msgstr "Done"
 
 #: src/components/ui/Modal/FilePreviewModal.tsx
 msgid "Download File"
@@ -3428,8 +3528,8 @@ msgstr "Error"
 #~ msgstr "Error loading theme:"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Error Output"
-msgstr "Error Output"
+#~ msgid "Error Output"
+#~ msgstr "Error Output"
 
 #: src/components/ui/FileUpload/FileUploadStates.tsx
 msgid "Error:"
@@ -3464,7 +3564,6 @@ msgstr "facets.<facet-id>.displayName"
 #~ msgstr "failed"
 
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Trace/steps/ToolUseStep.tsx
 msgid "Failed"
 msgstr "Failed"
 
@@ -3510,8 +3609,8 @@ msgid "Finishing dictation"
 msgstr "Finishing dictation"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Footnotes"
-msgstr "Footnotes"
+#~ msgid "Footnotes"
+#~ msgstr "Footnotes"
 
 #: src/pages/SearchPage.tsx
 msgid "Found {resultsCount} results"
@@ -3534,8 +3633,8 @@ msgid "How to Test:"
 msgstr "How to Test:"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Image"
-msgstr "Image"
+#~ msgid "Image"
+#~ msgstr "Image"
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "In Progress"
@@ -3550,8 +3649,8 @@ msgid "Include message"
 msgstr "Include message"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
-msgid "Input Parameters"
-msgstr "Input Parameters"
+#~ msgid "Input Parameters"
+#~ msgstr "Input Parameters"
 
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
@@ -3562,16 +3661,16 @@ msgid "Largest file context contributors:"
 msgstr "Largest file context contributors:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
-msgid "less than a second"
-msgstr "less than a second"
+#~ msgid "less than a second"
+#~ msgstr "less than a second"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Light mode"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Link"
-msgstr "Link"
+#~ msgid "Link"
+#~ msgstr "Link"
 
 #: src/components/ui/Chat/ChatInputAudioModeButton.tsx
 msgid "Listening"
@@ -3735,8 +3834,8 @@ msgid "assistant.form.prompt-optimizer.tooltip"
 msgstr "Optimize prompt"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Output"
-msgstr "Output"
+#~ msgid "Output"
+#~ msgstr "Output"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Please wait"
@@ -3856,8 +3955,8 @@ msgid "Retrying..."
 msgstr "Retrying..."
 
 #: src/components/ui/Trace/steps/ToolUseStep.tsx
-msgid "Running"
-msgstr "Running"
+#~ msgid "Running"
+#~ msgstr "Running"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 #~ msgid "sample rate: {0} Hz"
@@ -4019,12 +4118,12 @@ msgstr "Stop dictation"
 #~ msgstr "Stop recording"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped"
-msgstr "Stopped"
+#~ msgid "Stopped"
+#~ msgstr "Stopped"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped after {formatted}"
-msgstr "Stopped after {formatted}"
+#~ msgid "Stopped after {formatted}"
+#~ msgstr "Stopped after {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Subject"
@@ -4098,13 +4197,12 @@ msgid "The selected microphone is not available. Refresh the device list and try
 msgstr "The selected microphone is not available. Refresh the device list and try again."
 
 #: src/components/ui/Feedback/LoadingIndicator.tsx
-#: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "Thinking"
 msgstr "Thinking"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
-msgid "Thinking…"
-msgstr "Thinking…"
+#~ msgid "Thinking…"
+#~ msgstr "Thinking…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -4115,12 +4213,12 @@ msgid "This message is using {percentUsed}% of the available token limit ({total
 msgstr "This message is using {percentUsed}% of the available token limit ({totalTokensFormatted} of {maxTokensFormatted})."
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought"
-msgstr "Thought"
+#~ msgid "Thought"
+#~ msgstr "Thought"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought for {formatted}"
-msgstr "Thought for {formatted}"
+#~ msgid "Thought for {formatted}"
+#~ msgstr "Thought for {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "To"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1294,6 +1294,26 @@ msgid "chat.message.aria"
 msgstr "mensaje"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Feedback/CopyErrorButton.tsx
 msgid "chat.message.error.copy_report"
 msgstr "Copiar informe de error"
@@ -1392,6 +1412,21 @@ msgstr "Se superó el límite de solicitudes o la cuota. Esto también puede ocu
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.error.variant.rate_limit.cta"
 msgstr "Vuelve a intentarlo en un minuto y reduce la longitud o la cantidad de archivos adjuntos."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.footnotes"
+msgstr "Notas al pie"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.image.fallback_alt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.link.fallback"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
@@ -2757,6 +2792,51 @@ msgid "sharing.type.user"
 msgstr "Usuario"
 
 #. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallInput.tsx
+msgid "toolcall.input.title"
+msgstr "Parámetros de entrada"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.error"
+msgstr "Salida de error"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.title"
+msgstr "Salida"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceDoneMarker.tsx
+msgid "trace.done"
+msgstr "Hecho"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "trace.duration.subsecond"
+msgstr "menos de un segundo"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped"
+msgstr "Detenido"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped_after"
+msgstr "Detenido tras {formatted}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought"
+msgstr "Pensado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought_for"
+msgstr "Pensado durante {formatted}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked"
 msgstr "Pensando…"
@@ -2765,6 +2845,26 @@ msgstr "Pensando…"
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked.done"
 msgstr "Pensamiento completado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ReasoningStep.tsx
+msgid "trace.reasoning.title"
+msgstr "Pensando"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "trace.thinking.placeholder"
+msgstr "Pensando…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.failed"
+msgstr "Falló"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.running"
+msgstr "En ejecución"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ImageLightbox.tsx
@@ -3225,20 +3325,20 @@ msgid "Conversational"
 msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copied"
-msgstr ""
+#~ msgid "Copied"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copied!"
-msgstr ""
+#~ msgid "Copied!"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copy"
-msgstr ""
+#~ msgid "Copy"
+#~ msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copy code"
-msgstr ""
+#~ msgid "Copy code"
+#~ msgstr ""
 
 #: src/hooks/audio/useGuidedAudioCapture.ts
 msgid "Could not capture audio from the microphone. Please try again."
@@ -3363,8 +3463,8 @@ msgid "Dismiss"
 msgstr "Descartar"
 
 #: src/components/ui/Trace/TraceDoneMarker.tsx
-msgid "Done"
-msgstr "Hecho"
+#~ msgid "Done"
+#~ msgstr "Hecho"
 
 #: src/components/ui/Modal/FilePreviewModal.tsx
 msgid "Download File"
@@ -3428,8 +3528,8 @@ msgstr "Error"
 #~ msgstr "Error al cargar el tema:"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Error Output"
-msgstr "Salida de error"
+#~ msgid "Error Output"
+#~ msgstr "Salida de error"
 
 #: src/components/ui/FileUpload/FileUploadStates.tsx
 msgid "Error:"
@@ -3464,7 +3564,6 @@ msgstr "facets.<facet-id>.displayName"
 #~ msgstr "falló"
 
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Trace/steps/ToolUseStep.tsx
 msgid "Failed"
 msgstr "Falló"
 
@@ -3510,8 +3609,8 @@ msgid "Finishing dictation"
 msgstr "Finalizando dictado"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Footnotes"
-msgstr "Notas al pie"
+#~ msgid "Footnotes"
+#~ msgstr "Notas al pie"
 
 #: src/pages/SearchPage.tsx
 msgid "Found {resultsCount} results"
@@ -3534,8 +3633,8 @@ msgid "How to Test:"
 msgstr "Cómo probar:"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Image"
-msgstr ""
+#~ msgid "Image"
+#~ msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "In Progress"
@@ -3550,8 +3649,8 @@ msgid "Include message"
 msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
-msgid "Input Parameters"
-msgstr "Parámetros de entrada"
+#~ msgid "Input Parameters"
+#~ msgstr "Parámetros de entrada"
 
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
@@ -3562,16 +3661,16 @@ msgid "Largest file context contributors:"
 msgstr "Mayores contribuciones de contexto de archivos:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
-msgid "less than a second"
-msgstr "menos de un segundo"
+#~ msgid "less than a second"
+#~ msgstr "menos de un segundo"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Modo claro"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Link"
-msgstr ""
+#~ msgid "Link"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInputAudioModeButton.tsx
 msgid "Listening"
@@ -3735,8 +3834,8 @@ msgid "assistant.form.prompt-optimizer.tooltip"
 msgstr "Optimizar el prompt"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Output"
-msgstr "Salida"
+#~ msgid "Output"
+#~ msgstr "Salida"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Please wait"
@@ -3856,8 +3955,8 @@ msgid "Retrying..."
 msgstr "Reintentando..."
 
 #: src/components/ui/Trace/steps/ToolUseStep.tsx
-msgid "Running"
-msgstr "En ejecución"
+#~ msgid "Running"
+#~ msgstr "En ejecución"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 #~ msgid "sample rate: {0} Hz"
@@ -4019,12 +4118,12 @@ msgstr "Detener dictado"
 #~ msgstr "Detener grabación"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped"
-msgstr "Detenido"
+#~ msgid "Stopped"
+#~ msgstr "Detenido"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped after {formatted}"
-msgstr "Detenido tras {formatted}"
+#~ msgid "Stopped after {formatted}"
+#~ msgstr "Detenido tras {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Subject"
@@ -4098,13 +4197,12 @@ msgid "The selected microphone is not available. Refresh the device list and try
 msgstr "El micrófono seleccionado no está disponible. Actualiza la lista de dispositivos e inténtalo de nuevo."
 
 #: src/components/ui/Feedback/LoadingIndicator.tsx
-#: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "Thinking"
 msgstr "Pensando"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
-msgid "Thinking…"
-msgstr "Pensando…"
+#~ msgid "Thinking…"
+#~ msgstr "Pensando…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -4115,12 +4213,12 @@ msgid "This message is using {percentUsed}% of the available token limit ({total
 msgstr "Este mensaje está usando {percentUsed}% del límite de tokens disponible ({totalTokensFormatted} de {maxTokensFormatted})."
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought"
-msgstr "Pensado"
+#~ msgid "Thought"
+#~ msgstr "Pensado"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought for {formatted}"
-msgstr "Pensado durante {formatted}"
+#~ msgid "Thought for {formatted}"
+#~ msgstr "Pensado durante {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "To"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1294,6 +1294,26 @@ msgid "chat.message.aria"
 msgstr "message"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Feedback/CopyErrorButton.tsx
 msgid "chat.message.error.copy_report"
 msgstr "Copier le rapport d’erreur"
@@ -1392,6 +1412,21 @@ msgstr "Limite de requêtes ou quota dépassé. Cela peut aussi arriver si votre
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.error.variant.rate_limit.cta"
 msgstr "Réessayez dans une minute et réduisez la longueur ou le nombre de pièces jointes."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.footnotes"
+msgstr "Notes de bas de page"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.image.fallback_alt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.link.fallback"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
@@ -2757,6 +2792,51 @@ msgid "sharing.type.user"
 msgstr "Utilisateur"
 
 #. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallInput.tsx
+msgid "toolcall.input.title"
+msgstr "Paramètres d'entrée"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.error"
+msgstr "Sortie d'erreur"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.title"
+msgstr "Sortie"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceDoneMarker.tsx
+msgid "trace.done"
+msgstr "Terminé"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "trace.duration.subsecond"
+msgstr "moins d'une seconde"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped"
+msgstr "Arrêté"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped_after"
+msgstr "Arrêté après {formatted}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought"
+msgstr "Réfléchi"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought_for"
+msgstr "Réfléchi pendant {formatted}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked"
 msgstr "Réflexion…"
@@ -2765,6 +2845,26 @@ msgstr "Réflexion…"
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked.done"
 msgstr "Réflexion terminée"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ReasoningStep.tsx
+msgid "trace.reasoning.title"
+msgstr "Réflexion"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "trace.thinking.placeholder"
+msgstr "Réflexion…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.failed"
+msgstr "Échec"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.running"
+msgstr "En cours"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ImageLightbox.tsx
@@ -3225,20 +3325,20 @@ msgid "Conversational"
 msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copied"
-msgstr ""
+#~ msgid "Copied"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copied!"
-msgstr ""
+#~ msgid "Copied!"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copy"
-msgstr ""
+#~ msgid "Copy"
+#~ msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copy code"
-msgstr ""
+#~ msgid "Copy code"
+#~ msgstr ""
 
 #: src/hooks/audio/useGuidedAudioCapture.ts
 msgid "Could not capture audio from the microphone. Please try again."
@@ -3363,8 +3463,8 @@ msgid "Dismiss"
 msgstr "Fermer"
 
 #: src/components/ui/Trace/TraceDoneMarker.tsx
-msgid "Done"
-msgstr "Terminé"
+#~ msgid "Done"
+#~ msgstr "Terminé"
 
 #: src/components/ui/Modal/FilePreviewModal.tsx
 msgid "Download File"
@@ -3428,8 +3528,8 @@ msgstr "Erreur"
 #~ msgstr "Erreur lors du chargement du thème :"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Error Output"
-msgstr "Sortie d'erreur"
+#~ msgid "Error Output"
+#~ msgstr "Sortie d'erreur"
 
 #: src/components/ui/FileUpload/FileUploadStates.tsx
 msgid "Error:"
@@ -3464,7 +3564,6 @@ msgstr "facets.<facet-id>.displayName"
 #~ msgstr "échoué"
 
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Trace/steps/ToolUseStep.tsx
 msgid "Failed"
 msgstr "Échec"
 
@@ -3510,8 +3609,8 @@ msgid "Finishing dictation"
 msgstr "Finalisation de la dictée"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Footnotes"
-msgstr "Notes de bas de page"
+#~ msgid "Footnotes"
+#~ msgstr "Notes de bas de page"
 
 #: src/pages/SearchPage.tsx
 msgid "Found {resultsCount} results"
@@ -3534,8 +3633,8 @@ msgid "How to Test:"
 msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Image"
-msgstr ""
+#~ msgid "Image"
+#~ msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "In Progress"
@@ -3550,8 +3649,8 @@ msgid "Include message"
 msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
-msgid "Input Parameters"
-msgstr "Paramètres d'entrée"
+#~ msgid "Input Parameters"
+#~ msgstr "Paramètres d'entrée"
 
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
@@ -3562,16 +3661,16 @@ msgid "Largest file context contributors:"
 msgstr "Principales contributions des fichiers au contexte :"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
-msgid "less than a second"
-msgstr "moins d'une seconde"
+#~ msgid "less than a second"
+#~ msgstr "moins d'une seconde"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Mode clair"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Link"
-msgstr ""
+#~ msgid "Link"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInputAudioModeButton.tsx
 msgid "Listening"
@@ -3735,8 +3834,8 @@ msgid "assistant.form.prompt-optimizer.tooltip"
 msgstr "Optimiser le prompt"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Output"
-msgstr "Sortie"
+#~ msgid "Output"
+#~ msgstr "Sortie"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Please wait"
@@ -3856,8 +3955,8 @@ msgid "Retrying..."
 msgstr "Nouvelle tentative..."
 
 #: src/components/ui/Trace/steps/ToolUseStep.tsx
-msgid "Running"
-msgstr "En cours"
+#~ msgid "Running"
+#~ msgstr "En cours"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 #~ msgid "sample rate: {0} Hz"
@@ -4019,12 +4118,12 @@ msgstr "Arrêter la dictée"
 #~ msgstr "Arrêter l'enregistrement"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped"
-msgstr "Arrêté"
+#~ msgid "Stopped"
+#~ msgstr "Arrêté"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped after {formatted}"
-msgstr "Arrêté après {formatted}"
+#~ msgid "Stopped after {formatted}"
+#~ msgstr "Arrêté après {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Subject"
@@ -4098,13 +4197,12 @@ msgid "The selected microphone is not available. Refresh the device list and try
 msgstr "Le microphone sélectionné n'est pas disponible. Actualisez la liste des appareils et réessayez."
 
 #: src/components/ui/Feedback/LoadingIndicator.tsx
-#: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "Thinking"
 msgstr "Réflexion"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
-msgid "Thinking…"
-msgstr "Réflexion…"
+#~ msgid "Thinking…"
+#~ msgstr "Réflexion…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -4115,12 +4213,12 @@ msgid "This message is using {percentUsed}% of the available token limit ({total
 msgstr "Ce message utilise {percentUsed}% de la limite de tokens disponible ({totalTokensFormatted} sur {maxTokensFormatted})."
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought"
-msgstr "Réfléchi"
+#~ msgid "Thought"
+#~ msgstr "Réfléchi"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought for {formatted}"
-msgstr "Réfléchi pendant {formatted}"
+#~ msgid "Thought for {formatted}"
+#~ msgstr "Réfléchi pendant {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "To"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1294,6 +1294,26 @@ msgid "chat.message.aria"
 msgstr "wiadomość"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.code.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copied"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoEmailSuggestion.tsx
+msgid "chat.message.email.copy"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Feedback/CopyErrorButton.tsx
 msgid "chat.message.error.copy_report"
 msgstr "Kopiuj raport błędu"
@@ -1392,6 +1412,21 @@ msgstr "Przekroczono limit zapytań lub przydział. Może się to też zdarzyć,
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.error.variant.rate_limit.cta"
 msgstr "Spróbuj ponownie za minutę i ogranicz długość lub liczbę załączników."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.footnotes"
+msgstr "Przypisy"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.image.fallback_alt"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/MessageContent.tsx
+msgid "chat.message.link.fallback"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
@@ -2757,6 +2792,51 @@ msgid "sharing.type.user"
 msgstr "Użytkownik"
 
 #. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallInput.tsx
+msgid "toolcall.input.title"
+msgstr "Parametry wejściowe"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.error"
+msgstr "Wyjście błędu"
+
+#. js-lingui-explicit-id
+#: src/components/ui/ToolCall/ToolCallOutput.tsx
+msgid "toolcall.output.title"
+msgstr "Wyjście"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceDoneMarker.tsx
+msgid "trace.done"
+msgstr "Gotowe"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/hooks/useThinkingDuration.ts
+msgid "trace.duration.subsecond"
+msgstr "mniej niż sekundę"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped"
+msgstr "Zatrzymano"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.stopped_after"
+msgstr "Zatrzymano po {formatted}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought"
+msgstr "Myślano"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceClusterHeader.tsx
+msgid "trace.header.thought_for"
+msgstr "Myślano przez {formatted}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked"
 msgstr "Myślę…"
@@ -2765,6 +2845,26 @@ msgstr "Myślę…"
 #: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "trace.reasoning.masked.done"
 msgstr "Myślenie zakończone"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ReasoningStep.tsx
+msgid "trace.reasoning.title"
+msgstr "Myślę"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
+msgid "trace.thinking.placeholder"
+msgstr "Myślę…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.failed"
+msgstr "Niepowodzenie"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/ToolUseStep.tsx
+msgid "trace.tool.running"
+msgstr "W toku"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Message/ImageLightbox.tsx
@@ -3225,20 +3325,20 @@ msgid "Conversational"
 msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copied"
-msgstr ""
+#~ msgid "Copied"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copied!"
-msgstr ""
+#~ msgid "Copied!"
+#~ msgstr ""
 
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
-msgid "Copy"
-msgstr ""
+#~ msgid "Copy"
+#~ msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Copy code"
-msgstr ""
+#~ msgid "Copy code"
+#~ msgstr ""
 
 #: src/hooks/audio/useGuidedAudioCapture.ts
 msgid "Could not capture audio from the microphone. Please try again."
@@ -3363,8 +3463,8 @@ msgid "Dismiss"
 msgstr "Odrzuć"
 
 #: src/components/ui/Trace/TraceDoneMarker.tsx
-msgid "Done"
-msgstr "Gotowe"
+#~ msgid "Done"
+#~ msgstr "Gotowe"
 
 #: src/components/ui/Modal/FilePreviewModal.tsx
 msgid "Download File"
@@ -3428,8 +3528,8 @@ msgstr "Błąd"
 #~ msgstr "Błąd wczytywania motywu:"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Error Output"
-msgstr "Wyjście błędu"
+#~ msgid "Error Output"
+#~ msgstr "Wyjście błędu"
 
 #: src/components/ui/FileUpload/FileUploadStates.tsx
 msgid "Error:"
@@ -3464,7 +3564,6 @@ msgstr "facets.<facet-id>.displayName"
 #~ msgstr "nie udało się"
 
 #: src/components/ui/Chat/ChatInput.tsx
-#: src/components/ui/Trace/steps/ToolUseStep.tsx
 msgid "Failed"
 msgstr "Niepowodzenie"
 
@@ -3510,8 +3609,8 @@ msgid "Finishing dictation"
 msgstr "Kończenie dyktowania"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Footnotes"
-msgstr "Przypisy"
+#~ msgid "Footnotes"
+#~ msgstr "Przypisy"
 
 #: src/pages/SearchPage.tsx
 msgid "Found {resultsCount} results"
@@ -3534,8 +3633,8 @@ msgid "How to Test:"
 msgstr "Jak testować:"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Image"
-msgstr ""
+#~ msgid "Image"
+#~ msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "In Progress"
@@ -3550,8 +3649,8 @@ msgid "Include message"
 msgstr ""
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
-msgid "Input Parameters"
-msgstr "Parametry wejściowe"
+#~ msgid "Input Parameters"
+#~ msgstr "Parametry wejściowe"
 
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
@@ -3562,16 +3661,16 @@ msgid "Largest file context contributors:"
 msgstr "Największy udział plików w kontekście:"
 
 #: src/components/ui/Trace/hooks/useThinkingDuration.ts
-msgid "less than a second"
-msgstr "mniej niż sekundę"
+#~ msgid "less than a second"
+#~ msgstr "mniej niż sekundę"
 
 #: src/components/ui/Controls/UserProfileDropdown.tsx
 #~ msgid "Light mode"
 #~ msgstr "Tryb jasny"
 
 #: src/components/ui/Message/MessageContent.tsx
-msgid "Link"
-msgstr ""
+#~ msgid "Link"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInputAudioModeButton.tsx
 msgid "Listening"
@@ -3735,8 +3834,8 @@ msgid "assistant.form.prompt-optimizer.tooltip"
 msgstr "Optymalizuj prompt"
 
 #: src/components/ui/ToolCall/ToolCallOutput.tsx
-msgid "Output"
-msgstr "Wyjście"
+#~ msgid "Output"
+#~ msgstr "Wyjście"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Please wait"
@@ -3856,8 +3955,8 @@ msgid "Retrying..."
 msgstr "Ponawianie..."
 
 #: src/components/ui/Trace/steps/ToolUseStep.tsx
-msgid "Running"
-msgstr "W toku"
+#~ msgid "Running"
+#~ msgstr "W toku"
 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 #~ msgid "sample rate: {0} Hz"
@@ -4019,12 +4118,12 @@ msgstr "Zatrzymaj dyktowanie"
 #~ msgstr "Zatrzymaj nagrywanie"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped"
-msgstr "Zatrzymano"
+#~ msgid "Stopped"
+#~ msgstr "Zatrzymano"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Stopped after {formatted}"
-msgstr "Zatrzymano po {formatted}"
+#~ msgid "Stopped after {formatted}"
+#~ msgstr "Zatrzymano po {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Subject"
@@ -4098,13 +4197,12 @@ msgid "The selected microphone is not available. Refresh the device list and try
 msgstr "Wybrany mikrofon jest niedostępny. Odśwież listę urządzeń i spróbuj ponownie."
 
 #: src/components/ui/Feedback/LoadingIndicator.tsx
-#: src/components/ui/Trace/steps/ReasoningStep.tsx
 msgid "Thinking"
 msgstr "Myślę"
 
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
-msgid "Thinking…"
-msgstr "Myślę…"
+#~ msgid "Thinking…"
+#~ msgstr "Myślę…"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."
@@ -4115,12 +4213,12 @@ msgid "This message is using {percentUsed}% of the available token limit ({total
 msgstr "Ta wiadomość używa {percentUsed}% dostępnego limitu tokenów ({totalTokensFormatted} z {maxTokensFormatted})."
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought"
-msgstr "Myślano"
+#~ msgid "Thought"
+#~ msgstr "Myślano"
 
 #: src/components/ui/Trace/TraceClusterHeader.tsx
-msgid "Thought for {formatted}"
-msgstr "Myślano przez {formatted}"
+#~ msgid "Thought for {formatted}"
+#~ msgstr "Myślano przez {formatted}"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "To"

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -167,7 +167,7 @@ interface ChatSharingFeatureConfig {
 /**
  * Configuration for trace/reasoning display features
  */
-interface TraceFeatureConfig {
+export interface TraceFeatureConfig {
   /** When true, model-generated reasoning title and body text are replaced with a masked label */
   maskReasoningText: boolean;
 }


### PR DESCRIPTION
Phase 1 of the component-kit de-duplication plan: give kits enough library surface to consume `MessageContent`/`Trace` from the base instead of maintaining forked copies (context: the Beckhoff kit currently carries ~2000 lines of frozen copies, which caused the missing status-indicator regression and stale ERMAIN-417 behavior).

**Commit 1 — library exports + runtime parity**
- `library/index.ts`: export the Trace subsystem (`Trace`, `groupIntoTraceClusters`, `isTraceablePart`, `durationFromTracePartsOrLegacyMessageTimestamps`, `TraceCluster`/`TraceablePart`), `ImageContentDisplay`, `EratoEmailSuggestion` (registry-aware wrapper), `useTraceFeature` + `TraceFeatureConfig`, `UiImagePart`.
- `componentKitReactRuntime.ts`: expose `window.ERATO_FEATURES = { useTraceFeature }` — byte-exact mirror of the beckhoff-branch implementation so the deployed kit works against stock main and the next downstream merge is conflict-free. (Version handshake deliberately deferred to the governance phase.)

**Commit 2 — stable i18n ids for the exported render tree**
- 20 auto-hash t-macro strings in Trace/ToolCall/MessageContent/EratoEmailSuggestion converted to explicit ids (`trace.*`, `toolcall.*`, `chat.message.*`, following the existing `trace.reasoning.masked` convention); existing de/fr/es/pl translations relocated in the `.po` catalogs.
- Makes these strings theme-overridable by stable key; a kit consuming host `Trace` gets localized labels ("Denkt nach…") for free.

**Reviewer note:** the id change alters compiled catalog keys — any customer theme overriding these strings *by hash id* would detach. Checked: no theme (beckhoff/trilux/novoferm) overrides any of the 20 affected strings.

**Verified:** typecheck, eslint, 123 unit tests, `build:lib`, lingui extract idempotent; catalogs compiled and tests re-run with the new ids live (placeholder interpolation `{formatted}` confirmed working in all locales).