### PR TITLE
E2E: streaming composer + message queue (ERMAIN-466/470)

### DIFF
--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -1,0 +1,423 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
+import { TAG_CI } from "./tags";
+
+/**
+ * End-to-end coverage for the "composer stays usable while a response streams"
+ * (ERMAIN-466, PR #837) and "queue the next message + auto-send on completion"
+ * (ERMAIN-470, PR #840) behaviours.
+ *
+ * These exercise the real Mock-LLM streaming path in the `many-models`
+ * scenario. The `long running N` mock streams `Second 1 passed` … `Second N
+ * passed. Complete!` at ~1s/chunk, which gives a controllable multi-second
+ * window to interact with the composer mid-stream. `fast` returns
+ * "Quick response!" quickly and is used as the queued follow-up message.
+ *
+ * Note: on this branch the textarea's `disabled` is driven by `composeLocked`
+ * (upload/record only), NOT `isPendingResponse` — so it stays editable while a
+ * response streams. The reliable "streaming in progress" signal is therefore
+ * the Stop button (`chat-input-stop-generation`), not a disabled textarea.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const messageBox = (page: Page): Locator =>
+  page.getByRole("textbox", { name: "Type a message..." });
+
+const stopButton = (page: Page): Locator =>
+  page.getByTestId("chat-input-stop-generation");
+
+const queuedChip = (page: Page): Locator =>
+  page.getByTestId("chat-input-queued-message");
+
+const selectMockModel = async (page: Page) => {
+  const modelSelectorButton = page.locator(
+    'button[aria-controls="model-selector-dropdown"]',
+  );
+  await expect(modelSelectorButton).toBeVisible();
+  await modelSelectorButton.click();
+  await page.getByRole("menuitem", { name: "Mock-LLM", exact: true }).click();
+  await expect(modelSelectorButton).toContainText("Mock-LLM");
+};
+
+const uploadFileInChat = async (page: Page, file: string) => {
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: /upload files/i }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(file);
+};
+
+/**
+ * Start a long-running streamed response and wait until it is actively
+ * streaming (Stop button shown + first chunk visible).
+ */
+const startLongRunningStream = async (page: Page, seconds: number) => {
+  const textbox = messageBox(page);
+  await expect(textbox).toBeVisible();
+  await textbox.fill(`long running ${seconds}`);
+  await textbox.press("Enter");
+  await expect(stopButton(page)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText("Second 1 passed")).toBeVisible({
+    timeout: 15000,
+  });
+};
+
+/** Wait until the whole turn (and any drained follow-up) has finished. */
+const waitForStreamToFinish = async (page: Page, timeout = 40000) => {
+  await expect(stopButton(page)).toHaveCount(0, { timeout });
+};
+
+test.describe("Streaming composer + message queue", () => {
+  test(
+    "composer stays editable and only offers Stop + Queue while a response streams",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 10);
+
+      const textbox = messageBox(page);
+      // ERMAIN-466: the textarea remains editable mid-stream.
+      await expect(textbox).toBeEnabled();
+      await textbox.fill("draft typed while streaming");
+      await expect(textbox).toHaveValue("draft typed while streaming");
+
+      // Typing (and having content) does not submit a second message.
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // ERMAIN-470: with content mid-stream the trailing slot is exactly
+      // Stop + Queue — the idle Send button is not rendered.
+      await expect(page.getByTestId("chat-input-queue-message")).toBeVisible();
+      await expect(stopButton(page)).toBeVisible();
+      await expect(page.getByTestId("chat-input-send-message")).toHaveCount(0);
+
+      // Clean up: stop the stream so the test finishes quickly.
+      await stopButton(page).click();
+      await waitForStreamToFinish(page, 15000);
+    },
+  );
+
+  test(
+    "Enter while streaming queues the next message and auto-sends it on completion",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 6);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+
+      // Queued, not sent: chip shows, composer clears, still one user message.
+      await expect(queuedChip(page)).toBeVisible();
+      await expect(queuedChip(page)).toContainText("fast");
+      await expect(textbox).toHaveValue("");
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // Auto-sends once the first turn finishes → second user + assistant turn.
+      await expect(page.getByTestId("message-user")).toHaveCount(2, {
+        timeout: 40000,
+      });
+      await expect(queuedChip(page)).toHaveCount(0);
+      await expect(page.getByTestId("message-user").last()).toContainText(
+        "fast",
+      );
+
+      await waitForStreamToFinish(page);
+      await expect(page.getByTestId("message-assistant").last()).toContainText(
+        "Quick response!",
+        { timeout: 15000 },
+      );
+    },
+  );
+
+  test(
+    "the Queue button queues the next message just like Enter",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 6);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await page.getByTestId("chat-input-queue-message").click();
+
+      await expect(queuedChip(page)).toBeVisible();
+      await expect(queuedChip(page)).toContainText("fast");
+      await expect(textbox).toHaveValue("");
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // And it still auto-sends on completion.
+      await expect(page.getByTestId("message-user")).toHaveCount(2, {
+        timeout: 40000,
+      });
+      await expect(queuedChip(page)).toHaveCount(0);
+    },
+  );
+
+  test(
+    "queuing a second message asks to replace, and Replace swaps the queued draft",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 10);
+
+      const textbox = messageBox(page);
+
+      // Queue the first candidate.
+      await textbox.fill("alpha queued");
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toContainText("alpha queued");
+
+      // Queuing a second one opens the danger confirmation dialog; the composer
+      // draft is left intact behind it.
+      await textbox.fill("beta queued");
+      await textbox.press("Enter");
+      const dialog = page.getByRole("dialog", {
+        name: "Replace the queued message?",
+      });
+      await expect(dialog).toBeVisible();
+
+      // Keep queued → dialog closes, original queued message survives.
+      // (The dialog buttons carry an aria-label for a11y, so match on their
+      // visible text rather than their accessible name.)
+      await dialog
+        .getByRole("button")
+        .filter({ hasText: "Keep queued" })
+        .click();
+      await expect(dialog).toBeHidden();
+      await expect(queuedChip(page)).toContainText("alpha queued");
+      await expect(textbox).toHaveValue("beta queued");
+
+      // Queue again and confirm Replace → queued draft is swapped.
+      await textbox.press("Enter");
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button").filter({ hasText: "Replace" }).click();
+      await expect(dialog).toBeHidden();
+      await expect(queuedChip(page)).toContainText("beta queued");
+      await expect(textbox).toHaveValue("");
+
+      // The replacement (not the discarded original) is what auto-sends.
+      await expect(page.getByTestId("message-user")).toHaveCount(2, {
+        timeout: 45000,
+      });
+      await expect(page.getByTestId("message-user").last()).toContainText(
+        "beta queued",
+      );
+      await expect(
+        page.getByTestId("message-user").filter({ hasText: "alpha queued" }),
+      ).toHaveCount(0);
+    },
+  );
+
+  test(
+    "cancelling the queued message prevents the auto-send",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 6);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toBeVisible();
+
+      await page.getByTestId("chat-input-queued-message-cancel").click();
+      await expect(queuedChip(page)).toHaveCount(0);
+
+      // Let the turn finish; nothing should be auto-sent.
+      await waitForStreamToFinish(page);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+      await expect(
+        page
+          .getByTestId("message-assistant")
+          .filter({ hasText: "Quick response!" }),
+      ).toHaveCount(0);
+    },
+  );
+
+  test(
+    "editing the queued message returns it to the composer and cancels the auto-send",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 6);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toBeVisible();
+
+      // Click the chip → the queued draft comes back into the composer.
+      await page.getByTestId("chat-input-queued-message-edit").click();
+      await expect(queuedChip(page)).toHaveCount(0);
+      await expect(textbox).toHaveValue("fast");
+
+      // It is a plain draft again, so completing the turn sends nothing.
+      await waitForStreamToFinish(page);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+      await expect(textbox).toHaveValue("fast");
+    },
+  );
+
+  test(
+    "Stop returns the queued draft to the composer without sending",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 10);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toBeVisible();
+
+      // Stopping aborts the turn and never auto-sends: the queued draft is
+      // returned to the composer.
+      await stopButton(page).click();
+      await waitForStreamToFinish(page, 15000);
+
+      await expect(queuedChip(page)).toHaveCount(0);
+      await expect(textbox).toHaveValue("fast");
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+    },
+  );
+
+  test(
+    "navigating away while a message is queued drops it to a draft and never background-sends",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(90000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 10);
+      await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 10000 });
+      const streamingChatId = page.url().split("/").pop();
+      expect(streamingChatId).toBeTruthy();
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toBeVisible();
+
+      // Navigate away to a brand-new chat while the message is still queued.
+      await ensureOpenSidebar(page);
+      await page
+        .getByRole("complementary")
+        .getByRole("button", { name: "New Chat", exact: true })
+        .click();
+      await expect(page).toHaveURL(/\/chat\/new$/);
+      await expect(queuedChip(page)).toHaveCount(0);
+
+      // Return to the original chat: the queued payload came back as a draft
+      // (never background-sent) and the chat still has a single user message.
+      await ensureOpenSidebar(page);
+      await page
+        .getByRole("complementary")
+        .locator(`[data-chat-id="${streamingChatId}"]`)
+        .click();
+      await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
+
+      await expect(messageBox(page)).toHaveValue("fast");
+      await expect(queuedChip(page)).toHaveCount(0);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+    },
+  );
+
+  test(
+    "a file attached during a new chat's first-turn stream attaches to that chat instead of orphaning one",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      await page.goto("/chat/new");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      // Send the first message of a brand-new chat and, WITHOUT waiting for the
+      // chat id to settle, attach a file. This races the null→realId creation so
+      // the upload happens while the committed chat id is still null — the exact
+      // window ERMAIN-466 fixes by routing the upload to the in-flight chat
+      // instead of spawning a separate, orphaned chat.
+      const textbox = messageBox(page);
+      await textbox.fill("long running 8");
+      await textbox.press("Enter");
+
+      const pdfPath = path.join(
+        __dirname,
+        "../test-files/sample-report-compressed.pdf",
+      );
+      await uploadFileInChat(page, pdfPath);
+
+      // The attachment lands on the streaming chat (not a new one).
+      await expect(page.getByText(/sample.*compressed.*pdf/i)).toBeVisible({
+        timeout: 15000,
+      });
+
+      // The chat resolved to a single id and the view never jumped to a
+      // different (orphan) chat.
+      await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 10000 });
+      const streamingChatId = page.url().split("/").pop();
+      expect(streamingChatId).toBeTruthy();
+
+      // Baseline the sidebar only once this chat is actually listed, so normal
+      // first-turn chat creation isn't mistaken for an orphan. Any extra chat
+      // spawned for the upload would push the count above this baseline.
+      await ensureOpenSidebar(page);
+      const sidebar = page.getByRole("complementary");
+      await expect(
+        sidebar.locator(`[data-chat-id="${streamingChatId}"]`),
+      ).toBeVisible({ timeout: 15000 });
+      const chatCountBaseline = await sidebar.locator("[data-chat-id]").count();
+
+      await waitForStreamToFinish(page);
+
+      // No orphan chat was created for the upload, and we're still on the same
+      // chat with its attachment.
+      const chatCountAfter = await sidebar.locator("[data-chat-id]").count();
+      expect(chatCountAfter).toBe(chatCountBaseline);
+      await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
+      await expect(page.getByText(/sample.*compressed.*pdf/i)).toBeVisible();
+    },
+  );
+});

