### PR TITLE
Reuse the shared Button for the add-menu trigger

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -5,6 +5,7 @@ import { Fragment, useId, useRef, useState } from "react";
 import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 
 import { AnchoredPopover } from "../Controls/AnchoredPopover";
+import { Button } from "../Controls/Button";
 import { CheckIcon, LoadingIcon, PlusIcon } from "../icons";
 
 import type React from "react";
@@ -309,27 +310,30 @@ export function ChatInputAddMenu({
       initialFocusSelector={NAVIGABLE_ITEM_SELECTOR}
       panelClassName="w-[min(20rem,calc(100vw-16px))] overflow-y-auto p-1"
       dataUi="chat-input-add-menu"
+      // `relative` is the only styling this needs beyond the shared Button:
+      // it anchors the absolutely-positioned count badge. Size, radius, hover
+      // and disabled states all come from `variant="icon-only"`, which this
+      // previously hand-rolled with the same tokens.
       trigger={(triggerProps) => (
-        <button
+        <Button
           {...triggerProps}
+          variant="icon-only"
+          size="sm"
           disabled={isBusy}
           aria-label={t({
             id: "chatInput.addMenu.trigger",
             message: "Add files and tools",
           })}
           data-testid="chat-input-add-menu-trigger"
-          className={clsx(
-            "relative inline-flex size-9 items-center justify-center rounded-md",
-            "text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover",
-            "disabled:cursor-not-allowed disabled:opacity-50",
-            className,
-          )}
+          className={clsx("relative", className)}
+          icon={
+            isProcessing ? (
+              <LoadingIcon className="size-5 animate-spin" />
+            ) : (
+              <PlusIcon className="size-5" />
+            )
+          }
         >
-          {isProcessing ? (
-            <LoadingIcon className="size-5 animate-spin" />
-          ) : (
-            <PlusIcon className="size-5" />
-          )}
           {showBadge && !isProcessing && (
             <span
               data-testid="chat-input-add-menu-badge"
@@ -338,7 +342,7 @@ export function ChatInputAddMenu({
               {selectedCount}
             </span>
           )}
-        </button>
+        </Button>
       )}
     >
       <div className="flex flex-col" data-ui="chat-input-add-menu-content">

--- a/frontend/src/components/ui/Chat/__tests__/ChatInputAddMenu.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/ChatInputAddMenu.test.tsx
@@ -12,7 +12,7 @@ import { ChatInputAddMenu } from "../ChatInputAddMenu";
  */
 describe("ChatInputAddMenu", () => {
   const fileSources = [
-    { key: "upload", label: "Upload from Computer", onSelect: vi.fn() },
+    { id: "upload", label: "Upload from Computer", onSelect: vi.fn() },
   ];
 
   it("wires the popover contract onto the trigger", () => {

--- a/frontend/src/components/ui/Chat/__tests__/ChatInputAddMenu.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/ChatInputAddMenu.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatInputAddMenu } from "../ChatInputAddMenu";
+
+/**
+ * The trigger is rendered through `AnchoredPopover`'s render-prop, which hands
+ * it a `ref` plus the aria/keyboard wiring. Since the trigger is a shared
+ * `Button` (a forwardRef component) receiving that bag via spread, these tests
+ * pin the wiring end-to-end — a dropped ref or swallowed handler would break
+ * the popover silently rather than failing to compile.
+ */
+describe("ChatInputAddMenu", () => {
+  const fileSources = [
+    { key: "upload", label: "Upload from Computer", onSelect: vi.fn() },
+  ];
+
+  it("wires the popover contract onto the trigger", () => {
+    render(<ChatInputAddMenu fileSources={fileSources} />);
+
+    const trigger = screen.getByTestId("chat-input-add-menu-trigger");
+
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("aria-controls");
+    expect(trigger).toHaveAccessibleName("Add files and tools");
+  });
+
+  it("opens and closes the menu on click", () => {
+    render(<ChatInputAddMenu fileSources={fileSources} />);
+
+    const trigger = screen.getByTestId("chat-input-add-menu-trigger");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Upload from Computer")).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("renders the count badge alongside the icon, and drops it while processing", () => {
+    const { rerender } = render(
+      <ChatInputAddMenu fileSources={fileSources} selectedCount={3} />,
+    );
+
+    expect(screen.getByTestId("chat-input-add-menu-badge")).toHaveTextContent(
+      "3",
+    );
+
+    rerender(
+      <ChatInputAddMenu
+        fileSources={fileSources}
+        selectedCount={3}
+        isProcessing
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("chat-input-add-menu-badge"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the trigger when disabled", () => {
+    render(<ChatInputAddMenu fileSources={fileSources} disabled />);
+
+    expect(screen.getByTestId("chat-input-add-menu-trigger")).toBeDisabled();
+  });
+});


### PR DESCRIPTION
The `+` trigger was a hand-rolled `<button>` reimplementing what `variant="icon-only"` already provides, with the same tokens: `size-9` == `btn-geometry-icon-sm` (36px), and an identical `text-theme-fg-secondary` / `hover:bg-theme-bg-hover` / disabled pair.

Hand-rolling it also put it outside the theming contract — the geometry was a literal `rounded-md` instead of `--theme-radius-control`, and it carried none of Button's `data-*` hooks, so a theme could not reach it.

Only `relative` remains at the call site; it anchors the count badge, which moves to `children` and stays out of the flex flow (it's `absolute`). The `AnchoredPopover` trigger bag — ref, aria, keyboard handlers — spreads onto Button unchanged, since Button is a forwardRef extending `ButtonHTMLAttributes`.

Adds `ChatInputAddMenu` tests, of which there were none: popover contract on the trigger, open/close, badge, disabled state.

**Visual delta:** radius `rounded-md` (6px) -> `--theme-radius-control` (8px under the default theme). Nothing else.

Independent of #843 — `variant="icon-only"` already carries icon geometry, so this doesn't need the new `geometry` prop.