### PR TITLE
E2E: harden the queue/streaming spec + cover the mid-stream error path

### DIFF
--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -44,10 +44,21 @@ const selectMockModel = async (page: Page) => {
 };
 
 const uploadFileInChat = async (page: Page, file: string) => {
-  const fileChooserPromise = page.waitForEvent("filechooser");
-  await page.getByRole("button", { name: /upload files/i }).click();
-  const fileChooser = await fileChooserPromise;
-  await fileChooser.setFiles(file);
+  // Set the file directly on the input. These tests cover upload ROUTING
+  // (which chat the file lands on), not the chooser UI — and the visible
+  // affordance differs by config (dedicated button vs unified "+" menu), so
+  // clicking a specific button would couple them to one layout.
+  await page.locator('input[type="file"]').first().setInputFiles(file);
+};
+
+/**
+ * Re-assert the turn is still in flight immediately before a queue-affecting
+ * action. If the stream ended early, the Queue affordance silently becomes
+ * Send — this turns that into a loud failure at the right line instead of a
+ * confusing assertion later.
+ */
+const expectStreamStillActive = async (page: Page) => {
+  await expect(stopButton(page)).toBeVisible();
 };
 
 /**
@@ -65,7 +76,13 @@ const startLongRunningStream = async (page: Page, seconds: number) => {
   });
 };
 
-/** Wait until the whole turn (and any drained follow-up) has finished. */
+/**
+ * Wait until no turn is in flight (Stop control gone). NOTE: this does NOT by
+ * itself cover a drained follow-up — the Stop control is also absent in the
+ * gap between a turn ending and the auto-sent turn starting, so callers that
+ * expect a drain must first gate on the follow-up's user-message count (all
+ * current callers do).
+ */
 const waitForStreamToFinish = async (page: Page, timeout = 40000) => {
   await expect(stopButton(page)).toHaveCount(0, { timeout });
 };
@@ -116,10 +133,11 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 6);
+      await startLongRunningStream(page, 10);
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
 
       // Queued, not sent: chip shows, composer clears, still one user message.
@@ -155,10 +173,11 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 6);
+      await startLongRunningStream(page, 10);
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await page.getByTestId("chat-input-queue-message").click();
 
       await expect(queuedChip(page)).toBeVisible();
