### PR TITLE
Separate button geometry from colour variant (theming contract)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2628,6 +2628,7 @@ export const ChatInput = ({
                     type="button"
                     variant="secondary"
                     size="sm"
+                    geometry="icon"
                     icon={
                       isDictationStarting ||
                       isDictating ||
@@ -2679,6 +2680,7 @@ export const ChatInput = ({
                       type="button"
                       variant="secondary"
                       size="sm"
+                      geometry="icon"
                       icon={<ArrowUpIcon className="size-5" />}
                       onClick={() => enqueueCurrentMessage()}
                       data-testid="chat-input-queue-message"
@@ -2690,6 +2692,7 @@ export const ChatInput = ({
                     type="button"
                     variant="secondary"
                     size="sm"
+                    geometry="icon"
                     icon={<StopIcon />}
                     onClick={() => {
                       // Stopping never auto-sends: return any queued draft to the
@@ -2727,6 +2730,7 @@ export const ChatInput = ({
                   type="submit"
                   variant="secondary"
                   size="sm"
+                  geometry="icon"
                   icon={<ArrowUpIcon className="size-5" />}
                   disabled={!canSendMessage || isSendDisabled}
                   data-testid={

--- a/frontend/src/components/ui/Controls/Button.test.tsx
+++ b/frontend/src/components/ui/Controls/Button.test.tsx
@@ -33,4 +33,63 @@ describe("Button", () => {
     expect(button.className).toContain("justify-center");
     expect(button.className).not.toContain("btn-geometry-sm");
   });
+
+  it("takes icon geometry from `geometry` while keeping the variant's fill", () => {
+    render(
+      <Button
+        variant="secondary"
+        size="sm"
+        geometry="icon"
+        icon={<span>+</span>}
+        aria-label="Send"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Send" });
+
+    expect(button.className).toContain("btn-geometry-icon-sm");
+    expect(button.className).not.toContain("btn-geometry-sm");
+    // The colour axis is untouched — this is the whole point of the prop.
+    expect(button.className).toContain("bg-theme-bg-secondary");
+    expect(button.className).toContain("border-theme-border");
+  });
+
+  it("exposes resolved geometry and variant as styling hooks", () => {
+    const { rerender } = render(
+      <Button variant="secondary" size="sm">
+        Text
+      </Button>,
+    );
+
+    let button = screen.getByRole("button", { name: "Text" });
+    expect(button.getAttribute("data-geometry")).toBe("sm");
+    expect(button.getAttribute("data-variant")).toBe("secondary");
+
+    rerender(
+      <Button
+        variant="secondary"
+        size="sm"
+        geometry="icon"
+        icon={<span>+</span>}
+        aria-label="Send"
+      />,
+    );
+
+    button = screen.getByRole("button", { name: "Send" });
+    expect(button.getAttribute("data-geometry")).toBe("icon-sm");
+    expect(button.getAttribute("data-variant")).toBe("secondary");
+  });
+
+  it("reads the pill radius from the theme token, not a hardcoded value", () => {
+    render(
+      <Button variant="secondary" shape="pill">
+        Pill
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Pill" });
+
+    expect(button.className).toContain("rounded-[var(--theme-radius-pill)]");
+    expect(button.className).not.toContain("rounded-full");
+  });
 });

--- a/frontend/src/components/ui/Controls/Button.tsx
+++ b/frontend/src/components/ui/Controls/Button.tsx
@@ -23,11 +23,23 @@ type ButtonSize = "sm" | "md" | "lg";
 // pass. Utilities still win over this since geometry lives in @layer components.
 type ButtonShape = "default" | "pill";
 
+// Geometry is the size/padding/radius axis, independent of the colour `variant`.
+// A button that renders only an icon should use "icon" (square, no inline
+// padding) whatever its colour is — before this existed, the only way to get
+// icon geometry was `variant="icon-only"`, which also forces a transparent
+// ghost look, so filled icon buttons were stuck with text-button geometry.
+type ButtonGeometry = "control" | "icon";
+
 interface ButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "aria-checked"> {
   variant?: ButtonVariant;
   size?: ButtonSize;
   shape?: ButtonShape;
+  /**
+   * Opt a non-`icon-only` button into square icon geometry. Defaults to
+   * "control" (text-button padding); `variant="icon-only"` implies "icon".
+   */
+  geometry?: ButtonGeometry;
   icon?: React.ReactNode;
   iconClassName?: string;
   children?: React.ReactNode;
@@ -105,6 +117,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       variant = "secondary",
       size = "md",
       shape = "default",
+      geometry = "control",
       icon,
       iconClassName,
       children,
@@ -189,6 +202,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       validateProps(props);
     }, [props]);
 
+    const usesIconGeometry = variant === "icon-only" || geometry === "icon";
+
     const buttonClasses = useMemo(
       () =>
         clsx(
@@ -197,23 +212,33 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           VARIANT_STYLES[variant],
           variant === "list-item"
             ? "btn-geometry-list-item"
-            : variant === "icon-only"
+            : usesIconGeometry
               ? ICON_SIZE_STYLES[size]
               : // Link is a text affordance — it intentionally carries no control
                 // geometry (no padding, min-height, or radius).
                 variant === "link"
                 ? ""
                 : CONTROL_SIZE_STYLES[size],
-          shape === "pill" && "rounded-full",
+          // Reads the token rather than Tailwind's hardcoded 9999px, so
+          // `radius.pill` in theme.json actually reaches pill buttons.
+          shape === "pill" && "rounded-[var(--theme-radius-pill)]",
           {
             "bg-theme-bg-selected": ariaPressed === true,
-            "justify-center": variant === "icon-only",
+            "justify-center": usesIconGeometry,
           },
           showOnHover && "theme-transition opacity-0 group-hover:opacity-100",
           "disabled:cursor-not-allowed disabled:opacity-50",
           className,
         ),
-      [variant, size, shape, ariaPressed, showOnHover, className],
+      [
+        variant,
+        size,
+        shape,
+        usesIconGeometry,
+        ariaPressed,
+        showOnHover,
+        className,
+      ],
     );
 
     const iconClasses = useMemo(
@@ -237,6 +262,19 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           type={type}
           onClick={handleClick}
           data-pressed={isPressed}
+          // Stable theming hooks: `data-geometry` is the resolved geometry
+          // (not the raw props), so theme.css can target "every icon control
+          // in this surface" without naming private btn-geometry-* classes.
+          data-geometry={
+            variant === "list-item"
+              ? "list-item"
+              : variant === "link"
+                ? "link"
+                : usesIconGeometry
+                  ? `icon-${size}`
+                  : size
+          }
+          data-variant={variant}
           {...ariaState}
           aria-label={ariaLabel}
           className={buttonClasses}


### PR DESCRIPTION
Icon geometry was only reachable via `variant="icon-only"`, which also forces a transparent ghost look. So filled icon buttons — the composer's send, stop, queue and dictation controls — rendered with text-button geometry: inline padding, 44x36 instead of a 36x36 square. Themes had no way to fix that: `--theme-radius-control` applies, but on a non-square button it yields a lozenge, and no DOM signal distinguished an icon control from a text one, so a theme could only guess at private `btn-geometry-*` class names.

- `geometry="icon"` opts a button into square geometry independently of colour. `variant="icon-only"` still implies it.
- Emit `data-geometry` (resolved: `icon-sm` | `sm` | ...) and `data-variant`, so `theme.css` can target controls without naming private classes. Before the props spread, so callers can override.
- `shape="pill"` reads `var(--theme-radius-pill)` instead of Tailwind's hardcoded `9999px` — `radius.pill` was a dead token. Identical rendering under the default theme, where pill is already `9999px`