### PR TITLE
Versioned ERATO_KIT_RUNTIME host surface for component kits

### DIFF
--- a/frontend/src/componentKitHostRuntime.ts
+++ b/frontend/src/componentKitHostRuntime.ts
@@ -1,0 +1,87 @@
+import { useNavigate } from "react-router-dom";
+
+import { ChatHistoryListSkeleton } from "./components/ui/Chat/ChatHistoryList";
+import { ModelSelector } from "./components/ui/Chat/ModelSelector";
+import { InteractiveContainer } from "./components/ui/Container/InteractiveContainer";
+import { Button } from "./components/ui/Controls/Button";
+import { DropdownMenu } from "./components/ui/Controls/DropdownMenu";
+import { Alert } from "./components/ui/Feedback/Alert";
+import { Avatar } from "./components/ui/Feedback/Avatar";
+import { FilePreviewButton } from "./components/ui/FileUpload/FilePreviewButton";
+import { FilePreviewLoading } from "./components/ui/FileUpload/FilePreviewLoading";
+import { ImageLightbox } from "./components/ui/Message/ImageLightbox";
+import { useStarterPromptsData } from "./hooks/chat/useStarterPrompts";
+import { useThemedIcon } from "./hooks/ui/useThemedIcon";
+import { useGetFile } from "./lib/generated/v1betaApi/v1betaApiComponents";
+import {
+  useMessageFeedbackFeature,
+  useTraceFeature,
+} from "./providers/FeatureConfigProvider";
+
+/**
+ * Host runtime surface for component kits. Kits run as separately built
+ * bundles on the host's React instance; hooks and components they render
+ * must be the host's own module instances (contexts, react-query client,
+ * router), so they are handed over here instead of being bundled or
+ * re-implemented kit-side.
+ *
+ * This module lives in the app graph (imported by main.tsx), NOT in the
+ * componentKitReactRuntime pre-app entry — bundling these imports into that
+ * entry would duplicate most of the app into the boot script. Consequence:
+ * the values are set before first render but AFTER kit bundles evaluate, so
+ * kits must read them lazily inside components/hooks, never at module scope.
+ *
+ * `version` is bumped on breaking shape changes; kits should warn loudly
+ * when it does not match what they were built against.
+ */
+export type ComponentKitHostRuntime = {
+  version: 1;
+  hooks: {
+    useTraceFeature: typeof useTraceFeature;
+    useMessageFeedbackFeature: typeof useMessageFeedbackFeature;
+    useStarterPromptsData: typeof useStarterPromptsData;
+    useThemedIcon: typeof useThemedIcon;
+    useGetFile: typeof useGetFile;
+    useNavigate: typeof useNavigate;
+  };
+  components: {
+    Alert: typeof Alert;
+    Avatar: typeof Avatar;
+    Button: typeof Button;
+    ChatHistoryListSkeleton: typeof ChatHistoryListSkeleton;
+    DropdownMenu: typeof DropdownMenu;
+    FilePreviewButton: typeof FilePreviewButton;
+    FilePreviewLoading: typeof FilePreviewLoading;
+    ImageLightbox: typeof ImageLightbox;
+    InteractiveContainer: typeof InteractiveContainer;
+    ModelSelector: typeof ModelSelector;
+  };
+};
+
+(
+  window as Window & {
+    ERATO_KIT_RUNTIME?: ComponentKitHostRuntime;
+  }
+).ERATO_KIT_RUNTIME = {
+  version: 1,
+  hooks: {
+    useTraceFeature,
+    useMessageFeedbackFeature,
+    useStarterPromptsData,
+    useThemedIcon,
+    useGetFile,
+    useNavigate,
+  },
+  components: {
+    Alert,
+    Avatar,
+    Button,
+    ChatHistoryListSkeleton,
+    DropdownMenu,
+    FilePreviewButton,
+    FilePreviewLoading,
+    ImageLightbox,
+    InteractiveContainer,
+    ModelSelector,
+  },
+};

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -51,10 +51,12 @@ const getPreviewUrl = (
  */
 export interface ChatMessageHostComponents {
   MessageContent: typeof MessageContent;
+  LoadingIndicator: typeof LoadingIndicator;
 }
 
 export const CHAT_MESSAGE_HOST_COMPONENTS: ChatMessageHostComponents = {
   MessageContent,
+  LoadingIndicator,
 };
 
 export interface ChatMessageProps {

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -17,6 +17,7 @@ export {
   type ChatMessageHostComponents,
   type ChatMessageProps,
 } from "@/components/ui/Chat/ChatMessage";
+export type { ComponentKitHostRuntime } from "@/componentKitHostRuntime";
 export * from "@/components/ui/MessageList";
 export {
   MessageContent,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import AppRoutes from "./App"; // App.tsx now exports AppRoutes
+import "./componentKitHostRuntime";
 import { initE2EOverrides } from "./config/componentRegistryE2E";
 import "./styles/globals.css"; // Corrected path to global stylesheet
 


### PR DESCRIPTION
Third piece of the component-kit de-duplication work (#822, #825): gives kits a typed, versioned runtime surface for the host hooks and UI atoms they currently fake with hand-written stubs.

**Background:** when the Beckhoff kit was extracted from the frontend tree, it lost access to host internals and grew a ~1100-line stub layer (`hostLibrary.tsx`). An audit found the stubs silently degrade real functionality: archive-without-confirm-dialog (stub DropdownMenu declares but never implements `confirmAction`), message feedback hardcoded off despite being enabled in customer config, `useGetFile` never resolving, full-page reloads instead of SPA navigation, `useStarterPromptsData` hardcoded empty, and several cosmetic/a11y losses (Avatar, ImageLightbox, InteractiveContainer keyboard handling).

**Change:**
- New `src/componentKitHostRuntime.ts` sets `window.ERATO_KIT_RUNTIME` with `version: 1`, hooks (`useTraceFeature`, `useMessageFeedbackFeature`, `useStarterPromptsData`, `useThemedIcon`, `useGetFile`, `useNavigate`) and components (Alert, Avatar, Button, ChatHistoryListSkeleton, DropdownMenu, FilePreviewButton, FilePreviewLoading, ImageLightbox, InteractiveContainer, ModelSelector). Kits replace their stubs with thin delegates and get host behavior — contexts, react-query client, and router included, since these are the running host's own module instances.
- `ComponentKitHostRuntime` type exported from the library (type-only, erased at runtime) so kits stay type-safe.
- `LoadingIndicator` added to `ChatMessageHostComponents` (renderer-scoped props channel from #825).
- `ERATO_FEATURES` left untouched for already-deployed kit bundles.