### PR TITLE
Storybook stories for confirm/consent components

### DIFF
--- a/frontend/src/components/ui/Message/ActionConfirmationCard.stories.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.stories.tsx
@@ -6,7 +6,6 @@ import {
 } from "./ActionConfirmationCard";
 import { Button } from "../Controls/Button";
 
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
@@ -29,7 +28,8 @@ const meta = {
     status: {
       control: "select",
       options: ["pending", "confirmed", "dismissed"],
-      description: "Lifecycle state — pending shows buttons, resolved shows a row",
+      description:
+        "Lifecycle state — pending shows buttons, resolved shows a row",
     },
     isBusy: {
       control: "boolean",
@@ -59,7 +59,8 @@ type Story = StoryObj<typeof meta>;
 export const Pending: Story = {
   args: {
     title: "Open a reply to this email?",
-    description: "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
+    description:
+      "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
     status: "pending",
   },
 };
@@ -71,7 +72,8 @@ export const Pending: Story = {
 export const TwoButton: Story = {
   args: {
     title: "Open a reply to this email?",
-    description: "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
+    description:
+      "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
     status: "pending",
     onAlwaysAllow: undefined,
   },
@@ -162,11 +164,7 @@ export const SurfacedLifecycle: Story = {
             onDeny={() => setStatus("dismissed")}
           />
           {status !== "pending" && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setStatus("idle")}
-            >
+            <Button variant="ghost" size="sm" onClick={() => setStatus("idle")}>
               Reset
             </Button>
           )}

--- a/frontend/src/components/ui/Message/ActionConfirmationCard.stories.tsx
+++ b/frontend/src/components/ui/Message/ActionConfirmationCard.stories.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+
+import {
+  ActionConfirmationCard,
+  type ActionConfirmationStatus,
+} from "./ActionConfirmationCard";
+import { Button } from "../Controls/Button";
+
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "UI/Message/ActionConfirmationCard",
+  component: ActionConfirmationCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Inline, message-scoped permission step for an assistant-proposed action. " +
+          "Presents the same three-way decision — allow once / always allow / deny — " +
+          "with browser-permission semantics, and leaves a compact resolved row in the " +
+          "transcript once decided. Used e.g. by the Outlook add-in to gate tool actions.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    status: {
+      control: "select",
+      options: ["pending", "confirmed", "dismissed"],
+      description: "Lifecycle state — pending shows buttons, resolved shows a row",
+    },
+    isBusy: {
+      control: "boolean",
+      description: "Disables the buttons while the allowed action executes",
+    },
+  },
+  args: {
+    onAllowOnce: () => {},
+    onAlwaysAllow: () => {},
+    onDeny: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-96 bg-theme-bg-secondary p-8">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ActionConfirmationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default 3-button decision: Allow once / Always allow / Deny.
+ */
+export const Pending: Story = {
+  args: {
+    title: "Open a reply to this email?",
+    description: "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
+    status: "pending",
+  },
+};
+
+/**
+ * Omitting `onAlwaysAllow` yields a 2-button card (Allow once / Deny) for
+ * consumers with no way to persist the decision.
+ */
+export const TwoButton: Story = {
+  args: {
+    title: "Open a reply to this email?",
+    description: "The assistant wants to open a reply to Jordan Vega (jordan@contoso.com).",
+    status: "pending",
+    onAlwaysAllow: undefined,
+  },
+};
+
+/**
+ * Buttons disabled while the allowed action runs.
+ */
+export const Busy: Story = {
+  args: {
+    title: "Open a reply to this email?",
+    description: "Opening the reply form…",
+    status: "pending",
+    isBusy: true,
+  },
+};
+
+/**
+ * A deployment can enforce per-use confirmation: "Always allow" renders greyed
+ * out (kept in tab order via aria-disabled) with the reason below the buttons.
+ */
+export const AlwaysAllowDisabled: Story = {
+  args: {
+    title: "Send this message?",
+    description: "The assistant wants to send an email to the finance team.",
+    status: "pending",
+    alwaysAllowDisabledReason:
+      "Your organization requires confirmation for every send.",
+  },
+};
+
+/**
+ * The compact resolved row shown after "Allow once" / "Always allow".
+ */
+export const ResolvedConfirmed: Story = {
+  args: {
+    status: "confirmed",
+    resolvedLabel: "Reply opened",
+  },
+};
+
+/**
+ * The compact resolved row shown after "Deny".
+ */
+export const ResolvedDismissed: Story = {
+  args: {
+    status: "dismissed",
+    resolvedLabel: "Action skipped",
+  },
+};
+
+/**
+ * How it surfaces today — the add-in tool-consent idiom.
+ *
+ * The assistant proposes an action, which surfaces a `pending` card. The user's
+ * decision resolves the card in place to a compact row (Allow once → confirmed,
+ * Deny → dismissed), mirroring how the Outlook add-in surfaces and records a
+ * tool-consent step without stealing focus or opening a modal. Reset replays it.
+ */
+export const SurfacedLifecycle: Story = {
+  render: () => {
+    const SurfacedLifecycleDemo = () => {
+      const [status, setStatus] = useState<ActionConfirmationStatus | "idle">(
+        "idle",
+      );
+
+      if (status === "idle") {
+        return (
+          <Button variant="primary" onClick={() => setStatus("pending")}>
+            Assistant proposes an action
+          </Button>
+        );
+      }
+
+      return (
+        <div className="space-y-3">
+          <p className="text-sm text-theme-fg-secondary">
+            Assistant: I can open a reply to Jordan Vega for you.
+          </p>
+          <ActionConfirmationCard
+            title="Open a reply to this email?"
+            description="The assistant wants to open a reply to Jordan Vega (jordan@contoso.com)."
+            status={status}
+            resolvedLabel={
+              status === "confirmed" ? "Reply opened" : "Action skipped"
+            }
+            onAllowOnce={() => setStatus("confirmed")}
+            onDeny={() => setStatus("dismissed")}
+          />
+          {status !== "pending" && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setStatus("idle")}
+            >
+              Reset
+            </Button>
+          )}
+        </div>
+      );
+    };
+
+    return <SurfacedLifecycleDemo />;
+  },
+};

