### PR TITLE
Fix chat-history dropdown overflow and double scrollbar (ERMAIN-464)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -289,7 +289,9 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
     return (
       <div
         className={clsx(
-          "flex w-full min-w-0 flex-col gap-1 overflow-y-auto",
+          // No overflow-y here: the sidebar wrapper (ChatHistorySidebar) owns the
+          // single scroll region; a second scroller caused rare double scrollbars.
+          "flex w-full min-w-0 flex-col gap-1",
           className,
         )}
         style={sidebarListStyle}

--- a/frontend/src/components/ui/Controls/AnchoredPopover.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.tsx
@@ -3,8 +3,10 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
+  useState,
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
@@ -99,6 +101,10 @@ export function AnchoredPopover({
   const panelId = useMemo(() => id ?? `popover-${reactId}`, [id, reactId]);
   // eslint-disable-next-line lingui/no-unlocalized-strings -- internal DOM id suffix
   const triggerId = `${panelId}-trigger`;
+
+  // Keep the panel hidden until it has been measured & positioned, so it never
+  // paints a first frame at its unclamped flow height.
+  const [isPositioned, setIsPositioned] = useState(false);
 
   const getPanelElement = useCallback(
     () => panelRef?.current ?? internalPanelRef.current,
@@ -200,12 +206,17 @@ export function AnchoredPopover({
     panelElement.style.maxHeight = `${maxHeight}px`;
   }, [getPanelElement, isOpen, preferredOrientation, viewportPadding]);
 
-  useEffect(() => {
+  // Position before paint (not in a post-paint useEffect): a bottom-anchored
+  // panel would otherwise paint one frame at unclamped height past the viewport
+  // bottom, adding a document-root scrollbar (ERMAIN-464).
+  useLayoutEffect(() => {
     if (!isOpen) {
+      setIsPositioned(false);
       return;
     }
 
     updatePosition();
+    setIsPositioned(true);
 
     const handleViewportChange = () => {
       requestAnimationFrame(updatePosition);
@@ -303,6 +314,7 @@ export function AnchoredPopover({
         boxShadow: "var(--theme-elevation-dropdown)",
         maxWidth: "calc(100vw - 16px)",
         ...panelStyle,
+        visibility: isPositioned ? "visible" : "hidden",
       }}
       role={role}
       aria-labelledby={triggerId}

--- a/frontend/src/components/ui/Controls/DropdownMenu.tsx
+++ b/frontend/src/components/ui/Controls/DropdownMenu.tsx
@@ -237,6 +237,7 @@ export const DropdownMenu = memo(
             minWidth: "var(--theme-layout-dropdown-min-width)",
           }}
           panelClassName={clsx(
+            "flex flex-col",
             matchContentWidth
               ? "w-max"
               : "w-[var(--theme-layout-dropdown-min-width)]",
@@ -265,7 +266,7 @@ export const DropdownMenu = memo(
           )}
         >
           <div
-            className="dropdown-panel-chrome-geometry overflow-y-auto"
+            className="dropdown-panel-chrome-geometry min-h-0 flex-1 overflow-y-auto overscroll-contain"
             role="none"
           >
             {items.map((item, index) => (

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -69,4 +69,28 @@ describe("DropdownMenu", () => {
       expect(firstItem).not.toHaveFocus();
     });
   });
+
+  it("positions before reveal and contains its own scroll (ERMAIN-464)", async () => {
+    render(<DropdownMenu items={[{ label: "Rename", onClick: vi.fn() }]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const menu = await screen.findByRole("menu");
+
+    // Panel is revealed only after the layout-effect positioning ran; the
+    // visibility guard is set explicitly (would be "hidden" if unpositioned).
+    expect(menu.style.visibility).toBe("visible");
+    // updatePosition clamped the panel to a pixel max-height.
+    expect(menu.style.maxHeight).toMatch(/^\d+px$/);
+    // Panel is a flex column that owns max-height; the inner list scrolls
+    // within it instead of overflowing the viewport.
+    expect(menu).toHaveClass("flex", "flex-col");
+    expect(menu.firstElementChild).toHaveClass(
+      "dropdown-panel-chrome-geometry",
+      "min-h-0",
+      "flex-1",
+      "overflow-y-auto",
+      "overscroll-contain",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Opening the "⋯" menu on the **last** chat item in the history sidebar could overflow the viewport and render two scrollbars.

## Root cause

- `AnchoredPopover` positioned the portaled `fixed` panel in a post-paint `useEffect`, so a bottom-anchored panel painted one frame at unclamped height past the viewport bottom → a document-root scrollbar.
- `maxHeight` was applied to the outer panel, but the scrollable element was an inner child with no flex containment, so a tall menu clipped/overflowed instead of scrolling internally.
- A redundant nested `overflow-y-auto` (sidebar wrapper + list) could independently render a second scrollbar in edge cases.

## Fix

- **`AnchoredPopover`**: position in `useLayoutEffect` and keep the panel `visibility: hidden` until measured, then reveal (measure → position → reveal), so no unclamped first frame.
- **`DropdownMenu`**: panel is `flex flex-col` and owns `max-height`; inner list is `min-h-0 flex-1 overflow-y-auto overscroll-contain` so it scrolls internally.
- **`ChatHistoryList`**: drop the redundant inner `overflow-y-auto`; the sidebar wrapper is the single scroll owner.

Fixed centrally in the shared dropdown primitive, so all dropdown consumers benefit.

## Tests

- Added a `DropdownMenu` regression test: panel is revealed only after positioning, clamps to a pixel `max-height`, is `flex flex-col`, and the inner list is contained (`min-h-0 flex-1 overflow-y-auto overscroll-contain`).
- Full suite passes; lint (`--max-warnings=0`) and typecheck clean.
