### PR TITLE
Chat input stays usable while a response is generating (ERMAIN-466)

### DIFF
--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -127,10 +127,20 @@ export const chatIsReadyToChat = async (
     }
     await expect(textbox).toBeVisible();
     // The "Loading" text disappears as soon as any content has streamed in
-    // (the loader is suppressed once content is present), but the textbox
-    // stays disabled until the entire stream has finished. Use the same
-    // loadingTimeoutMs for the textbox-enabled wait so we cover the full
-    // streaming window, not just the pre-content phase.
+    // (the loader is suppressed once content is present), so it does not mark
+    // the end of a turn. The composer textarea no longer does either: since
+    // ERMAIN-466 it stays enabled *while* a response streams (only Send/Enter
+    // are blocked). The Stop button is present iff a turn is in flight
+    // (isPendingResponse), so waiting for it to disappear is what now covers
+    // the full streaming window — including multi-step tool calls, which stay
+    // in a single pending turn. For the initial-ready call there is no turn in
+    // flight, so it is already absent and this passes immediately.
+    await expect(page.getByTestId("chat-input-stop-generation")).toHaveCount(
+      0,
+      loadingOpts,
+    );
+    // The textarea can still be disabled for non-streaming reasons (an upload
+    // or recording in progress); keep guarding those.
     await expect(textbox).toBeEnabled(loadingOpts);
   });
 };

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -33,6 +33,8 @@ const mockUseFacets = vi.fn();
 const mockUseCreateChat = vi.fn();
 const mockFetchGetFile = vi.fn();
 const mockModelSelector = vi.fn();
+const mockFacetSelector = vi.fn();
+const mockFileUploadControl = vi.fn();
 const mockUseAudioDictationRecorder = vi.fn();
 const mockUseAudioTranscriptionRecorder = vi.fn();
 
@@ -112,7 +114,15 @@ vi.mock("@/components/ui/FileUpload", () => ({
 }));
 
 vi.mock("@/components/ui/FileUpload/FileUploadWithTokenCheck", () => ({
-  FileUploadWithTokenCheck: () => <div data-testid="file-upload-control" />,
+  FileUploadWithTokenCheck: (props: { disabled?: boolean }) => {
+    mockFileUploadControl(props);
+    return (
+      <div
+        data-testid="file-upload-control"
+        data-disabled={String(Boolean(props.disabled))}
+      />
+    );
+  },
 }));
 
 const mockChatInputTokenUsage = vi.fn();
