### PR TITLE
Dropdown menus: soft active highlight + arrow-key roving navigation

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -1,8 +1,8 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
-import { Fragment, useCallback, useId, useRef, useState } from "react";
+import { Fragment, useId, useRef, useState } from "react";
 
-import { useKeyboard } from "@/hooks/useKeyboard";
+import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 
 import { AnchoredPopover } from "../Controls/AnchoredPopover";
 import { CheckIcon, LoadingIcon, PlusIcon } from "../icons";
@@ -139,84 +139,11 @@ export function ChatInputAddMenu({
 
   // Roving focus across the navigable rows (skips natively-disabled ones;
   // aria-disabled tool rows stay reachable so they remain perceivable).
-  const getNavigableItems = useCallback(
-    () =>
-      panelRef.current
-        ? Array.from(
-            panelRef.current.querySelectorAll<HTMLElement>(
-              NAVIGABLE_ITEM_SELECTOR,
-            ),
-          )
-        : [],
-    [],
-  );
-
-  const moveFocus = useCallback(
-    (delta: number) => {
-      const items = getNavigableItems();
-      if (items.length === 0) {
-        return;
-      }
-      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
-      const nextIndex =
-        currentIndex < 0
-          ? delta > 0
-            ? 0
-            : items.length - 1
-          : (currentIndex + delta + items.length) % items.length;
-      items[nextIndex].focus();
-    },
-    [getNavigableItems],
-  );
-
-  const focusEdge = useCallback(
-    (edge: "first" | "last") => {
-      const items = getNavigableItems();
-      if (items.length === 0) {
-        return;
-      }
-      (edge === "first" ? items[0] : items[items.length - 1]).focus();
-    },
-    [getNavigableItems],
-  );
-
-  const onArrowDown = useCallback(
-    (e: KeyboardEvent) => {
-      e.preventDefault();
-      moveFocus(1);
-    },
-    [moveFocus],
-  );
-  const onArrowUp = useCallback(
-    (e: KeyboardEvent) => {
-      e.preventDefault();
-      moveFocus(-1);
-    },
-    [moveFocus],
-  );
-  const onHome = useCallback(
-    (e: KeyboardEvent) => {
-      e.preventDefault();
-      focusEdge("first");
-    },
-    [focusEdge],
-  );
-  const onEnd = useCallback(
-    (e: KeyboardEvent) => {
-      e.preventDefault();
-      focusEdge("last");
-    },
-    [focusEdge],
-  );
-
-  // Escape + focus-return are handled by AnchoredPopover; we add navigation.
-  useKeyboard({
-    target: panelRef,
+  // Escape + focus-return are handled by AnchoredPopover; this adds navigation.
+  useRovingMenuFocus({
+    containerRef: panelRef,
     enabled: isOpen,
-    onArrowDown,
-    onArrowUp,
-    onHome,
-    onEnd,
+    itemSelector: NAVIGABLE_ITEM_SELECTOR,
   });
 
   const renderActionRow = (item: AddMenuActionItem, testId: string) => (

--- a/frontend/src/components/ui/Controls/AnchoredPopover.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
   type ReactNode,
@@ -24,6 +25,7 @@ export interface AnchoredPopoverTriggerProps {
   id: string;
   type: "button";
   onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
   "aria-expanded": boolean;
   "aria-controls": string;
   "aria-haspopup"?: "menu" | "dialog" | "listbox" | "tree" | "grid";
@@ -98,6 +100,10 @@ export function AnchoredPopover({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const internalPanelRef = useRef<HTMLDivElement>(null);
   const wasOpenRef = useRef(false);
+  // How the current open was initiated. Keyboard opens (Enter/Space/ArrowDown
+  // on the trigger) focus the first item; pointer opens focus only the panel
+  // container so nothing looks pre-selected. See the focus effect below.
+  const openViaKeyboardRef = useRef(false);
   const panelId = useMemo(() => id ?? `popover-${reactId}`, [id, reactId]);
   // eslint-disable-next-line lingui/no-unlocalized-strings -- internal DOM id suffix
   const triggerId = `${panelId}-trigger`;
@@ -268,13 +274,26 @@ export function AnchoredPopover({
   }, [getPanelElement, isOpen, onOpenChange]);
 
   useEffect(() => {
-    if (!isOpen || !initialFocusSelector) {
+    if (!isOpen) {
       return;
     }
 
     requestAnimationFrame(() => {
+      const panelElement = getPanelElement();
+      if (!panelElement) {
+        return;
+      }
+
+      // Keyboard-open (WAI-ARIA menu-button pattern): focus the first item so
+      // arrow keys start from a defined position. Pointer-open: focus only the
+      // panel container so nothing looks pre-selected — arrows still work
+      // because the roving handler is bound to the panel and falls back to the
+      // first/last item when nothing is focused within it.
       const focusTarget =
-        getPanelElement()?.querySelector(initialFocusSelector);
+        openViaKeyboardRef.current && initialFocusSelector
+          ? panelElement.querySelector(initialFocusSelector)
+          : panelElement;
+
       if (focusTarget instanceof HTMLElement) {
         focusTarget.focus();
       }
@@ -296,7 +315,19 @@ export function AnchoredPopover({
     onClick: (event) => {
       event.preventDefault();
       event.stopPropagation();
+      // Space/Enter dispatch a synthetic click; detail === 0 marks a
+      // keyboard-driven activation (a real pointer click has detail >= 1).
+      openViaKeyboardRef.current = event.detail === 0;
       onOpenChange(!isOpen);
+    },
+    onKeyDown: (event) => {
+      // ArrowDown/ArrowUp open the menu and land on the first/last item, per
+      // the WAI-ARIA menu-button pattern. Enter/Space fall through to onClick.
+      if (!isOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+        event.preventDefault();
+        openViaKeyboardRef.current = true;
+        onOpenChange(true);
+      }
     },
     "aria-expanded": isOpen,
     "aria-controls": panelId,
@@ -307,7 +338,13 @@ export function AnchoredPopover({
     <div
       ref={setPanelElement}
       id={panelId}
-      className={clsx("theme-transition fixed z-[9999] border", panelClassName)}
+      className={clsx(
+        "theme-transition fixed z-[9999] border focus:outline-none",
+        panelClassName,
+      )}
+      // Focusable container so a pointer-open can hold focus without any item
+      // looking pre-selected; roving arrow-key nav then works from here.
+      tabIndex={-1}
       style={{
         backgroundColor: "var(--theme-shell-dropdown)",
         borderColor: "var(--theme-border-dropdown)",

--- a/frontend/src/components/ui/Controls/DropdownMenu.tsx
+++ b/frontend/src/components/ui/Controls/DropdownMenu.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { useState, useRef, useCallback, memo, useEffect } from "react";
 
+import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 import { useKeyboard } from "@/hooks/useKeyboard";
 
 import { AnchoredPopover } from "./AnchoredPopover";
@@ -46,6 +47,11 @@ export interface DropdownMenuProps {
   onOpenChange?: (isOpen: boolean) => void;
 }
 
+// Navigable rows for roving focus and initial keyboard focus; natively-disabled
+// items are skipped so arrow keys land only on actionable rows.
+// eslint-disable-next-line lingui/no-unlocalized-strings -- CSS selector, not user-facing
+const MENU_ITEM_SELECTOR = '[role="menuitem"]:not(:disabled)';
+
 const MenuItem = memo(
   ({
     item,
@@ -59,15 +65,19 @@ const MenuItem = memo(
     <button
       className={clsx(
         "dropdown-item-geometry",
-        "w-full text-left text-sm",
+        "w-full rounded-md text-left text-sm",
         "flex items-center gap-2",
         "theme-transition",
         "disabled:cursor-not-allowed disabled:opacity-50",
-        "focus-ring-inset",
+        // Keyboard-active row: soft rounded highlight with a faint 1px inset
+        // border — deliberately lighter than hover/selected and free of the
+        // old 2px focus ring, so an arrowed-to item reads as "active" not
+        // "pre-selected" (ERMAIN-467).
+        "focus:outline-none focus:ring-1 focus:ring-inset",
         noWrap && "whitespace-nowrap",
         item.variant === "danger"
-          ? "text-theme-error-fg hover:bg-theme-error-bg focus:bg-theme-error-bg"
-          : "text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:text-theme-fg-primary",
+          ? "text-theme-error-fg hover:bg-theme-error-bg focus:bg-theme-error-bg focus:ring-theme-error-border"
+          : "text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:ring-theme-border-dropdown",
       )}
       onClick={onSelect}
       disabled={item.disabled}
@@ -180,30 +190,19 @@ export const DropdownMenu = memo(
       setConfirmingItem(null); // Just close the confirmation dialog
     }, []);
 
+    // ArrowUp/Down/Home/End roving nav across enabled items (WAI-ARIA
+    // menu-button pattern). Escape-close + focus-return live in AnchoredPopover;
+    // we keep Escape here too so closeMenu can guard against an in-flight click.
+    useRovingMenuFocus({
+      containerRef: menuRef,
+      enabled: isOpen,
+      itemSelector: MENU_ITEM_SELECTOR,
+    });
+
     useKeyboard({
       target: menuRef,
       enabled: isOpen,
       onEscape: closeMenu,
-      onTab: (e) => {
-        e.preventDefault();
-        const menuItems =
-          menuRef.current?.querySelectorAll('[role="menuitem"]');
-        if (!menuItems?.length) return;
-
-        const currentIndex = Array.from(menuItems).findIndex(
-          (item) => item === document.activeElement,
-        );
-
-        const nextIndex = e.shiftKey
-          ? currentIndex <= 0
-            ? menuItems.length - 1
-            : currentIndex - 1
-          : currentIndex >= menuItems.length - 1
-            ? 0
-            : currentIndex + 1;
-
-        (menuItems[nextIndex] as HTMLElement).focus();
-      },
     });
 
     useEffect(() => {
@@ -228,7 +227,7 @@ export const DropdownMenu = memo(
             horizontal: preferredOrientation?.horizontal ?? align,
           }}
           initialFocusSelector={
-            autoFocusFirstItem ? '[role="menuitem"]' : undefined
+            autoFocusFirstItem ? MENU_ITEM_SELECTOR : undefined
           }
           panelRef={menuRef}
           panelStyle={{
@@ -252,6 +251,7 @@ export const DropdownMenu = memo(
               size="sm"
               variant={triggerButtonVariant}
               onClick={triggerProps.onClick}
+              onKeyDown={triggerProps.onKeyDown}
               className={clsx(
                 "flex min-w-fit items-center justify-center",
                 triggerButtonClassName,

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -37,8 +37,10 @@ describe("DropdownMenu", () => {
         "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
       minWidth: "var(--theme-layout-dropdown-min-width)",
     });
-    expect(menuItem.className).toContain("focus-ring-inset");
-    expect(menuItem.className).not.toContain("focus:bg-theme-bg-accent");
+    // Active row uses the soft light highlight, not the old 2px dark ring.
+    expect(menuItem.className).not.toContain("focus-ring-inset");
+    expect(menuItem.className).toContain("focus:bg-theme-bg-hover");
+    expect(menuItem.className).toContain("focus:ring-1");
     expect(screen.getByRole("menu").firstElementChild).toHaveClass(
       "dropdown-panel-chrome-geometry",
     );
@@ -92,6 +94,133 @@ describe("DropdownMenu", () => {
       "overflow-y-auto",
       "overscroll-contain",
     );
+  });
+
+  it("focuses the panel (no item) on a pointer-open (ERMAIN-467)", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { label: "Rename", onClick: vi.fn() },
+          { label: "Delete", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    // A real pointer click carries detail >= 1; keyboard-triggered clicks have
+    // detail 0. Simulate a pointer click here.
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }), {
+      detail: 1,
+    });
+
+    const menu = await screen.findByRole("menu");
+
+    await waitFor(() => {
+      expect(menu).toHaveFocus();
+    });
+    expect(screen.getByRole("menuitem", { name: "Rename" })).not.toHaveFocus();
+  });
+
+  it("focuses the first item on a keyboard-open (ERMAIN-467)", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { label: "Rename", onClick: vi.fn() },
+          { label: "Delete", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    // Keyboard activation (Enter/Space) dispatches a synthetic click with
+    // detail 0.
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }), {
+      detail: 0,
+    });
+
+    const firstItem = await screen.findByRole("menuitem", { name: "Rename" });
+
+    await waitFor(() => {
+      expect(firstItem).toHaveFocus();
+    });
+  });
+
+  it("opens and focuses the first item on ArrowDown on the trigger (ERMAIN-467)", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { label: "Rename", onClick: vi.fn() },
+          { label: "Delete", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const firstItem = await screen.findByRole("menuitem", { name: "Rename" });
+
+    await waitFor(() => {
+      expect(firstItem).toHaveFocus();
+    });
+  });
+
+  it("wraps arrow-key navigation and jumps with Home/End (ERMAIN-467)", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { label: "Rename", onClick: vi.fn() },
+          { label: "Share", onClick: vi.fn() },
+          { label: "Delete", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }), {
+      detail: 1,
+    });
+    const menu = await screen.findByRole("menu");
+    const [rename, share, del] = screen.getAllByRole("menuitem");
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(rename).toHaveFocus();
+
+    fireEvent.keyDown(rename, { key: "ArrowUp" });
+    expect(del).toHaveFocus();
+
+    fireEvent.keyDown(del, { key: "Home" });
+    expect(rename).toHaveFocus();
+
+    fireEvent.keyDown(rename, { key: "End" });
+    expect(del).toHaveFocus();
+
+    fireEvent.keyDown(del, { key: "ArrowDown" });
+    expect(rename).toHaveFocus();
+
+    // sanity: middle item reachable
+    fireEvent.keyDown(rename, { key: "ArrowDown" });
+    expect(share).toHaveFocus();
+  });
+
+  it("skips disabled items during arrow-key navigation (ERMAIN-467)", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { label: "Rename", onClick: vi.fn() },
+          { label: "Share", onClick: vi.fn(), disabled: true },
+          { label: "Delete", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }), {
+      detail: 1,
+    });
+    const menu = await screen.findByRole("menu");
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toHaveFocus();
+
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveFocus();
   });
 
   it("closes on an outside pointerdown so tap-outside dismisses on touch (ERMAIN-465)", async () => {

--- a/frontend/src/hooks/ui/index.ts
+++ b/frontend/src/hooks/ui/index.ts
@@ -12,3 +12,4 @@ export * from "./useScrollEvents";
 export * from "./useFilePreviewModal";
 export * from "./useThemedIcon";
 export * from "./usePageAlignment";
+export * from "./useRovingMenuFocus";

--- a/frontend/src/hooks/ui/useRovingMenuFocus.ts
+++ b/frontend/src/hooks/ui/useRovingMenuFocus.ts
@@ -1,0 +1,111 @@
+import { useCallback } from "react";
+
+import { useKeyboard } from "@/hooks/useKeyboard";
+
+import type { RefObject } from "react";
+
+interface UseRovingMenuFocusOptions {
+  /** Container whose descendant items are navigated. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Only bind key handlers while the menu is open. */
+  enabled: boolean;
+  /**
+   * CSS selector matching the navigable rows. Should exclude disabled items so
+   * arrow-key navigation skips them (e.g. `[role="menuitem"]:not(:disabled)`).
+   */
+  itemSelector: string;
+}
+
+/**
+ * WAI-ARIA menu roving focus: ArrowUp/Down wrap through the navigable items,
+ * Home/End jump to the edges. Items carry `tabIndex={-1}`; focus roves between
+ * them via `.focus()`. Shared by the chat "+" menu and `DropdownMenu` so the
+ * kebab and plus menus behave identically.
+ *
+ * Escape-close and focus-return to the trigger are owned by `AnchoredPopover`;
+ * this hook only adds the navigation keys.
+ */
+export function useRovingMenuFocus({
+  containerRef,
+  enabled,
+  itemSelector,
+}: UseRovingMenuFocusOptions) {
+  const getNavigableItems = useCallback(
+    () =>
+      containerRef.current
+        ? Array.from(
+            containerRef.current.querySelectorAll<HTMLElement>(itemSelector),
+          )
+        : [],
+    [containerRef, itemSelector],
+  );
+
+  const moveFocus = useCallback(
+    (delta: number) => {
+      const items = getNavigableItems();
+      if (items.length === 0) {
+        return;
+      }
+      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+      const nextIndex =
+        currentIndex < 0
+          ? delta > 0
+            ? 0
+            : items.length - 1
+          : (currentIndex + delta + items.length) % items.length;
+      items[nextIndex].focus();
+    },
+    [getNavigableItems],
+  );
+
+  const focusEdge = useCallback(
+    (edge: "first" | "last") => {
+      const items = getNavigableItems();
+      if (items.length === 0) {
+        return;
+      }
+      (edge === "first" ? items[0] : items[items.length - 1]).focus();
+    },
+    [getNavigableItems],
+  );
+
+  const onArrowDown = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      moveFocus(1);
+    },
+    [moveFocus],
+  );
+  const onArrowUp = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      moveFocus(-1);
+    },
+    [moveFocus],
+  );
+  const onHome = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      focusEdge("first");
+    },
+    [focusEdge],
+  );
+  const onEnd = useCallback(
+    (e: KeyboardEvent) => {
+      e.preventDefault();
+      focusEdge("last");
+    },
+    [focusEdge],
+  );
+
+  useKeyboard({
+    target: containerRef,
+    enabled,
+    onArrowDown,
+    onArrowUp,
+    onHome,
+    onEnd,
+  });
+
+  return { moveFocus, focusEdge };
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -158,6 +158,10 @@ export default {
         theme: {
           focus: "var(--theme-focus-ring)",
           "focus-error": "var(--theme-focus-ring-error)",
+          // Faint 1px ring for the keyboard-active dropdown/menu row — a soft
+          // "active" affordance distinct from the heavier focus ring.
+          "border-dropdown": "var(--theme-border-dropdown)",
+          "error-border": "var(--theme-error-border)",
         },
       },
     },


### PR DESCRIPTION
Opening a menu (chat-history kebab, model/facet selectors, etc.) previously showed the first item wrapped in a heavy 2px focus ring, so it looked pre-selected even on a mouse open. This reworks focus handling to the WAI-ARIA menu-button pattern:

- **Pointer-open** focuses the panel container (`tabIndex={-1}`) — no item highlighted.
- **Keyboard-open** (Enter/Space, or ArrowUp/Down on the trigger) focuses the first item.
- **ArrowUp/Down** wrap, **Home/End** jump, and disabled items are skipped.
- The keyboard-active row now uses a **soft rounded background + faint 1px inset border** instead of the dark ring — distinct from hover and from `bg-theme-bg-selected` (reserved for selected). The danger variant keeps its error background.

The roving-focus logic already living in `ChatInputAddMenu` is extracted into a shared `useRovingMenuFocus` hook and reused by `DropdownMenu` (replacing its old Tab-only cycling), so the plus-menu and kebab menus now behave identically. Escape-close and focus-return to the trigger continue to live centrally in `AnchoredPopover`.

Blast radius: all `DropdownMenu` consumers (ChatHistoryList kebab, ModelSelector, FacetSelector, FileSourceSelector, AudioInputTabContent, AssistantsListPage, SearchPage) plus the chat `+` menu.

Tests cover pointer- vs keyboard-open focus targets, ArrowDown-on-trigger open, wrap/Home/End navigation, and disabled-item skipping.