--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -93,10 +93,12 @@ test.describe("Streaming composer + message queue", () => {
       await expect(page.getByTestId("message-user")).toHaveCount(1);
 
       // ERMAIN-470: with content mid-stream the trailing slot is exactly
-      // Stop + Queue — the idle Send button is not rendered.
+      // Stop + Queue — neither the idle Send button nor the dictation-start
+      // button is rendered (the "at most two trailing controls" rule).
       await expect(page.getByTestId("chat-input-queue-message")).toBeVisible();
       await expect(stopButton(page)).toBeVisible();
       await expect(page.getByTestId("chat-input-send-message")).toHaveCount(0);
+      await expect(page.getByTestId("chat-input-record-audio")).toHaveCount(0);
 
       // Clean up: stop the stream so the test finishes quickly.
       await stopButton(page).click();
@@ -418,6 +420,54 @@ test.describe("Streaming composer + message queue", () => {
       expect(chatCountAfter).toBe(chatCountBaseline);
       await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
       await expect(page.getByText(/sample.*compressed.*pdf/i)).toBeVisible();
+    },
+  );
+
+  test(
+    "a queued message carries its attachment through to the auto-sent turn",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(90000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 8);
+
+      // Attach a file mid-stream (routes to the streaming chat, ERMAIN-466),
+      // then queue a "cite files" message that carries it. The queue stores
+      // attachedFiles, and the drain must forward them on the auto-send
+      // (ERMAIN-470) — otherwise the follow-up turn has no file to cite.
+      const pdfPath = path.join(
+        __dirname,
+        "../test-files/sample-report-compressed.pdf",
+      );
+      await uploadFileInChat(page, pdfPath);
+      await expect(page.getByText(/sample.*compressed.*pdf/i)).toBeVisible({
+        timeout: 15000,
+      });
+
+      const textbox = messageBox(page);
+      await textbox.fill("cite files");
+      await page.getByTestId("chat-input-queue-message").click();
+
+      await expect(queuedChip(page)).toBeVisible();
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // On completion the queued message auto-sends WITH the attachment, so the
+      // cite-files mock (which lists erato-file:// links found in the request)
+      // answers with a citation link — proving the file reached the backend.
+      await expect(page.getByTestId("message-user")).toHaveCount(2, {
+        timeout: 45000,
+      });
+      await expect(queuedChip(page)).toHaveCount(0);
+
+      await waitForStreamToFinish(page);
+      const lastAssistant = page.getByTestId("message-assistant").last();
+      await expect(
+        lastAssistant.getByRole("link", { name: "Link" }).first(),
+      ).toBeVisible({ timeout: 15000 });
     },
   );
 });

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -5,6 +5,7 @@ import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { componentRegistry } from "@/config/componentRegistry";
+import { useComposeSessionStore } from "@/hooks/chat/store/composeSessionStore";
 import { useConfirmationRegistryStore } from "@/hooks/chat/store/confirmationRegistryStore";
 import { useMessageQueueStore } from "@/hooks/chat/store/messageQueueStore";
 import { messages as enMessages } from "@/locales/en/messages.json";
