### PR TITLE
Composer UX consistency: token-driven styling, attachment tree restructure, first-message consent fix

### DIFF
--- a/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
+++ b/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
@@ -202,6 +202,12 @@ export interface FilePreviewBaseProps {
   filenameTruncateLength?: number;
   /** Additional CSS classes for the filename element */
   filenameClassName?: string;
+  /**
+   * Render without the chip chrome (border/background/radius) so a parent
+   * surface can own it — e.g. a selectable row that wraps the checkbox and
+   * preview in one chip.
+   */
+  chromeless?: boolean;
 }
 
 /**
@@ -221,6 +227,7 @@ export const FilePreviewBase: React.FC<FilePreviewBaseProps> = ({
   removeButton,
   filenameTruncateLength: _filenameTruncateLength = 30,
   filenameClassName = "",
+  chromeless = false,
 }) => {
   const { iconMappings } = useTheme();
 
@@ -261,7 +268,9 @@ export const FilePreviewBase: React.FC<FilePreviewBaseProps> = ({
 
   return (
     <div
-      className={`${FILE_PREVIEW_STYLES.container} ${className}`}
+      className={`${
+        chromeless ? "flex items-center gap-2" : FILE_PREVIEW_STYLES.container
+      } ${className}`}
       data-filetype={fileType}
     >
       {/* File icon */}

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -189,7 +189,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   return (
     <label
       className={clsx(
-        "flex w-full items-start gap-2",
+        "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border border-[var(--theme-border)] bg-[var(--theme-bg-secondary)] p-2",
         !selected && "opacity-50",
       )}
     >
@@ -198,7 +198,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
         checked={selected}
         onChange={onToggle}
         disabled={disabled}
-        className="mt-1 size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
+        className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
         aria-label={`${t`Include`} ${filename}`}
       />
       <div className="min-w-0 flex-1">
@@ -211,6 +211,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
           showFileType={showFileType}
           filenameTruncateLength={filenameTruncateLength}
           filenameClassName="max-w-full"
+          chromeless
         />
         {invalid && validation.reason && (
           <p className="mt-0.5 text-xs text-[var(--theme-error-fg)]">
@@ -238,21 +239,27 @@ interface ThreadMessageGroupSectionProps {
 const ThreadMessageHeaderText: React.FC<{
   label: string;
   sublabel?: string;
-}> = ({ label, sublabel }) => (
-  <div className="min-w-0 flex-1">
-    <p
-      className="truncate text-sm font-medium text-theme-fg-primary"
-      title={label}
-    >
-      {label}
-    </p>
-    {sublabel && (
-      <p className="truncate text-xs text-theme-fg-muted" title={sublabel}>
-        {sublabel}
+  metaLabel?: string;
+}> = ({ label, sublabel, metaLabel }) => {
+  // Meta stays in the text stack (like the group header's "N messages")
+  // instead of floating right-aligned on its own.
+  const secondLine = [sublabel, metaLabel].filter(Boolean).join(" · ");
+  return (
+    <div className="min-w-0 flex-1">
+      <p
+        className="truncate text-sm font-medium text-theme-fg-primary"
+        title={label}
+      >
+        {label}
       </p>
-    )}
-  </div>
-);
+      {secondLine && (
+        <p className="truncate text-xs text-theme-fg-muted" title={secondLine}>
+          {secondLine}
+        </p>
+      )}
+    </div>
+  );
+};
 
 const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
   label,
@@ -273,11 +280,33 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
   return (
     <div
       className={clsx(
-        "rounded-md border border-theme-border bg-theme-bg-secondary p-2",
+        "rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary p-2",
         !selected && "opacity-60",
       )}
     >
       <div className="flex items-center gap-2">
+        {/* Fixed columns across tree levels: disclosure, selection, text. */}
+        {hasAttachments ? (
+          // Only render the chevron when there's something to expand —
+          // an empty thread message has no attachments to show, so a
+          // disclosure toggle would dangle without any payload.
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            className="inline-flex size-4 shrink-0 items-center justify-center text-theme-fg-muted"
+            aria-expanded={!collapsed}
+            aria-controls={panelId}
+            aria-label={`${t`Toggle attachments`} ${label}`}
+          >
+            {collapsed ? (
+              <ChevronRightIcon className="size-4" />
+            ) : (
+              <ChevronDownIcon className="size-4" />
+            )}
+          </button>
+        ) : (
+          <span className="size-4 shrink-0" aria-hidden="true" />
+        )}
         <input
           type="checkbox"
           checked={selected}
@@ -288,30 +317,19 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
           onClick={(event) => event.stopPropagation()}
         />
         {hasAttachments ? (
-          // Only render the chevron when there's something to expand —
-          // an empty thread message has no attachments to show, so a
-          // disclosure toggle would dangle without any payload.
           <button
             type="button"
             onClick={() => setCollapsed((value) => !value)}
             className="flex min-w-0 flex-1 items-start gap-2 text-left"
-            aria-expanded={!collapsed}
-            aria-controls={panelId}
+            tabIndex={-1}
           >
-            <span
-              className="mt-0.5 inline-flex shrink-0 items-center text-theme-fg-muted"
-              aria-hidden="true"
-            >
-              {collapsed ? (
-                <ChevronRightIcon className="size-4" />
-              ) : (
-                <ChevronDownIcon className="size-4" />
-              )}
-            </span>
-            <ThreadMessageHeaderText label={label} sublabel={sublabel} />
-            <span className="shrink-0 text-xs text-theme-fg-muted">
-              {attachmentCount === 1 ? t`1 file` : t`${attachmentCount} files`}
-            </span>
+            <ThreadMessageHeaderText
+              label={label}
+              sublabel={sublabel}
+              metaLabel={
+                attachmentCount === 1 ? t`1 file` : t`${attachmentCount} files`
+              }
+            />
           </button>
         ) : (
           <div className="flex min-w-0 flex-1 items-start gap-2">
@@ -468,7 +486,7 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
             : baseItems;
         const hiddenCount = isCollapsed ? 0 : itemCount - visibleItems.length;
         const sectionClassName = stickyGroupHeaders
-          ? "rounded-md bg-[var(--theme-bg-primary)]"
+          ? "rounded-[var(--theme-radius-input)] bg-[var(--theme-bg-primary)]"
           : FILE_PREVIEW_STYLES.group.container;
         const headerClassName = clsx(
           stickyGroupHeaders
@@ -477,7 +495,9 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
           stickyGroupHeaders &&
             clsx(
               "sticky top-0 z-10 border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] px-3 pb-2 pt-3",
-              isCollapsed ? "rounded-md" : "rounded-t-md",
+              isCollapsed
+                ? "rounded-[var(--theme-radius-input)]"
+                : "rounded-t-[var(--theme-radius-input)]",
             ),
         );
         const itemsClassName = clsx(

--- a/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
+++ b/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
@@ -35,7 +35,7 @@ export const FILE_PREVIEW_STYLES = {
   },
   group: {
     container:
-      "rounded-md border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] p-3",
+      "rounded-[var(--theme-radius-input)] border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] p-3",
     header: "mb-2 flex min-w-0 items-start gap-2",
     title: "truncate text-sm font-medium text-[var(--theme-fg-secondary)]",
     meta: "text-xs text-[var(--theme-fg-muted)]",

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4224,6 +4224,10 @@ msgstr "Diese Nachricht verwendet {percentUsed}% des verfügbaren Token-Limits (
 msgid "To"
 msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Toggle attachments"
+msgstr "Anhänge umschalten"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
 msgstr "Token-Limit überschritten"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -4224,6 +4224,10 @@ msgstr "This message is using {percentUsed}% of the available token limit ({tota
 msgid "To"
 msgstr "To"
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Toggle attachments"
+msgstr "Toggle attachments"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
 msgstr "Token Limit Exceeded"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4224,6 +4224,10 @@ msgstr "Este mensaje está usando {percentUsed}% del límite de tokens disponibl
 msgid "To"
 msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Toggle attachments"
+msgstr "Alternar adjuntos"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
 msgstr "Límite de tokens excedido"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4224,6 +4224,10 @@ msgstr "Ce message utilise {percentUsed}% de la limite de tokens disponible ({to
 msgid "To"
 msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Toggle attachments"
+msgstr "Afficher ou masquer les pièces jointes"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
 msgstr "Limite de tokens dépassée"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4224,6 +4224,10 @@ msgstr "Ta wiadomość używa {percentUsed}% dostępnego limitu tokenów ({total
 msgid "To"
 msgstr ""
 
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "Toggle attachments"
+msgstr "Przełącz załączniki"
+
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
 msgstr "Przekroczony limit tokenów"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -22,6 +22,13 @@
     overscroll-behavior: none;
   }
 
+  /* Native checkboxes/radios ignore border/background utilities; accent-color
+     is the only themable knob without replacing the control. */
+  input[type="checkbox"],
+  input[type="radio"] {
+    accent-color: var(--theme-fg-accent);
+  }
+
   /* #root no longer needs to be a flex container here, 
      as its immediate child in App.tsx will handle the main screen layout */
 

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -568,10 +568,18 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     // the next snapshot is treated as history and nothing in the switched-to
     // chat can be considered "just completed". The pending send identity
     // belongs to the abandoned chat's in-flight exchange, so drop it too.
+    // Exception: a brand-new chat receiving its id on first send (null → id)
+    // is the same conversation continuing — resetting here would drop the
+    // in-flight exchange's identity and silently disable the consent prompt
+    // for the very first reply draft.
     if (freshTrackerChatIdRef.current !== currentChatId) {
+      const isNewChatGettingItsId =
+        freshTrackerChatIdRef.current == null && currentChatId != null;
       freshTrackerChatIdRef.current = currentChatId;
-      freshTrackerRef.current = new FreshCompletionTracker();
-      pendingSendItemIdentityRef.current = null;
+      if (!isNewChatGettingItsId) {
+        freshTrackerRef.current = new FreshCompletionTracker();
+        pendingSendItemIdentityRef.current = null;
+      }
     }
     const newlyFresh = freshTrackerRef.current.observe(messages, messageOrder);
     if (newlyFresh.length > 0) {

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -856,7 +856,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           <button
             type="button"
             onClick={() => void createNewChat()}
-            className="rounded-md bg-theme-bg-tertiary px-3 py-1 text-xs font-medium text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover"
+            className="rounded-[var(--theme-radius-control)] bg-theme-bg-tertiary px-3 py-1 text-xs font-medium text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover"
           >
             {t({
               id: "officeAddin.chat.newChat",

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -822,9 +822,7 @@ export const AddinChatInput = forwardRef<
       }
     >
       {shouldShowEmailSourcePreview && (
-        <div
-          className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] overflow-hidden overscroll-none px-2 pb-1 sm:px-4"
-        >
+        <div className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] overflow-hidden overscroll-none px-2 pb-1 sm:px-4">
           <div
             className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus:ring-2 focus:ring-theme-focus"
             role="region"

--- a/office-addin/src/components/AddinChatInput.tsx
+++ b/office-addin/src/components/AddinChatInput.tsx
@@ -822,7 +822,9 @@ export const AddinChatInput = forwardRef<
       }
     >
       {shouldShowEmailSourcePreview && (
-        <div className="mx-auto w-full max-w-4xl overflow-hidden overscroll-none px-2 pb-1 sm:px-4">
+        <div
+          className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] overflow-hidden overscroll-none px-2 pb-1 sm:px-4"
+        >
           <div
             className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus:ring-2 focus:ring-theme-focus"
             role="region"
@@ -849,7 +851,7 @@ export const AddinChatInput = forwardRef<
       )}
 
       {isExpandingDroppedEmails && (
-        <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
+        <div className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] px-2 pb-1 sm:px-4">
           <div
             className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary"
             role="status"
@@ -871,7 +873,7 @@ export const AddinChatInput = forwardRef<
       )}
 
       {host === "Outlook" && hasActiveSelection && (
-        <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
+        <div className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] px-2 pb-1 sm:px-4">
           <div className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary">
             <span className="shrink-0">&#x2702;</span>
             <span className="min-w-0 truncate">
@@ -894,7 +896,7 @@ export const AddinChatInput = forwardRef<
       )}
 
       {hasDraftContextChip && (
-        <div className="mx-auto w-full max-w-4xl px-2 pb-1 sm:px-4">
+        <div className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] px-2 pb-1 sm:px-4">
           <div className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary">
             <span className="shrink-0">&#x1F4DD;</span>
             <span className="min-w-0 truncate">


### PR DESCRIPTION
Follow-up to #827 (import-map host sharing). Three commits, three concerns:

## Styling consistency (base + themed resolve from one source)
- **Native checkbox/radio accent** (`75b4056b`): the existing Tailwind classes on checkboxes (`rounded`, `border-*`, `text-*`) are inert on native controls — checkboxes rendered browser-default in every theme. One global `accent-color: var(--theme-fg-accent)` rule fixes base, custom themes, and component kits at once.
- **Tokenized composer radii/widths** (`bfd0aaf1`): replaced hardcoded values that only *coincidentally* matched the default theme:
  - add-in composer wrappers used `max-w-4xl` (= 56rem = the default `--theme-layout-chat-input-max-width`) — themes that widen the token broke gutter alignment between the attachment card and the chat input;
  - grouped-attachments card/rows/sticky-headers used `rounded-md` while the input shell resolves `--theme-radius-input` → now `input`/`message` tokens (base: 16/8px, themed scales accordingly);
  - add-in "New Chat" button → `--theme-radius-control`.

## Grouped attachment tree restructure (`bfd0aaf1`)
- Fixed columns across tree levels: **disclosure | selection | text** (icon chevron button with aria-label; text still click-to-toggle, out of tab order).
- Meta ("1 file") joined the stacked text line instead of floating right — matches the group header's "N messages" pattern.
- Selectable rows are now single chip surfaces with the checkbox inside (additive `chromeless` prop on `FilePreviewBase`).
- New "Toggle attachments" string translated (de/es/fr/pl).

**Reviewer note:** these two commits visibly change the default web rendering (rounder card, restructured rows) — intended, so base and customer themes stay internally consistent from one code path. Flagged follow-up, deliberately not included: moving the default card onto the input-shell surface family (`--theme-shell-chat-input`).

## Add-in consent-prompt bug (`e75fb08a`)
The reply consent flow (`presentation = "auto_prompt"`) silently never fired for the **first message of a new chat**: the fresh-completion tracker treated the `null → id` chat-id assignment as a chat switch and dropped the in-flight send's item identity, so the completion was never stamped `isFreshCompletion` (fail-closed → buttons-only, no error). Fix mirrors the existing `isNewChatGettingItsId` pattern from the draft-dedup logic. Validated live in Outlook (fiber probe: artifact had `proposed` + `presentation` but no freshness stamp before; consent card appears after).