### PR TITLE
Keep chat composer usable while a response streams (ERMAIN-466)

### DIFF
--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -127,10 +127,20 @@ export const chatIsReadyToChat = async (
     }
     await expect(textbox).toBeVisible();
     // The "Loading" text disappears as soon as any content has streamed in
-    // (the loader is suppressed once content is present), but the textbox
-    // stays disabled until the entire stream has finished. Use the same
-    // loadingTimeoutMs for the textbox-enabled wait so we cover the full
-    // streaming window, not just the pre-content phase.
+    // (the loader is suppressed once content is present), so it does not mark
+    // the end of a turn. The composer textarea no longer does either: since
+    // ERMAIN-466 it stays enabled *while* a response streams (only Send/Enter
+    // are blocked). The Stop button is present iff a turn is in flight
+    // (isPendingResponse), so waiting for it to disappear is what now covers
+    // the full streaming window — including multi-step tool calls, which stay
+    // in a single pending turn. For the initial-ready call there is no turn in
+    // flight, so it is already absent and this passes immediately.
+    await expect(page.getByTestId("chat-input-stop-generation")).toHaveCount(
+      0,
+      loadingOpts,
+    );
+    // The textarea can still be disabled for non-streaming reasons (an upload
+    // or recording in progress); keep guarding those.
     await expect(textbox).toBeEnabled(loadingOpts);
   });
 };

--- a/frontend/src/components/ui/Assistant/AssistantForm.tsx
+++ b/frontend/src/components/ui/Assistant/AssistantForm.tsx
@@ -25,6 +25,7 @@ import {
   usePromptOptimizer,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useAssistantsFeature } from "@/providers/FeatureConfigProvider";
