### PR TITLE
Drop the whole superseded tail when editing or regenerating a non-last message (ERMAIN-469)

### DIFF
--- a/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
+++ b/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
@@ -1,0 +1,181 @@
+import { expect, Locator, Page, test } from "@playwright/test";
+import { chatIsReadyToChat, selectModel } from "./shared";
+import { TAG_CI } from "./tags";
+
+/**
+ * ERMAIN-469: editing or regenerating a message that is NOT the last turn must
+ * drop every later turn immediately, not just the next assistant.
+ *
+ * The backend deactivates the whole tail and reactivates only the new lineage,
+ * but the frontend used to prune just one message pair. The survivors kept
+ * their original (older) `createdAt`, and since the message list sorts purely
+ * by that timestamp they rendered ABOVE the optimistic edit and its streaming
+ * reply — until the post-stream refetch silently removed them.
+ *
+ * The bug is only visible WHILE streaming, so these tests assert mid-stream and
+ * then again after completion (to prove nothing re-orders). `long running <N>`
+ * streams one `Second N passed` chunk per second, which is what makes that
+ * window wide enough to assert in.
+ */
+
+const messageBox = (page: Page): Locator =>
+  page.getByRole("textbox", { name: "Type a message..." });
+
+const stopButton = (page: Page): Locator =>
+  page.getByTestId("chat-input-stop-generation");
+
+/** Every rendered message, in DOM order. */
+const chatMessages = (page: Page): Locator =>
+  page.locator('[data-ui="chat-message"]');
+
+/** The rendered roles, in DOM order — the thing the bug actually corrupted. */
+const messageRoles = async (page: Page): Promise<string[]> =>
+  chatMessages(page).evaluateAll((nodes) =>
+    nodes.map((node) => node.getAttribute("data-role") ?? ""),
+  );
+
+/** Send a message that falls through to the default mock and wait for the turn. */
+const sendSettledMessage = async (page: Page, text: string) => {
+  const textbox = messageBox(page);
+  await expect(textbox).toBeEnabled();
+  await textbox.fill(text);
+  await textbox.press("Enter");
+  await chatIsReadyToChat(page, {
+    expectAssistantResponse: true,
+    loadingTimeoutMs: 30000,
+  });
+};
+
+/**
+ * Build `[u1, a1, u2, a2, u3, a3]`. The texts deliberately avoid every mock
+ * trigger substring so each turn resolves via the fast default response.
+ */
+const seedThreeTurnConversation = async (page: Page) => {
+  await sendSettledMessage(page, "Alpha one");
+  await sendSettledMessage(page, "Beta two");
+  await sendSettledMessage(page, "Gamma three");
+
+  await expect(page.getByTestId("message-user")).toHaveCount(3);
+  await expect(page.getByTestId("message-assistant")).toHaveCount(3);
+};
+
+/** Wait until the streamed turn is genuinely in flight, with content on screen. */
+const waitForStreamingToStart = async (page: Page) => {
+  await expect(stopButton(page)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText("Second 1 passed")).toBeVisible({
+    timeout: 20000,
+  });
+};
+
+const waitForStreamToFinish = async (page: Page, timeout = 60000) => {
+  await expect(stopButton(page)).toHaveCount(0, { timeout });
+};
+
+/**
+ * The whole point of ERMAIN-469: exactly one prefix turn survives, and the
+ * replacement turn is last. Asserted identically mid-stream and post-refetch.
+ */
+const expectSingleTrailingBranch = async (page: Page) => {
+  await expect(page.getByTestId("message-user")).toHaveCount(2);
+  await expect(page.getByTestId("message-assistant")).toHaveCount(2);
+
+  // The stale third turn must be gone, not merely re-sorted.
+  await expect(page.getByText("Gamma three")).toHaveCount(0);
+
+  expect(await messageRoles(page)).toEqual([
+    "user",
+    "assistant",
+    "user",
+    "assistant",
+  ]);
+
+  // The surviving prefix is the untouched first turn.
+  await expect(chatMessages(page).first()).toContainText("Alpha one");
+  // ...and the streaming reply is genuinely last, with nothing floating above.
+  await expect(chatMessages(page).last()).toContainText("Second");
+};
+
+test.describe("Edit / regenerate lineage pruning", () => {
+  test(
+    "editing a non-last user message drops every later turn while the reply streams",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(120000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectModel(page, "Mock-LLM");
+
+      await seedThreeTurnConversation(page);
+
+      // Edit the SECOND user message — the case the bug was specific to.
+      const secondUserMessage = page.getByTestId("message-user").nth(1);
+      await expect(secondUserMessage).toContainText("Beta two");
+      await secondUserMessage.hover();
+      const editButton = secondUserMessage.getByLabel("Edit message");
+      await editButton.waitFor({ state: "visible", timeout: 10000 });
+      await editButton.click();
+
+      const editTextbox = page.getByRole("textbox", {
+        name: "Edit your message...",
+      });
+      await expect(editTextbox).toBeVisible({ timeout: 30000 });
+      await editTextbox.fill("long running 8");
+
+      const saveButton = page.getByTestId("chat-input-save-edit");
+      await expect(saveButton).toBeEnabled();
+      await saveButton.click();
+
+      await waitForStreamingToStart(page);
+
+      // MID-STREAM: this is the state ERMAIN-469 reported as broken.
+      await expectSingleTrailingBranch(page);
+      await expect(chatMessages(page).nth(2)).toContainText("long running 8");
+
+      // And the corrected state must survive the post-stream refetch without a
+      // visible re-order.
+      await waitForStreamToFinish(page);
+      await chatIsReadyToChat(page, { loadingTimeoutMs: 30000 });
+      await expectSingleTrailingBranch(page);
+      await expect(chatMessages(page).last()).toContainText("Complete!");
+    },
+  );
+
+  test(
+    "regenerating a non-last assistant message drops every later turn while the reply streams",
+    { tag: TAG_CI },
+    async ({ page }) => {
+      test.setTimeout(120000);
+
+      await page.goto("/");
+      await chatIsReadyToChat(page);
+      await selectModel(page, "Mock-LLM");
+
+      // The regenerated turn replays its own user message, so the long-running
+      // trigger has to live in that message rather than in the edit.
+      await sendSettledMessage(page, "Alpha one");
+      await sendSettledMessage(page, "long running 6");
+      await sendSettledMessage(page, "Gamma three");
+      await expect(page.getByTestId("message-assistant")).toHaveCount(3);
+
+      const secondAssistantMessage = page
+        .getByTestId("message-assistant")
+        .nth(1);
+      await secondAssistantMessage.hover();
+      const regenerateButton = secondAssistantMessage.getByLabel(
+        "Regenerate response",
+      );
+      await regenerateButton.waitFor({ state: "visible", timeout: 10000 });
+      await regenerateButton.click();
+
+      await waitForStreamingToStart(page);
+
+      await expectSingleTrailingBranch(page);
+      await expect(chatMessages(page).nth(2)).toContainText("long running 6");
+
+      await waitForStreamToFinish(page);
+      await chatIsReadyToChat(page, { loadingTimeoutMs: 30000 });
+      await expectSingleTrailingBranch(page);
+    },
+  );
+});