@@ -124,7 +134,15 @@ vi.mock("./ChatInputTokenUsage", () => ({
 }));
 
 vi.mock("./FacetSelector", () => ({
-  FacetSelector: () => null,
+  FacetSelector: (props: { disabled?: boolean }) => {
+    mockFacetSelector(props);
+    return (
+      <div
+        data-testid="facet-selector"
+        data-disabled={String(Boolean(props.disabled))}
+      />
+    );
+  },
 }));
 
 vi.mock("./ModelSelector", () => ({
@@ -323,6 +341,217 @@ describe("ChatInput", () => {
 
     expect(textarea).toHaveFocus();
     otherButton.remove();
+  });
+
+  it("keeps the composer interactive while a response is generating (only send is blocked)", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseUploadFeature.mockReturnValue({ enabled: true });
+    mockUseFacets.mockReturnValue({
+      data: {
+        facets: [{ id: "facet-1", name: "Tool", default_enabled: false }],
+        global_facet_settings: undefined,
+      },
+      error: null,
+    });
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: true,
+      isMessagingLoading: false,
+      isUploading: false,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={vi.fn()} handleFileAttachments={vi.fn()} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Type a message...")).not.toBeDisabled();
+    expect(screen.getByTestId("file-upload-control")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+    expect(screen.getByTestId("facet-selector")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+
+    expect(
+      screen.getByTestId("chat-input-stop-generation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-input-send-message"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not submit on Enter while a response is generating", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const onSendMessage = vi.fn();
+
+    // Mirrors the real createSubmitHandler guard, wrapped in a spy so the test
+    // also pins ChatInput's wiring: it must feed the generation state into the
+    // handler's lock argument rather than relying on the mock's own guard.
+    const createSubmitHandler = vi.fn(
+      (
+        message: string,
+        _attachedFiles: FileUploadItem[],
+        innerOnSend: (message: string, inputFileIds?: string[]) => void,
+        isLoading: boolean,
+        disabled: boolean,
+      ) =>
+        (event: FormEvent) => {
+          event.preventDefault();
+          if (isLoading || disabled) return;
+          const trimmed = message.trim();
+          if (trimmed) innerOnSend(trimmed);
+        },
+    );
+
+    mockUseChatInputHandlers.mockReturnValue({
+      attachedFiles: [],
+      fileError: null,
+      setFileError: vi.fn(),
+      handleFilesUploaded: vi.fn(),
+      handleRemoveFile: vi.fn(),
+      handleRemoveAllFiles: vi.fn(),
+      setAttachedFiles: vi.fn(),
+      createSubmitHandler,
+    });
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: true,
+      isMessagingLoading: false,
+      isUploading: false,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={onSendMessage} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    const textarea = screen.getByPlaceholderText("Type a message...");
+    fireEvent.change(textarea, { target: { value: "next message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(createSubmitHandler.mock.calls.at(-1)?.[3]).toBe(true);
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
+  describe("mid-stream facet persistence (ERMAIN-466)", () => {
+    const facets = [
+      { id: "facet-1", name: "Tool One", default_enabled: false },
+      { id: "facet-2", name: "Tool Two", default_enabled: false },
+    ];
+
+    const latestFacetProps = () =>
+      mockFacetSelector.mock.calls.at(-1)?.[0] as {
+        selectedFacetIds: string[];
+        onSelectionChange: (ids: string[]) => void;
+      };
+
+    const renderChatInput = async (chatId: string | null) => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (id: string | null) => (
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              onSendMessage={vi.fn()}
+              handleFileAttachments={vi.fn()}
+              chatId={id}
+            />
+          </I18nProvider>
+        </QueryClientProvider>
+      );
+      const { rerender } = render(ui(chatId));
+      return { rerender: (id: string | null) => rerender(ui(id)) };
+    };
+
+    beforeEach(() => {
+      mockUseUploadFeature.mockReturnValue({ enabled: true });
+      mockUseFacets.mockReturnValue({
+        data: { facets, global_facet_settings: undefined },
+        error: null,
+      });
+    });
+
+    it("keeps a facet chosen mid-stream when a new chat acquires its real id", async () => {
+      const { rerender } = await renderChatInput(null);
+
+      // User picks a tool while the first response is still generating.
+      act(() => {
+        latestFacetProps().onSelectionChange(["facet-1"]);
+      });
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+
+      // chat_created flips chatId null -> real id (same compose session).
+      rerender("real-chat-id");
+
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+    });
+
+    it("re-initializes facets on a genuine chat switch", async () => {
+      const { rerender } = await renderChatInput("chat-a");
+
+      act(() => {
+        latestFacetProps().onSelectionChange(["facet-1"]);
+      });
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+
+      rerender("chat-b");
+
+      expect(latestFacetProps().selectedFacetIds).toEqual([]);
+    });
+  });
+
+  it("locks the composer while an upload is in progress", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: false,
+      isMessagingLoading: false,
+      isUploading: true,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={vi.fn()} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Type a message...")).toBeDisabled();
   });
 
   it("does not leak the previous chat's draft into a newly opened chat", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -369,6 +369,11 @@ export const ChatInput = ({
   // Add state for file button processing
   const [isFileButtonProcessing, setIsFileButtonProcessing] = useState(false);
   const pendingSelectedFacetIdsRef = useRef<string[] | null>(null);
+  // Compose session for which the user interactively chose facets. Once set,
+  // the init effect treats that selection as authoritative so a chatId /
+  // initialSelectedFacetIds change can't wipe it — notably the new-chat
+  // null->real-id rename, which keeps the same composeSessionId. (ERMAIN-466)
+  const userSelectedFacetsSessionRef = useRef<string | null>(null);
   const pendingSelectedChatProviderIdRef = useRef<string | null>(null);
   const audioTranscriptionStatusLastPollAtRef = useRef(0);
   const audioTranscriptionStatusPollIndexRef = useRef(0);
@@ -675,6 +680,7 @@ export const ChatInput = ({
         return;
       }
 
+      userSelectedFacetsSessionRef.current = composeSessionId;
       const isSelected = selectedFacetIds.includes(facetId);
       const nextSelectedFacetIds = isSelected
         ? selectedFacetIds.filter((id) => id !== facetId)
@@ -685,6 +691,7 @@ export const ChatInput = ({
     },
     [
       applySelectedFacetIds,
+      composeSessionId,
       enforceSelectedFacetIds,
       globalFacetSettings?.only_single_facet,
       selectedFacetIds,
@@ -835,8 +842,28 @@ export const ChatInput = ({
       return;
     }
 
-    const hasExplicitInitialSelection = initialSelectedFacetIds !== undefined;
     const hasPendingSelection = pendingSelectedFacetIdsRef.current !== null;
+
+    // A facet the user picked for this compose session outranks re-init: don't
+    // let a chatId / initialSelectedFacetIds change wipe it (the new-chat
+    // null->real-id rename keeps the session, so a tool chosen mid-generation
+    // survives). Genuine chat switches change the session and still re-init; an
+    // explicit imperative push always applies. (ERMAIN-466)
+    if (
+      !hasPendingSelection &&
+      !enforceSelectedFacetIds &&
+      userSelectedFacetsSessionRef.current === composeSessionId
+    ) {
+      setSelectedFacetIds((previousSelectedFacetIds) => {
+        const sanitized = sanitizeFacetSelection(previousSelectedFacetIds);
+        return areFacetIdListsEqual(previousSelectedFacetIds, sanitized)
+          ? previousSelectedFacetIds
+          : sanitized;
+      });
+      return;
+    }
+
+    const hasExplicitInitialSelection = initialSelectedFacetIds !== undefined;
     const initialSelection = hasPendingSelection
       ? pendingSelectedFacetIdsRef.current
       : hasExplicitInitialSelection
@@ -863,6 +890,8 @@ export const ChatInput = ({
   }, [
     availableFacets,
     chatId,
+    composeSessionId,
+    enforceSelectedFacetIds,
     facetIdsByDefault,
     initialSelectedFacetIds,
     onFacetSelectionChange,
@@ -1123,15 +1152,20 @@ export const ChatInput = ({
     [externalUploadFiles, handleFilesUploaded],
   );
 
+  // Split so the composer stays live during generation (ERMAIN-466): only
+  // sendLocked gates Send/Enter; composeLocked gates the draft surfaces.
+  const sendLocked = isLoading || isPendingResponse;
+  const composeLocked =
+    disabled ||
+    isUploading ||
+    isFileButtonProcessing ||
+    isRecording ||
+    isRecordingUpload;
+  const isDisabled = composeLocked || sendLocked;
+
   const handleTextareaPaste = useCallback(
     (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
-      if (
-        disabled ||
-        isLoading ||
-        isPendingResponse ||
-        isUploading ||
-        !externalUploadFiles
-      ) {
+      if (composeLocked || !externalUploadFiles) {
         return;
       }
 
@@ -1153,26 +1187,8 @@ export const ChatInput = ({
       event.preventDefault();
       void uploadFiles(imageFiles);
     },
-    [
-      disabled,
-      isLoading,
-      isPendingResponse,
-      isUploading,
-      externalUploadFiles,
-      uploadFiles,
-    ],
+    [composeLocked, externalUploadFiles, uploadFiles],
   );
-
-  // Combine disabled states
-  // Use isPendingResponse instead of isStreaming to disable immediately when send is clicked
-  const isDisabled =
-    disabled ||
-    isUploading || // From context (drag & drop)
-    isLoading ||
-    isPendingResponse || // True immediately when send is clicked
-    isFileButtonProcessing || // From button callback
-    isRecording || // Prevent edits while recording
-    isRecordingUpload; // Prevent edits while uploading recording
 
   // Collapse the file-upload button and the Tools dropdown into a single "+"
   // menu (ChatInputAddControls): on mobile, or whenever a host registers extra
@@ -1784,7 +1800,7 @@ export const ChatInput = ({
           assistantId={assistantId}
           previousMessageId={previousMessageId}
           chatProviderId={selectedModel?.chat_provider_id}
-          disabled={isDisabled}
+          disabled={composeLocked}
           onLimitExceeded={handleMessageTokenLimitExceeded}
         />
 
@@ -1872,7 +1888,7 @@ export const ChatInput = ({
             onRemoveFile={handleRemoveFileById}
             onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
             onFilePreview={onFilePreview}
-            disabled={isDisabled}
+            disabled={composeLocked}
             showFileTypes={showFileTypes}
             surfaceVariant="message"
           />
@@ -1944,7 +1960,7 @@ export const ChatInput = ({
               onRemoveFile={handleRemoveFileById}
               onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
               onFilePreview={onFilePreview}
-              disabled={isDisabled}
+              disabled={composeLocked}
               showFileTypes={showFileTypes}
             />
           )}
@@ -1969,9 +1985,7 @@ export const ChatInput = ({
                     : placeholder
               }
               rows={1}
-              disabled={
-                isLoading || isPendingResponse || disabled || isUploading
-              }
+              disabled={composeLocked}
               tabIndex={0}
               autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
               className={clsx(
@@ -2020,7 +2034,7 @@ export const ChatInput = ({
                     facets={availableFacets}
                     selectedFacetIds={selectedFacetIds}
                     onToggleFacet={toggleFacetId}
-                    disabled={isDisabled}
+                    disabled={composeLocked}
                     uploadDisabled={attachedFiles.length >= maxFiles}
                     toolsDisabled={enforceSelectedFacetIds}
                   />
@@ -2049,12 +2063,7 @@ export const ChatInput = ({
                         iconOnly
                         className="p-1"
                         disabled={
-                          attachedFiles.length >= maxFiles ||
-                          isLoading ||
-                          isPendingResponse ||
-                          disabled ||
-                          isUploading || // isUploading from context (drag & drop)
-                          isFileButtonProcessing // Add button processing state
+                          attachedFiles.length >= maxFiles || composeLocked
                         }
                       />
                     )}
@@ -2063,6 +2072,8 @@ export const ChatInput = ({
                         facets={availableFacets}
                         selectedFacetIds={selectedFacetIds}
                         onSelectionChange={(nextSelectedFacetIds) => {
+                          userSelectedFacetsSessionRef.current =
+                            composeSessionId;
                           setSelectedFacetIds(nextSelectedFacetIds);
                           onFacetSelectionChange?.(nextSelectedFacetIds);
                         }}
@@ -2073,7 +2084,7 @@ export const ChatInput = ({
                           globalFacetSettings?.show_facet_indicator_with_display_name ??
                           false
                         }
-                        disabled={isDisabled || enforceSelectedFacetIds}
+                        disabled={composeLocked || enforceSelectedFacetIds}
                       />
                     )}
                   </>

--- a/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
+++ b/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
@@ -2,6 +2,10 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import {
+  NEW_CHAT_STREAM_KEY,
+  useMessagingStore,
+} from "@/hooks/chat/store/messagingStore";
+import {
   useUploadFile,
   useCreateChat,
   fetchUploadFile,
@@ -83,9 +87,16 @@ describe("useFileDropzone", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Reset the Zustand store
+    // Reset the Zustand stores
     act(() => {
       useFileUploadStore.getState().reset();
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: false,
+        newlyCreatedChatId: null,
+        streamingByKey: {},
+        streamKeyAliases: {},
+        activeStreamKey: NEW_CHAT_STREAM_KEY,
+      });
     });
 
     // Setup fetchUploadFile mock using vi.mocked
@@ -329,5 +340,104 @@ describe("useFileDropzone", () => {
 
     // API should not be called
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("routes a first-turn upload to the streaming chat instead of orphaning it", async () => {
+    act(() => {
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: true,
+        newlyCreatedChatId: "streaming-chat-id",
+      });
+    });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFiles([testFile]);
+    });
+
+    expect(mockCreateChatMutateAsync).not.toHaveBeenCalled();
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "streaming-chat-id" },
+      }),
+    );
+    expect(useFileUploadStore.getState().silentChatId).toBeNull();
+  });
+
+  it("waits for chat_created before uploading a first-turn file", async () => {
+    act(() => {
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: true,
+        newlyCreatedChatId: null,
+      });
+    });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      const uploadPromise = result.current.uploadFiles([testFile]);
+      // chat_created lands just after the file is attached.
+      useMessagingStore.getState().setNewlyCreatedChatIdInStore("late-chat-id");
+      await uploadPromise;
+    });
+
+    expect(mockCreateChatMutateAsync).not.toHaveBeenCalled();
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "late-chat-id" },
+      }),
+    );
+  });
+
+  it("creates a silent chat for a fresh compose with no streaming first turn", async () => {
+    mockCreateChatMutateAsync.mockResolvedValue({ chat_id: "silent-chat-id" });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFiles([testFile]);
+    });
+
+    expect(mockCreateChatMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "silent-chat-id" },
+      }),
+    );
+    expect(useFileUploadStore.getState().silentChatId).toBe("silent-chat-id");
   });
 });

--- a/frontend/src/hooks/files/useFileDropzone.ts
+++ b/frontend/src/hooks/files/useFileDropzone.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useRef } from "react";
 import { useDropzone } from "react-dropzone";
 
 import {
+  NEW_CHAT_STREAM_KEY,
+  useMessagingStore,
+} from "@/hooks/chat/store/messagingStore";
+import {
   useCreateChat,
   fetchUploadFile,
   type UploadFileVariables,
@@ -29,6 +33,56 @@ import type { FileType } from "@/utils/fileTypes";
 import type { FileRejection } from "react-dropzone";
 
 const logger = createLogger("HOOK", "useFileDropzone");
+
+const FIRST_TURN_CHAT_ID_TIMEOUT_MS = 4000;
+
+/**
+ * The chat id of a brand-new chat's in-flight first turn, or null for a genuine
+ * fresh compose. Attaching a file mid-first-turn has a null committed `chatId`,
+ * so without this the upload would spawn a second, orphaned chat (ERMAIN-466).
+ * `newlyCreatedChatId` is reset on new-chat/navigation, so it never leaks a
+ * stale id into a fresh compose.
+ */
+async function resolveInFlightNewChatId(): Promise<string | null> {
+  const store = useMessagingStore.getState();
+
+  // Set for attach-then-send (its silent-chat id) and send-first once
+  // `chat_created` lands.
+  if (store.newlyCreatedChatId) {
+    return store.newlyCreatedChatId;
+  }
+
+  // Send-first before `chat_created`: real id not reported yet. A fresh compose
+  // has neither signal, so bail and let the caller create a silent chat.
+  const firstTurnInFlight =
+    store.getStreaming(NEW_CHAT_STREAM_KEY).currentMessageId !== null ||
+    store.isAwaitingFirstStreamChunkForNewChat;
+  if (!firstTurnInFlight) {
+    return null;
+  }
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutId);
+      unsubscribe();
+      resolve(value);
+    };
+    const timeoutId = setTimeout(
+      () => finish(null),
+      FIRST_TURN_CHAT_ID_TIMEOUT_MS,
+    );
+    const unsubscribe = useMessagingStore.subscribe((state) => {
+      if (state.newlyCreatedChatId) {
+        finish(state.newlyCreatedChatId);
+      }
+    });
+  });
+}
 
 interface UseFileDropzoneProps {
   /** Array of accepted file types */
@@ -191,10 +245,10 @@ export function useFileDropzone({
 
         const filesToUpload = files.slice(0, multiple ? maxFiles : 1);
 
-        // Determine which chat ID to use for the upload
         let uploadChatId = chatId;
+        uploadChatId ??= await resolveInFlightNewChatId();
 
-        // If no chatId exists, create one silently first
+        // No chat yet — create one silently.
         if (!uploadChatId) {
           logger.log("Creating silent chat for file uploads");
           const createChatResult = await createChatMutation.mutateAsync({


### PR DESCRIPTION
ERMAIN-466.

During generation the whole composer was disabled. Now only Send/Enter are blocked — the textarea, paste-to-attach, file menu, and tool/facet selection stay live so the next message can be prepared while streaming.

Supporting fixes so mid-stream prep is correct:
- A tool picked mid-stream survives the new-chat null→real-id navigation (previously reset on redirect; existing chats were unaffected).
- A file attached during a brand-new chat's first turn routes to the streaming chat instead of creating an orphaned one.

Add-in inherits all three via the shared `ChatInput`/`useFileDropzone` (no add-in change); it picks them up on the next library re-pack.