+import { mergeUniqueFilesById } from "@/utils/file/mergeUniqueFilesById";
 
 import type { TokenUsageEstimationResult } from "@/hooks/chat/useTokenUsageEstimation";
 import type {
@@ -35,23 +36,6 @@ import type React from "react";
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal form field key
 const FACET_IDS_FIELD: keyof AssistantFormData = "facetIds";
-
-function mergeUniqueFilesById(
-  existingFiles: FileUploadItem[],
-  newFiles: FileUploadItem[],
-) {
-  const seenFileIds = new Set(existingFiles.map((file) => file.id));
-  const uniqueNewFiles = newFiles.filter((file) => {
-    if (seenFileIds.has(file.id)) {
-      return false;
-    }
-
-    seenFileIds.add(file.id);
-    return true;
-  });
-
-  return [...existingFiles, ...uniqueNewFiles];
-}
 
 function buildFormData(
   initialData?: Partial<AssistantFormData>,

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -33,6 +33,8 @@ const mockUseFacets = vi.fn();
 const mockUseCreateChat = vi.fn();
 const mockFetchGetFile = vi.fn();
 const mockModelSelector = vi.fn();
+const mockFacetSelector = vi.fn();
+const mockFileUploadControl = vi.fn();
 const mockUseAudioDictationRecorder = vi.fn();
 const mockUseAudioTranscriptionRecorder = vi.fn();
 
@@ -112,7 +114,15 @@ vi.mock("@/components/ui/FileUpload", () => ({
 }));
 
 vi.mock("@/components/ui/FileUpload/FileUploadWithTokenCheck", () => ({
-  FileUploadWithTokenCheck: () => <div data-testid="file-upload-control" />,
+  FileUploadWithTokenCheck: (props: { disabled?: boolean }) => {
+    mockFileUploadControl(props);
+    return (
+      <div
+        data-testid="file-upload-control"
+        data-disabled={String(Boolean(props.disabled))}
+      />
+    );
+  },
 }));
 
 const mockChatInputTokenUsage = vi.fn();
@@ -124,7 +134,15 @@ vi.mock("./ChatInputTokenUsage", () => ({
 }));
 
 vi.mock("./FacetSelector", () => ({
-  FacetSelector: () => null,
+  FacetSelector: (props: { disabled?: boolean }) => {
+    mockFacetSelector(props);
+    return (
+      <div
+        data-testid="facet-selector"
+        data-disabled={String(Boolean(props.disabled))}
+      />
+    );
+  },
 }));
 
 vi.mock("./ModelSelector", () => ({
@@ -323,6 +341,217 @@ describe("ChatInput", () => {
 
     expect(textarea).toHaveFocus();
     otherButton.remove();
+  });
+
+  it("keeps the composer interactive while a response is generating (only send is blocked)", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseUploadFeature.mockReturnValue({ enabled: true });
+    mockUseFacets.mockReturnValue({
+      data: {
+        facets: [{ id: "facet-1", name: "Tool", default_enabled: false }],
+        global_facet_settings: undefined,
+      },
+      error: null,
+    });
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: true,
+      isMessagingLoading: false,
+      isUploading: false,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={vi.fn()} handleFileAttachments={vi.fn()} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Type a message...")).not.toBeDisabled();
+    expect(screen.getByTestId("file-upload-control")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+    expect(screen.getByTestId("facet-selector")).toHaveAttribute(
+      "data-disabled",
+      "false",
+    );
+
+    expect(
+      screen.getByTestId("chat-input-stop-generation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("chat-input-send-message"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not submit on Enter while a response is generating", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const onSendMessage = vi.fn();
+
+    // Mirrors the real createSubmitHandler guard, wrapped in a spy so the test
+    // also pins ChatInput's wiring: it must feed the generation state into the
+    // handler's lock argument rather than relying on the mock's own guard.
+    const createSubmitHandler = vi.fn(
+      (
+        message: string,
+        _attachedFiles: FileUploadItem[],
+        innerOnSend: (message: string, inputFileIds?: string[]) => void,
+        isLoading: boolean,
+        disabled: boolean,
+      ) =>
+        (event: FormEvent) => {
+          event.preventDefault();
+          if (isLoading || disabled) return;
+          const trimmed = message.trim();
+          if (trimmed) innerOnSend(trimmed);
+        },
+    );
+
+    mockUseChatInputHandlers.mockReturnValue({
+      attachedFiles: [],
+      fileError: null,
+      setFileError: vi.fn(),
+      handleFilesUploaded: vi.fn(),
+      handleRemoveFile: vi.fn(),
+      handleRemoveAllFiles: vi.fn(),
+      setAttachedFiles: vi.fn(),
+      createSubmitHandler,
+    });
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: true,
+      isMessagingLoading: false,
+      isUploading: false,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={onSendMessage} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    const textarea = screen.getByPlaceholderText("Type a message...");
+    fireEvent.change(textarea, { target: { value: "next message" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    expect(createSubmitHandler.mock.calls.at(-1)?.[3]).toBe(true);
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
+  describe("mid-stream facet persistence (ERMAIN-466)", () => {
+    const facets = [
+      { id: "facet-1", name: "Tool One", default_enabled: false },
+      { id: "facet-2", name: "Tool Two", default_enabled: false },
+    ];
+
+    const latestFacetProps = () =>
+      mockFacetSelector.mock.calls.at(-1)?.[0] as {
+        selectedFacetIds: string[];
+        onSelectionChange: (ids: string[]) => void;
+      };
+
+    const renderChatInput = async (chatId: string | null) => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (id: string | null) => (
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              onSendMessage={vi.fn()}
+              handleFileAttachments={vi.fn()}
+              chatId={id}
+            />
+          </I18nProvider>
+        </QueryClientProvider>
+      );
+      const { rerender } = render(ui(chatId));
+      return { rerender: (id: string | null) => rerender(ui(id)) };
+    };
+
+    beforeEach(() => {
+      mockUseUploadFeature.mockReturnValue({ enabled: true });
+      mockUseFacets.mockReturnValue({
+        data: { facets, global_facet_settings: undefined },
+        error: null,
+      });
+    });
+
+    it("keeps a facet chosen mid-stream when a new chat acquires its real id", async () => {
+      const { rerender } = await renderChatInput(null);
+
+      // User picks a tool while the first response is still generating.
+      act(() => {
+        latestFacetProps().onSelectionChange(["facet-1"]);
+      });
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+
+      // chat_created flips chatId null -> real id (same compose session).
+      rerender("real-chat-id");
+
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+    });
+
+    it("re-initializes facets on a genuine chat switch", async () => {
+      const { rerender } = await renderChatInput("chat-a");
+
+      act(() => {
+        latestFacetProps().onSelectionChange(["facet-1"]);
+      });
+      expect(latestFacetProps().selectedFacetIds).toEqual(["facet-1"]);
+
+      rerender("chat-b");
+
+      expect(latestFacetProps().selectedFacetIds).toEqual([]);
+    });
+  });
+
+  it("locks the composer while an upload is in progress", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    mockUseChatContext.mockReturnValue({
+      isPendingResponse: false,
+      isMessagingLoading: false,
+      isUploading: true,
+      cancelMessage: vi.fn(),
+    });
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={vi.fn()} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByPlaceholderText("Type a message...")).toBeDisabled();
   });
 
   it("does not leak the previous chat's draft into a newly opened chat", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -5,13 +5,16 @@ import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { componentRegistry } from "@/config/componentRegistry";
+import { useConfirmationRegistryStore } from "@/hooks/chat/store/confirmationRegistryStore";
+import { useMessageQueueStore } from "@/hooks/chat/store/messageQueueStore";
 import { messages as enMessages } from "@/locales/en/messages.json";
 
 import { ChatInput } from "./ChatInput";
 import { useToastStore } from "../Toast/toastStore";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
-import type { Messages } from "@lingui/core";
+import type { ChatContextValue } from "@/providers/ChatProvider";
+import type { I18n, Messages } from "@lingui/core";
 import type {
   ButtonHTMLAttributes,
   FormEvent,
@@ -48,6 +51,13 @@ vi.mock("@/providers/FeatureConfigProvider", () => ({
   useAudioTranscriptionFeature: () => mockUseAudioTranscriptionFeature(),
   useAudioDictationFeature: () => mockUseAudioDictationFeature(),
   useAudioConversationalFeature: () => mockUseAudioConversationalFeature(),
+  useErrorReportFeature: () => ({
+    showVerboseAssistantErrors: false,
+    showCopyErrorReport: false,
+    errorReportTemplate: "",
+    environment: "test",
+    platform: "web",
+  }),
 }));
 
 vi.mock("@/hooks/i18n", () => ({
@@ -182,6 +192,8 @@ vi.mock("../Feedback/ChatWarnings/BudgetWarning", () => ({
 
 vi.mock("../icons", () => ({
   ArrowUpIcon: () => <span>send</span>,
+  CloseIcon: () => <span>close</span>,
+  EditIcon: () => <span>edit</span>,
   LoadingIcon: (props: HTMLAttributes<HTMLSpanElement>) => (
     <span {...props}>loading</span>
   ),
@@ -3359,6 +3371,449 @@ describe("ChatInput", () => {
 
       expect(requestSubmitSpy).not.toHaveBeenCalled();
       requestSubmitSpy.mockRestore();
+    });
+  });
+
+  describe("message queue (ERMAIN-470)", () => {
+    const CHAT_ID = "chat-q";
+
+    const flushTimers = async () => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+    };
+
+    const renderQueue = (
+      initialContext: Partial<ChatContextValue>,
+      onSendMessage: (
+        message: string,
+        inputFileIds?: string[],
+        modelId?: string,
+        selectedFacetIds?: string[],
+      ) => void,
+      i18n: I18n,
+    ) => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const ui = (
+        context: Partial<ChatContextValue>,
+        props: { disabled?: boolean } = {},
+      ) => {
+        mockUseChatContext.mockReturnValue({
+          isPendingResponse: false,
+          isMessagingLoading: false,
+          isUploading: false,
+          cancelMessage: vi.fn(),
+          messagingError: null,
+          ...context,
+        });
+        return (
+          <QueryClientProvider client={queryClient}>
+            <I18nProvider i18n={i18n}>
+              <ChatInput
+                onSendMessage={onSendMessage}
+                chatId={CHAT_ID}
+                {...props}
+              />
+            </I18nProvider>
+          </QueryClientProvider>
+        );
+      };
+      const { rerender } = render(ui(initialContext));
+      return (
+        context: Partial<ChatContextValue>,
+        props: { disabled?: boolean } = {},
+      ) => rerender(ui(context, props));
+    };
+
+    beforeEach(() => {
+      useConfirmationRegistryStore.setState({ pendingIdsByChatId: {} });
+      useMessageQueueStore.setState({ queuedBySessionId: {} });
+    });
+
+    it("queues the draft on Enter while generating instead of sending", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("next message");
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("");
+    });
+
+    it("auto-sends the queued message once the turn fully completes", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      rerender({ isPendingResponse: false });
+      await flushTimers();
+
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "next message",
+        undefined,
+        undefined,
+        [],
+      );
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("returns the queued message to the composer when the chip is clicked", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      fireEvent.click(screen.getByTestId("chat-input-queued-message-edit"));
+
+      expect(textarea).toHaveValue("next message");
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("cancels the queued message from the chip without sending", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      fireEvent.click(screen.getByTestId("chat-input-queued-message-cancel"));
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+
+      rerender({ isPendingResponse: false });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("restores the queued message to the composer on Stop and never auto-sends", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const cancelMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true, cancelMessage },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      fireEvent.click(screen.getByTestId("chat-input-stop-generation"));
+
+      expect(cancelMessage).toHaveBeenCalledTimes(1);
+      expect(textarea).toHaveValue("next message");
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+
+      rerender({ isPendingResponse: false, cancelMessage });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("restores the queued message when the turn errors instead of sending", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      rerender({
+        isPendingResponse: false,
+        messagingError: new Error("stream failed"),
+      });
+      await flushTimers();
+
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("next message");
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("holds the auto-send while a confirmation card is pending, then sends when it resolves", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      // A tool-consent card is pending for this chat when the turn completes.
+      act(() => {
+        useConfirmationRegistryStore
+          .getState()
+          .registerConfirmation(CHAT_ID, "card-1");
+      });
+      rerender({ isPendingResponse: false });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+
+      // Resolving the card releases the drain.
+      act(() => {
+        useConfirmationRegistryStore
+          .getState()
+          .unregisterConfirmation(CHAT_ID, "card-1");
+      });
+      await flushTimers();
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "next message",
+        undefined,
+        undefined,
+        [],
+      );
+    });
+
+    it("holds the auto-send while the composer is disabled (add-in busy), then sends when it clears", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      // Turn completes while the composer is still busy (e.g. the add-in is
+      // expanding a dropped email) — must not send ahead of staged attachments.
+      rerender({ isPendingResponse: false }, { disabled: true });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+
+      // The busy gate clears and the queued message drains.
+      rerender({ isPendingResponse: false }, { disabled: false });
+      await flushTimers();
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("auto-sends the queued attachments' file ids on completion", async () => {
+      const attachedFiles = [
+        {
+          id: "file-1",
+          filename: "report.pdf",
+          download_url: "/files/report.pdf",
+          preview_url: undefined,
+          file_contents_unavailable_missing_permissions: false,
+          file_capability: {
+            extensions: ["pdf"],
+            id: "pdf",
+            mime_types: ["application/pdf"],
+            operations: ["extract_text"],
+          },
+        },
+      ] as unknown as FileUploadItem[];
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles,
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+      });
+
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "with attachment" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      rerender({ isPendingResponse: false });
+      await flushTimers();
+
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "with attachment",
+        ["file-1"],
+        undefined,
+        [],
+      );
+    });
+
+    it("sends exactly once across a multi-step turn that bounces pending true->false->true->false", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      // First completion edge arms the drain, but a follow-up tool step flips
+      // pending back true before the deferred send fires — it must not send yet.
+      rerender({ isPendingResponse: false });
+      rerender({ isPendingResponse: true });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+
+      // Only the final completion drains, exactly once.
+      rerender({ isPendingResponse: false });
+      await flushTimers();
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows a Send/Queue button beside Stop while streaming with content", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      // Empty composer while streaming → only Stop.
+      expect(
+        screen.getByTestId("chat-input-stop-generation"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-queue-message"),
+      ).not.toBeInTheDocument();
+
+      // Typing surfaces the Send/Queue button alongside Stop (two controls).
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "next message" } });
+      expect(
+        screen.getByTestId("chat-input-queue-message"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-stop-generation"),
+      ).toBeInTheDocument();
+    });
+
+    it("queues via the Send/Queue button just like Enter", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "clicked queue" } });
+      fireEvent.click(screen.getByTestId("chat-input-queue-message"));
+
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("clicked queue");
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("");
+    });
+
+    it("confirms before overwriting an existing queued message, then replaces", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "first" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("first");
+
+      // Queuing again raises the confirm; the store is not touched yet and the
+      // new draft stays in the composer.
+      fireEvent.change(textarea, { target: { value: "second" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(
+        screen.getByText("Replace the queued message?"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("first");
+      expect(textarea).toHaveValue("second");
+      expect(onSendMessage).not.toHaveBeenCalled();
+
+      // Replace swaps in the new draft and clears the composer.
+      fireEvent.click(screen.getByText("Replace"));
+      expect(
+        screen.queryByText("Replace the queued message?"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("second");
+      expect(textarea).toHaveValue("");
+    });
+
+    it("keeps both the queued message and the new draft when overwrite is declined", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      renderQueue({ isPendingResponse: true }, onSendMessage, i18n);
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      fireEvent.change(textarea, { target: { value: "first" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      fireEvent.change(textarea, { target: { value: "second" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(
+        screen.getByText("Replace the queued message?"),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Keep queued"));
+      expect(
+        screen.queryByText("Replace the queued message?"),
+      ).not.toBeInTheDocument();
+      // Original queue kept; new draft still in the composer — nothing lost.
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("first");
+      expect(textarea).toHaveValue("second");
     });
   });
 });

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import clsx from "clsx";
 import {
   useState,
@@ -11,12 +11,24 @@ import {
 
 import { FileAttachmentsPreview } from "@/components/ui/FileUpload";
 import { FileUploadWithTokenCheck } from "@/components/ui/FileUpload/FileUploadWithTokenCheck";
+import { ConfirmationDialog } from "@/components/ui/Modal/ConfirmationDialog";
 import { componentRegistry } from "@/config/componentRegistry";
 import { useAudioDictationRecorder } from "@/hooks/audio/useAudioDictationRecorder";
 import { useAudioTranscriptionRecorder } from "@/hooks/audio/useAudioTranscriptionRecorder";
 import { useTokenManagement, useActiveModelSelection } from "@/hooks/chat";
+import {
+  useConfirmationRegistryStore,
+  useHasPendingConfirmation,
+} from "@/hooks/chat/store/confirmationRegistryStore";
+import {
+  useMessageQueueStore,
+  useQueuedMessage,
+} from "@/hooks/chat/store/messageQueueStore";
 import { useMessagingStore } from "@/hooks/chat/store/messagingStore";
-import { useComposeSession } from "@/hooks/chat/useComposeSession";
+import {
+  useComposeSession,
+  type ComposeDraftState,
+} from "@/hooks/chat/useComposeSession";
 import { UnsupportedFileTypeError } from "@/hooks/files/errors";
 import { useFileUploadStore } from "@/hooks/files/useFileUploadStore";
 import { useOptionalTranslation } from "@/hooks/i18n";
@@ -38,8 +50,16 @@ import {
 import { extractTextFromContent } from "@/utils/adapters/contentPartAdapter";
 import { resolveChatSendErrorMessage } from "@/utils/chatSendErrorMessage";
 import { createLogger } from "@/utils/debugLogger";
+import { mergeUniqueFilesById } from "@/utils/file/mergeUniqueFilesById";
 
-import { ArrowUpIcon, LoadingIcon, StopIcon, VoiceIcon } from "../icons";
+import {
+  ArrowUpIcon,
+  CloseIcon,
+  EditIcon,
+  LoadingIcon,
+  StopIcon,
+  VoiceIcon,
+} from "../icons";
 import { ChatInputAddControls } from "./ChatInputAddControls";
 import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
 import { ChatInputTokenUsage } from "./ChatInputTokenUsage";
@@ -275,6 +295,31 @@ function appendDictationText(current: string, transcript: string): string {
     return text;
   }
   return /\s$/.test(current) ? `${current}${text}` : `${current} ${text}`;
+}
+
+// Fold two compose drafts into one, preserving both texts and de-duplicating
+// files. Used to return a queued message to the composer (abort/error, or the
+// "drop to draft" that happens when the user leaves a chat mid-generation)
+// without clobbering anything the user has since typed. (ERMAIN-470)
+function mergeComposeDrafts(
+  primary: ComposeDraftState,
+  secondary: ComposeDraftState,
+): ComposeDraftState {
+  const primaryHasText = primary.message.trim().length > 0;
+  const secondaryHasText = secondary.message.trim().length > 0;
+  const message =
+    primaryHasText && secondaryHasText
+      ? `${primary.message}\n${secondary.message}`
+      : primaryHasText
+        ? primary.message
+        : secondary.message;
+  return {
+    message,
+    attachedFiles: mergeUniqueFilesById(
+      primary.attachedFiles,
+      secondary.attachedFiles,
+    ),
+  };
 }
 
 /**
@@ -616,6 +661,126 @@ export const ChatInput = ({
 
   const [selectedFacetIds, setSelectedFacetIds] = useState<string[]>([]);
 
+  // --- Queue-the-next-message (ERMAIN-470) ---------------------------------
+  // The queued payload lives in the messageQueueStore keyed by the stable
+  // compose session (so it survives the new-chat null->real-id rename and stays
+  // isolated per chat). Reading it through a store selector keeps the chip and
+  // drain reactive without a manual invalidation token.
+  const queuedMessage = useQueuedMessage(composeSessionId);
+  const setQueuedBySessionId = useMessageQueueStore((state) => state.setQueued);
+  const clearQueuedBySessionId = useMessageQueueStore(
+    (state) => state.clearQueued,
+  );
+  const getQueuedBySessionId = useMessageQueueStore((state) => state.getQueued);
+  // A queued message is "armed" the moment its turn ends; the actual send is
+  // deferred one frame so a just-completed add-in turn's confirmation card can
+  // register and hold the drain.
+  const [isDrainArmed, setIsDrainArmed] = useState(false);
+  // Depth-1 overwrite guard: a message is already queued and the user is trying
+  // to queue another. We ask for confirmation (data-loss safety) before
+  // replacing, rather than silently clobbering the earlier draft.
+  const [queueReplacePending, setQueueReplacePending] = useState(false);
+  const hasPendingConfirmation = useHasPendingConfirmation(chatId);
+
+  // Enter-while-a-turn-is-generating queues the draft instead of sending.
+  // Gated on isPendingResponse specifically (a turn is in flight) — not the
+  // broader send lock, which also covers the initial history load that produces
+  // no completion edge to drain on. Returns true when it consumed the event.
+  const enqueueCurrentMessage = useCallback((): boolean => {
+    if (mode !== "compose" || !isPendingResponse || isAnyTokenLimitExceeded) {
+      return false;
+    }
+    // Leave the audio/dictation auto-send flows untouched.
+    if (
+      isDictating ||
+      isDictationStarting ||
+      isDictationCompleting ||
+      isCapturingAudio
+    ) {
+      return false;
+    }
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage && attachedFiles.length === 0) {
+      return false;
+    }
+    // Depth-1: a message is already queued — confirm before overwriting it
+    // (data-loss safety) rather than silently replacing. Both Enter and the
+    // Send/Queue button reach this choke point, so the guard covers both.
+    if (getQueuedBySessionId(composeSessionId)) {
+      setQueueReplacePending(true);
+      return true;
+    }
+    setQueuedBySessionId(composeSessionId, {
+      message: trimmedMessage,
+      attachedFiles,
+    });
+    setMessage("");
+    handleRemoveAllFiles();
+    return true;
+  }, [
+    mode,
+    isPendingResponse,
+    isAnyTokenLimitExceeded,
+    isDictating,
+    isDictationStarting,
+    isDictationCompleting,
+    isCapturingAudio,
+    message,
+    attachedFiles,
+    getQueuedBySessionId,
+    setQueuedBySessionId,
+    composeSessionId,
+    handleRemoveAllFiles,
+  ]);
+
+  // Confirmed overwrite: replace the queued message with the current composer
+  // draft and clear the composer.
+  const commitQueueReplace = useCallback(() => {
+    const trimmedMessage = message.trim();
+    if (trimmedMessage || attachedFiles.length > 0) {
+      setQueuedBySessionId(composeSessionId, {
+        message: trimmedMessage,
+        attachedFiles,
+      });
+      setMessage("");
+      handleRemoveAllFiles();
+    }
+    setQueueReplacePending(false);
+  }, [
+    message,
+    attachedFiles,
+    setQueuedBySessionId,
+    composeSessionId,
+    handleRemoveAllFiles,
+  ]);
+
+  // Return a queued payload to the composer (chip click-to-edit, abort, error),
+  // merging with whatever the user has typed since so nothing is lost.
+  const restoreQueuedToComposer = useCallback(
+    (queued: ComposeDraftState) => {
+      const merged = mergeComposeDrafts(queued, { message, attachedFiles });
+      setMessage(merged.message);
+      setAttachedFiles(merged.attachedFiles.slice(0, maxFiles));
+      clearQueuedBySessionId(composeSessionId);
+      setIsDrainArmed(false);
+      setQueueReplacePending(false);
+    },
+    [
+      message,
+      attachedFiles,
+      maxFiles,
+      setAttachedFiles,
+      clearQueuedBySessionId,
+      composeSessionId,
+    ],
+  );
+
+  const cancelQueuedMessage = useCallback(() => {
+    clearQueuedBySessionId(composeSessionId);
+    setIsDrainArmed(false);
+    setQueueReplacePending(false);
+  }, [clearQueuedBySessionId, composeSessionId]);
+
   const facetIdsByDefault = useMemo(() => {
     return availableFacets
       .filter((facet) => facet.default_enabled)
@@ -818,7 +983,19 @@ export const ChatInput = ({
       return;
     }
 
-    saveComposeDraftBySessionId(previousSessionId, { message, attachedFiles });
+    // Leaving a chat with a queued message drops it back to a draft on that
+    // chat (ERMAIN-470): it never auto-sends in the background and reappears in
+    // the composer when the user returns.
+    const outgoingQueued = getQueuedBySessionId(previousSessionId);
+    const outgoingDraft = outgoingQueued
+      ? mergeComposeDrafts(outgoingQueued, { message, attachedFiles })
+      : { message, attachedFiles };
+    saveComposeDraftBySessionId(previousSessionId, outgoingDraft);
+    if (outgoingQueued) {
+      clearQueuedBySessionId(previousSessionId);
+      setIsDrainArmed(false);
+      setQueueReplacePending(false);
+    }
     const incoming = getComposeDraftBySessionId(composeSessionId);
     activeComposeSessionIdRef.current = composeSessionId;
     setMessage(incoming.message);
@@ -830,6 +1007,8 @@ export const ChatInput = ({
     attachedFiles,
     getComposeDraftBySessionId,
     saveComposeDraftBySessionId,
+    getQueuedBySessionId,
+    clearQueuedBySessionId,
     setAttachedFiles,
   ]);
 
@@ -1130,11 +1309,108 @@ export const ChatInput = ({
     wasPendingResponseRef.current = isPendingResponse;
 
     if (wasPendingResponse && !isPendingResponse && mode === "compose") {
+      // The turn just ended (completed, closed, aborted, or errored — the
+      // falling edge covers them all). Arm the drain if a message is queued for
+      // this session; the drain effect decides send-vs-restore and holds while
+      // a confirmation card is pending. Abort clears the queue before this fires
+      // (Stop restores it), so an aborted turn never arms. (ERMAIN-470)
+      if (getQueuedBySessionId(composeSessionId)) {
+        setIsDrainArmed(true);
+      }
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
       });
     }
-  }, [isPendingResponse, mode]);
+  }, [isPendingResponse, mode, getQueuedBySessionId, composeSessionId]);
+
+  // Drain the queued message once its turn has fully finished (ERMAIN-470).
+  // Runs on the armed edge and whenever the hold inputs change (a confirmation
+  // card resolving, an error arriving). The send is deferred one frame so a
+  // just-completed add-in turn's confirmation card — which registers in a
+  // post-commit effect — can hold the drain before we commit to sending.
+  useEffect(() => {
+    if (!isDrainArmed) {
+      return;
+    }
+    const queued = getQueuedBySessionId(composeSessionId);
+    if (!queued) {
+      setIsDrainArmed(false);
+      return;
+    }
+    // A fresh turn started before we could drain — wait for its edge.
+    if (isPendingResponse) {
+      return;
+    }
+    // The turn failed — return the queued content to the composer, never send.
+    if (messagingError) {
+      restoreQueuedToComposer(queued);
+      return;
+    }
+    // Hold on a new chat's first turn until its real id has propagated. The
+    // confirmation registry is keyed by chatId (the add-in card only knows the
+    // real id), while the queue is keyed by composeSessionId which exists
+    // before chatId does — so draining while chatId is still null could send
+    // past a consent card about to register under the real id. chatId always
+    // becomes non-null after chat_created, so this only defers, never wedges.
+    if (!chatId) {
+      return;
+    }
+    // Hold while a tool-consent card is unresolved (add-in). This effect
+    // re-runs when the card resolves and hasPendingConfirmation flips false.
+    if (hasPendingConfirmation) {
+      return;
+    }
+    // Hold while the composer surface is busy (the add-in raises `disabled`
+    // during email drop/expansion and upload). Draining now would send ahead of
+    // attachments still being staged; the effect re-runs when `disabled` clears.
+    if (disabled) {
+      return;
+    }
+    // Defer past this commit's post-render effects (a just-completed add-in
+    // turn registers its confirmation card in one of them) before deciding.
+    const timer = setTimeout(() => {
+      // Re-check imperatively: a confirmation card may have registered in the
+      // tick we just waited out.
+      if (useConfirmationRegistryStore.getState().hasPending(chatId)) {
+        return;
+      }
+      const stillQueued = getQueuedBySessionId(composeSessionId);
+      if (!stillQueued) {
+        setIsDrainArmed(false);
+        return;
+      }
+      // Clear before sending so a re-render during the (async, in the add-in)
+      // onSendMessage can't re-drain the same payload.
+      clearQueuedBySessionId(composeSessionId);
+      setIsDrainArmed(false);
+      setQueueReplacePending(false);
+      // Model/facets are read live (not snapshotted at enqueue) so a selection
+      // the user changes while the message waits applies to the sent message.
+      onSendMessage(
+        stillQueued.message,
+        stillQueued.attachedFiles.length > 0
+          ? stillQueued.attachedFiles.map((file) => file.id)
+          : undefined,
+        selectedModel?.chat_provider_id,
+        selectedFacetIds,
+      );
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [
+    isDrainArmed,
+    isPendingResponse,
+    messagingError,
+    hasPendingConfirmation,
+    disabled,
+    getQueuedBySessionId,
+    composeSessionId,
+    chatId,
+    clearQueuedBySessionId,
+    restoreQueuedToComposer,
+    onSendMessage,
+    selectedModel,
+    selectedFacetIds,
+  ]);
 
   const uploadFiles = useCallback(
     async (files: File[]) => {
@@ -1288,6 +1564,25 @@ export const ChatInput = ({
       isDictationStarting ||
       isDictationCompleting);
 
+  // Like canSendMessage but for queuing the next message DURING a streaming
+  // turn (ERMAIN-470): valid only while a turn is in flight, gated on real
+  // content, and suppressed during any audio/dictation capture (which own their
+  // own send path) so the trailing controls never exceed Stop + one action.
+  const canQueueMessage =
+    mode === "compose" &&
+    isPendingResponse &&
+    hasComposeContent &&
+    !isAnyTokenLimitExceeded &&
+    !disabled &&
+    !isUploading &&
+    !isRecording &&
+    !hasIncompleteAudioTranscription &&
+    !isDictationCompleting &&
+    !isConversationalAudioActive &&
+    !isDictating &&
+    !isDictationStarting &&
+    !isCapturingAudio;
+
   const shouldShowAudioModeSelector =
     audioConversationalEnabled &&
     audioTranscriptionEnabled &&
@@ -1300,7 +1595,11 @@ export const ChatInput = ({
     (audioConversationalEnabled || audioTranscriptionEnabled) &&
     mode === "compose" &&
     (isAudioMode ||
-      (!hasComposeContent &&
+      // Don't offer to START an audio mode while a response streams — the
+      // trailing slot is Stop (+ Send/Queue). An already-active session keeps
+      // its own live control (render further up). (ERMAIN-470)
+      (!isPendingResponse &&
+        !hasComposeContent &&
         !isRecording &&
         !isRecordingUpload &&
         !isCapturingAudio &&
@@ -1942,6 +2241,67 @@ export const ChatInput = ({
           </Alert>
         )}
 
+        {/* Queued next message: auto-sends when the current turn finishes.
+            Geometry comes from the same message tokens as the sibling error
+            Alert / attachment preview; `data-ui` lets kits restyle it. */}
+        {queuedMessage && (
+          <div
+            className="theme-transition mb-2 flex items-center gap-2 border border-[var(--theme-border-chat-input)] bg-theme-bg-secondary text-sm"
+            style={{
+              borderRadius: "var(--theme-radius-message)",
+              padding:
+                "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
+            }}
+            data-ui="chat-input-queued-message"
+            data-testid="chat-input-queued-message"
+            role="status"
+            aria-live="polite"
+          >
+            <span className="shrink-0 text-theme-fg-muted">
+              {t`Queued — sends when response finishes`}
+            </span>
+            <button
+              type="button"
+              onClick={() => restoreQueuedToComposer(queuedMessage)}
+              className="theme-transition focus-ring-tight flex min-w-0 flex-1 items-center gap-1 text-left text-theme-fg-primary hover:underline"
+              aria-label={t`Edit queued message`}
+              title={t`Edit queued message`}
+              data-testid="chat-input-queued-message-edit"
+            >
+              <EditIcon className="size-3.5 shrink-0" />
+              <span className="truncate">
+                {queuedMessage.message.trim() ||
+                  plural(queuedMessage.attachedFiles.length, {
+                    one: "# attachment ready to send",
+                    other: "# attachments ready to send",
+                  })}
+              </span>
+            </button>
+            <Button
+              variant="icon-only"
+              size="sm"
+              icon={<CloseIcon className="size-4" />}
+              onClick={cancelQueuedMessage}
+              aria-label={t`Cancel queued message`}
+              data-testid="chat-input-queued-message-cancel"
+            />
+          </div>
+        )}
+
+        {/* Depth-1 overwrite guard: replacing a queued message is a data-loss
+            action, so confirm it (danger) rather than silently clobbering.
+            Shared across web + add-in via ModalBase. (ERMAIN-470) */}
+        <ConfirmationDialog
+          isOpen={queueReplacePending && queuedMessage !== null}
+          onClose={() => setQueueReplacePending(false)}
+          onConfirm={commitQueueReplace}
+          title={t`Replace the queued message?`}
+          message={t`Only one message can be queued. Replacing discards the message you queued earlier.`}
+          confirmButtonText={t`Replace`}
+          cancelButtonText={t`Keep queued`}
+          confirmButtonVariant="danger"
+        />
+
         <div
           className={clsx(
             "w-full",
@@ -1974,6 +2334,12 @@ export const ChatInput = ({
               onKeyDown={(e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
+                  // While a turn is generating, Enter queues the draft to
+                  // auto-send when the turn finishes (ERMAIN-470); otherwise it
+                  // submits normally.
+                  if (enqueueCurrentMessage()) {
+                    return;
+                  }
                   handleSubmit(e);
                 }
               }}
@@ -2227,6 +2593,12 @@ export const ChatInput = ({
                 !isAudioMode &&
                 !isRecording &&
                 !isRecordingUpload &&
+                // Keep the trailing controls at ≤2 (ERMAIN-470): while a
+                // response streams with composer content, the Send/Queue button
+                // takes this slot, so hide the idle dictation start — but keep
+                // the live waveform, which is its own stop control.
+                ((isCapturingAudio && isDictating) ||
+                  !(hasComposeContent && isPendingResponse)) &&
                 // Spinner until capture is live; the waveform appears only
                 // once real audio is flowing.
                 (isCapturingAudio && isDictating ? (
@@ -2236,7 +2608,6 @@ export const ChatInput = ({
                     disabled={
                       disabled ||
                       isLoading ||
-                      isPendingResponse ||
                       isUploading ||
                       isFileButtonProcessing ||
                       isAnyTokenLimitExceeded
@@ -2271,7 +2642,6 @@ export const ChatInput = ({
                     disabled={
                       disabled ||
                       isLoading ||
-                      isPendingResponse ||
                       isUploading ||
                       isFileButtonProcessing ||
                       isDictationCompleting ||
@@ -2295,15 +2665,43 @@ export const ChatInput = ({
                   />
                 ))}
               {isPendingResponse ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  icon={<StopIcon />}
-                  onClick={cancelMessage}
-                  data-testid="chat-input-stop-generation"
-                  aria-label={t`Stop`}
-                />
+                <>
+                  {/* Queue the next message while the response streams — same
+                      arrow as Send; the tooltip and the "Queued…" chip explain
+                      the deferred behavior. Routes through enqueueCurrentMessage
+                      (like Enter), NOT a submit, which handleSubmit would no-op
+                      during streaming. (ERMAIN-470) */}
+                  {canQueueMessage && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
+                      icon={<ArrowUpIcon className="size-5" />}
+                      onClick={() => enqueueCurrentMessage()}
+                      data-testid="chat-input-queue-message"
+                      aria-label={t`Queue message`}
+                      title={t`Queue — sends when the response finishes`}
+                    />
+                  )}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    icon={<StopIcon />}
+                    onClick={() => {
+                      // Stopping never auto-sends: return any queued draft to the
+                      // composer, then abort. Clearing the queue here also means
+                      // the completion edge won't arm a drain. (ERMAIN-470)
+                      const queued = getQueuedBySessionId(composeSessionId);
+                      if (queued) {
+                        restoreQueuedToComposer(queued);
+                      }
+                      cancelMessage();
+                    }}
+                    data-testid="chat-input-stop-generation"
+                    aria-label={t`Stop`}
+                  />
+                </>
               ) : showAudioModeButton ? (
                 isConversationalAudioActive ? (
                   <ChatInputAudioModeButton

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -369,6 +369,11 @@ export const ChatInput = ({
   // Add state for file button processing
   const [isFileButtonProcessing, setIsFileButtonProcessing] = useState(false);
   const pendingSelectedFacetIdsRef = useRef<string[] | null>(null);
+  // Compose session for which the user interactively chose facets. Once set,
+  // the init effect treats that selection as authoritative so a chatId /
+  // initialSelectedFacetIds change can't wipe it — notably the new-chat
+  // null->real-id rename, which keeps the same composeSessionId. (ERMAIN-466)
+  const userSelectedFacetsSessionRef = useRef<string | null>(null);
   const pendingSelectedChatProviderIdRef = useRef<string | null>(null);
   const audioTranscriptionStatusLastPollAtRef = useRef(0);
   const audioTranscriptionStatusPollIndexRef = useRef(0);
@@ -675,6 +680,7 @@ export const ChatInput = ({
         return;
       }
 
+      userSelectedFacetsSessionRef.current = composeSessionId;
       const isSelected = selectedFacetIds.includes(facetId);
       const nextSelectedFacetIds = isSelected
         ? selectedFacetIds.filter((id) => id !== facetId)
@@ -685,6 +691,7 @@ export const ChatInput = ({
     },
     [
       applySelectedFacetIds,
+      composeSessionId,
       enforceSelectedFacetIds,
       globalFacetSettings?.only_single_facet,
       selectedFacetIds,
@@ -835,8 +842,28 @@ export const ChatInput = ({
       return;
     }
 
-    const hasExplicitInitialSelection = initialSelectedFacetIds !== undefined;
     const hasPendingSelection = pendingSelectedFacetIdsRef.current !== null;
+
+    // A facet the user picked for this compose session outranks re-init: don't
+    // let a chatId / initialSelectedFacetIds change wipe it (the new-chat
+    // null->real-id rename keeps the session, so a tool chosen mid-generation
+    // survives). Genuine chat switches change the session and still re-init; an
+    // explicit imperative push always applies. (ERMAIN-466)
+    if (
+      !hasPendingSelection &&
+      !enforceSelectedFacetIds &&
+      userSelectedFacetsSessionRef.current === composeSessionId
+    ) {
+      setSelectedFacetIds((previousSelectedFacetIds) => {
+        const sanitized = sanitizeFacetSelection(previousSelectedFacetIds);
+        return areFacetIdListsEqual(previousSelectedFacetIds, sanitized)
+          ? previousSelectedFacetIds
+          : sanitized;
+      });
+      return;
+    }
+
+    const hasExplicitInitialSelection = initialSelectedFacetIds !== undefined;
     const initialSelection = hasPendingSelection
       ? pendingSelectedFacetIdsRef.current
       : hasExplicitInitialSelection
@@ -863,6 +890,8 @@ export const ChatInput = ({
   }, [
     availableFacets,
     chatId,
+    composeSessionId,
+    enforceSelectedFacetIds,
     facetIdsByDefault,
     initialSelectedFacetIds,
     onFacetSelectionChange,
@@ -1123,15 +1152,20 @@ export const ChatInput = ({
     [externalUploadFiles, handleFilesUploaded],
   );
 
+  // Split so the composer stays live during generation (ERMAIN-466): only
+  // sendLocked gates Send/Enter; composeLocked gates the draft surfaces.
+  const sendLocked = isLoading || isPendingResponse;
+  const composeLocked =
+    disabled ||
+    isUploading ||
+    isFileButtonProcessing ||
+    isRecording ||
+    isRecordingUpload;
+  const isDisabled = composeLocked || sendLocked;
+
   const handleTextareaPaste = useCallback(
     (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
-      if (
-        disabled ||
-        isLoading ||
-        isPendingResponse ||
-        isUploading ||
-        !externalUploadFiles
-      ) {
+      if (composeLocked || !externalUploadFiles) {
         return;
       }
 
@@ -1153,26 +1187,8 @@ export const ChatInput = ({
       event.preventDefault();
       void uploadFiles(imageFiles);
     },
-    [
-      disabled,
-      isLoading,
-      isPendingResponse,
-      isUploading,
-      externalUploadFiles,
-      uploadFiles,
-    ],
+    [composeLocked, externalUploadFiles, uploadFiles],
   );
-
-  // Combine disabled states
-  // Use isPendingResponse instead of isStreaming to disable immediately when send is clicked
-  const isDisabled =
-    disabled ||
-    isUploading || // From context (drag & drop)
-    isLoading ||
-    isPendingResponse || // True immediately when send is clicked
-    isFileButtonProcessing || // From button callback
-    isRecording || // Prevent edits while recording
-    isRecordingUpload; // Prevent edits while uploading recording
 
   // Collapse the file-upload button and the Tools dropdown into a single "+"
   // menu (ChatInputAddControls): on mobile, or whenever a host registers extra
@@ -1784,7 +1800,7 @@ export const ChatInput = ({
           assistantId={assistantId}
           previousMessageId={previousMessageId}
           chatProviderId={selectedModel?.chat_provider_id}
-          disabled={isDisabled}
+          disabled={composeLocked}
           onLimitExceeded={handleMessageTokenLimitExceeded}
         />
 
@@ -1872,7 +1888,7 @@ export const ChatInput = ({
             onRemoveFile={handleRemoveFileById}
             onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
             onFilePreview={onFilePreview}
-            disabled={isDisabled}
+            disabled={composeLocked}
             showFileTypes={showFileTypes}
             surfaceVariant="message"
           />
@@ -1944,7 +1960,7 @@ export const ChatInput = ({
               onRemoveFile={handleRemoveFileById}
               onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
               onFilePreview={onFilePreview}
-              disabled={isDisabled}
+              disabled={composeLocked}
               showFileTypes={showFileTypes}
             />
           )}
@@ -1969,9 +1985,7 @@ export const ChatInput = ({
                     : placeholder
               }
               rows={1}
-              disabled={
-                isLoading || isPendingResponse || disabled || isUploading
-              }
+              disabled={composeLocked}
               tabIndex={0}
               autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
               className={clsx(
@@ -2020,7 +2034,7 @@ export const ChatInput = ({
                     facets={availableFacets}
                     selectedFacetIds={selectedFacetIds}
                     onToggleFacet={toggleFacetId}
-                    disabled={isDisabled}
+                    disabled={composeLocked}
                     uploadDisabled={attachedFiles.length >= maxFiles}
                     toolsDisabled={enforceSelectedFacetIds}
                   />
@@ -2049,12 +2063,7 @@ export const ChatInput = ({
                         iconOnly
                         className="p-1"
                         disabled={
-                          attachedFiles.length >= maxFiles ||
-                          isLoading ||
-                          isPendingResponse ||
-                          disabled ||
-                          isUploading || // isUploading from context (drag & drop)
-                          isFileButtonProcessing // Add button processing state
+                          attachedFiles.length >= maxFiles || composeLocked
                         }
                       />
                     )}
@@ -2063,6 +2072,8 @@ export const ChatInput = ({
                         facets={availableFacets}
                         selectedFacetIds={selectedFacetIds}
                         onSelectionChange={(nextSelectedFacetIds) => {
+                          userSelectedFacetsSessionRef.current =
+                            composeSessionId;
                           setSelectedFacetIds(nextSelectedFacetIds);
                           onFacetSelectionChange?.(nextSelectedFacetIds);
                         }}
@@ -2073,7 +2084,7 @@ export const ChatInput = ({
                           globalFacetSettings?.show_facet_indicator_with_display_name ??
                           false
                         }
-                        disabled={isDisabled || enforceSelectedFacetIds}
+                        disabled={composeLocked || enforceSelectedFacetIds}
                       />
                     )}
                   </>

--- a/frontend/src/hooks/chat/store/__tests__/confirmationRegistryStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/confirmationRegistryStore.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useConfirmationRegistryStore } from "../confirmationRegistryStore";
+
+describe("confirmationRegistryStore", () => {
+  beforeEach(() => {
+    useConfirmationRegistryStore.setState({ pendingIdsByChatId: {} });
+  });
+
+  const store = () => useConfirmationRegistryStore.getState();
+
+  it("reports no pending confirmation by default", () => {
+    expect(store().hasPending("chat-a")).toBe(false);
+    expect(store().hasPending(null)).toBe(false);
+    expect(store().hasPending(undefined)).toBe(false);
+  });
+
+  it("holds while any card for the chat is registered and releases when all clear", () => {
+    store().registerConfirmation("chat-a", "card-1");
+    store().registerConfirmation("chat-a", "card-2");
+    expect(store().hasPending("chat-a")).toBe(true);
+
+    store().unregisterConfirmation("chat-a", "card-1");
+    expect(store().hasPending("chat-a")).toBe(true);
+
+    store().unregisterConfirmation("chat-a", "card-2");
+    expect(store().hasPending("chat-a")).toBe(false);
+  });
+
+  it("isolates pending state per chat", () => {
+    store().registerConfirmation("chat-a", "card-1");
+    expect(store().hasPending("chat-a")).toBe(true);
+    expect(store().hasPending("chat-b")).toBe(false);
+  });
+
+  it("is idempotent for repeated register/unregister", () => {
+    store().registerConfirmation("chat-a", "card-1");
+    store().registerConfirmation("chat-a", "card-1");
+    store().unregisterConfirmation("chat-a", "card-1");
+    expect(store().hasPending("chat-a")).toBe(false);
+    // Unregistering an unknown id is a no-op.
+    store().unregisterConfirmation("chat-a", "card-1");
+    expect(store().hasPending("chat-a")).toBe(false);
+  });
+});

--- a/frontend/src/hooks/chat/store/__tests__/messageQueueStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/messageQueueStore.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useMessageQueueStore } from "../messageQueueStore";
+
+describe("messageQueueStore", () => {
+  beforeEach(() => {
+    useMessageQueueStore.setState({ queuedBySessionId: {} });
+  });
+
+  const store = () => useMessageQueueStore.getState();
+
+  it("returns null for a session with nothing queued", () => {
+    expect(store().getQueued("session-a")).toBeNull();
+  });
+
+  it("stores, reads, and clears a queued message per session", () => {
+    store().setQueued("session-a", { message: "queued", attachedFiles: [] });
+    expect(store().getQueued("session-a")).toEqual({
+      message: "queued",
+      attachedFiles: [],
+    });
+
+    store().clearQueued("session-a");
+    expect(store().getQueued("session-a")).toBeNull();
+  });
+
+  it("isolates queues per session", () => {
+    store().setQueued("session-a", { message: "a", attachedFiles: [] });
+    expect(store().getQueued("session-b")).toBeNull();
+    expect(store().getQueued("session-a")?.message).toBe("a");
+  });
+});

--- a/frontend/src/hooks/chat/store/confirmationRegistryStore.ts
+++ b/frontend/src/hooks/chat/store/confirmationRegistryStore.ts
@@ -1,0 +1,91 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+/**
+ * Tracks unresolved client-action confirmation cards (the add-in's
+ * `ActionConfirmationCard`) per chat, so the message queue's auto-send drain
+ * can hold while a tool-consent question is still pending (ERMAIN-470).
+ *
+ * A card registers itself while it is in the "pending" state and deregisters
+ * once resolved (allow/deny) or when its renderer unmounts. The web surface
+ * has no confirmation cards, so nothing ever registers and every drain reads
+ * `hasPending === false`.
+ *
+ * The hold is best-effort: a card whose renderer is unmounted (e.g. scrolled
+ * out of a virtualized message list) deregisters, so it can't wedge the queue.
+ */
+interface ConfirmationRegistryStore {
+  // chatId -> registration ids of currently-pending confirmation cards.
+  pendingIdsByChatId: Partial<Record<string, string[]>>;
+  registerConfirmation: (chatId: string, registrationId: string) => void;
+  unregisterConfirmation: (chatId: string, registrationId: string) => void;
+  hasPending: (chatId: string | null | undefined) => boolean;
+}
+
+const hasPendingIn = (
+  pendingIdsByChatId: Partial<Record<string, string[]>>,
+  chatId: string | null | undefined,
+): boolean =>
+  chatId ? (pendingIdsByChatId[chatId]?.length ?? 0) > 0 : false;
+
+export const useConfirmationRegistryStore = create<ConfirmationRegistryStore>()(
+  devtools(
+    (set, get) => ({
+      pendingIdsByChatId: {},
+      registerConfirmation: (chatId, registrationId) =>
+        set(
+          (prev) => {
+            const existing = prev.pendingIdsByChatId[chatId] ?? [];
+            if (existing.includes(registrationId)) {
+              return prev;
+            }
+            return {
+              pendingIdsByChatId: {
+                ...prev.pendingIdsByChatId,
+                [chatId]: [...existing, registrationId],
+              },
+            };
+          },
+          false,
+          "confirmationRegistry/registerConfirmation",
+        ),
+      unregisterConfirmation: (chatId, registrationId) =>
+        set(
+          (prev) => {
+            const existing = prev.pendingIdsByChatId[chatId];
+            if (!existing?.includes(registrationId)) {
+              return prev;
+            }
+            const next = existing.filter((id) => id !== registrationId);
+            const nextByChatId = { ...prev.pendingIdsByChatId };
+            if (next.length === 0) {
+              delete nextByChatId[chatId];
+            } else {
+              nextByChatId[chatId] = next;
+            }
+            return { pendingIdsByChatId: nextByChatId };
+          },
+          false,
+          "confirmationRegistry/unregisterConfirmation",
+        ),
+      hasPending: (chatId) => hasPendingIn(get().pendingIdsByChatId, chatId),
+    }),
+    {
+      name: "Confirmation Registry Store",
+      store: "confirmation-registry-store",
+      enabled: process.env.NODE_ENV === "development",
+    },
+  ),
+);
+
+/**
+ * Reactive read of whether `chatId` has any unresolved confirmation card.
+ * Returns a boolean, so the default `Object.is` equality keeps re-renders
+ * limited to genuine true<->false flips.
+ */
+export const useHasPendingConfirmation = (
+  chatId: string | null | undefined,
+): boolean =>
+  useConfirmationRegistryStore((state) =>
+    hasPendingIn(state.pendingIdsByChatId, chatId),
+  );

--- a/frontend/src/hooks/chat/store/confirmationRegistryStore.ts
+++ b/frontend/src/hooks/chat/store/confirmationRegistryStore.ts
@@ -25,8 +25,7 @@ interface ConfirmationRegistryStore {
 const hasPendingIn = (
   pendingIdsByChatId: Partial<Record<string, string[]>>,
   chatId: string | null | undefined,
-): boolean =>
-  chatId ? (pendingIdsByChatId[chatId]?.length ?? 0) > 0 : false;
+): boolean => (chatId ? (pendingIdsByChatId[chatId]?.length ?? 0) > 0 : false);
 
 export const useConfirmationRegistryStore = create<ConfirmationRegistryStore>()(
   devtools(

--- a/frontend/src/hooks/chat/store/messageQueueStore.ts
+++ b/frontend/src/hooks/chat/store/messageQueueStore.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+import type { ComposeDraftState } from "@/hooks/chat/useComposeSession";
+
+/**
+ * The depth-1 "send when the current turn finishes" queue (ERMAIN-470), keyed
+ * by the stable `composeSessionId` from useComposeSession so it survives the
+ * new-chat null->real-id rename and stays isolated per chat. A reactive store
+ * (rather than a ref map) so the composer chip and the drain re-render off it
+ * directly — no manual invalidation token.
+ */
+interface MessageQueueStore {
+  queuedBySessionId: Partial<Record<string, ComposeDraftState>>;
+  setQueued: (sessionId: string, queued: ComposeDraftState) => void;
+  clearQueued: (sessionId: string) => void;
+  getQueued: (sessionId: string) => ComposeDraftState | null;
+}
+
+const readQueued = (
+  queuedBySessionId: Partial<Record<string, ComposeDraftState>>,
+  sessionId: string,
+): ComposeDraftState | null => queuedBySessionId[sessionId] ?? null;
+
+export const useMessageQueueStore = create<MessageQueueStore>()(
+  devtools(
+    (set, get) => ({
+      queuedBySessionId: {},
+      setQueued: (sessionId, queued) =>
+        set(
+          (prev) => ({
+            queuedBySessionId: {
+              ...prev.queuedBySessionId,
+              [sessionId]: queued,
+            },
+          }),
+          false,
+          "messageQueue/setQueued",
+        ),
+      clearQueued: (sessionId) =>
+        set(
+          (prev) => {
+            if (!prev.queuedBySessionId[sessionId]) {
+              return prev;
+            }
+            const next = { ...prev.queuedBySessionId };
+            delete next[sessionId];
+            return { queuedBySessionId: next };
+          },
+          false,
+          "messageQueue/clearQueued",
+        ),
+      getQueued: (sessionId) => readQueued(get().queuedBySessionId, sessionId),
+    }),
+    {
+      name: "Message Queue Store",
+      store: "message-queue-store",
+      enabled: process.env.NODE_ENV === "development",
+    },
+  ),
+);
+
+/** Reactive read of the message queued for `sessionId`, or null. */
+export const useQueuedMessage = (
+  sessionId: string,
+): ComposeDraftState | null =>
+  useMessageQueueStore((state) => readQueued(state.queuedBySessionId, sessionId));

--- a/frontend/src/hooks/chat/store/messageQueueStore.ts
+++ b/frontend/src/hooks/chat/store/messageQueueStore.ts
@@ -61,7 +61,7 @@ export const useMessageQueueStore = create<MessageQueueStore>()(
 );
 
 /** Reactive read of the message queued for `sessionId`, or null. */
-export const useQueuedMessage = (
-  sessionId: string,
-): ComposeDraftState | null =>
-  useMessageQueueStore((state) => readQueued(state.queuedBySessionId, sessionId));
+export const useQueuedMessage = (sessionId: string): ComposeDraftState | null =>
+  useMessageQueueStore((state) =>
+    readQueued(state.queuedBySessionId, sessionId),
+  );

--- a/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
+++ b/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
@@ -2,6 +2,10 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import {
+  NEW_CHAT_STREAM_KEY,
+  useMessagingStore,
+} from "@/hooks/chat/store/messagingStore";
+import {
   useUploadFile,
   useCreateChat,
   fetchUploadFile,
@@ -83,9 +87,16 @@ describe("useFileDropzone", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Reset the Zustand store
+    // Reset the Zustand stores
     act(() => {
       useFileUploadStore.getState().reset();
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: false,
+        newlyCreatedChatId: null,
+        streamingByKey: {},
+        streamKeyAliases: {},
+        activeStreamKey: NEW_CHAT_STREAM_KEY,
+      });
     });
 
     // Setup fetchUploadFile mock using vi.mocked
@@ -329,5 +340,104 @@ describe("useFileDropzone", () => {
 
     // API should not be called
     expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("routes a first-turn upload to the streaming chat instead of orphaning it", async () => {
+    act(() => {
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: true,
+        newlyCreatedChatId: "streaming-chat-id",
+      });
+    });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFiles([testFile]);
+    });
+
+    expect(mockCreateChatMutateAsync).not.toHaveBeenCalled();
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "streaming-chat-id" },
+      }),
+    );
+    expect(useFileUploadStore.getState().silentChatId).toBeNull();
+  });
+
+  it("waits for chat_created before uploading a first-turn file", async () => {
+    act(() => {
+      useMessagingStore.setState({
+        isAwaitingFirstStreamChunkForNewChat: true,
+        newlyCreatedChatId: null,
+      });
+    });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      const uploadPromise = result.current.uploadFiles([testFile]);
+      // chat_created lands just after the file is attached.
+      useMessagingStore.getState().setNewlyCreatedChatIdInStore("late-chat-id");
+      await uploadPromise;
+    });
+
+    expect(mockCreateChatMutateAsync).not.toHaveBeenCalled();
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "late-chat-id" },
+      }),
+    );
+  });
+
+  it("creates a silent chat for a fresh compose with no streaming first turn", async () => {
+    mockCreateChatMutateAsync.mockResolvedValue({ chat_id: "silent-chat-id" });
+
+    const mockFetchUploadFile = vi.mocked(fetchUploadFile);
+    mockFetchUploadFile.mockResolvedValue({
+      files: [createMockUploadedFile("file1", "test1.pdf")],
+    });
+
+    const { result } = renderHook(() =>
+      useFileDropzone({ chatId: null, multiple: true }),
+    );
+
+    const testFile = new File(["test content"], "test1.pdf", {
+      type: "application/pdf",
+    });
+
+    await act(async () => {
+      await result.current.uploadFiles([testFile]);
+    });
+
+    expect(mockCreateChatMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchUploadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryParams: { chat_id: "silent-chat-id" },
+      }),
+    );
+    expect(useFileUploadStore.getState().silentChatId).toBe("silent-chat-id");
   });
 });

--- a/frontend/src/hooks/files/useFileDropzone.ts
+++ b/frontend/src/hooks/files/useFileDropzone.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useRef } from "react";
 import { useDropzone } from "react-dropzone";
 
 import {
+  NEW_CHAT_STREAM_KEY,
+  useMessagingStore,
+} from "@/hooks/chat/store/messagingStore";
+import {
   useCreateChat,
   fetchUploadFile,
   type UploadFileVariables,
@@ -29,6 +33,56 @@ import type { FileType } from "@/utils/fileTypes";
 import type { FileRejection } from "react-dropzone";
 
 const logger = createLogger("HOOK", "useFileDropzone");
+
+const FIRST_TURN_CHAT_ID_TIMEOUT_MS = 4000;
+
+/**
+ * The chat id of a brand-new chat's in-flight first turn, or null for a genuine
+ * fresh compose. Attaching a file mid-first-turn has a null committed `chatId`,
+ * so without this the upload would spawn a second, orphaned chat (ERMAIN-466).
+ * `newlyCreatedChatId` is reset on new-chat/navigation, so it never leaks a
+ * stale id into a fresh compose.
+ */
+async function resolveInFlightNewChatId(): Promise<string | null> {
+  const store = useMessagingStore.getState();
+
+  // Set for attach-then-send (its silent-chat id) and send-first once
+  // `chat_created` lands.
+  if (store.newlyCreatedChatId) {
+    return store.newlyCreatedChatId;
+  }
+
+  // Send-first before `chat_created`: real id not reported yet. A fresh compose
+  // has neither signal, so bail and let the caller create a silent chat.
+  const firstTurnInFlight =
+    store.getStreaming(NEW_CHAT_STREAM_KEY).currentMessageId !== null ||
+    store.isAwaitingFirstStreamChunkForNewChat;
+  if (!firstTurnInFlight) {
+    return null;
+  }
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutId);
+      unsubscribe();
+      resolve(value);
+    };
+    const timeoutId = setTimeout(
+      () => finish(null),
+      FIRST_TURN_CHAT_ID_TIMEOUT_MS,
+    );
+    const unsubscribe = useMessagingStore.subscribe((state) => {
+      if (state.newlyCreatedChatId) {
+        finish(state.newlyCreatedChatId);
+      }
+    });
+  });
+}
 
 interface UseFileDropzoneProps {
   /** Array of accepted file types */
@@ -191,10 +245,10 @@ export function useFileDropzone({
 
         const filesToUpload = files.slice(0, multiple ? maxFiles : 1);
 
-        // Determine which chat ID to use for the upload
         let uploadChatId = chatId;
+        uploadChatId ??= await resolveInFlightNewChatId();
 
-        // If no chatId exists, create one silently first
+        // No chat yet — create one silently.
         if (!uploadChatId) {
           logger.log("Creating silent chat for file uploads");
           const createChatResult = await createChatMutation.mutateAsync({

--- a/frontend/src/hooks/files/useFileUploadStore.ts
+++ b/frontend/src/hooks/files/useFileUploadStore.ts
@@ -2,6 +2,8 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
+import { mergeUniqueFilesById } from "@/utils/file/mergeUniqueFilesById";
+
 import type { UploadError } from "./errors";
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
@@ -60,23 +62,6 @@ const initialState = {
   error: null,
   silentChatId: null,
 };
-
-function mergeUniqueFilesById(
-  existingFiles: FileUploadItem[],
-  newFiles: FileUploadItem[],
-) {
-  const seenFileIds = new Set(existingFiles.map((file) => file.id));
-  const uniqueNewFiles = newFiles.filter((file) => {
-    if (seenFileIds.has(file.id)) {
-      return false;
-    }
-
-    seenFileIds.add(file.id);
-    return true;
-  });
-
-  return [...existingFiles, ...uniqueNewFiles];
-}
 
 /**
  * Zustand store for file uploads

--- a/frontend/src/hooks/ui/useChatInputHandlers.ts
+++ b/frontend/src/hooks/ui/useChatInputHandlers.ts
@@ -7,28 +7,12 @@
 import { useState, useCallback } from "react";
 
 import { createLogger } from "@/utils/debugLogger";
+import { mergeUniqueFilesById } from "@/utils/file/mergeUniqueFilesById";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { FormEvent } from "react";
 
 const logger = createLogger("HOOK", "useChatInputHandlers");
-
-function mergeUniqueFilesById(
-  existingFiles: FileUploadItem[],
-  newFiles: FileUploadItem[],
-) {
-  const seenFileIds = new Set(existingFiles.map((file) => file.id));
-  const uniqueNewFiles = newFiles.filter((file) => {
-    if (seenFileIds.has(file.id)) {
-      return false;
-    }
-
-    seenFileIds.add(file.id);
-    return true;
-  });
-
-  return [...existingFiles, ...uniqueNewFiles];
-}
 
 function isAudioTranscriptionAttachment(file: FileUploadItem): boolean {
   return Boolean(file.audio_transcription);

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -182,6 +182,10 @@ export {
 } from "@/hooks/ui";
 export { useMessageFeedback } from "@/hooks/chat/useMessageFeedback";
 export { useMessagingStore } from "@/hooks/chat/store/messagingStore";
+export {
+  useConfirmationRegistryStore,
+  useHasPendingConfirmation,
+} from "@/hooks/chat/store/confirmationRegistryStore";
 export { useProfile } from "@/hooks/useProfile";
 export {
   usePersistedState,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2931,6 +2931,11 @@ msgstr ""
 msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
 msgstr "{0, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
 
+#. placeholder {0}: queuedMessage.attachedFiles.length
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+msgstr "{0, plural, one {# Anhang bereit zum Senden} other {# Anhänge bereit zum Senden}}"
+
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #~ msgid "{0} items"
 #~ msgstr ""
@@ -3050,6 +3055,10 @@ msgstr "Datei anhängen"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "attachment"
 msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+#~ msgid "Attachment ready to send"
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -3201,6 +3210,10 @@ msgstr "Abbrechen"
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel action"
 msgstr "Aktion abbrechen"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Cancel queued message"
+msgstr "Wartende Nachricht abbrechen"
 
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Cancel starting dictation"
@@ -3504,6 +3517,10 @@ msgid "Edit Assistant Settings"
 msgstr "Assistenten-Einstellungen bearbeiten"
 
 #: src/components/ui/Chat/ChatInput.tsx
+msgid "Edit queued message"
+msgstr "Wartende Nachricht bearbeiten"
+
+#: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit your message..."
 msgstr "Bearbeiten Sie Ihre Nachricht..."
 
@@ -3655,6 +3672,10 @@ msgstr "Nachricht einbeziehen"
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
 msgstr "Ungültiges Datum für MessageTimestamp bereitgestellt, aktuelles Datum wird verwendet"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Keep queued"
+msgstr "In Warteschlange behalten"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Largest file context contributors:"
@@ -3824,6 +3845,10 @@ msgstr "Rauschunterdrückung: {noiseSuppression}"
 msgid "of"
 msgstr "von"
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Only one message can be queued. Replacing discards the message you queued earlier."
+msgstr "Es kann nur eine Nachricht in die Warteschlange gestellt werden. Beim Ersetzen wird die zuvor eingereihte Nachricht verworfen."
+
 #: src/components/ui/Controls/DropdownMenu.tsx
 msgid "Open menu"
 msgstr "Menü öffnen"
@@ -3874,6 +3899,18 @@ msgstr "Vorschau:"
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Progress: {0}%"
 #~ msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue — sends when the response finishes"
+msgstr "In Warteschlange – wird nach der Antwort gesendet"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue message"
+msgstr "Nachricht in Warteschlange stellen"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queued — sends when response finishes"
+msgstr "In Warteschlange – wird nach der Antwort gesendet"
 
 #: src/components/ui/Message/MessageContent.tsx
 #~ msgid "Reasoning"
@@ -3941,6 +3978,14 @@ msgstr "Alle Dateien entfernen"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Removing this audio attachment will also clear its transcription. Continue?"
 msgstr "Wenn dieser Audioanhang entfernt wird, wird auch seine Transkription gelöscht. Fortfahren?"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace"
+msgstr "Ersetzen"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace the queued message?"
+msgstr "Wartende Nachricht ersetzen?"
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx
 msgid "Reset to Browser Detection"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2931,6 +2931,11 @@ msgstr "(no body)"
 msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
 msgstr "{0, plural, =0 {No files} one {# file} other {# files}}"
 
+#. placeholder {0}: queuedMessage.attachedFiles.length
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+msgstr "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #~ msgid "{0} items"
 #~ msgstr "{0} items"
@@ -3050,6 +3055,10 @@ msgstr "Attach File"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "attachment"
 msgstr "attachment"
+
+#: src/components/ui/Chat/ChatInput.tsx
+#~ msgid "Attachment ready to send"
+#~ msgstr "Attachment ready to send"
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -3201,6 +3210,10 @@ msgstr "Cancel"
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel action"
 msgstr "Cancel action"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Cancel queued message"
+msgstr "Cancel queued message"
 
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Cancel starting dictation"
@@ -3504,6 +3517,10 @@ msgid "Edit Assistant Settings"
 msgstr "Edit Assistant Settings"
 
 #: src/components/ui/Chat/ChatInput.tsx
+msgid "Edit queued message"
+msgstr "Edit queued message"
+
+#: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit your message..."
 msgstr "Edit your message..."
 
@@ -3655,6 +3672,10 @@ msgstr "Include message"
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
 msgstr "Invalid date provided to MessageTimestamp, using current date"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Keep queued"
+msgstr "Keep queued"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Largest file context contributors:"
@@ -3824,6 +3845,10 @@ msgstr "noise suppression: {noiseSuppression}"
 msgid "of"
 msgstr "of"
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Only one message can be queued. Replacing discards the message you queued earlier."
+msgstr "Only one message can be queued. Replacing discards the message you queued earlier."
+
 #: src/components/ui/Controls/DropdownMenu.tsx
 msgid "Open menu"
 msgstr "Open menu"
@@ -3874,6 +3899,18 @@ msgstr "Preview:"
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Progress: {0}%"
 #~ msgstr "Progress: {0}%"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue — sends when the response finishes"
+msgstr "Queue — sends when the response finishes"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue message"
+msgstr "Queue message"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queued — sends when response finishes"
+msgstr "Queued — sends when response finishes"
 
 #: src/components/ui/Message/MessageContent.tsx
 #~ msgid "Reasoning"
@@ -3941,6 +3978,14 @@ msgstr "Remove all files"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Removing this audio attachment will also clear its transcription. Continue?"
 msgstr "Removing this audio attachment will also clear its transcription. Continue?"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace"
+msgstr "Replace"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace the queued message?"
+msgstr "Replace the queued message?"
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx
 msgid "Reset to Browser Detection"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2931,6 +2931,11 @@ msgstr ""
 msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
 msgstr "{0, plural, =0 {Sin archivos} one {# archivo} other {# archivos}}"
 
+#. placeholder {0}: queuedMessage.attachedFiles.length
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+msgstr ""
+
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #~ msgid "{0} items"
 #~ msgstr ""
@@ -3050,6 +3055,10 @@ msgstr "Adjuntar archivo"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "attachment"
 msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+#~ msgid "Attachment ready to send"
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -3201,6 +3210,10 @@ msgstr "Cancelar"
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel action"
 msgstr "Cancelar acción"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Cancel queued message"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Cancel starting dictation"
@@ -3504,6 +3517,10 @@ msgid "Edit Assistant Settings"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
+msgid "Edit queued message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit your message..."
 msgstr ""
 
@@ -3655,6 +3672,10 @@ msgstr "Incluir mensaje"
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
 msgstr "Fecha inválida proporcionada a MessageTimestamp, usando fecha actual"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Keep queued"
+msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Largest file context contributors:"
@@ -3824,6 +3845,10 @@ msgstr "supresión de ruido: {noiseSuppression}"
 msgid "of"
 msgstr "de"
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Only one message can be queued. Replacing discards the message you queued earlier."
+msgstr ""
+
 #: src/components/ui/Controls/DropdownMenu.tsx
 msgid "Open menu"
 msgstr "Abrir menú"
@@ -3874,6 +3899,18 @@ msgstr "Vista previa:"
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Progress: {0}%"
 #~ msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue — sends when the response finishes"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queued — sends when response finishes"
+msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
 #~ msgid "Reasoning"
@@ -3941,6 +3978,14 @@ msgstr "Eliminar todos los archivos"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Removing this audio attachment will also clear its transcription. Continue?"
 msgstr "Eliminar este adjunto de audio también borrará su transcripción. ¿Continuar?"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace the queued message?"
+msgstr ""
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx
 msgid "Reset to Browser Detection"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2931,6 +2931,11 @@ msgstr ""
 msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
 msgstr "{0, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
 
+#. placeholder {0}: queuedMessage.attachedFiles.length
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+msgstr ""
+
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #~ msgid "{0} items"
 #~ msgstr ""
@@ -3050,6 +3055,10 @@ msgstr "Joindre un fichier"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "attachment"
 msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+#~ msgid "Attachment ready to send"
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -3201,6 +3210,10 @@ msgstr "Annuler"
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel action"
 msgstr "Annuler l'action"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Cancel queued message"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Cancel starting dictation"
@@ -3504,6 +3517,10 @@ msgid "Edit Assistant Settings"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
+msgid "Edit queued message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit your message..."
 msgstr ""
 
@@ -3655,6 +3672,10 @@ msgstr "Inclure le message"
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
 msgstr "Date invalide fournie à MessageTimestamp, utilisation de la date actuelle"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Keep queued"
+msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Largest file context contributors:"
@@ -3824,6 +3845,10 @@ msgstr "réduction du bruit : {noiseSuppression}"
 msgid "of"
 msgstr "sur"
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Only one message can be queued. Replacing discards the message you queued earlier."
+msgstr ""
+
 #: src/components/ui/Controls/DropdownMenu.tsx
 msgid "Open menu"
 msgstr "Ouvrir le menu"
@@ -3874,6 +3899,18 @@ msgstr "Aperçu :"
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Progress: {0}%"
 #~ msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue — sends when the response finishes"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queued — sends when response finishes"
+msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
 #~ msgid "Reasoning"
@@ -3941,6 +3978,14 @@ msgstr "Supprimer tous les fichiers"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Removing this audio attachment will also clear its transcription. Continue?"
 msgstr "Supprimer cette pièce jointe audio effacera aussi sa transcription. Continuer ?"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace the queued message?"
+msgstr ""
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx
 msgid "Reset to Browser Detection"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2931,6 +2931,11 @@ msgstr ""
 msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
 msgstr "{0, plural, =0 {Brak plików} one {# plik} few {# pliki} other {# plików}}"
 
+#. placeholder {0}: queuedMessage.attachedFiles.length
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "{0, plural, one {# attachment ready to send} other {# attachments ready to send}}"
+msgstr ""
+
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #~ msgid "{0} items"
 #~ msgstr ""
@@ -3050,6 +3055,10 @@ msgstr "Dołącz plik"
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "attachment"
 msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+#~ msgid "Attachment ready to send"
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -3201,6 +3210,10 @@ msgstr "Anuluj"
 #: src/components/ui/Modal/ConfirmationDialog.tsx
 msgid "Cancel action"
 msgstr "Anuluj akcję"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Cancel queued message"
+msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Cancel starting dictation"
@@ -3504,6 +3517,10 @@ msgid "Edit Assistant Settings"
 msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
+msgid "Edit queued message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit your message..."
 msgstr ""
 
@@ -3655,6 +3672,10 @@ msgstr "Uwzględnij wiadomość"
 #: src/components/ui/Message/MessageTimestamp.tsx
 msgid "Invalid date provided to MessageTimestamp, using current date"
 msgstr "Podano nieprawidłową datę do MessageTimestamp, używam bieżącej daty"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Keep queued"
+msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Largest file context contributors:"
@@ -3824,6 +3845,10 @@ msgstr "redukcja szumów: {noiseSuppression}"
 msgid "of"
 msgstr "z"
 
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Only one message can be queued. Replacing discards the message you queued earlier."
+msgstr ""
+
 #: src/components/ui/Controls/DropdownMenu.tsx
 msgid "Open menu"
 msgstr "Otwórz menu"
@@ -3874,6 +3899,18 @@ msgstr "Podgląd:"
 #: src/components/ui/Chat/ChatInput.tsx
 #~ msgid "Progress: {0}%"
 #~ msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue — sends when the response finishes"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queue message"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Queued — sends when response finishes"
+msgstr ""
 
 #: src/components/ui/Message/MessageContent.tsx
 #~ msgid "Reasoning"
@@ -3941,6 +3978,14 @@ msgstr "Usuń wszystkie pliki"
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Removing this audio attachment will also clear its transcription. Continue?"
 msgstr "Usunięcie tego załącznika audio usunie również jego transkrypcję. Kontynuować?"
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace"
+msgstr ""
+
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "Replace the queued message?"
+msgstr ""
 
 #: src/components/ui/Settings/LocaleDetectionTest.tsx
 msgid "Reset to Browser Detection"

--- a/frontend/src/utils/file/mergeUniqueFilesById.ts
+++ b/frontend/src/utils/file/mergeUniqueFilesById.ts
@@ -1,0 +1,23 @@
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+/**
+ * Append `newFiles` to `existingFiles`, dropping any whose id already appears
+ * (first occurrence wins). Shared by the composer, the file-upload store, and
+ * the assistant form so attaching the same upload twice is a no-op.
+ */
+export function mergeUniqueFilesById(
+  existingFiles: FileUploadItem[],
+  newFiles: FileUploadItem[],
+): FileUploadItem[] {
+  const seenFileIds = new Set(existingFiles.map((file) => file.id));
+  const uniqueNewFiles = newFiles.filter((file) => {
+    if (seenFileIds.has(file.id)) {
+      return false;
+    }
+
+    seenFileIds.add(file.id);
+    return true;
+  });
+
+  return [...existingFiles, ...uniqueNewFiles];
+}

--- a/office-addin/src/components/__tests__/OutlookEratoAppointmentRenderer.test.tsx
+++ b/office-addin/src/components/__tests__/OutlookEratoAppointmentRenderer.test.tsx
@@ -68,6 +68,16 @@ vi.mock("@erato/frontend/library", () => ({
   useChatContext: () => mockUseChatContext(),
   useOutlookArtifact: () => mockUseOutlookArtifact(),
   usePersistedState: () => mockUsePersistedState(),
+  useConfirmationRegistryStore: (
+    selector: (state: {
+      registerConfirmation: () => void;
+      unregisterConfirmation: () => void;
+    }) => unknown,
+  ) =>
+    selector({
+      registerConfirmation: () => {},
+      unregisterConfirmation: () => {},
+    }),
 }));
 
 vi.mock("../../providers/OutlookMailItemProvider", () => ({

--- a/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
+++ b/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
@@ -387,7 +387,8 @@ describe("OutlookEratoEmailRenderer — confirmation-card item snapshot", () => 
       "chat-1",
       expect.any(String),
     );
-    const registrationId = mockRegisterConfirmation.mock.calls[0]?.[1] as string;
+    const registrationId = mockRegisterConfirmation.mock
+      .calls[0]?.[1] as string;
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "deny" }));

--- a/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
+++ b/office-addin/src/components/__tests__/OutlookEratoEmailRenderer.test.tsx
@@ -21,6 +21,8 @@ const mockUsePersistedState = vi.fn();
 const mockOpenReplyForm = vi.fn();
 const mockGetReadModeRecipientSummary = vi.fn();
 const mockCopyEmailToClipboard = vi.fn();
+const mockRegisterConfirmation = vi.fn();
+const mockUnregisterConfirmation = vi.fn();
 
 vi.mock("@erato/frontend/library", () => ({
   // Mirrors the real card's lifecycle contract: decision buttons only while
@@ -71,6 +73,16 @@ vi.mock("@erato/frontend/library", () => ({
   useChatContext: () => mockUseChatContext(),
   useOutlookArtifact: () => mockUseOutlookArtifact(),
   usePersistedState: () => mockUsePersistedState(),
+  useConfirmationRegistryStore: (
+    selector: (state: {
+      registerConfirmation: (chatId: string, id: string) => void;
+      unregisterConfirmation: (chatId: string, id: string) => void;
+    }) => unknown,
+  ) =>
+    selector({
+      registerConfirmation: mockRegisterConfirmation,
+      unregisterConfirmation: mockUnregisterConfirmation,
+    }),
 }));
 
 vi.mock("../../providers/OutlookMailItemProvider", () => ({
@@ -131,6 +143,7 @@ function prime(options: {
     itemIdentity: options.currentItemIdentity,
   });
   mockUseChatContext.mockReturnValue({
+    currentChatId: "chat-1",
     messages: {
       [options.artifact.messageId]: {
         id: options.artifact.messageId,
@@ -360,6 +373,30 @@ describe("OutlookEratoEmailRenderer — confirmation-card item snapshot", () => 
     });
 
     expect(mockOpenReplyForm).toHaveBeenCalledWith(REPLY, "Draft body", false);
+  });
+
+  // The add-in half of the ERMAIN-470 message-queue hold: a pending card
+  // registers into the shared confirmation registry (keyed by chat) and
+  // deregisters when resolved, so the composer's auto-send drain waits.
+  it("registers the pending confirmation and deregisters it on resolve", async () => {
+    primeAutoCard();
+    render(<OutlookEratoEmailRenderer content="Draft body" isHtml={false} />);
+
+    expect(screen.getByTestId("confirmation-card")).toBeInTheDocument();
+    expect(mockRegisterConfirmation).toHaveBeenCalledWith(
+      "chat-1",
+      expect.any(String),
+    );
+    const registrationId = mockRegisterConfirmation.mock.calls[0]?.[1] as string;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "deny" }));
+    });
+
+    expect(mockUnregisterConfirmation).toHaveBeenCalledWith(
+      "chat-1",
+      registrationId,
+    );
   });
 });
 

--- a/office-addin/src/hooks/useClientActionConfirmFlow.ts
+++ b/office-addin/src/hooks/useClientActionConfirmFlow.ts
@@ -1,4 +1,7 @@
-import { useChatContext } from "@erato/frontend/library";
+import {
+  useChatContext,
+  useConfirmationRegistryStore,
+} from "@erato/frontend/library";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { resolveAutoPromptBehavior } from "../utils/clientActionPolicy";
@@ -154,7 +157,34 @@ export function useClientActionConfirmFlow<
   // form, "ask" surfaces the inline confirmation card). If the summary can't
   // be snapshotted, requestConfirmation returns false and nothing happens —
   // the buttons remain as fallback.
-  const { messages, messageOrder } = useChatContext();
+  const { messages, messageOrder, currentChatId } = useChatContext();
+
+  // Publish this card's pending state to the shared registry so the chat
+  // composer's message queue holds its auto-send while a tool-consent card is
+  // unresolved (ERMAIN-470). Keyed by chatId — the same value ChatInput reads —
+  // with a per-instance id so multiple fences each hold independently.
+  const isConfirmPending = confirmCard !== null;
+  const [registrationId] = useState(() => globalThis.crypto.randomUUID());
+  const registerConfirmation = useConfirmationRegistryStore(
+    (state) => state.registerConfirmation,
+  );
+  const unregisterConfirmation = useConfirmationRegistryStore(
+    (state) => state.unregisterConfirmation,
+  );
+  useEffect(() => {
+    if (!currentChatId || !isConfirmPending) {
+      return;
+    }
+    registerConfirmation(currentChatId, registrationId);
+    return () => unregisterConfirmation(currentChatId, registrationId);
+  }, [
+    currentChatId,
+    isConfirmPending,
+    registrationId,
+    registerConfirmation,
+    unregisterConfirmation,
+  ]);
+
   const isLatestAssistantMessage = useMemo(() => {
     if (!args.messageId) {
       return false;
@@ -213,7 +243,7 @@ export function useClientActionConfirmFlow<
 
   return {
     confirmCard,
-    isConfirmPending: confirmCard !== null,
+    isConfirmPending,
     requestConfirmation,
     allowCard,
     denyCard,


### PR DESCRIPTION
This pull request introduces two new Zustand stores for managing chat message queues and confirmation card state, refactors file upload logic to better handle first-turn uploads in new chats, and consolidates file merge logic into a single utility. It also adds comprehensive tests for the new stores and updates localization files for new UI strings.

**New Zustand stores and related tests:**

* Added `useMessageQueueStore` for per-session message queuing, allowing messages to be queued and sent once the current turn finishes. Includes a full test suite in `messageQueueStore.test.ts`. [[1]](diffhunk://#diff-62909ba9c636012f2d6a62388c12cb7041883a953606ef617f3f7eb5b658fad6R1-R67) [[2]](diffhunk://#diff-0180c81cdd786ef1017a3249c21699ff5a6a9e08ec900d9bcf0e53c049de0978R1-R32)
* Added `useConfirmationRegistryStore` to track pending confirmation cards per chat, preventing the message queue from auto-sending while user consent is pending. Includes a full test suite in `confirmationRegistryStore.test.ts`. [[1]](diffhunk://#diff-5b385f00dc02efd151762217072b79cc1e2039f3947f9e7393f6ae903daa9673R1-R91) [[2]](diffhunk://#diff-9ef3644fb982fc99120fa4f7456f2dab55b563d4768c00ef177a7c7bf4a2071bR1-R45)

**File upload logic improvements:**

* Updated `useFileDropzone` to correctly associate file uploads with the in-flight chat during the first turn, preventing orphaned chats and ensuring files are attached to the correct conversation. Includes new logic for resolving the chat ID and related tests. [[1]](diffhunk://#diff-d1ca5223fa14a0ad80d7a23d294840436907dc034f41aaa8de270b449d2c92a7R37-R86) [[2]](diffhunk://#diff-d1ca5223fa14a0ad80d7a23d294840436907dc034f41aaa8de270b449d2c92a7L194-R251) [[3]](diffhunk://#diff-e3d77e3e6a064fade77e3ccdebad836db4bf0e8f8f572700e2ef4ceabe846b33R344-R442)

**Codebase simplification and reuse:**

* Centralized the `mergeUniqueFilesById` helper in `@/utils/file/mergeUniqueFilesById` and updated all usages to import from this location, removing duplicate implementations. [[1]](diffhunk://#diff-44dd1d7d67805d66175fd4e9a36e6ac22b578500a94359ea1e955c1bdc4bf90fR28) [[2]](diffhunk://#diff-44dd1d7d67805d66175fd4e9a36e6ac22b578500a94359ea1e955c1bdc4bf90fL39-L55) [[3]](diffhunk://#diff-35a7ac4f5d8d77ca3d2bc1ebf34f54f40388035de02dc2ac64caa8369dd5e65bR5-R6) [[4]](diffhunk://#diff-35a7ac4f5d8d77ca3d2bc1ebf34f54f40388035de02dc2ac64caa8369dd5e65bL64-L80) [[5]](diffhunk://#diff-a8534121f8314101115060632d3b4a8fd485f06d7fba83d41487810a94ec9c29R10-L32)

**Localization:**

* Added and updated German translations for new UI strings related to queued message attachments and cancellation. [[1]](diffhunk://#diff-62c9b815ddf02e79819e14c84686a33295a4c0d51985a9f04050e41852684135R2934-R2938) [[2]](diffhunk://#diff-62c9b815ddf02e79819e14c84686a33295a4c0d51985a9f04050e41852684135R3059-R3062) [[3]](diffhunk://#diff-62c9b815ddf02e79819e14c84686a33295a4c0d51985a9f04050e41852684135R3214-R3217)

**Exports:**

* Exported the new confirmation registry hooks from the library index for external usage.