### PR TITLE
Put the file-upload button on the shared Button and tokenise its styles

### DIFF
--- a/frontend/src/components/ui/FileUpload/FileUploadButton.tsx
+++ b/frontend/src/components/ui/FileUpload/FileUploadButton.tsx
@@ -1,13 +1,13 @@
 import { t } from "@lingui/core/macro";
-import { useState, memo, Suspense } from "react";
+import { memo, Suspense } from "react";
 import { useDropzone } from "react-dropzone";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { FileTypeUtil } from "@/utils/fileTypes";
 
+import { Button } from "../Controls";
 import { PlusIcon } from "../icons";
 import { FileUploadLoading, FileUploadError } from "./FileUploadStates";
-import { BUTTON_STYLES } from "./fileUploadStyles";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { FileType } from "@/utils/fileTypes";
@@ -60,8 +60,6 @@ const FileUploadButtonInner = memo<FileUploadButtonProps>(
     isUploading = false,
     uploadError = null,
   }) => {
-    const [isHovered, setIsHovered] = useState(false);
-
     // Setup react-dropzone
     const { getRootProps, getInputProps, open } = useDropzone({
       onDrop: (acceptedFiles) => {
@@ -84,15 +82,6 @@ const FileUploadButtonInner = memo<FileUploadButtonProps>(
       noKeyboard: true,
     });
 
-    // Handle hover states
-    function handleMouseEnter() {
-      setIsHovered(true);
-    }
-
-    function handleMouseLeave() {
-      setIsHovered(false);
-    }
-
     // Show loading state if uploading
     if (isUploading) {
       return <FileUploadLoading className={className} />;
@@ -103,31 +92,29 @@ const FileUploadButtonInner = memo<FileUploadButtonProps>(
       return <FileUploadError error={uploadError} className={className} />;
     }
 
-    // Compute button styles based on props and state
-    const buttonStyles = [
-      BUTTON_STYLES.base,
-      iconOnly ? BUTTON_STYLES.iconOnly : BUTTON_STYLES.withLabel,
-      isHovered ? BUTTON_STYLES.hover : BUTTON_STYLES.default,
-      className,
-    ].join(" ");
-
-    const iconStyles = `size-5 ${isHovered ? "text-blue-500" : "text-[var(--theme-fg-muted)]"}`;
-
     return (
       <div {...getRootProps({ className: "contents" })}>
         <input {...getInputProps()} />
-        <button
+        {/* The secondary variant already carries this button's fill and its
+            hover; the previous hand-rolled version tracked hover in React
+            state purely to swap in a hardcoded blue that no token could
+            reach. Sibling states (uploading, error) have used Button for a
+            while — this brings the idle state in line. */}
+        <Button
           type="button"
-          className={buttonStyles}
+          variant="secondary"
+          // sm keeps the icon form at 36px, matching the add-menu trigger and
+          // send button it sits beside in the composer row.
+          size={iconOnly ? "sm" : "md"}
+          geometry={iconOnly ? "icon" : "control"}
+          className={className}
           onClick={open}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
           disabled={disabled || isUploading}
           aria-label={iconOnly ? label : undefined}
+          icon={<PlusIcon className="size-5" />}
         >
-          <PlusIcon className={iconStyles} />
           {!iconOnly && <span>{label}</span>}
-        </button>
+        </Button>
       </div>
     );
   },

--- a/frontend/src/components/ui/FileUpload/__tests__/FileUploadButton.test.tsx
+++ b/frontend/src/components/ui/FileUpload/__tests__/FileUploadButton.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FileUploadButton } from "../FileUploadButton";
+
+/**
+ * The idle button used to be a hand-rolled <button> whose hover swapped in a
+ * hardcoded `bg-blue-100` / `text-blue-500` via React state — unreachable by
+ * any theme token. These pin the shared-Button geometry and the absence of
+ * palette literals, so a regression shows up here rather than in a theme.
+ */
+describe("FileUploadButton", () => {
+  it("uses shared icon geometry sized to match its composer siblings", () => {
+    render(<FileUploadButton label="Attach" iconOnly />);
+
+    const button = screen.getByRole("button", { name: "Attach" });
+
+    expect(button).toHaveAttribute("data-geometry", "icon-sm");
+    expect(button).toHaveAttribute("data-variant", "secondary");
+    expect(button.className).toContain("btn-geometry-icon-sm");
+  });
+
+  it("uses control geometry and renders the label when not icon-only", () => {
+    render(<FileUploadButton label="Attach files" iconOnly={false} />);
+
+    const button = screen.getByRole("button", { name: /Attach files/ });
+
+    expect(button).toHaveAttribute("data-geometry", "md");
+    expect(screen.getByText("Attach files")).toBeInTheDocument();
+  });
+
+  it("carries no hardcoded palette colours", () => {
+    render(<FileUploadButton label="Attach" iconOnly />);
+
+    const button = screen.getByRole("button", { name: "Attach" });
+
+    expect(button.className).not.toMatch(/\bbg-blue-/);
+    expect(button.className).not.toMatch(/\btext-blue-/);
+    expect(button.innerHTML).not.toMatch(/text-blue-/);
+    // The fill comes from the variant's tokens.
+    expect(button.className).toContain("bg-theme-bg-secondary");
+    expect(button.className).toContain("hover:bg-theme-bg-hover");
+  });
+
+  it("is disabled when the disabled prop is set", () => {
+    render(<FileUploadButton label="Attach" iconOnly disabled />);
+
+    expect(screen.getByRole("button", { name: "Attach" })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
+++ b/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
@@ -1,21 +1,4 @@
 /**
- * Shared styles for file upload components
- */
-export const BUTTON_STYLES = {
-  base: "inline-flex items-center rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-[var(--theme-focus-ring)] theme-transition",
-  iconOnly: "justify-center p-1.5", // eslint-disable-line lingui/no-unlocalized-strings
-  withLabel: "gap-2 px-4 py-2",
-  default:
-    "bg-[var(--theme-bg-secondary)] text-[var(--theme-fg-secondary)] hover:bg-[var(--theme-bg-hover)]",
-  hover: "bg-blue-100 text-[var(--theme-fg-accent)]",
-  loading:
-    "inline-flex items-center justify-center rounded-md bg-[var(--theme-bg-secondary)] p-1.5 text-[var(--theme-fg-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--theme-focus-ring)]",
-  error:
-    "inline-flex items-center justify-center rounded-md bg-[var(--theme-error-bg)] p-1.5 text-[var(--theme-error-fg)] focus:outline-none focus:ring-2 focus:ring-[var(--theme-error-border)]",
-  disabled: "opacity-50 cursor-not-allowed",
-};
-
-/**
  * Styles for the file preview elements
  */
 export const FILE_PREVIEW_STYLES = {
@@ -31,7 +14,7 @@ export const FILE_PREVIEW_STYLES = {
   progress: {
     container:
       "w-full h-1 bg-[var(--theme-bg-primary)] rounded-full overflow-hidden",
-    bar: "h-full bg-blue-500 transition-all duration-300 ease-in-out",
+    bar: "h-full bg-[var(--theme-action-primary-bg)] transition-all duration-300 ease-in-out",
   },
   group: {
     container:
@@ -52,7 +35,9 @@ export const DROP_ZONE_STYLES = {
     "border-2 border-dashed rounded-lg p-4 text-center transition-colors",
   default:
     "border-[var(--theme-border)] hover:border-[var(--theme-border-focus)]",
-  active: "border-blue-500 bg-blue-50 dark:bg-blue-900/20",
+  // Focus border + accent fill is the app's existing "active drop target"
+  // language, and it resolves per theme — so no `dark:` variant is needed.
+  active: "border-[var(--theme-border-focus)] bg-[var(--theme-bg-accent)]",
   disabled: "opacity-50 cursor-not-allowed",
   text: "text-sm text-[var(--theme-fg-secondary)]",
   icon: "size-8 mx-auto mb-2 text-[var(--theme-fg-muted)]",

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -61,7 +61,6 @@ export { FileUploadError } from "@/components/ui/FileUpload/FileUploadStates";
 export { FileUploadLoading } from "@/components/ui/FileUpload/FileUploadStates";
 export type { FileUploadErrorProps } from "@/components/ui/FileUpload/FileUploadStates";
 export type { FileUploadLoadingProps } from "@/components/ui/FileUpload/FileUploadStates";
-export { BUTTON_STYLES } from "@/components/ui/FileUpload/fileUploadStyles";
 export { DROP_ZONE_STYLES } from "@/components/ui/FileUpload/fileUploadStyles";
 export { FILE_PREVIEW_STYLES } from "@/components/ui/FileUpload/fileUploadStyles";
 export { DefaultGroupedFileAttachmentsPreview } from "@/components/ui/FileUpload/GroupedFileAttachmentsPreview";


### PR DESCRIPTION
**Stacked on #843** — base is `fix/button-geometry-theming-contract`, since the icon form needs the `geometry` prop. Retarget to `main` once #843 lands.

The idle upload button was a hand-rolled `<button>` tracking hover in React state purely to swap in `bg-blue-100` with a `text-blue-500` icon. No theme token could reach either. Its sibling states (uploading, error) have used `Button` for a while — only the idle state was out of line.

The palette does have a blue scale, but `status.info` maps to **neutral**: the design language is monochrome, so these blues were outliers rather than a themed accent. Replaced with tokens that already express the same intent:

| was | now |
|---|---|
| button hover `bg-blue-100` + `text-blue-500` | `variant="secondary"`'s own `hover:bg-theme-bg-hover` — `isHovered` and both mouse handlers deleted |
| progress bar `bg-blue-500` | `--theme-action-primary-bg` |
| drop zone active `border-blue-500 bg-blue-50 dark:bg-blue-900/20` | `--theme-border-focus` + `--theme-bg-accent`, resolves per theme so the `dark:` variant goes away |

`BUTTON_STYLES` is now entirely unused — `loading`/`error`/`disabled` were already dead, since `FileUploadStates` moved to `Button` earlier — so it's removed and the generated shared barrel drops it with it. No component kit referenced it.

Adds `FileUploadButton` tests, of which there were none.

**Visual delta (default theme):** icon form 32x32 `rounded-md` -> 36x36 at `--theme-radius-control`, matching the add-menu trigger and send button beside it. Labelled form inline padding 16px -> 12px.