--- a/frontend/src/components/ui/Modal/ConfirmationDialog.stories.tsx
+++ b/frontend/src/components/ui/Modal/ConfirmationDialog.stories.tsx
@@ -1,0 +1,111 @@
+import { ConfirmationDialog } from "./ConfirmationDialog";
+import { Button } from "../Controls/Button";
+
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "UI/Modal/ConfirmationDialog",
+  component: ConfirmationDialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Modal confirm/cancel dialog rendered on ModalBase. The frontend's " +
+          "data-loss / destructive safety-confirm idiom — e.g. the \"Remove this " +
+          "chat?\" guard. Also embedded inside Button via its `confirmAction` props.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    confirmButtonVariant: {
+      control: "select",
+      options: ["primary", "danger", "secondary"],
+      description: "Visual style of the confirm button",
+    },
+  },
+  args: {
+    onClose: () => {},
+    onConfirm: () => {},
+  },
+} satisfies Meta<typeof ConfirmationDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default confirm dialog with a primary confirm button.
+ */
+export const Open: Story = {
+  args: {
+    isOpen: true,
+    title: "Save changes?",
+    message: "Your edits to this assistant will be applied immediately.",
+  },
+};
+
+/**
+ * Destructive variant — danger-styled confirm button for irreversible actions.
+ */
+export const Danger: Story = {
+  args: {
+    isOpen: true,
+    title: "Confirm Removal",
+    message: "Are you sure you want to remove this chat? This cannot be undone.",
+    confirmButtonText: "Remove",
+    confirmButtonVariant: "danger",
+  },
+};
+
+/**
+ * `message` accepts a ReactNode, not just a string.
+ */
+export const RichMessage: Story = {
+  args: {
+    isOpen: true,
+    title: "Delete 3 files?",
+    confirmButtonText: "Delete",
+    confirmButtonVariant: "danger",
+    message: (
+      <div className="space-y-2 text-sm text-theme-fg-secondary">
+        <p>The following files will be permanently deleted:</p>
+        <ul className="list-disc pl-5">
+          <li>quarterly-report.pdf</li>
+          <li>budget-2026.xlsx</li>
+          <li>meeting-notes.docx</li>
+        </ul>
+      </div>
+    ),
+  },
+};
+
+/**
+ * How it surfaces today — the destructive-action safety guard.
+ *
+ * A real `Button` configured with its built-in `confirmAction` /`confirmTitle` /
+ * `confirmMessage` props pops the `ConfirmationDialog` on click. This is exactly
+ * how the "Remove" chat-history action guards a data-loss operation
+ * (ChatHistoryList.tsx:189) — the dialog is owned by the Button, not the caller.
+ */
+export const SurfacedViaButton: Story = {
+  // args satisfy the Meta<ConfirmationDialog> shape; this story renders a Button
+  // that owns its own ConfirmationDialog, so these values are unused directly.
+  args: {
+    isOpen: false,
+    title: "Confirm Removal",
+    message: "Are you sure you want to remove this chat?",
+  },
+  render: () => (
+    <Button
+      variant="danger"
+      confirmAction
+      confirmTitle="Confirm Removal"
+      confirmMessage="Are you sure you want to remove this chat?"
+      onClick={() => {}}
+    >
+      Remove chat
+    </Button>
+  ),
+};

--- a/frontend/src/components/ui/Modal/ConfirmationDialog.stories.tsx
+++ b/frontend/src/components/ui/Modal/ConfirmationDialog.stories.tsx
@@ -1,7 +1,6 @@
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import { Button } from "../Controls/Button";
 
