### PR TITLE
Pass host MessageContent to ChatMessageRenderer overrides

### DIFF
--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -42,6 +42,21 @@ const getPreviewUrl = (
 ): string =>
   typeof file.preview_url === "string" ? file.preview_url : file.download_url;
 
+/**
+ * Host-implemented building blocks handed to `ChatMessageRenderer` overrides.
+ * Component kits run in a separately built bundle, so importing these from
+ * `@erato/frontend/library` would duplicate module state (React contexts, the
+ * lingui i18n instance) — receiving the host's own instances via props is the
+ * only identity-safe channel.
+ */
+export interface ChatMessageHostComponents {
+  MessageContent: typeof MessageContent;
+}
+
+export const CHAT_MESSAGE_HOST_COMPONENTS: ChatMessageHostComponents = {
+  MessageContent,
+};
+
 export interface ChatMessageProps {
   message: UiChatMessage;
   className?: string;
@@ -72,6 +87,8 @@ export interface ChatMessageProps {
   onViewFeedback?: (messageId: string, feedback: MessageFeedback) => void;
   /** Map of all files from the entire conversation keyed by file ID */
   allFilesById?: Record<string, FileUploadItem>;
+  /** Optional so pre-existing renderers and tests remain valid call sites. */
+  hostComponents?: ChatMessageHostComponents;
 }
 
 export const ChatMessage = memo(function ChatMessage({

--- a/frontend/src/components/ui/MessageList/MessageItem.tsx
+++ b/frontend/src/components/ui/MessageList/MessageItem.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 
 import { mapMessageToUiMessage } from "@/utils/adapters/messageAdapter";
 
-import { ChatMessage } from "../Chat/ChatMessage";
+import { CHAT_MESSAGE_HOST_COMPONENTS, ChatMessage } from "../Chat/ChatMessage";
 
 import type { ChatMessageProps } from "../Chat/ChatMessage";
 import type {
@@ -75,6 +75,7 @@ export const MessageItem = memo<MessageItemProps>(
           onFilePreview={onFilePreview}
           onViewFeedback={onViewFeedback}
           allFilesById={allFilesById}
+          hostComponents={CHAT_MESSAGE_HOST_COMPONENTS}
         />
       </div>
     );

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -14,6 +14,7 @@ export * from "@/components/ui/Chat";
 export { ChatInputControlsProvider } from "@/components/ui/Chat/ChatInputControlsContext";
 export {
   ChatMessage,
+  type ChatMessageHostComponents,
   type ChatMessageProps,
 } from "@/components/ui/Chat/ChatMessage";
 export * from "@/components/ui/MessageList";


### PR DESCRIPTION
Follow-up to #822: gives component kits an identity-safe way to consume the host's `MessageContent` instead of maintaining a forked copy.

`ChatMessageProps` gains an optional `hostComponents: { MessageContent }`, passed by `MessageItem` as a module-level constant (stable reference, safe for the custom memo comparison). Mirrors the existing `controls` prop pattern.

Why props and not the library bundle or a window global: kits run in a separately built bundle — importing component values from `dist-library` would duplicate module state (React contexts, the lingui i18n instance), silently breaking theming and feature flags inside the kit. Receiving the running host's own component via props is the only channel that preserves module identity, and it stays typed via the exported `ChatMessageHostComponents`.

First consumer: the Beckhoff kit deletes its ~2000-line MessageContent/Trace copies and shrinks its bundle by 84% (kit-side change staged in the customer repo, pending this PR + downstream merge).