### PR TITLE
Force interactive login on sign-in button

### DIFF
--- a/office-addin/src/auth/AuthSource.ts
+++ b/office-addin/src/auth/AuthSource.ts
@@ -32,6 +32,14 @@ export interface AcquireBootstrapOptions {
    */
   forceRefresh?: boolean;
   /**
+   * Skip the silent MSAL acquire and ask the user to authenticate immediately.
+   * This is reserved for an explicit user action (the AuthGate sign-in button):
+   * MSAL's silent `forceRefresh` refreshes the access token, but some NAA hosts
+   * can keep returning the same expired ID token that oauth2-proxy rejected.
+   * An interactive acquire is then required to mint a new identity token.
+   */
+  forceInteraction?: boolean;
+  /**
    * When true the source MAY open interactive UI (popup) if a silent acquire
    * fails. Maps to the old `allowPopup`: init/timed-refresh pass false, the
    * user-driven retry passes true. Background timers/focus must pass false.

--- a/office-addin/src/auth/__tests__/entraAuthSource.test.ts
+++ b/office-addin/src/auth/__tests__/entraAuthSource.test.ts
@@ -119,6 +119,74 @@ describe("createEntraAuthSource", () => {
     expect(pca.acquireTokenPopup).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "ID token",
+      refreshedIdToken: "id-token",
+      refreshedAccessToken: "new-access-token",
+      unchangedTokens: ["id_token"],
+    },
+    {
+      name: "access token",
+      refreshedIdToken: "new-id-token",
+      refreshedAccessToken: "access-token",
+      unchangedTokens: ["access_token"],
+    },
+    {
+      name: "ID and access tokens",
+      refreshedIdToken: "id-token",
+      refreshedAccessToken: "access-token",
+      unchangedTokens: ["id_token", "access_token"],
+    },
+  ])(
+    "warns without logging credentials when a force refresh reuses the $name",
+    async ({ refreshedIdToken, refreshedAccessToken, unchangedTokens }) => {
+      const refreshedResult = {
+        ...authenticationResult,
+        idToken: refreshedIdToken,
+        accessToken: refreshedAccessToken,
+      } as AuthenticationResult;
+      const pca = createPcaMock();
+      (pca.acquireTokenSilent as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(authenticationResult)
+        .mockResolvedValueOnce(refreshedResult);
+      const { source } = await initializedSource(pca);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await source.acquireBootstrapToken();
+      await source.acquireBootstrapToken({ forceRefresh: true });
+
+      expect(warn).toHaveBeenCalledWith(
+        "MSAL bootstrap token refresh returned unchanged token values",
+        { unchangedTokens, refreshMode: "silent" },
+      );
+      const serializedWarning = JSON.stringify(warn.mock.calls);
+      expect(serializedWarning).not.toContain("new-id-token");
+      expect(serializedWarning).not.toContain("new-access-token");
+      warn.mockRestore();
+    },
+  );
+
+  it("does not warn when a force refresh replaces both bootstrap tokens", async () => {
+    const refreshedResult = {
+      ...authenticationResult,
+      idToken: "new-id-token",
+      accessToken: "new-access-token",
+    } as AuthenticationResult;
+    const pca = createPcaMock();
+    (pca.acquireTokenSilent as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(authenticationResult)
+      .mockResolvedValueOnce(refreshedResult);
+    const { source } = await initializedSource(pca);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await source.acquireBootstrapToken();
+    await source.acquireBootstrapToken({ forceRefresh: true });
+
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("falls back to a popup when interaction is required AND allowed", async () => {
     const { InteractionRequiredAuthError } = await import(
       "@azure/msal-browser"
@@ -143,6 +211,37 @@ describe("createEntraAuthSource", () => {
       }),
     );
     expect(pca.setActiveAccount).toHaveBeenCalledWith(account);
+  });
+
+  it("acquires interactively without trying the silent cache when explicitly forced", async () => {
+    const pca = createPcaMock();
+    const { source } = await initializedSource(pca);
+
+    await expect(
+      source.acquireBootstrapToken({
+        allowInteraction: true,
+        forceInteraction: true,
+      }),
+    ).resolves.toEqual({ idToken: "id-token", accessToken: "access-token" });
+    expect(pca.acquireTokenSilent).not.toHaveBeenCalled();
+    expect(pca.acquireTokenPopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes: ["User.Read"],
+        prompt: "select_account",
+        loginHint: "user@example.com",
+      }),
+    );
+  });
+
+  it("rejects a forced interaction when interactive UI is not allowed", async () => {
+    const pca = createPcaMock();
+    const { source } = await initializedSource(pca);
+
+    await expect(
+      source.acquireBootstrapToken({ forceInteraction: true }),
+    ).rejects.toBeInstanceOf(InteractionRequiredError);
+    expect(pca.acquireTokenSilent).not.toHaveBeenCalled();
+    expect(pca.acquireTokenPopup).not.toHaveBeenCalled();
   });
 
   it("translates a disallowed interaction into InteractionRequiredError", async () => {

--- a/office-addin/src/auth/entraAuthSource.ts
+++ b/office-addin/src/auth/entraAuthSource.ts
@@ -90,13 +90,36 @@ export function createEntraAuthSource(
 ): AuthSource & GraphCapableSource {
   let pca: IPublicClientApplication | null = null;
   let loginHint: string | undefined;
+  // Kept in memory only so an explicit refresh can verify what MSAL actually
+  // returned. Never log either value: both are credentials.
+  let previousBootstrapToken: BootstrapToken | null = null;
 
   async function acquireMsalResult(
     instance: IPublicClientApplication,
     scopes: string[],
     allowInteraction: boolean,
     forceRefresh: boolean,
+    forceInteraction = false,
   ): Promise<AuthenticationResult> {
+    const acquireInteractively = async (): Promise<AuthenticationResult> => {
+      const result = await instance.acquireTokenPopup({
+        scopes,
+        prompt: "select_account",
+        ...(loginHint ? { loginHint } : {}),
+      });
+      if (result.account) {
+        instance.setActiveAccount(result.account);
+      }
+      return result;
+    };
+
+    if (forceInteraction) {
+      if (!allowInteraction) {
+        throw new InteractionRequiredError("MSAL interaction required");
+      }
+      return acquireInteractively();
+    }
+
     try {
       return await instance.acquireTokenSilent({
         scopes,
@@ -106,15 +129,7 @@ export function createEntraAuthSource(
     } catch (silentError) {
       if (requiresInteractiveSignIn(silentError)) {
         if (allowInteraction) {
-          const result = await instance.acquireTokenPopup({
-            scopes,
-            prompt: "select_account",
-            ...(loginHint ? { loginHint } : {}),
-          });
-          if (result.account) {
-            instance.setActiveAccount(result.account);
-          }
-          return result;
+          return acquireInteractively();
         }
         // Translate to a host-agnostic signal so the core stays MSAL-free.
         throw new InteractionRequiredError("MSAL interaction required", {
@@ -193,12 +208,41 @@ export function createEntraAuthSource(
         OAUTH2_PROXY_SESSION_SCOPES,
         opts.allowInteraction ?? false,
         opts.forceRefresh ?? false,
+        opts.forceInteraction ?? false,
       );
       applyResult(instance, result);
-      return {
+      const token: BootstrapToken = {
         idToken: result.idToken,
         accessToken: result.accessToken,
       };
+
+      if (
+        previousBootstrapToken &&
+        (opts.forceRefresh || opts.forceInteraction)
+      ) {
+        const unchangedTokens: string[] = [];
+        if (token.idToken === previousBootstrapToken.idToken) {
+          unchangedTokens.push("id_token");
+        }
+        if (
+          token.accessToken !== undefined &&
+          token.accessToken === previousBootstrapToken.accessToken
+        ) {
+          unchangedTokens.push("access_token");
+        }
+        if (unchangedTokens.length > 0) {
+          console.warn(
+            "MSAL bootstrap token refresh returned unchanged token values",
+            {
+              unchangedTokens,
+              refreshMode: opts.forceInteraction ? "interactive" : "silent",
+            },
+          );
+        }
+      }
+
+      previousBootstrapToken = token;
+      return token;
     },
 
     async acquireGraphToken(

--- a/office-addin/src/providers/SessionAuthProvider.tsx
+++ b/office-addin/src/providers/SessionAuthProvider.tsx
@@ -273,16 +273,19 @@ export function SessionAuthProvider({
       allowInteraction,
       status,
       forceRefresh = false,
+      forceInteraction = false,
       shouldContinue,
     }: {
       allowInteraction: boolean;
       status: Extract<Oauth2ProxySessionStatus, "establishing" | "refreshing">;
       forceRefresh?: boolean;
+      forceInteraction?: boolean;
       shouldContinue?: () => boolean;
     }): Promise<void> => {
       const token = await authSource.acquireBootstrapToken({
         allowInteraction,
         ...(forceRefresh ? { forceRefresh: true } : {}),
+        ...(forceInteraction ? { forceInteraction: true } : {}),
       });
       if (shouldContinue && !shouldContinue()) {
         return;
@@ -290,9 +293,17 @@ export function SessionAuthProvider({
       setIsBootstrapAcquired(true);
 
       try {
-        await redeemSessionForToken(token, status, forceRefresh);
+        await redeemSessionForToken(
+          token,
+          status,
+          forceRefresh || forceInteraction,
+        );
       } catch (redeemError) {
-        if (forceRefresh || !isUnauthorizedRedeemError(redeemError)) {
+        if (
+          forceRefresh ||
+          forceInteraction ||
+          !isUnauthorizedRedeemError(redeemError)
+        ) {
           throw redeemError;
         }
 
@@ -375,11 +386,15 @@ export function SessionAuthProvider({
   }, [acquireAndRedeemSession, authSource, initNonce]);
 
   const refreshSession = useCallback(
-    async (allowInteraction: boolean): Promise<void> => {
+    async (
+      allowInteraction: boolean,
+      forceInteraction = false,
+    ): Promise<void> => {
       try {
         await acquireAndRedeemSession({
           allowInteraction,
           status: "refreshing",
+          forceInteraction,
         });
       } catch (refreshError) {
         const message = formatAuthenticationError(refreshError);
@@ -572,7 +587,11 @@ export function SessionAuthProvider({
 
     setIsInitialized(false);
     try {
-      await refreshSession(true);
+      // This button is the user's explicit request to sign in. Go straight to
+      // interactive NAA instead of first accepting another silent cached ID
+      // token: oauth2-proxy may have rejected that ID token as expired even
+      // after MSAL force-refreshed its accompanying access token.
+      await refreshSession(true, true);
     } catch (authenticationError) {
       setError(formatAuthenticationError(authenticationError));
     } finally {

--- a/office-addin/src/providers/__tests__/OutlookAuthProvider.test.tsx
+++ b/office-addin/src/providers/__tests__/OutlookAuthProvider.test.tsx
@@ -332,6 +332,63 @@ describe("OutlookAuthProvider", () => {
     );
   });
 
+  it("uses interactive sign-in when silent refresh keeps returning an expired ID token", async () => {
+    const expiredResult = {
+      ...authenticationResult,
+      idToken: "expired-id-token",
+      accessToken: "refreshed-access-token",
+    } as AuthenticationResult;
+    const freshInteractiveResult = {
+      ...authenticationResult,
+      idToken: "fresh-interactive-id-token",
+      accessToken: "fresh-interactive-access-token",
+    } as AuthenticationResult;
+    const pca = createPcaMock();
+    (pca.acquireTokenSilent as Mock).mockResolvedValue(expiredResult);
+    (pca.acquireTokenPopup as Mock).mockResolvedValue(freshInteractiveResult);
+    vi.mocked(createNestablePublicClientApplication).mockResolvedValue(pca);
+    const fetcher = stubFetchSequence([
+      () => new Response("Unauthorized", { status: 401 }),
+      () => new Response("Unauthorized", { status: 401 }),
+      () => new Response("{}", { status: 202 }),
+    ]);
+
+    render(
+      <OutlookAuthProvider>
+        <AuthProbe />
+      </OutlookAuthProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("initialized")).toHaveTextContent("true"),
+    );
+    expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+    expect(screen.getByTestId("error")).toHaveTextContent(
+      "Could not establish a secure Erato session.",
+    );
+
+    fireEvent.click(screen.getByTestId("retry"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("true"),
+    );
+    expect(pca.acquireTokenSilent).toHaveBeenCalledTimes(2);
+    expect(pca.acquireTokenSilent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ forceRefresh: true }),
+    );
+    expect(pca.acquireTokenPopup).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(fetcher.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          id_token: "fresh-interactive-id-token",
+          access_token: "fresh-interactive-access-token",
+        }),
+      }),
+    );
+  });
+
   it("redeems a fresh session on the refresh timer before expiry", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
Fallback flow in case of NAA returning expired ID tokens

Related Linear issue: ERMAIN-459