### PR TITLE
Recover the turn when the model calls an unoffered tool (no more empty assistant message)

### DIFF
--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -2795,11 +2795,16 @@ async fn stream_generate_chat_completion<
             }
 
             if !allowed_tool_names.contains(unfinished_tool_call.fn_name.as_str()) {
-                tool_call_started_at.remove(&unfinished_tool_call.call_id);
+                // Refuse the CALL, never the TURN — a `return Err` here kills
+                // the generation (user sees an empty message); an error
+                // response lets the model recover in prose.
                 let error_message = format!(
                     "Proposed tool call '{}' is not allowed for this request",
                     unfinished_tool_call.fn_name
                 );
+                let tool_call_started = tool_call_started_at
+                    .remove(&unfinished_tool_call.call_id)
+                    .unwrap_or_else(now_timestamp);
                 persist_otel_tool_call(
                     tracing_client.as_ref(),
                     &unfinished_tool_call,
@@ -2812,8 +2817,21 @@ async fn stream_generate_chat_completion<
                     Some(&error_message),
                 )
                 .await;
-                let error = eyre!(error_message);
-                return Err(error);
+                current_message_content.push(ContentPart::ToolUse(ToolUse {
+                    tool_call_id: unfinished_tool_call.call_id.clone(),
+                    status: MessageToolCallStatus::Error,
+                    tool_name: unfinished_tool_call.fn_name.clone(),
+                    input: Some(unfinished_tool_call.fn_arguments.clone()),
+                    progress_message: None,
+                    output: Some(json!({ "status": "error", "error": error_message })),
+                    started_at: Some(tool_call_started),
+                    ended_at: Some(now_timestamp()),
+                }));
+                current_turn_tool_responses.push(genai::chat::ToolResponse {
+                    call_id: unfinished_tool_call.call_id.clone(),
+                    content: error_message,
+                });
+                continue;
             }
 
             // Client-action proposals are never executed server-side: validate

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -3780,3 +3780,78 @@ async fn test_client_action_invalid_proposal_then_valid_retry_succeeds(pool: Poo
     assert_eq!(tool_use_parts[1]["output"]["status"], "proposed");
     assert_eq!(tool_use_parts[1]["output"]["action"], "outlook.reply_all");
 }
+
+/// A call to a tool that was never offered (no facet ⇒ empty allow-list)
+/// must be refused per-CALL and answered so the model recovers — not kill
+/// the whole turn into an empty assistant message.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_unoffered_tool_call_recovers_instead_of_killing_the_turn(pool: Pool<Postgres>) {
+    const NOT_ALLOWED: &str = "not allowed for this request";
+    let mut mocks = MockSet::new();
+    // Turn 1: hallucinate a tool nothing offered.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[], &[NOT_ALLOWED]));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[(
+                "call_ghost",
+                "totally_made_up_tool",
+                json!({}),
+            )]),
+        );
+    });
+    // Turn 2: the corrective error arrived → finish with text.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[NOT_ALLOWED], &[]));
+        mock_llm_sse_response(then, build_openai_text_streaming_response(&["Recovered."]));
+    });
+
+    let (app_config, _server) = setup_mock_llm_server_with_mocks(mocks).await;
+    let app_state = test_app_state(app_config, pool).await;
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "user_message": "hi" }))
+        .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    // The turn completes with the recovery text — no error event, no dead turn.
+    assert_eq!(extract_full_text(&events), "Recovered.");
+    assert!(
+        !events
+            .iter()
+            .filter_map(|event| serde_json::from_str::<Value>(&event.data).ok())
+            .any(|json| json["message_type"] == "error"),
+        "the refused tool call must not surface as a turn-killing error event"
+    );
+
+    // The refusal is persisted as an error tool_use part the model saw.
+    let chat_id = extract_chat_id(&events).expect("Expected chat_id");
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let tool_use_parts =
+        fetch_assistant_tool_use_parts(&server, &chat_id, &assistant_message_id).await;
+    assert_eq!(tool_use_parts.len(), 1, "Got: {tool_use_parts:?}");
+    assert_eq!(tool_use_parts[0]["tool_call_id"], "call_ghost");
+    assert_eq!(tool_use_parts[0]["status"], "error");
+    assert!(
+        tool_use_parts[0]["output"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains(NOT_ALLOWED)),
+        "Got: {}",
+        tool_use_parts[0]["output"]
+    );
+}


### PR DESCRIPTION
A model calling a tool that isn't in the request's allow-list hit a `return Err` in the generation loop (`message_streaming.rs`), which killed the whole turn — the user saw a **blank assistant message** with no explanation.

Now the *call* is refused, not the *turn*: an error `ToolUse` part is recorded and a tool error is returned to the model so it recovers in prose. Mirrors the existing non-streaming client-tool fallback a few lines below. A model that keeps re-calling the refused tool is bounded by the loop's existing iteration budget.

**How it surfaces:** the scheduling `outlook_schedule` facet dropping mid-conversation (fixed separately in #819) left the model coached by history to call `propose_client_action`/`fetch_availability` on a turn that no longer offered them → dead turn. But the failure shape is general — any facet/allow-list/tool drift, or a plain hallucinated tool name, hit the same kill path.