### PR TITLE
Take dropdown trigger geometry from the control token

### DIFF
--- a/frontend/src/components/ui/Chat/ModelSelector.tsx
+++ b/frontend/src/components/ui/Chat/ModelSelector.tsx
@@ -187,7 +187,7 @@ export const ModelSelector = ({
         onOpenChange={setIsDropdownOpen}
         matchContentWidth
         triggerButtonVariant="secondary"
-        triggerButtonClassName="min-w-[10rem] justify-between gap-2 rounded-[var(--theme-radius-input)] px-3 py-2 shadow-sm"
+        triggerButtonClassName="min-w-[10rem] justify-between gap-2"
         triggerIcon={
           <div className="flex min-w-0 flex-1 items-center gap-2">
             {selectedModel?.model_icon ? (

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -238,4 +238,26 @@ describe("DropdownMenu", () => {
     });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
   });
+
+  it("takes its geometry from the shared control token, not a caller override", () => {
+    render(
+      <DropdownMenu
+        items={[{ label: "Rename", onClick: vi.fn() }]}
+        triggerButtonVariant="secondary"
+        triggerButtonClassName="min-w-[10rem] justify-between gap-2"
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+
+    // btn-geometry-sm resolves --theme-radius-control, so a theme scoping that
+    // token to a surface reaches this trigger like any other button.
+    expect(trigger.className).toContain("btn-geometry-sm");
+    expect(trigger).toHaveAttribute("data-geometry", "sm");
+    // Layout is the caller's business; skin is not.
+    expect(trigger.className).toContain("justify-between");
+    expect(trigger.className).not.toMatch(/rounded-\[/);
+    expect(trigger.className).not.toMatch(/\bshadow-sm\b/);
+    expect(trigger.className).not.toMatch(/\bpx-3\b|\bpy-2\b/);
+  });
 });

--- a/frontend/src/components/ui/Settings/AudioInputTabContent.tsx
+++ b/frontend/src/components/ui/Settings/AudioInputTabContent.tsx
@@ -105,7 +105,7 @@ export function AudioInputTabContent({ isActive }: AudioInputTabContentProps) {
         items={audioInputItems}
         align="left"
         triggerButtonVariant="secondary"
-        triggerButtonClassName="w-full justify-between gap-2 rounded-[var(--theme-radius-input)] px-3 py-2 shadow-sm"
+        triggerButtonClassName="w-full justify-between gap-2"
         matchContentWidth={false}
         onOpenChange={setIsAudioInputDropdownOpen}
         triggerIcon={


### PR DESCRIPTION
The model picker and the audio-input picker both hand-rolled geometry onto the shared Button:

```
rounded-[var(--theme-radius-input)] px-3 py-2 shadow-sm
```

`px-3 py-2` just restated `--theme-spacing-control-padding-x/y` by hand — redundant. The radius was actively wrong: `--theme-radius-input` belongs to the composer shell, attachment groups, settings cards and the share dialog, so **a theme could not round these triggers without reshaping all of those too**. It also left them at 16px beside 8px neighbours once the composer's other controls moved onto shared geometry (#843, #844).

Dropping the skin leaves layout only (`min-w`/`w-full`, `justify-between`, `gap`). Geometry comes from `btn-geometry-sm`, so these now read `--theme-radius-control` like every other button — and a theme scoping that token to a `data-ui` surface reaches them:

```css
[data-ui="chat-input-controls"] { --theme-radius-control: 9999px; }
```

**Visual delta (default theme):** radius 16px -> 8px, drop shadow removed, padding unchanged.

Adds a `DropdownMenu` test pinning the trigger to shared geometry and asserting no `rounded-[…]` / `shadow-sm` / `px-3 py-2` leaks back in.