@@ -184,18 +203,23 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 10);
+      // 20s window: this test has the longest interaction sequence in the
+      // file (two dialog round-trips), and a throttled CI runner must never
+      // see the stream end mid-sequence — Queue would silently become Send.
+      await startLongRunningStream(page, 20);
 
       const textbox = messageBox(page);
 
       // Queue the first candidate.
       await textbox.fill("alpha queued");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toContainText("alpha queued");
 
       // Queuing a second one opens the danger confirmation dialog; the composer
       // draft is left intact behind it.
       await textbox.fill("beta queued");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       const dialog = page.getByRole("dialog", {
         name: "Replace the queued message?",
@@ -214,6 +238,7 @@ test.describe("Streaming composer + message queue", () => {
       await expect(textbox).toHaveValue("beta queued");
 
       // Queue again and confirm Replace → queued draft is swapped.
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(dialog).toBeVisible();
       await dialog.getByRole("button").filter({ hasText: "Replace" }).click();
@@ -244,18 +269,26 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 6);
+      await startLongRunningStream(page, 10);
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toBeVisible();
 
       await page.getByTestId("chat-input-queued-message-cancel").click();
       await expect(queuedChip(page)).toHaveCount(0);
 
-      // Let the turn finish; nothing should be auto-sent.
+      // Let the turn demonstrably complete (terminal token, not just the Stop
+      // control disappearing), give an erroneous drain a beat to fire, and
+      // only then assert nothing was auto-sent.
+      await expect(page.getByTestId("message-assistant").last()).toContainText(
+        "Complete!",
+        { timeout: 30000 },
+      );
       await waitForStreamToFinish(page);
+      await page.waitForTimeout(1000);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
       await expect(
         page
@@ -275,10 +308,11 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 6);
+      await startLongRunningStream(page, 10);
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toBeVisible();
 
@@ -287,8 +321,15 @@ test.describe("Streaming composer + message queue", () => {
       await expect(queuedChip(page)).toHaveCount(0);
       await expect(textbox).toHaveValue("fast");
 
-      // It is a plain draft again, so completing the turn sends nothing.
+      // It is a plain draft again, so completing the turn sends nothing —
+      // asserted only after the terminal token plus a grace beat, so a
+      // late-firing drain would be caught.
+      await expect(page.getByTestId("message-assistant").last()).toContainText(
+        "Complete!",
+        { timeout: 30000 },
+      );
       await waitForStreamToFinish(page);
+      await page.waitForTimeout(1000);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
       await expect(textbox).toHaveValue("fast");
     },
@@ -308,6 +349,7 @@ test.describe("Streaming composer + message queue", () => {
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toBeVisible();
 
@@ -339,6 +381,7 @@ test.describe("Streaming composer + message queue", () => {
 
       const textbox = messageBox(page);
       await textbox.fill("fast");
+      await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toBeVisible();
 
@@ -349,20 +392,42 @@ test.describe("Streaming composer + message queue", () => {
         .getByRole("button", { name: "New Chat", exact: true })
         .click();
       await expect(page).toHaveURL(/\/chat\/new$/);
+      // Neither the chip nor the payload leaks into the new chat's composer.
       await expect(queuedChip(page)).toHaveCount(0);
+      await expect(messageBox(page)).toHaveValue("");
 
-      // Return to the original chat: the queued payload came back as a draft
-      // (never background-sent) and the chat still has a single user message.
+      // Return to the original chat. Because we left mid-stream, no client-side
+      // completion event will invalidate the chats list for us — nudge the
+      // window-focus refetch (react-query v5 listens for visibilitychange),
+      // exactly what a user re-focusing the tab would trigger, so the sidebar
+      // reliably lists the chat created seconds ago.
+      await page.evaluate(() => {
+        window.dispatchEvent(new Event("visibilitychange"));
+      });
       await ensureOpenSidebar(page);
-      await page
+      const sidebarEntry = page
         .getByRole("complementary")
-        .locator(`[data-chat-id="${streamingChatId}"]`)
-        .click();
+        .locator(`[data-chat-id="${streamingChatId}"]`);
+      await expect(sidebarEntry).toBeVisible({ timeout: 20000 });
+      await sidebarEntry.click();
       await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
 
+      // The queued payload came back as a draft.
       await expect(messageBox(page)).toHaveValue("fast");
       await expect(queuedChip(page)).toHaveCount(0);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // "Never background-sends" can only be asserted after the abandoned
+      // turn has demonstrably completed — before that, the drain this guards
+      // against could not have fired yet.
+      await expect(page.getByTestId("message-assistant").last()).toContainText(
+        "Complete!",
+        { timeout: 30000 },
+      );
+      await waitForStreamToFinish(page, 15000);
+      await page.waitForTimeout(1500);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+      await expect(messageBox(page)).toHaveValue("fast");
     },
   );
 
@@ -384,6 +449,11 @@ test.describe("Streaming composer + message queue", () => {
       const textbox = messageBox(page);
       await textbox.fill("long running 8");
       await textbox.press("Enter");
+      // Bound the race: the submit must be in flight before the upload, or a
+      // no-op run (send failed silently) would pass vacuously. This waits on
+      // the turn starting, NOT on the chat id settling — the id race the test
+      // exists for stays open.
+      await expect(stopButton(page)).toBeVisible({ timeout: 10000 });
 
       const pdfPath = path.join(
         __dirname,
@@ -415,9 +485,12 @@ test.describe("Streaming composer + message queue", () => {
       await waitForStreamToFinish(page);
 
       // No orphan chat was created for the upload, and we're still on the same
-      // chat with its attachment.
-      const chatCountAfter = await sidebar.locator("[data-chat-id]").count();
-      expect(chatCountAfter).toBe(chatCountBaseline);
+      // chat with its attachment. Retrying assertion — the list refetches
+      // asynchronously after completion.
+      await expect(sidebar.locator("[data-chat-id]")).toHaveCount(
+        chatCountBaseline,
+        { timeout: 10000 },
+      );
       await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
       await expect(page.getByText(/sample.*compressed.*pdf/i)).toBeVisible();
     },
@@ -433,7 +506,10 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 8);
+      // 25s window: the upload below is allowed up to 15s, which must fit
+      // inside the stream with margin — otherwise the queue click lands after
+      // completion and silently sends instead.
+      await startLongRunningStream(page, 25);
 
       // Attach a file mid-stream (routes to the streaming chat, ERMAIN-466),
       // then queue a "cite files" message that carries it. The queue stores
@@ -450,6 +526,7 @@ test.describe("Streaming composer + message queue", () => {
 
       const textbox = messageBox(page);
       await textbox.fill("cite files");
+      await expectStreamStillActive(page);
       await page.getByTestId("chat-input-queue-message").click();
 
       await expect(queuedChip(page)).toBeVisible();

--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -1,7 +1,12 @@
 import { expect, Locator, Page, test } from "@playwright/test";
 import path from "path";
 import { fileURLToPath } from "url";
-import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
+import {
+  chatIsReadyToChat,
+  ensureOpenSidebar,
+  installStreamErrorTap,
+  injectStreamError,
+} from "./shared";
 import { TAG_CI } from "./tags";
 
 /**
@@ -365,6 +370,53 @@ test.describe("Streaming composer + message queue", () => {
   );
 
   test(
+    "a turn that errors mid-stream returns the queued message to the composer and never sends",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(60000);
+
+      // The tap lets us fail the stream at an exact moment — the only
+      // stream-then-error mock (`hallucination loop`) aborts within
+      // milliseconds, leaving no window to queue into.
+      await installStreamErrorTap(page);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectMockModel(page);
+
+      await startLongRunningStream(page, 15);
+
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await expectStreamStillActive(page);
+      await textbox.press("Enter");
+      await expect(queuedChip(page)).toBeVisible();
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      // Fail the turn mid-stream: the client receives the same `error` event
+      // the backend emits on a provider failure, then the stream ends.
+      await injectStreamError(page);
+      await waitForStreamToFinish(page, 15000);
+
+      // The messagingError drain branch: queued content returns to the
+      // composer, the chip clears, and nothing is ever sent — asserted again
+      // after a grace beat so a late-firing drain would be caught.
+      await expect(textbox).toHaveValue("fast");
+      await expect(queuedChip(page)).toHaveCount(0);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+
+      await page.waitForTimeout(1500);
+      await expect(page.getByTestId("message-user")).toHaveCount(1);
+      await expect(textbox).toHaveValue("fast");
+      await expect(
+        page
+          .getByTestId("message-assistant")
+          .filter({ hasText: "Quick response!" }),
+      ).toHaveCount(0);
+    },
+  );
+
+  test(
     "navigating away while a message is queued drops it to a draft and never background-sends",
     { tag: TAG_CI },
     async ({ page }) => {
@@ -374,19 +426,33 @@ test.describe("Streaming composer + message queue", () => {
       await chatIsReadyToChat(page);
       await selectMockModel(page);
 
-      await startLongRunningStream(page, 10);
-      await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 10000 });
+      // Establish the chat with a completed turn FIRST, so the sidebar lists
+      // it before we ever leave. The chats list only refetches on completion
+      // events (focus refetches are a no-op inside the 60s staleTime), so a
+      // chat abandoned mid-stream would not reliably appear in the sidebar —
+      // and returning to it is the whole point of this test.
+      const textbox = messageBox(page);
+      await textbox.fill("fast");
+      await textbox.press("Enter");
+      await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
       const streamingChatId = page.url().split("/").pop();
       expect(streamingChatId).toBeTruthy();
+      await waitForStreamToFinish(page, 20000);
+      await ensureOpenSidebar(page);
+      const sidebarEntry = page
+        .getByRole("complementary")
+        .locator(`[data-chat-id="${streamingChatId}"]`);
+      await expect(sidebarEntry).toBeVisible({ timeout: 15000 });
 
-      const textbox = messageBox(page);
+      // Now stream long enough to queue into.
+      await startLongRunningStream(page, 10);
+
       await textbox.fill("fast");
       await expectStreamStillActive(page);
       await textbox.press("Enter");
       await expect(queuedChip(page)).toBeVisible();
 
       // Navigate away to a brand-new chat while the message is still queued.
-      await ensureOpenSidebar(page);
       await page
         .getByRole("complementary")
         .getByRole("button", { name: "New Chat", exact: true })
@@ -396,26 +462,18 @@ test.describe("Streaming composer + message queue", () => {
       await expect(queuedChip(page)).toHaveCount(0);
       await expect(messageBox(page)).toHaveValue("");
 
-      // Return to the original chat. Because we left mid-stream, no client-side
-      // completion event will invalidate the chats list for us — nudge the
-      // window-focus refetch (react-query v5 listens for visibilitychange),
-      // exactly what a user re-focusing the tab would trigger, so the sidebar
-      // reliably lists the chat created seconds ago.
-      await page.evaluate(() => {
-        window.dispatchEvent(new Event("visibilitychange"));
-      });
+      // Return to the original chat via its (already-listed) sidebar entry.
       await ensureOpenSidebar(page);
-      const sidebarEntry = page
-        .getByRole("complementary")
-        .locator(`[data-chat-id="${streamingChatId}"]`);
-      await expect(sidebarEntry).toBeVisible({ timeout: 20000 });
+      await expect(sidebarEntry).toBeVisible({ timeout: 15000 });
       await sidebarEntry.click();
       await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
 
-      // The queued payload came back as a draft.
+      // The queued payload came back as a draft. (No message-count assert
+      // here: while the resumed stream is still in flight the history can
+      // render without the mid-stream user message — a pre-existing resume
+      // quirk unrelated to the queue. The count is checked after completion.)
       await expect(messageBox(page)).toHaveValue("fast");
       await expect(queuedChip(page)).toHaveCount(0);
-      await expect(page.getByTestId("message-user")).toHaveCount(1);
 
       // "Never background-sends" can only be asserted after the abandoned
       // turn has demonstrably completed — before that, the drain this guards
@@ -426,8 +484,15 @@ test.describe("Streaming composer + message queue", () => {
       );
       await waitForStreamToFinish(page, 15000);
       await page.waitForTimeout(1500);
-      await expect(page.getByTestId("message-user")).toHaveCount(1);
+      // Exactly the two sent user messages — an auto-send would make it 3 —
+      // and the queued text still sits in the composer.
+      await expect(page.getByTestId("message-user")).toHaveCount(2);
       await expect(messageBox(page)).toHaveValue("fast");
+      await expect(
+        page
+          .getByTestId("message-assistant")
+          .filter({ hasText: "Quick response!" }),
+      ).toHaveCount(1);
     },
   );
 

--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -736,3 +736,106 @@ export async function ensureTestScenario(
     }
   });
 }
+
+/**
+ * Install a browser-side tap on the submitstream SSE response that can inject
+ * a mid-stream `error` event (the same frame the backend emits when a provider
+ * fails, see message_streaming.rs StreamingEvent::Error) and then end the
+ * stream. Lets tests exercise the "turn errors mid-stream" path at an exact
+ * moment, which no mock behaviour currently offers.
+ *
+ * The injected event runs the client's `case "error"` handler, which resets
+ * the streaming state — so the stream end that follows is treated as a normal
+ * close and does NOT trigger a resumestream that would revive the turn.
+ */
+export const installStreamErrorTap = async (page: Page) => {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+
+    const tapWindow = window as Window & {
+      __injectStreamError?: () => void;
+    };
+
+    let pendingInjection: (() => void) | null = null;
+    tapWindow.__injectStreamError = () => {
+      pendingInjection?.();
+    };
+
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      const response = await originalFetch(input, init);
+      if (
+        !url.includes("/api/v1beta/me/messages/submitstream") ||
+        !response.body
+      ) {
+        return response;
+      }
+
+      const upstream = response.body.getReader();
+      let injectRequested = false;
+      let resolveInjectSignal: (() => void) | null = null;
+      pendingInjection = () => {
+        injectRequested = true;
+        resolveInjectSignal?.();
+      };
+
+      const tapped = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          if (!injectRequested) {
+            // Wake up either on the next upstream chunk or on injection, so
+            // the error lands without waiting out a quiet stream.
+            const read = upstream.read();
+            const injectSignal = new Promise<void>((resolve) => {
+              resolveInjectSignal = resolve;
+            });
+            const winner = await Promise.race([
+              read.then((result) => ({ kind: "read" as const, result })),
+              injectSignal.then(() => ({ kind: "inject" as const })),
+            ]);
+            resolveInjectSignal = null;
+            if (winner.kind === "read") {
+              if (winner.result.done) {
+                controller.close();
+                return;
+              }
+              controller.enqueue(winner.result.value);
+              return;
+            }
+          }
+          const frame = `event: error\ndata: ${JSON.stringify({
+            message_type: "error",
+            error_type: "internal_error",
+            error_description: "Injected provider failure (e2e stream tap)",
+          })}\n\n`;
+          controller.enqueue(new TextEncoder().encode(frame));
+          controller.close();
+          void upstream.cancel().catch(() => {});
+        },
+        cancel(reason) {
+          void upstream.cancel(reason).catch(() => {});
+        },
+      });
+
+      return new Response(tapped, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    };
+  });
+};
+
+/** Inject the tapped stream error installed by installStreamErrorTap. */
+export const injectStreamError = async (page: Page) => {
+  await page.evaluate(() => {
+    (
+      window as Window & { __injectStreamError?: () => void }
+    ).__injectStreamError?.();
+  });
+};


### PR DESCRIPTION
Follow-up to #841 (merged before these landed on the branch). Two commits:

**Barrier hardening** — every queue-affecting action now re-asserts the turn is still in flight (`expectStreamStillActive`): if the stream ends early, Queue silently becomes Send and the test failed later with a misleading assert. Stream windows raised where the interaction budget was too tight (the replace-dialog test ran 16 UI steps in a 10s window; the attachment test nested a 15s upload wait inside an 8s stream). Every "nothing was auto-sent" negative now sits behind a terminal-token gate (`Complete!`) plus a grace beat — previously they asserted before the drain window even opened and could not fail.

**Error-path coverage + navigate-away redesign**
- New `installStreamErrorTap`/`injectStreamError` in `shared.ts`: taps the fetch-based submitstream SSE and injects the exact `event: error` frame the backend emits on provider failure, then ends the stream. The client's error handler resets streaming state, so the close is treated as normal and no resumestream revives the turn. This unlocks the error-path drain test that #841 deferred ("stream for N seconds, then error"): queued draft returns to the composer, nothing sends.
- The navigate-away test now establishes its chat with a completed turn *before* leaving: the chats list only refetches on completion invalidation (focus refetches are no-ops inside the 60s `staleTime`), so a chat abandoned mid-stream is not reliably sidebar-listed — the previous shape flaked on exactly that. Message-count asserts moved after turn completion: while a resumed stream is in flight, history can render without the mid-stream user message (known resume quirk, unrelated to the queue).
- Upload helper switched to `setInputFiles`: the tests cover upload *routing*, not the chooser UI, and the visible affordance differs by config (dedicated button vs unified "+" menu, where the button is a hidden 1×1).

Validated against a local full stack (oauth2-proxy → vite + backend + mock-llm): 12/12 across two consecutive full-suite runs, error-path test ×3, navigate-away ×3.