--- a/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
+++ b/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
@@ -34,16 +34,28 @@ const messageRoles = async (page: Page): Promise<string[]> =>
     nodes.map((node) => node.getAttribute("data-role") ?? ""),
   );
 
-/** Send a message that falls through to the default mock and wait for the turn. */
-const sendSettledMessage = async (page: Page, text: string) => {
+/**
+ * Send a message and wait for its turn to settle.
+ *
+ * `chatIsReadyToChat`'s `expectAssistantResponse` assertion is strict-mode, so
+ * it throws once a second assistant message exists. Wait on turn completion
+ * (the Stop button clearing) and assert the turn counts here instead.
+ */
+const sendSettledMessage = async (
+  page: Page,
+  text: string,
+  expectedTurns: number,
+) => {
   const textbox = messageBox(page);
   await expect(textbox).toBeEnabled();
   await textbox.fill(text);
   await textbox.press("Enter");
-  await chatIsReadyToChat(page, {
-    expectAssistantResponse: true,
-    loadingTimeoutMs: 30000,
-  });
+  await chatIsReadyToChat(page, { loadingTimeoutMs: 30000 });
+
+  await expect(page.getByTestId("message-user")).toHaveCount(expectedTurns);
+  await expect(page.getByTestId("message-assistant")).toHaveCount(
+    expectedTurns,
+  );
 };
 
 /**
@@ -51,12 +63,9 @@ const sendSettledMessage = async (page: Page, text: string) => {
  * trigger substring so each turn resolves via the fast default response.
  */
 const seedThreeTurnConversation = async (page: Page) => {
-  await sendSettledMessage(page, "Alpha one");
-  await sendSettledMessage(page, "Beta two");
-  await sendSettledMessage(page, "Gamma three");
-
-  await expect(page.getByTestId("message-user")).toHaveCount(3);
-  await expect(page.getByTestId("message-assistant")).toHaveCount(3);
+  await sendSettledMessage(page, "Alpha one", 1);
+  await sendSettledMessage(page, "Beta two", 2);
+  await sendSettledMessage(page, "Gamma three", 3);
 };
 
 /** Wait until the streamed turn is genuinely in flight, with content on screen. */
@@ -153,9 +162,9 @@ test.describe("Edit / regenerate lineage pruning", () => {
 
       // The regenerated turn replays its own user message, so the long-running
       // trigger has to live in that message rather than in the edit.
-      await sendSettledMessage(page, "Alpha one");
-      await sendSettledMessage(page, "long running 6");
-      await sendSettledMessage(page, "Gamma three");
+      await sendSettledMessage(page, "Alpha one", 1);
+      await sendSettledMessage(page, "long running 6", 2);
+      await sendSettledMessage(page, "Gamma three", 3);
       await expect(page.getByTestId("message-assistant")).toHaveCount(3);
 
       const secondAssistantMessage = page

--- a/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
+++ b/e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts
@@ -3,19 +3,10 @@ import { chatIsReadyToChat, selectModel } from "./shared";
 import { TAG_CI } from "./tags";
 
 /**
- * ERMAIN-469: editing or regenerating a message that is NOT the last turn must
- * drop every later turn immediately, not just the next assistant.
- *
- * The backend deactivates the whole tail and reactivates only the new lineage,
- * but the frontend used to prune just one message pair. The survivors kept
- * their original (older) `createdAt`, and since the message list sorts purely
- * by that timestamp they rendered ABOVE the optimistic edit and its streaming
- * reply — until the post-stream refetch silently removed them.
- *
- * The bug is only visible WHILE streaming, so these tests assert mid-stream and
- * then again after completion (to prove nothing re-orders). `long running <N>`
- * streams one `Second N passed` chunk per second, which is what makes that
- * window wide enough to assert in.
+ * Stale turns are only visible while the replacement streams, so these tests
+ * assert mid-stream and again after completion. The `long running <N>` mock
+ * trigger streams one `Second N passed` chunk per second, which is what makes
+ * the mid-stream window wide enough to assert in.
  */
 
 const messageBox = (page: Page): Locator =>
@@ -24,23 +15,16 @@ const messageBox = (page: Page): Locator =>
 const stopButton = (page: Page): Locator =>
   page.getByTestId("chat-input-stop-generation");
 
-/** Every rendered message, in DOM order. */
 const chatMessages = (page: Page): Locator =>
   page.locator('[data-ui="chat-message"]');
 
-/** The rendered roles, in DOM order — the thing the bug actually corrupted. */
 const messageRoles = async (page: Page): Promise<string[]> =>
   chatMessages(page).evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute("data-role") ?? ""),
   );
 
-/**
- * Send a message and wait for its turn to settle.
- *
- * `chatIsReadyToChat`'s `expectAssistantResponse` assertion is strict-mode, so
- * it throws once a second assistant message exists. Wait on turn completion
- * (the Stop button clearing) and assert the turn counts here instead.
- */
+// `chatIsReadyToChat`'s `expectAssistantResponse` assertion is strict-mode, so
+// it throws once a second assistant message exists; assert turn counts here.
 const sendSettledMessage = async (
   page: Page,
   text: string,
@@ -58,17 +42,14 @@ const sendSettledMessage = async (
   );
 };
 
-/**
- * Build `[u1, a1, u2, a2, u3, a3]`. The texts deliberately avoid every mock
- * trigger substring so each turn resolves via the fast default response.
- */
+// The texts avoid every mock trigger substring, so each turn resolves via the
+// fast default response.
 const seedThreeTurnConversation = async (page: Page) => {
   await sendSettledMessage(page, "Alpha one", 1);
   await sendSettledMessage(page, "Beta two", 2);
   await sendSettledMessage(page, "Gamma three", 3);
 };
 
-/** Wait until the streamed turn is genuinely in flight, with content on screen. */
 const waitForStreamingToStart = async (page: Page) => {
   await expect(stopButton(page)).toBeVisible({ timeout: 15000 });
   await expect(page.getByText("Second 1 passed")).toBeVisible({
@@ -80,16 +61,10 @@ const waitForStreamToFinish = async (page: Page, timeout = 60000) => {
   await expect(stopButton(page)).toHaveCount(0, { timeout });
 };
 
-/**
- * The whole point of ERMAIN-469: exactly one prefix turn survives, and the
- * replacement turn is last. Asserted identically mid-stream and post-refetch.
- */
+// Exactly one prefix turn survives, and the replacement turn is last.
 const expectSingleTrailingBranch = async (page: Page) => {
   await expect(page.getByTestId("message-user")).toHaveCount(2);
   await expect(page.getByTestId("message-assistant")).toHaveCount(2);
-
-  // The stale third turn must be gone, not merely re-sorted.
-  await expect(page.getByText("Gamma three")).toHaveCount(0);
 
   expect(await messageRoles(page)).toEqual([
     "user",
@@ -98,9 +73,7 @@ const expectSingleTrailingBranch = async (page: Page) => {
     "assistant",
   ]);
 
-  // The surviving prefix is the untouched first turn.
   await expect(chatMessages(page).first()).toContainText("Alpha one");
-  // ...and the streaming reply is genuinely last, with nothing floating above.
   await expect(chatMessages(page).last()).toContainText("Second");
 };
 
@@ -117,7 +90,6 @@ test.describe("Edit / regenerate lineage pruning", () => {
 
       await seedThreeTurnConversation(page);
 
-      // Edit the SECOND user message — the case the bug was specific to.
       const secondUserMessage = page.getByTestId("message-user").nth(1);
       await expect(secondUserMessage).toContainText("Beta two");
       await secondUserMessage.hover();
@@ -137,12 +109,10 @@ test.describe("Edit / regenerate lineage pruning", () => {
 
       await waitForStreamingToStart(page);
 
-      // MID-STREAM: this is the state ERMAIN-469 reported as broken.
       await expectSingleTrailingBranch(page);
       await expect(chatMessages(page).nth(2)).toContainText("long running 8");
 
-      // And the corrected state must survive the post-stream refetch without a
-      // visible re-order.
+      // The same state must survive the post-stream refetch.
       await waitForStreamToFinish(page);
       await chatIsReadyToChat(page, { loadingTimeoutMs: 30000 });
       await expectSingleTrailingBranch(page);
@@ -160,12 +130,11 @@ test.describe("Edit / regenerate lineage pruning", () => {
       await chatIsReadyToChat(page);
       await selectModel(page, "Mock-LLM");
 
-      // The regenerated turn replays its own user message, so the long-running
-      // trigger has to live in that message rather than in the edit.
+      // Regenerate replays the existing user message, so the long-running
+      // trigger has to be seeded into it.
       await sendSettledMessage(page, "Alpha one", 1);
       await sendSettledMessage(page, "long running 6", 2);
       await sendSettledMessage(page, "Gamma three", 3);
-      await expect(page.getByTestId("message-assistant")).toHaveCount(3);
 
       const secondAssistantMessage = page
         .getByTestId("message-assistant")

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1081,13 +1081,9 @@ describe("useChatMessaging", () => {
       await result.current.regenerateMessage("msg-assistant-regenerate");
     });
 
-    expect(result.current.messages["msg-user-first"]).toBeDefined();
-    expect(result.current.messages["msg-assistant-regenerate"]).toBeUndefined();
-    expect(result.current.messages["msg-user-later"]).toBeUndefined();
-    expect(result.current.messages["msg-assistant-later"]).toBeUndefined();
     expect(result.current.messageOrder).toEqual(["msg-user-first"]);
 
-    // Hidden, not deleted — the API snapshot survives for the refetch.
+    // Hidden, not deleted: the API snapshot has to survive for the refetch.
     expect(
       useMessagingStore.getState().getApiMessages("chat1")["msg-user-later"],
     ).toBeDefined();
@@ -1119,8 +1115,6 @@ describe("useChatMessaging", () => {
         "chat1",
       );
 
-      // A later turn that only exists locally — hiding does not filter these,
-      // so it must be removed outright or it keeps rendering.
       useMessagingStore.getState().addUserMessage(
         {
           id: "temp-user-later",
@@ -1537,12 +1531,8 @@ describe("useChatMessaging", () => {
       await result.current.editMessage("msg-user-edit", "Edited content");
     });
 
-    expect(result.current.messages["msg-user-keep"]).toBeDefined();
     expect(result.current.messages["msg-user-edit"]).toBeUndefined();
     expect(result.current.messages["msg-assistant-following"]).toBeUndefined();
-    // The backend deactivates the whole tail, not just the next assistant.
-    expect(result.current.messages["msg-user-later"]).toBeUndefined();
-    expect(result.current.messages["msg-assistant-later"]).toBeUndefined();
 
     const optimisticEditedMessage = Object.values(result.current.messages).find(
       (message) =>
@@ -1555,18 +1545,10 @@ describe("useChatMessaging", () => {
     );
     expect(optimisticEditedMessage).toBeDefined();
 
-    // The symptom this guards is ordering: the edit and its streaming reply
-    // must be last, with no stale turn floating above them.
     expect(result.current.messageOrder).toEqual([
       "msg-user-keep",
       optimisticEditedMessage!.id,
     ]);
-
-    // Superseded messages are hidden, not destroyed, so a failed edit can be
-    // restored by the refetch.
-    expect(
-      useMessagingStore.getState().getApiMessages("chat1")["msg-user-later"],
-    ).toBeDefined();
   });
 
   it("should handle canceling a message", async () => {

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1036,6 +1036,63 @@ describe("useChatMessaging", () => {
     );
   });
 
+  it("should hide every later turn when regenerating a non-last assistant", async () => {
+    const { result } = renderHook(() => useChatMessaging("chat1"), {
+      wrapper: TestWrapper,
+    });
+
+    await act(async () => {
+      useMessagingStore.getState().setApiMessages(
+        [
+          {
+            id: "msg-user-first",
+            content: [{ content_type: "text", text: "First" }],
+            role: "user",
+            createdAt: "2026-02-20T10:00:00.000Z",
+            status: "complete",
+          },
+          {
+            id: "msg-assistant-regenerate",
+            content: [{ content_type: "text", text: "Old response" }],
+            role: "assistant",
+            createdAt: "2026-02-20T10:01:00.000Z",
+            status: "complete",
+          },
+          {
+            id: "msg-user-later",
+            content: [{ content_type: "text", text: "Later message" }],
+            role: "user",
+            createdAt: "2026-02-20T10:02:00.000Z",
+            status: "complete",
+          },
+          {
+            id: "msg-assistant-later",
+            content: [{ content_type: "text", text: "Later response" }],
+            role: "assistant",
+            createdAt: "2026-02-20T10:03:00.000Z",
+            status: "complete",
+          },
+        ],
+        "chat1",
+      );
+    });
+
+    await act(async () => {
+      await result.current.regenerateMessage("msg-assistant-regenerate");
+    });
+
+    expect(result.current.messages["msg-user-first"]).toBeDefined();
+    expect(result.current.messages["msg-assistant-regenerate"]).toBeUndefined();
+    expect(result.current.messages["msg-user-later"]).toBeUndefined();
+    expect(result.current.messages["msg-assistant-later"]).toBeUndefined();
+    expect(result.current.messageOrder).toEqual(["msg-user-first"]);
+
+    // Hidden, not deleted — the API snapshot survives for the refetch.
+    expect(
+      useMessagingStore.getState().getApiMessages("chat1")["msg-user-later"],
+    ).toBeDefined();
+  });
+
   it("should preserve per-chat streaming state when switching chats", async () => {
     mockUseChatMessages.mockReturnValue({
       data: undefined,
@@ -1375,7 +1432,7 @@ describe("useChatMessaging", () => {
     expect(orderedMessages[1].role).toBe("assistant");
   });
 
-  it("should remove replaced user and following assistant immediately on edit submit", async () => {
+  it("should remove the replaced user message and every later turn on edit submit", async () => {
     const { result } = renderHook(() => useChatMessaging("chat1"), {
       wrapper: TestWrapper,
     });
@@ -1411,6 +1468,13 @@ describe("useChatMessaging", () => {
             createdAt: "2026-02-20T10:03:00.000Z",
             status: "complete",
           },
+          {
+            id: "msg-assistant-later",
+            content: [{ content_type: "text", text: "Later response" }],
+            role: "assistant",
+            createdAt: "2026-02-20T10:04:00.000Z",
+            status: "complete",
+          },
         ],
         "chat1",
       );
@@ -1423,9 +1487,12 @@ describe("useChatMessaging", () => {
       await result.current.editMessage("msg-user-edit", "Edited content");
     });
 
+    expect(result.current.messages["msg-user-keep"]).toBeDefined();
     expect(result.current.messages["msg-user-edit"]).toBeUndefined();
     expect(result.current.messages["msg-assistant-following"]).toBeUndefined();
-    expect(result.current.messages["msg-user-later"]).toBeDefined();
+    // The backend deactivates the whole tail, not just the next assistant.
+    expect(result.current.messages["msg-user-later"]).toBeUndefined();
+    expect(result.current.messages["msg-assistant-later"]).toBeUndefined();
 
     const optimisticEditedMessage = Object.values(result.current.messages).find(
       (message) =>
@@ -1437,6 +1504,19 @@ describe("useChatMessaging", () => {
         ),
     );
     expect(optimisticEditedMessage).toBeDefined();
+
+    // The symptom this guards is ordering: the edit and its streaming reply
+    // must be last, with no stale turn floating above them.
+    expect(result.current.messageOrder).toEqual([
+      "msg-user-keep",
+      optimisticEditedMessage!.id,
+    ]);
+
+    // Superseded messages are hidden, not destroyed, so a failed edit can be
+    // restored by the refetch.
+    expect(
+      useMessagingStore.getState().getApiMessages("chat1")["msg-user-later"],
+    ).toBeDefined();
   });
 
   it("should handle canceling a message", async () => {

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1093,6 +1093,56 @@ describe("useChatMessaging", () => {
     ).toBeDefined();
   });
 
+  it("should drop superseded turns that are still held as local user messages", async () => {
+    const { result } = renderHook(() => useChatMessaging("chat1"), {
+      wrapper: TestWrapper,
+    });
+
+    await act(async () => {
+      useMessagingStore.getState().setApiMessages(
+        [
+          {
+            id: "msg-user-first",
+            content: [{ content_type: "text", text: "First" }],
+            role: "user",
+            createdAt: "2026-02-20T10:00:00.000Z",
+            status: "complete",
+          },
+          {
+            id: "msg-assistant-regenerate",
+            content: [{ content_type: "text", text: "Old response" }],
+            role: "assistant",
+            createdAt: "2026-02-20T10:01:00.000Z",
+            status: "complete",
+          },
+        ],
+        "chat1",
+      );
+
+      // A later turn that only exists locally — hiding does not filter these,
+      // so it must be removed outright or it keeps rendering.
+      useMessagingStore.getState().addUserMessage(
+        {
+          id: "temp-user-later",
+          content: [{ content_type: "text", text: "Later message" }],
+          role: "user",
+          createdAt: "2026-02-20T10:02:00.000Z",
+          status: "complete",
+        },
+        "chat1",
+      );
+    });
+
+    expect(result.current.messages["temp-user-later"]).toBeDefined();
+
+    await act(async () => {
+      await result.current.regenerateMessage("msg-assistant-regenerate");
+    });
+
+    expect(result.current.messages["temp-user-later"]).toBeUndefined();
+    expect(result.current.messageOrder).toEqual(["msg-user-first"]);
+  });
+
   it("should preserve per-chat streaming state when switching chats", async () => {
     mockUseChatMessages.mockReturnValue({
       data: undefined,

--- a/frontend/src/hooks/chat/store/messagingStore.ts
+++ b/frontend/src/hooks/chat/store/messagingStore.ts
@@ -53,7 +53,7 @@ export interface MessagingStore {
   getApiMessages: (streamKey?: string | null) => Record<string, Message>;
   getHiddenMessageIds: (streamKey?: string | null) => string[];
   setApiMessages: (messages: Message[], streamKey?: string | null) => void;
-  hideMessageId: (messageId: string, streamKey?: string | null) => void;
+  hideMessageIds: (messageIds: string[], streamKey?: string | null) => void;
   clearHiddenMessageIds: (streamKey?: string | null) => void;
   clearApiMessages: (streamKey?: string | null) => void;
   clearAllApiMessages: () => void;
@@ -397,14 +397,17 @@ export const useMessagingStore = create<MessagingStore>()(
             false,
             "messaging/setApiMessages",
           ),
-        hideMessageId: (messageId, streamKey) =>
+        hideMessageIds: (messageIds, streamKey) =>
           set(
             (prev) => {
               const inputKey = resolveStreamKey(streamKey);
               const resolvedKey = resolveStreamKeyFromState(prev, inputKey);
               const previousHiddenMessageIds =
                 prev.hiddenMessageIdsByKey[resolvedKey] ?? [];
-              if (previousHiddenMessageIds.includes(messageId)) {
+              const addedMessageIds = messageIds.filter(
+                (messageId) => !previousHiddenMessageIds.includes(messageId),
+              );
+              if (addedMessageIds.length === 0) {
                 return prev;
               }
 
@@ -412,12 +415,15 @@ export const useMessagingStore = create<MessagingStore>()(
                 ...prev,
                 hiddenMessageIdsByKey: {
                   ...prev.hiddenMessageIdsByKey,
-                  [resolvedKey]: [...previousHiddenMessageIds, messageId],
+                  [resolvedKey]: [
+                    ...previousHiddenMessageIds,
+                    ...addedMessageIds,
+                  ],
                 },
               };
             },
             false,
-            "messaging/hideMessageId",
+            "messaging/hideMessageIds",
           ),
         clearHiddenMessageIds: (streamKey) =>
           set(

--- a/frontend/src/hooks/chat/store/messagingStore.ts
+++ b/frontend/src/hooks/chat/store/messagingStore.ts
@@ -63,6 +63,7 @@ export interface MessagingStore {
     options?: { includeApiMessages?: boolean },
   ) => Record<string, Message>;
   addUserMessage: (message: Message, streamKey?: string | null) => void;
+  removeUserMessages: (messageIds: string[], streamKey?: string | null) => void;
   clearUserMessages: (streamKey?: string | null) => void;
   // New method to only clear messages that are not in sending state
   clearCompletedUserMessages: (streamKey?: string | null) => void;
@@ -561,6 +562,47 @@ export const useMessagingStore = create<MessagingStore>()(
           );
         },
         // New method that only clears messages that are not in sending state
+        // Superseded turns must be dropped from the local user messages as
+        // well as hidden: `buildRenderableMessages` applies hidden ids to API
+        // messages only, so a locally-held user message would keep rendering.
+        removeUserMessages: (messageIds, streamKey) =>
+          set(
+            (prev) => {
+              const inputKey = resolveStreamKey(streamKey);
+              const resolvedKey = resolveStreamKeyFromState(prev, inputKey);
+              const previousUserMessages =
+                prev.userMessagesByKey[resolvedKey] ?? EMPTY_MESSAGES;
+              const removableIds = messageIds.filter(
+                (messageId) => messageId in previousUserMessages,
+              );
+              if (removableIds.length === 0) {
+                return prev;
+              }
+
+              const nextUserMessages = { ...previousUserMessages };
+              for (const messageId of removableIds) {
+                delete nextUserMessages[messageId];
+              }
+
+              const activeResolvedKey = resolveStreamKeyFromState(
+                prev,
+                prev.activeStreamKey,
+              );
+              return {
+                ...prev,
+                userMessagesByKey: {
+                  ...prev.userMessagesByKey,
+                  [resolvedKey]: nextUserMessages,
+                },
+                userMessages:
+                  activeResolvedKey === resolvedKey
+                    ? nextUserMessages
+                    : prev.userMessages,
+              };
+            },
+            false,
+            "messaging/removeUserMessages",
+          ),
         clearCompletedUserMessages: (streamKey) => {
           set(
             (prev) => {

--- a/frontend/src/hooks/chat/store/messagingStore.ts
+++ b/frontend/src/hooks/chat/store/messagingStore.ts
@@ -561,10 +561,6 @@ export const useMessagingStore = create<MessagingStore>()(
             "messaging/clearUserMessages",
           );
         },
-        // New method that only clears messages that are not in sending state
-        // Superseded turns must be dropped from the local user messages as
-        // well as hidden: `buildRenderableMessages` applies hidden ids to API
-        // messages only, so a locally-held user message would keep rendering.
         removeUserMessages: (messageIds, streamKey) =>
           set(
             (prev) => {
@@ -603,6 +599,7 @@ export const useMessagingStore = create<MessagingStore>()(
             false,
             "messaging/removeUserMessages",
           ),
+        // New method that only clears messages that are not in sending state
         clearCompletedUserMessages: (streamKey) => {
           set(
             (prev) => {

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -219,6 +219,9 @@ export function useChatMessaging(
   );
   const setApiMessages = useMessagingStore((state) => state.setApiMessages);
   const hideMessageIds = useMessagingStore((state) => state.hideMessageIds);
+  const removeUserMessages = useMessagingStore(
+    (state) => state.removeUserMessages,
+  );
   const clearHiddenMessageIds = useMessagingStore(
     (state) => state.clearHiddenMessageIds,
   );
@@ -1585,6 +1588,22 @@ export function useChatMessaging(
     ],
   );
 
+  /**
+   * Take an edit's or regenerate's superseded turns out of the render tree.
+   *
+   * Hiding covers the API snapshot without destroying it, so a request that
+   * fails before streaming is restored by the refetch (which clears hidden ids
+   * anyway). Locally-held user messages are not covered by the hidden filter,
+   * so those are removed outright.
+   */
+  const dropSupersededMessages = useCallback(
+    (supersededMessageIds: string[], targetStreamKey: string) => {
+      hideMessageIds(supersededMessageIds, targetStreamKey);
+      removeUserMessages(supersededMessageIds, targetStreamKey);
+    },
+    [hideMessageIds, removeUserMessages],
+  );
+
   // Edit an existing message (rerun with modified user content and optional files)
   const editMessage = useCallback(
     async (
@@ -1607,55 +1626,7 @@ export function useChatMessaging(
         messageId,
       );
 
-      // Hidden rather than deleted: the API snapshot stays intact so an edit
-      // that fails before streaming can be restored by the refetch, which
-      // clears hidden ids anyway.
-      hideMessageIds(supersededMessageIds, streamKey);
-
-      // Hiding only filters API messages, so superseded *local* user messages
-      // (the edited one, plus any optimistic turn after it) must be dropped.
-      useMessagingStore.setState((prevState) => {
-        const resolveStreamKeyFromState = (
-          streamKeyToResolve: string,
-          aliases: Record<string, string>,
-        ): string => {
-          let resolvedKey = streamKeyToResolve;
-          const visited = new Set<string>();
-          while (aliases[resolvedKey] && !visited.has(resolvedKey)) {
-            visited.add(resolvedKey);
-            resolvedKey = aliases[resolvedKey];
-          }
-          return resolvedKey;
-        };
-
-        const resolvedStreamKey = resolveStreamKeyFromState(
-          streamKey,
-          prevState.streamKeyAliases,
-        );
-        const resolvedActiveStreamKey = resolveStreamKeyFromState(
-          prevState.activeStreamKey,
-          prevState.streamKeyAliases,
-        );
-
-        const previousUserMessages =
-          prevState.userMessagesByKey[resolvedStreamKey] ?? {};
-        const nextUserMessages = { ...previousUserMessages };
-        for (const id of supersededMessageIds) {
-          delete nextUserMessages[id];
-        }
-
-        return {
-          ...prevState,
-          userMessagesByKey: {
-            ...prevState.userMessagesByKey,
-            [resolvedStreamKey]: nextUserMessages,
-          },
-          userMessages:
-            resolvedActiveStreamKey === resolvedStreamKey
-              ? nextUserMessages
-              : prevState.userMessages,
-        };
-      });
+      dropSupersededMessages(supersededMessageIds, streamKey);
 
       // Keep UX responsive and allow user_message_saved to reconcile temp -> real.
       const optimisticEditedUserMessage = createOptimisticUserMessage(
@@ -1788,7 +1759,7 @@ export function useChatMessaging(
       getSSECleanupForKey,
       setSSECleanupForKey,
       addUserMessage,
-      hideMessageIds,
+      dropSupersededMessages,
     ],
   );
 
@@ -1817,7 +1788,7 @@ export function useChatMessaging(
       // Keep the old assistant — and every turn after it, which the backend
       // deactivates too — out of the render tree while the replacement branch
       // is streaming, without mutating the cached API snapshot.
-      hideMessageIds(
+      dropSupersededMessages(
         collectSupersededMessageIds(
           useMessagingStore.getState().getRenderableMessages(streamKey),
           currentMessageId,
@@ -1942,7 +1913,7 @@ export function useChatMessaging(
       streamKey,
       getSSECleanupForKey,
       setSSECleanupForKey,
-      hideMessageIds,
+      dropSupersededMessages,
       clearHiddenMessageIds,
     ],
   );

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -30,6 +30,7 @@ import {
 import { mapApiMessageToUiMessage } from "@/utils/adapters/messageAdapter";
 import {
   createOptimisticUserMessage,
+  collectSupersededMessageIds,
   constructSubmitStreamRequestBody,
 } from "@/utils/chat/messageUtils";
 import { createLogger } from "@/utils/debugLogger";
@@ -217,7 +218,7 @@ export function useChatMessaging(
     (state) => state.getRenderableMessages,
   );
   const setApiMessages = useMessagingStore((state) => state.setApiMessages);
-  const hideMessageId = useMessagingStore((state) => state.hideMessageId);
+  const hideMessageIds = useMessagingStore((state) => state.hideMessageIds);
   const clearHiddenMessageIds = useMessagingStore(
     (state) => state.clearHiddenMessageIds,
   );
@@ -1598,26 +1599,21 @@ export function useChatMessaging(
         return;
       }
 
-      const messageIdsToRemove = new Set<string>([messageId]);
-      const editedMessageIndex = messageOrder.indexOf(messageId);
-      if (editedMessageIndex >= 0) {
-        for (let i = editedMessageIndex + 1; i < messageOrder.length; i++) {
-          const nextMessage = messages[messageOrder[i]];
-          if (!nextMessage) {
-            continue;
-          }
-          if (nextMessage.role === "assistant") {
-            messageIdsToRemove.add(nextMessage.id);
-            break;
-          }
-          if (nextMessage.role === "user") {
-            break;
-          }
-        }
-      }
+      // Read the order from the store rather than the render closure, so this
+      // callback does not need `messages`/`messageOrder` as deps — those change
+      // on every stream chunk.
+      const supersededMessageIds = collectSupersededMessageIds(
+        useMessagingStore.getState().getRenderableMessages(streamKey),
+        messageId,
+      );
 
-      // Optimistically remove the edited message and its immediately following
-      // assistant message so stale responses disappear as soon as edit is submitted.
+      // Hidden rather than deleted: the API snapshot stays intact so an edit
+      // that fails before streaming can be restored by the refetch, which
+      // clears hidden ids anyway.
+      hideMessageIds(supersededMessageIds, streamKey);
+
+      // Hiding only filters API messages, so superseded *local* user messages
+      // (the edited one, plus any optimistic turn after it) must be dropped.
       useMessagingStore.setState((prevState) => {
         const resolveStreamKeyFromState = (
           streamKeyToResolve: string,
@@ -1641,26 +1637,15 @@ export function useChatMessaging(
           prevState.streamKeyAliases,
         );
 
-        const previousApiMessages =
-          prevState.apiMessagesByKey[resolvedStreamKey] ?? {};
-        const nextApiMessages = { ...previousApiMessages };
-        for (const id of messageIdsToRemove) {
-          delete nextApiMessages[id];
-        }
-
         const previousUserMessages =
           prevState.userMessagesByKey[resolvedStreamKey] ?? {};
         const nextUserMessages = { ...previousUserMessages };
-        for (const id of messageIdsToRemove) {
+        for (const id of supersededMessageIds) {
           delete nextUserMessages[id];
         }
 
         return {
           ...prevState,
-          apiMessagesByKey: {
-            ...prevState.apiMessagesByKey,
-            [resolvedStreamKey]: nextApiMessages,
-          },
           userMessagesByKey: {
             ...prevState.userMessagesByKey,
             [resolvedStreamKey]: nextUserMessages,
@@ -1796,8 +1781,6 @@ export function useChatMessaging(
       platform,
       processStreamEvent,
       resetStreaming,
-      messages,
-      messageOrder,
       setError,
       setSSEAbortCallback,
       isStreamCurrentlyActive,
@@ -1805,6 +1788,7 @@ export function useChatMessaging(
       getSSECleanupForKey,
       setSSECleanupForKey,
       addUserMessage,
+      hideMessageIds,
     ],
   );
 
@@ -1830,9 +1814,16 @@ export function useChatMessaging(
         setSSECleanupForKey(streamKey, null);
       }
 
-      // Keep the old assistant out of the render tree while the replacement
-      // branch is streaming, without mutating the cached API snapshot.
-      hideMessageId(currentMessageId, streamKey);
+      // Keep the old assistant — and every turn after it, which the backend
+      // deactivates too — out of the render tree while the replacement branch
+      // is streaming, without mutating the cached API snapshot.
+      hideMessageIds(
+        collectSupersededMessageIds(
+          useMessagingStore.getState().getRenderableMessages(streamKey),
+          currentMessageId,
+        ),
+        streamKey,
+      );
 
       setSubmittingForKey(streamKey, true);
 
@@ -1951,7 +1942,7 @@ export function useChatMessaging(
       streamKey,
       getSSECleanupForKey,
       setSSECleanupForKey,
-      hideMessageId,
+      hideMessageIds,
       clearHiddenMessageIds,
     ],
   );

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1588,14 +1588,9 @@ export function useChatMessaging(
     ],
   );
 
-  /**
-   * Take an edit's or regenerate's superseded turns out of the render tree.
-   *
-   * Hiding covers the API snapshot without destroying it, so a request that
-   * fails before streaming is restored by the refetch (which clears hidden ids
-   * anyway). Locally-held user messages are not covered by the hidden filter,
-   * so those are removed outright.
-   */
+  // Hiding keeps the API snapshot intact so a failed request is restored by the
+  // refetch, but `buildRenderableMessages` applies hidden ids to API messages
+  // only, so locally-held user messages have to be removed outright.
   const dropSupersededMessages = useCallback(
     (supersededMessageIds: string[], targetStreamKey: string) => {
       hideMessageIds(supersededMessageIds, targetStreamKey);
@@ -1618,9 +1613,8 @@ export function useChatMessaging(
         return;
       }
 
-      // Read the order from the store rather than the render closure, so this
-      // callback does not need `messages`/`messageOrder` as deps — those change
-      // on every stream chunk.
+      // Read from the store, not the render closure, so this callback does not
+      // depend on `messages`/`messageOrder`, which change on every stream chunk.
       const supersededMessageIds = collectSupersededMessageIds(
         useMessagingStore.getState().getRenderableMessages(streamKey),
         messageId,
@@ -1785,9 +1779,6 @@ export function useChatMessaging(
         setSSECleanupForKey(streamKey, null);
       }
 
-      // Keep the old assistant — and every turn after it, which the backend
-      // deactivates too — out of the render tree while the replacement branch
-      // is streaming, without mutating the cached API snapshot.
       dropSupersededMessages(
         collectSupersededMessageIds(
           useMessagingStore.getState().getRenderableMessages(streamKey),

--- a/frontend/src/utils/chat/messageUtils.test.ts
+++ b/frontend/src/utils/chat/messageUtils.test.ts
@@ -43,10 +43,6 @@ describe("collectSupersededMessageIds", () => {
     ]);
   });
 
-  it("returns only the anchor when it is already last", () => {
-    expect(collectSupersededMessageIds(conversation(), "a3")).toEqual(["a3"]);
-  });
-
   it("orders by createdAt rather than insertion order", () => {
     const outOfOrder: Record<string, Message> = {
       a3: message("a3", "assistant", "2026-02-20T10:05:00.000Z"),

--- a/frontend/src/utils/chat/messageUtils.test.ts
+++ b/frontend/src/utils/chat/messageUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+
+import { collectSupersededMessageIds } from "./messageUtils";
+
+import type { Message } from "@/types/chat";
+
+const message = (
+  id: string,
+  role: Message["role"],
+  createdAt: string,
+): Message => ({
+  id,
+  content: [{ content_type: "text", text: id }],
+  role,
+  createdAt,
+  status: "complete",
+});
+
+const conversation = (): Record<string, Message> => ({
+  u1: message("u1", "user", "2026-02-20T10:00:00.000Z"),
+  a1: message("a1", "assistant", "2026-02-20T10:01:00.000Z"),
+  u2: message("u2", "user", "2026-02-20T10:02:00.000Z"),
+  a2: message("a2", "assistant", "2026-02-20T10:03:00.000Z"),
+  u3: message("u3", "user", "2026-02-20T10:04:00.000Z"),
+  a3: message("a3", "assistant", "2026-02-20T10:05:00.000Z"),
+});
+
+describe("collectSupersededMessageIds", () => {
+  it("returns the edited user message and every later turn", () => {
+    expect(collectSupersededMessageIds(conversation(), "u2")).toEqual([
+      "u2",
+      "a2",
+      "u3",
+      "a3",
+    ]);
+  });
+
+  it("returns the regenerated assistant and every later turn", () => {
+    expect(collectSupersededMessageIds(conversation(), "a2")).toEqual([
+      "a2",
+      "u3",
+      "a3",
+    ]);
+  });
+
+  it("returns only the anchor when it is already last", () => {
+    expect(collectSupersededMessageIds(conversation(), "a3")).toEqual(["a3"]);
+  });
+
+  it("orders by createdAt rather than insertion order", () => {
+    const outOfOrder: Record<string, Message> = {
+      a3: message("a3", "assistant", "2026-02-20T10:05:00.000Z"),
+      u2: message("u2", "user", "2026-02-20T10:02:00.000Z"),
+      u1: message("u1", "user", "2026-02-20T10:00:00.000Z"),
+    };
+
+    expect(collectSupersededMessageIds(outOfOrder, "u2")).toEqual(["u2", "a3"]);
+  });
+
+  it("falls back to the anchor alone when it is not in the list", () => {
+    expect(
+      collectSupersededMessageIds(conversation(), "temp-user-999"),
+    ).toEqual(["temp-user-999"]);
+  });
+});

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -26,6 +26,34 @@ export function createOptimisticUserMessage(
 }
 
 /**
+ * Collects the message ids that an edit or regenerate supersedes: the anchor
+ * message itself plus everything ordered after it.
+ *
+ * This mirrors the backend, which deactivates every message in the chat and
+ * reactivates only the new lineage (`submit_message` in models/message.rs).
+ * Pruning less leaves stale turns visible with their original (older)
+ * `createdAt`, so they sort above the replacement while it streams.
+ *
+ * @param messages The currently renderable messages, keyed by id.
+ * @param anchorMessageId The edited user message, or the regenerated assistant.
+ * @returns The anchor id followed by every later message id.
+ */
+export function collectSupersededMessageIds(
+  messages: Record<string, Message>,
+  anchorMessageId: string,
+): string[] {
+  const orderedIds = Object.values(messages)
+    .sort(
+      (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    )
+    .map((message) => message.id);
+
+  const anchorIndex = orderedIds.indexOf(anchorMessageId);
+  return anchorIndex >= 0 ? orderedIds.slice(anchorIndex) : [anchorMessageId];
+}
+
+/**
  * Merges API messages with local user messages, prioritizing API messages
  * and de-duplicating user messages based on content.
  * @param apiMessages Messages fetched from the API.

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -26,17 +26,8 @@ export function createOptimisticUserMessage(
 }
 
 /**
- * Collects the message ids that an edit or regenerate supersedes: the anchor
- * message itself plus everything ordered after it.
- *
- * This mirrors the backend, which deactivates every message in the chat and
- * reactivates only the new lineage (`submit_message` in models/message.rs).
- * Pruning less leaves stale turns visible with their original (older)
- * `createdAt`, so they sort above the replacement while it streams.
- *
- * @param messages The currently renderable messages, keyed by id.
- * @param anchorMessageId The edited user message, or the regenerated assistant.
- * @returns The anchor id followed by every later message id.
+ * The anchor message plus every message after it, mirroring the backend, which
+ * deactivates the whole tail and reactivates only the new lineage.
  */
 export function collectSupersededMessageIds(
   messages: Record<string, Message>,


### PR DESCRIPTION
Fixes [ERMAIN-469](https://linear.app/erato-labs/issue/ERMAIN-469/ghost-downstream-messages-float-above-the-streaming-reply-when).

## Problem

Editing a user message (or regenerating an assistant message) that is **not** the last turn left the downstream turns on screen, rendered *above* the streaming reply, until the post-stream refetch quietly removed them.

With `[u1, a1, u2, a2, u3, a3]`, editing `u2` showed:

```
u1, a1, u3, a3, u2(edited), <streaming reply>
```

## Cause

The backend deactivates every message in the chat and reactivates only the new lineage (`submit_message`, `backend/erato/src/models/message.rs`). The frontend pruned far less:

- **edit** removed the edited message plus the *first following assistant* only — the loop stopped at the next user message
- **regenerate** hid only the single target assistant

Whatever survived kept its original (older) `createdAt`, and the message list sorts purely on that, so stale turns sorted above the optimistic edit and its reply. Correct state only arrived via the refetch's active-thread filter.

## Change

Both paths now prune the anchor plus every later message, mirroring the backend's active-thread set. Shared between them:

- `collectSupersededMessageIds` (`messageUtils.ts`) — pure, returns the anchor and everything ordered after it
- `dropSupersededMessages` (`useChatMessaging.ts`) — hides *and* removes, so edit and regenerate cannot drift apart again

Two details worth calling out for review:

- **Hide rather than delete.** Edit used to hard-delete from `apiMessagesByKey`. It now hides, like regenerate already did, so a request that fails before streaming is restored by the refetch (which clears hidden ids anyway) instead of having destroyed the snapshot.
- **`removeUserMessages` store action.** `buildRenderableMessages` applies hidden ids to API messages *only*, so a superseded turn still held in `userMessagesByKey` kept rendering. Edit happened to compensate with an inline `setState`; regenerate did not. Both now go through the same step, and that inline block is gone.

Also drops `messages`/`messageOrder` from `editMessage`'s dependency array — the order is now read from the store, so the callback is no longer recreated on every stream chunk.

The add-in consumes the same hook, so it is covered by the same fix. Its exchange-anchor lookup (`AddinChat.tsx`) resolves `exchangeAssistantId` *before* `editMessage` mutates the store, so the broader pruning does not affect it — verified, no change needed.

## Tests

New e2e specs (`e2e-tests/tests/edit-regenerate-lineage.many-models.spec.ts`, `@ci`, both browsers) covering edit and regenerate of a non-last message. They assert **mid-stream** — counts, DOM order via `data-role`, and the stale turn's absence — then again after the refetch to prove nothing re-orders. `long running <N>` from the mock LLM provides the window.

Both were confirmed to **fail against the pre-fix code** (3 user messages mid-stream instead of 2), so neither is vacuous.

The e2e caught a real defect the unit tests missed: the regenerate path still rendered a superseded turn held as a local user message. That is what the `removeUserMessages` change above addresses, and there is now a unit test seeding that state directly.

Unit coverage: `useChatMessaging.test.ts` had the bug pinned as expected behaviour (`msg-user-later` asserted to survive an edit) — corrected, plus new cases for non-last regenerate, the local-user-message path, and resulting `messageOrder`. Five cases for `collectSupersededMessageIds`.