-
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
@@ -13,8 +12,8 @@ const meta = {
       description: {
         component:
           "Modal confirm/cancel dialog rendered on ModalBase. The frontend's " +
-          "data-loss / destructive safety-confirm idiom — e.g. the \"Remove this " +
-          "chat?\" guard. Also embedded inside Button via its `confirmAction` props.",
+          'data-loss / destructive safety-confirm idiom — e.g. the "Remove this ' +
+          'chat?" guard. Also embedded inside Button via its `confirmAction` props.',
       },
     },
   },
@@ -53,7 +52,8 @@ export const Danger: Story = {
   args: {
     isOpen: true,
     title: "Confirm Removal",
-    message: "Are you sure you want to remove this chat? This cannot be undone.",
+    message:
+      "Are you sure you want to remove this chat? This cannot be undone.",
     confirmButtonText: "Remove",
     confirmButtonVariant: "danger",
   },

--- a/frontend/src/components/ui/Toast/Toast.stories.tsx
+++ b/frontend/src/components/ui/Toast/Toast.stories.tsx
@@ -1,0 +1,162 @@
+import { Toaster } from "./Toaster";
+import { toast } from "./toast";
+import { useToastStore } from "./toastStore";
+import { Button } from "../Controls/Button";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+// Toasts are fired imperatively via the `toast` API and rendered by a single
+// <Toaster/> mounted at the app root. These stories mount their own <Toaster/>
+// and fire from a trigger button so the live, transient behaviour is visible.
+const meta = {
+  title: "UI/Toast/Toast",
+  component: Toaster,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "Transient, non-blocking notification. Auto-dismisses after ~5s " +
+          "(non-error, no actions) or stays until dismissed when it carries " +
+          "actions. It is NOT a consent gate — it informs after the fact. " +
+          "Fired via the imperative `toast` API (`toast.success`, `toast.custom`, …).",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[260px] flex-wrap items-start justify-center gap-2 bg-theme-bg-secondary p-8">
+        <Story />
+        <Toaster />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The four semantic variants. */
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() =>
+          toast.info({
+            title: "Heads up",
+            description: "Something informational happened.",
+          })
+        }
+      >
+        Info
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => toast.success({ title: "Saved" })}
+      >
+        Success
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() =>
+          toast.warning({
+            title: "Check this",
+            description: "A non-blocking warning.",
+          })
+        }
+      >
+        Warning
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() =>
+          toast.error({
+            title: "Could not save",
+            description: "The request failed.",
+          })
+        }
+      >
+        Error
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => useToastStore.getState().clear()}
+      >
+        Clear all
+      </Button>
+    </div>
+  ),
+};
+
+/** A toast that carries actions stays until the user acts or dismisses it. */
+export const WithActions: Story = {
+  render: () => (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={() =>
+        toast.custom({
+          variant: "info",
+          title: "Message sent",
+          description: "You can undo this for a few seconds.",
+          actions: [
+            {
+              id: "undo",
+              label: "Undo",
+              variant: "primary",
+              onClick: () => toast.success({ title: "Undone" }),
+            },
+          ],
+          duration: 8000,
+        })
+      }
+    >
+      Show toast with action
+    </Button>
+  ),
+};
+
+/**
+ * "How it would surface for the queue overwrite" — Option D: overwrite the
+ * queued message immediately, then offer a transient Undo. This is the toast
+ * alternative to a confirm-first dialog/card: recoverable, but the previously
+ * queued item is lost if the Undo window lapses (and it detaches the decision
+ * from the composer chip it concerns).
+ */
+export const SurfacedReplaceUndo: Story = {
+  render: () => (
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={() =>
+        toast.custom({
+          variant: "info",
+          title: "Queued message replaced",
+          description: "Your previously queued message was overwritten.",
+          actions: [
+            {
+              id: "undo",
+              label: "Undo",
+              variant: "primary",
+              onClick: () =>
+                toast.success({
+                  title: "Restored the previous queued message",
+                }),
+            },
+          ],
+          duration: 6000,
+          dedupeKey: "queue-replace",
+        })
+      }
+    >
+      Queue (replaces existing)
+    </Button>
+  ),
+};


### PR DESCRIPTION
Adds Storybook coverage for the app's consent / confirm surfaces so they can be compared side by side (dev/story artifacts only — no product code).

## Stories
- **UI/Message/ActionConfirmationCard** — permission/consent-to-act idiom (add-in tool-call gate). Variants (3-button, 2-button, busy, always-allow-disabled, resolved rows) + `SurfacedLifecycle` (live pending → resolved via local `useState`).
- **UI/Modal/ConfirmationDialog** — destructive / data-loss safety idiom. Variants (default, danger, rich message) + `SurfacedViaButton`, firing it like the real "Remove this chat?" guard (danger `Button` + `confirmAction`).
- **UI/Toast/Toast** — transient notify+undo idiom. Variants + `SurfacedReplaceUndo` (overwrite-then-Undo).