@@ -213,6 +214,10 @@ describe("ChatInput", () => {
       clear: vi.fn(),
     });
     useToastStore.setState({ toasts: [] });
+    useComposeSessionStore.setState({
+      sessionIdByChatKey: {},
+      draftsBySessionId: {},
+    });
 
     const { i18n } = await import("@lingui/core");
     i18n.load("en", enMessages as unknown as Messages);
@@ -3401,8 +3406,13 @@ describe("ChatInput", () => {
       });
       const ui = (
         context: Partial<ChatContextValue>,
-        props: { disabled?: boolean } = {},
+        props: {
+          disabled?: boolean;
+          remountKey?: number;
+          chatId?: string | null;
+        } = {},
       ) => {
+        const { remountKey = 1, chatId = CHAT_ID, ...inputProps } = props;
         mockUseChatContext.mockReturnValue({
           isPendingResponse: false,
           isMessagingLoading: false,
@@ -3415,9 +3425,10 @@ describe("ChatInput", () => {
           <QueryClientProvider client={queryClient}>
             <I18nProvider i18n={i18n}>
               <ChatInput
+                key={remountKey}
                 onSendMessage={onSendMessage}
-                chatId={CHAT_ID}
-                {...props}
+                chatId={chatId}
+                {...inputProps}
               />
             </I18nProvider>
           </QueryClientProvider>
@@ -3426,7 +3437,11 @@ describe("ChatInput", () => {
       const { rerender } = render(ui(initialContext));
       return (
         context: Partial<ChatContextValue>,
-        props: { disabled?: boolean } = {},
+        props: {
+          disabled?: boolean;
+          remountKey?: number;
+          chatId?: string | null;
+        } = {},
       ) => rerender(ui(context, props));
     };
 
@@ -3544,6 +3559,114 @@ describe("ChatInput", () => {
 
       rerender({ isPendingResponse: false, cancelMessage });
       await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("keeps a queued message across a remount instead of dropping it", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("Type a message..."), {
+        target: { value: "next message" },
+      });
+      fireEvent.keyDown(screen.getByPlaceholderText("Type a message..."), {
+        key: "Enter",
+        shiftKey: false,
+      });
+      expect(
+        screen.getByTestId("chat-input-queued-message-edit"),
+      ).toHaveTextContent("next message");
+
+      // Clicking "New Chat" bumps ChatProvider's newChatCounter, which is the
+      // `key` on <Chat> in ChatPageStructure — so the ChatInput subtree
+      // remounts underneath the queued message.
+      rerender({ isPendingResponse: true }, { remountKey: 2 });
+      await flushTimers();
+
+      // The payload becomes the chat's draft rather than staying queued: the
+      // user returns to it in a later render, and nothing is left in the queue
+      // to fire once the abandoned turn settles.
+      const sessionId = Object.keys(
+        useComposeSessionStore.getState().sessionIdByChatKey,
+      ).map(
+        (chatKey) =>
+          useComposeSessionStore.getState().sessionIdByChatKey[chatKey],
+      )[0];
+      expect(
+        useComposeSessionStore.getState().draftsBySessionId[sessionId!],
+      ).toEqual({ message: "next message", attachedFiles: [] });
+      expect(useMessageQueueStore.getState().queuedBySessionId).toEqual({});
+
+      rerender({ isPendingResponse: false }, { remountKey: 2 });
+      await flushTimers();
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("restores the dropped draft into the composer on returning to the chat", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("Type a message..."), {
+        target: { value: "next message" },
+      });
+      fireEvent.keyDown(screen.getByPlaceholderText("Type a message..."), {
+        key: "Enter",
+        shiftKey: false,
+      });
+
+      // The New Chat button remounts (mountKey) and navigates (chatId -> null).
+      // Which lands first is not guaranteed, so the drop-to-draft has to hold
+      // either way: here the remount is observed before the navigation.
+      rerender({ isPendingResponse: true }, { remountKey: 2 });
+      await flushTimers();
+      rerender({ isPendingResponse: false }, { remountKey: 2, chatId: null });
+      await flushTimers();
+
+      rerender({ isPendingResponse: false }, { remountKey: 2 });
+      await flushTimers();
+
+      expect(screen.getByPlaceholderText("Type a message...")).toHaveValue(
+        "next message",
+      );
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("restores the dropped draft when navigation lands before the remount", async () => {
+      const { i18n } = await import("@lingui/core");
+      const onSendMessage = vi.fn();
+      const rerender = renderQueue(
+        { isPendingResponse: true },
+        onSendMessage,
+        i18n,
+      );
+
+      fireEvent.change(screen.getByPlaceholderText("Type a message..."), {
+        target: { value: "next message" },
+      });
+      fireEvent.keyDown(screen.getByPlaceholderText("Type a message..."), {
+        key: "Enter",
+        shiftKey: false,
+      });
+
+      rerender({ isPendingResponse: false }, { remountKey: 2, chatId: null });
+      await flushTimers();
+
+      rerender({ isPendingResponse: false }, { remountKey: 2 });
+      await flushTimers();
+
+      expect(screen.getByPlaceholderText("Type a message...")).toHaveValue(
+        "next message",
+      );
       expect(onSendMessage).not.toHaveBeenCalled();
     });
 

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useMemo,
   useImperativeHandle,
@@ -368,6 +369,12 @@ export const ChatInput = ({
   onControlledIsAudioModeChange,
   ref,
 }: ChatInputPropsWithRef) => {
+  const {
+    sessionId: composeSessionId,
+    getActiveSessionId,
+    getDraft: getComposeDraftBySessionId,
+    saveDraft: saveComposeDraftBySessionId,
+  } = useComposeSession({ chatId });
   const [message, setMessage] = useState("");
   const [internalIsAudioMode, setInternalIsAudioMode] = useState(false);
   const [conversationStartSignal, setConversationStartSignal] = useState(0);
@@ -404,12 +411,6 @@ export const ChatInput = ({
   const audioModeRestartSawPendingResponseRef = useRef(false);
   const previousModeRef = useRef<"compose" | "edit">(mode);
   const previousEditMessageIdRef = useRef<string | undefined>(undefined);
-  const {
-    sessionId: composeSessionId,
-    getActiveSessionId,
-    getDraft: getComposeDraftBySessionId,
-    saveDraft: saveComposeDraftBySessionId,
-  } = useComposeSession({ chatId });
   const dictationTargetRef = useRef<DictationTarget | null>(null);
   // Add state for file button processing
   const [isFileButtonProcessing, setIsFileButtonProcessing] = useState(false);
@@ -957,9 +958,18 @@ export const ChatInput = ({
   // swap reads it.
   const activeComposeSessionIdRef = useRef(composeSessionId);
 
+  const hasPersistedInitialDraftRef = useRef(false);
+
   // Persist compose-mode draft state for the currently active session.
   useEffect(() => {
     if (mode !== "compose") {
+      return;
+    }
+    // The mount write only echoes the draft we seeded from, and on a remount
+    // it would land after the outgoing instance folded its queued message into
+    // that same draft — clobbering it with the empty composer. Skip it.
+    if (!hasPersistedInitialDraftRef.current) {
+      hasPersistedInitialDraftRef.current = true;
       return;
     }
     saveComposeDraftBySessionId(activeComposeSessionIdRef.current, {
@@ -967,6 +977,51 @@ export const ChatInput = ({
       attachedFiles,
     });
   }, [mode, message, attachedFiles, saveComposeDraftBySessionId]);
+
+  // Seed the composer from this session's stored draft, so a remount (New Chat
+  // bumping ChatProvider's mountKey, or the empty-state → messages layout flip)
+  // doesn't present an empty composer for a chat that has one. This has to be a
+  // layout effect: the outgoing instance's teardown below runs in the same
+  // phase, and seeding any earlier would read the draft before it folds its
+  // queued message in.
+  useLayoutEffect(() => {
+    if (mode !== "compose") {
+      return;
+    }
+    const draft = getComposeDraftBySessionId(activeComposeSessionIdRef.current);
+    if (draft.message) {
+      setMessage(draft.message);
+    }
+    if (draft.attachedFiles.length) {
+      setAttachedFiles(draft.attachedFiles);
+    }
+    // Mount-only: later session switches are handled by the switch effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // A remount tears this component down without a session switch, so the
+  // switch effect below never runs. Fold any queued message back into the
+  // chat's draft here, or it stays in the queue store waiting for a turn that
+  // this chat is no longer showing — and would auto-send on return. (ERMAIN-470)
+  useLayoutEffect(() => {
+    return () => {
+      const sessionId = activeComposeSessionIdRef.current;
+      const queued = getQueuedBySessionId(sessionId);
+      if (!queued) {
+        return;
+      }
+      saveComposeDraftBySessionId(
+        sessionId,
+        mergeComposeDrafts(queued, getComposeDraftBySessionId(sessionId)),
+      );
+      clearQueuedBySessionId(sessionId);
+    };
+  }, [
+    getQueuedBySessionId,
+    getComposeDraftBySessionId,
+    saveComposeDraftBySessionId,
+    clearQueuedBySessionId,
+  ]);
 
   // On chat switch, persist outgoing draft against the previous session and
   // restore the incoming draft for the new session. Because the session id

--- a/frontend/src/hooks/chat/__tests__/useComposeSession.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useComposeSession.test.ts
@@ -61,6 +61,31 @@ describe("useComposeSession", () => {
     expect(result.current.sessionId).toBe(sessionA);
   });
 
+  it("keeps a chat's session when it is revisited via the new-chat route", () => {
+    const initialProps: { chatId: string | null } = { chatId: "chat-a" };
+    const { result, rerender } = renderHook(
+      ({ chatId }: { chatId: string | null }) => useComposeSession({ chatId }),
+      { initialProps },
+    );
+
+    const sessionA = result.current.sessionId;
+    result.current.saveDraft(sessionA, {
+      message: "unsent draft",
+      attachedFiles: [],
+    });
+
+    // Leaving via the New Chat button parks us on the sentinel before we
+    // navigate back — this must not be mistaken for a chat_created rename.
+    rerender({ chatId: null });
+    rerender({ chatId: "chat-a" });
+
+    expect(result.current.sessionId).toBe(sessionA);
+    expect(result.current.getDraft(result.current.sessionId)).toEqual({
+      message: "unsent draft",
+      attachedFiles: [],
+    });
+  });
+
   it("persists and retrieves drafts by session id", () => {
     const { result } = renderHook(() =>
       useComposeSession({ chatId: "chat-a" }),

--- a/frontend/src/hooks/chat/store/composeSessionStore.ts
+++ b/frontend/src/hooks/chat/store/composeSessionStore.ts
@@ -1,0 +1,100 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+import type { ComposeDraftState } from "@/hooks/chat/useComposeSession";
+
+/**
+ * Compose-session identity and per-session drafts, keyed by chat.
+ *
+ * This lives outside the component tree because `ChatInput` is torn down and
+ * rebuilt underneath the user: the New Chat button bumps `newChatCounter` in
+ * ChatProvider, which is the `key` on `<Chat>`, and the empty-state → messages
+ * layout flip remounts it by position. Holding either map in a ref meant a
+ * remount minted a fresh session id for the same chat, orphaning that chat's
+ * draft and any queued message. (ERMAIN-470)
+ */
+interface ComposeSessionStore {
+  sessionIdByChatKey: Partial<Record<string, string>>;
+  draftsBySessionId: Partial<Record<string, ComposeDraftState>>;
+  resolveSessionId: (chatKey: string) => string;
+  adoptSessionId: (fromChatKey: string, toChatKey: string) => void;
+  getDraft: (sessionId: string) => ComposeDraftState;
+  saveDraft: (sessionId: string, draft: ComposeDraftState) => void;
+}
+
+export const EMPTY_COMPOSE_DRAFT: ComposeDraftState = Object.freeze({
+  message: "",
+  attachedFiles: [],
+});
+
+export const useComposeSessionStore = create<ComposeSessionStore>()(
+  devtools(
+    (set, get) => ({
+      sessionIdByChatKey: {},
+      draftsBySessionId: {},
+
+      resolveSessionId: (chatKey) => {
+        const existing = get().sessionIdByChatKey[chatKey];
+        if (existing) {
+          return existing;
+        }
+        const minted = globalThis.crypto.randomUUID();
+        set(
+          (prev) => ({
+            sessionIdByChatKey: {
+              ...prev.sessionIdByChatKey,
+              [chatKey]: minted,
+            },
+          }),
+          false,
+          "composeSession/resolveSessionId",
+        );
+        return minted;
+      },
+
+      // Sentinel → real chatId: the session bound to the new-chat key follows
+      // the chat into its real identity, so the session id itself is unchanged
+      // and only the lookup key moves.
+      //
+      // Only a chat that has never been seen can inherit. Navigating from the
+      // new-chat route back into an existing chat looks identical from here,
+      // and adopting there would hand that chat the empty new-chat session and
+      // strand its own draft.
+      adoptSessionId: (fromChatKey, toChatKey) =>
+        set(
+          (prev) => {
+            const inherited = prev.sessionIdByChatKey[fromChatKey];
+            if (inherited === undefined || prev.sessionIdByChatKey[toChatKey]) {
+              return prev;
+            }
+            const next = { ...prev.sessionIdByChatKey };
+            delete next[fromChatKey];
+            next[toChatKey] = inherited;
+            return { sessionIdByChatKey: next };
+          },
+          false,
+          "composeSession/adoptSessionId",
+        ),
+
+      getDraft: (sessionId) =>
+        get().draftsBySessionId[sessionId] ?? EMPTY_COMPOSE_DRAFT,
+
+      saveDraft: (sessionId, draft) =>
+        set(
+          (prev) => ({
+            draftsBySessionId: {
+              ...prev.draftsBySessionId,
+              [sessionId]: draft,
+            },
+          }),
+          false,
+          "composeSession/saveDraft",
+        ),
+    }),
+    {
+      name: "Compose Session Store",
+      store: "compose-session-store",
+      enabled: process.env.NODE_ENV === "development",
+    },
+  ),
+);

--- a/frontend/src/hooks/chat/useComposeSession.ts
+++ b/frontend/src/hooks/chat/useComposeSession.ts
@@ -1,16 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useComposeSessionStore } from "@/hooks/chat/store/composeSessionStore";
+
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
 export interface ComposeDraftState {
   message: string;
   attachedFiles: FileUploadItem[];
 }
-
-const EMPTY_DRAFT: ComposeDraftState = Object.freeze({
-  message: "",
-  attachedFiles: [],
-});
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- internal sentinel key, never user-facing
 const NEW_CHAT_KEY = "__new-chat__";
@@ -19,41 +16,33 @@ function chatIdKey(chatId: string | null | undefined): string {
   return chatId ?? NEW_CHAT_KEY;
 }
 
-function generateSessionId(): string {
-  return globalThis.crypto.randomUUID();
-}
-
 /**
- * Owns a stable compose-session identity per chat that survives a
- * chatId rename mid-session (e.g. the `null` → real-UUID transition
- * after `chat_created`). Async producers (dictation, paste handlers)
- * should capture the returned `sessionId` once and route updates by
- * comparing against `getActiveSessionId()` at delivery time, rather
- * than holding a value derived from `chatId` directly.
+ * Owns a stable compose-session identity per chat that survives a chatId
+ * rename mid-session (e.g. the `null` → real-UUID transition after
+ * `chat_created`) and a remount of the component tree. Async producers
+ * (dictation, paste handlers) should capture the returned `sessionId` once and
+ * route updates by comparing against `getActiveSessionId()` at delivery time,
+ * rather than holding a value derived from `chatId` directly.
+ *
+ * Identity and drafts live in `composeSessionStore` rather than in refs here,
+ * so that a remount cannot orphan the chat's draft or queued message.
  */
 export function useComposeSession({
   chatId,
 }: {
   chatId: string | null | undefined;
 }) {
-  const sessionIdByChatKeyRef = useRef<Map<string, string>>(new Map());
-  const draftsBySessionIdRef = useRef<Map<string, ComposeDraftState>>(
-    new Map(),
+  const resolveSessionId = useComposeSessionStore(
+    (state) => state.resolveSessionId,
   );
-
-  const resolveActiveSessionId = useCallback((): string => {
-    const key = chatIdKey(chatId);
-    const existing = sessionIdByChatKeyRef.current.get(key);
-    if (existing) {
-      return existing;
-    }
-    const minted = generateSessionId();
-    sessionIdByChatKeyRef.current.set(key, minted);
-    return minted;
-  }, [chatId]);
+  const adoptSessionId = useComposeSessionStore(
+    (state) => state.adoptSessionId,
+  );
+  const getDraft = useComposeSessionStore((state) => state.getDraft);
+  const saveDraft = useComposeSessionStore((state) => state.saveDraft);
 
   const [activeSessionId, setActiveSessionId] = useState<string>(() =>
-    resolveActiveSessionId(),
+    resolveSessionId(chatIdKey(chatId)),
   );
 
   const previousChatKeyRef = useRef<string>(chatIdKey(chatId));
@@ -66,41 +55,21 @@ export function useComposeSession({
       return;
     }
 
-    // Sentinel → real chatId: the session that was bound to `null`
-    // follows the chat into its real identity. The session id itself
-    // stays the same; only the lookup key changes.
     if (previousKey === NEW_CHAT_KEY && nextKey !== NEW_CHAT_KEY) {
-      const sentinelSessionId = sessionIdByChatKeyRef.current.get(NEW_CHAT_KEY);
-      if (sentinelSessionId !== undefined) {
-        sessionIdByChatKeyRef.current.delete(NEW_CHAT_KEY);
-        sessionIdByChatKeyRef.current.set(nextKey, sentinelSessionId);
-      }
+      adoptSessionId(NEW_CHAT_KEY, nextKey);
     }
 
     previousChatKeyRef.current = nextKey;
 
-    const nextSessionId =
-      sessionIdByChatKeyRef.current.get(nextKey) ?? generateSessionId();
-    sessionIdByChatKeyRef.current.set(nextKey, nextSessionId);
+    const nextSessionId = resolveSessionId(nextKey);
     setActiveSessionId((current) =>
       current === nextSessionId ? current : nextSessionId,
     );
-  }, [chatId]);
+  }, [chatId, adoptSessionId, resolveSessionId]);
 
   const getActiveSessionId = useCallback(
     () => activeSessionId,
     [activeSessionId],
-  );
-
-  const getDraft = useCallback((sessionId: string): ComposeDraftState => {
-    return draftsBySessionIdRef.current.get(sessionId) ?? EMPTY_DRAFT;
-  }, []);
-
-  const saveDraft = useCallback(
-    (sessionId: string, draft: ComposeDraftState) => {
-      draftsBySessionIdRef.current.set(sessionId, draft);
-    },
-    [],
   );
 
   return {


### PR DESCRIPTION
Adds end-to-end coverage for the two behaviours shipped in #837 (ERMAIN-466, composer stays usable while a response streams) and #840 (ERMAIN-470, queue the next message + auto-send on completion), now merged to `main`.

One new Playwright spec, `e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts`, `@ci`-tagged in the `many-models` scenario. It drives the real Mock-LLM streaming path via the `long running N` mock (a controllable multi-second window) with `fast` → "Quick response!" as the queued follow-up.

**10 tests:**
- composer textarea stays editable mid-stream; trailing controls are exactly Stop + Queue (no idle Send, no dictation-start)
- Enter while streaming queues the next message and it auto-sends on completion
- the Queue button behaves like Enter
- overwriting a queued message → Replace / Keep-queued `ConfirmationDialog` (both paths, verifies the swap)
- cancelling the queued chip prevents the auto-send
- editing the queued chip returns it to the composer and cancels the auto-send
- Stop returns the queued draft to the composer without sending
- navigating away while queued drops it to a draft (never background-sends, reappears on return)
- a file attached during a new chat's first-turn stream attaches to that chat instead of orphaning one
- a queued message carries its attachment through to the auto-sent turn (verified via the cite-files citation link)

**Notes**
- Relies on the completion barrier fixed in #837: since the textarea now stays enabled while streaming, tests use the Stop button (`chat-input-stop-generation`) as the "turn in flight" signal, not a disabled textarea.
- The add-in tool-consent queue-hold (`confirmationRegistryStore`) is not web-e2e-testable (web `useHasPendingConfirmation` is always false) and stays covered by unit tests.

**Deliberately not covered (rationale / follow-ups)**
- **Error-path restore** (turn errors → queued draft returns to composer). This is a distinct drain branch (`messagingError`) from Stop/navigate-away, but the only stream-then-error mock (`hallucination loop`) aborts within milliseconds, leaving no reliable window to queue into. Cleanly testable only after adding a "stream for N seconds, then error" mock — worth a follow-up.
- **Facet/tool selection stays live mid-stream** and **a mid-stream facet survives the new-chat redirect** (#837): needs a user-selectable facet configured in the `many-models` scenario; deferred to avoid scenario changes here.
- **Dictation can start mid-stream** (#840 UX decision): audio-capture timing is fragile in e2e; left to the existing `ChatInput` unit tests.