### PR TITLE
Dropdown: pointerdown outside-close for touch tap-outside dismiss (ERMAIN-465)

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { Preview } from "@storybook/react";
+import type { Preview } from "@storybook/react";
 import React, { useEffect, useState } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -9,9 +9,9 @@ import "non.geist"; // Imports Geist Sans Variable
 import "non.geist/mono"; // Imports Geist Mono Variable
 import {
   ThemeProvider,
-  ThemeMode,
   useTheme,
 } from "../src/components/providers/ThemeProvider";
+import type { ThemeMode } from "../src/components/providers/ThemeProvider";
 import { FeatureConfigProvider } from "../src/providers/FeatureConfigProvider";
 import { defaultTheme, darkTheme } from "../src/config/theme";
 import { themes as storybookThemes } from "@storybook/theming";

--- a/frontend/src/components/ui/Controls/AnchoredPopover.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.tsx
@@ -236,7 +236,7 @@ export function AnchoredPopover({
       return;
     }
 
-    const handlePointerDown = (event: MouseEvent) => {
+    const handlePointerDown = (event: PointerEvent) => {
       const target = event.target as Node;
 
       if (
@@ -256,11 +256,13 @@ export function AnchoredPopover({
       }
     };
 
-    document.addEventListener("mousedown", handlePointerDown);
+    // pointerdown (not mousedown) so tap-outside dismisses on touch surfaces
+    // (Outlook add-in / mobile), where synthesized mousedown is delayed/suppressed.
+    document.addEventListener("pointerdown", handlePointerDown);
     document.addEventListener("keydown", handleEscape);
 
     return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleEscape);
     };
   }, [getPanelElement, isOpen, onOpenChange]);

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -93,4 +93,20 @@ describe("DropdownMenu", () => {
       "overscroll-contain",
     );
   });
+
+  it("closes on an outside pointerdown so tap-outside dismisses on touch (ERMAIN-465)", async () => {
+    render(<DropdownMenu items={[{ label: "Rename", onClick: vi.fn() }]} />);
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    fireEvent.click(trigger);
+    await screen.findByRole("menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-ui="dropdown-panel"]')).toBeNull();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
 });


### PR DESCRIPTION
## Summary

The "multiple ⋯ menus open at once" symptom was resolved by ERMAIN-464: correcting the popover's `fixed` positioning stopped the overgrown panel from overlapping neighbouring row triggers, so the existing document outside-close now reliably closes the previously-open menu when another trigger is pressed. No list-level single-open coordination is needed.

One residual gap remained, only on **touch** surfaces (Outlook add-in `platform-office-addin`, and the mobile layout): the outside-close listened on `document.mousedown`, and on touch a synthesized `mousedown` can be delayed or suppressed — so a tap outside an open menu might not dismiss it.

## Change

- `AnchoredPopover`: outside-close now listens on `pointerdown` instead of `mousedown` (fires uniformly for mouse, touch, and pen). One handler, two listeners; `PointerEvent extends MouseEvent` so the target check is unchanged.
- Added a `DropdownMenu` regression test: an outside `pointerdown` closes the menu (`aria-expanded` → false).

## Also included

- `.storybook/preview.tsx`: two type-only imports (`Preview`, `ThemeMode`) — pre-existing value imports of type-only exports that broke `storybook dev` in this checkout.

## Out of scope (intentionally dropped)

Removing the 100 ms close timeout, and adding a controlled `isOpen` prop + list-level single-open state — both are gold-plating with no user-facing effect now that ERMAIN-464 restored single-open on click.
