### PR TITLE
Fix queued-message chip theming and narrow-pane layout (ERMAIN-470)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2242,11 +2242,16 @@ export const ChatInput = ({
         )}
 
         {/* Queued next message: auto-sends when the current turn finishes.
-            Geometry comes from the same message tokens as the sibling error
-            Alert / attachment preview; `data-ui` lets kits restyle it. */}
+            Geometry AND surface colors come from the same message tokens as the
+            sibling attachment preview (`--theme-border-attachment` on
+            bg-primary), so the two read as one family. Not
+            `--theme-border-chat-input`: the stock theme aliases both to
+            `--theme-border`, but themes that split them treat chat-input as a
+            shell-only token they re-specify per surface, which would leave this
+            chip borderless. `data-ui` lets kits restyle it. */}
         {queuedMessage && (
           <div
-            className="theme-transition mb-2 flex items-center gap-2 border border-[var(--theme-border-chat-input)] bg-theme-bg-secondary text-sm"
+            className="theme-transition mb-2 flex items-center gap-2 border bg-theme-bg-primary text-sm [border-color:var(--theme-border-attachment)]"
             style={{
               borderRadius: "var(--theme-radius-message)",
               padding:

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2242,13 +2242,8 @@ export const ChatInput = ({
         )}
 
         {/* Queued next message: auto-sends when the current turn finishes.
-            Geometry AND surface colors come from the same message tokens as the
-            sibling attachment preview (`--theme-border-attachment` on
-            bg-primary), so the two read as one family. Not
-            `--theme-border-chat-input`: the stock theme aliases both to
-            `--theme-border`, but themes that split them treat chat-input as a
-            shell-only token they re-specify per surface, which would leave this
-            chip borderless. `data-ui` lets kits restyle it. */}
+            Geometry and surface tokens match the sibling attachment preview;
+            `data-ui` lets kits restyle it. */}
         {queuedMessage && (
           <div
             className="theme-transition mb-2 flex items-center gap-2 border bg-theme-bg-primary text-sm [border-color:var(--theme-border-attachment)]"
@@ -2262,14 +2257,8 @@ export const ChatInput = ({
             role="status"
             aria-live="polite"
           >
-            {/* Both the label and the message yield space as the row narrows
-                (the add-in's ~320px task pane, where this same component
-                renders). The label is boilerplate and shrinks from its natural
-                width; `flex-auto` — not `flex-1` — keeps the message's own
-                width in the shrink calculation, so it can't collapse to zero
-                and leave a chip that says something is queued but not what.
-                Matches the add-in's sibling status chips, which truncate text
-                and reserve `shrink-0` for fixed-size affordances. */}
+            {/* flex-auto, not flex-1: a zero basis would collapse the message
+                to nothing in the add-in's ~320px pane. */}
             <span className="min-w-0 truncate text-theme-fg-muted">
               {t`Queued — sends when response finishes`}
             </span>

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2262,13 +2262,21 @@ export const ChatInput = ({
             role="status"
             aria-live="polite"
           >
-            <span className="shrink-0 text-theme-fg-muted">
+            {/* Both the label and the message yield space as the row narrows
+                (the add-in's ~320px task pane, where this same component
+                renders). The label is boilerplate and shrinks from its natural
+                width; `flex-auto` — not `flex-1` — keeps the message's own
+                width in the shrink calculation, so it can't collapse to zero
+                and leave a chip that says something is queued but not what.
+                Matches the add-in's sibling status chips, which truncate text
+                and reserve `shrink-0` for fixed-size affordances. */}
+            <span className="min-w-0 truncate text-theme-fg-muted">
               {t`Queued — sends when response finishes`}
             </span>
             <button
               type="button"
               onClick={() => restoreQueuedToComposer(queuedMessage)}
-              className="theme-transition focus-ring-tight flex min-w-0 flex-1 items-center gap-1 text-left text-theme-fg-primary hover:underline"
+              className="theme-transition focus-ring-tight flex min-w-0 flex-auto items-center gap-1 text-left text-theme-fg-primary hover:underline"
               aria-label={t`Edit queued message`}
               title={t`Edit queued message`}
               data-testid="chat-input-queued-message-edit"
@@ -2288,6 +2296,7 @@ export const ChatInput = ({
               icon={<CloseIcon className="size-4" />}
               onClick={cancelQueuedMessage}
               aria-label={t`Cancel queued message`}
+              className="shrink-0"
               data-testid="chat-input-queued-message-cancel"
             />
           </div>


### PR DESCRIPTION
Two presentation fixes to the queued-message chip. No behavior change.

1. Use the sibling attachment preview's surface tokens (`--theme-border-attachment` on bg-primary) instead of `--theme-border-chat-input` on bg-secondary. No-op in the stock theme, which aliases both border tokens; matters for themes that split them.

2. Let the row shrink. `shrink-0` was on the label, so in the add-in's ~320px pane the message collapsed first. Label truncates now; message uses `flex-auto` so it keeps a non-zero basis.

Lint, prettier, 67 ChatInput tests pass.