### PR TITLE
Move popover and sidebar-row surfaces out of inline styles

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
@@ -75,11 +75,9 @@ describe("ChatHistoryList", () => {
       '[data-ui="chat-history-item"]',
     );
 
-    expect(historyItem).toHaveStyle({
-      minHeight: "var(--theme-spacing-sidebar-row-height)",
-      borderRadius: "var(--theme-radius-shell)",
-      backgroundColor: "var(--theme-shell-sidebar-selected)",
-    });
+    expect(historyItem).toHaveClass("sidebar-row-geometry");
+    expect(historyItem).toHaveClass("sidebar-row-selected");
+    expect(historyItem?.getAttribute("style") ?? "").toBe("");
     expect(historyItem).not.toHaveClass(
       "hover:bg-[var(--theme-shell-sidebar-hover)]",
     );
@@ -89,9 +87,7 @@ describe("ChatHistoryList", () => {
       padding:
         "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
     });
-    expect(historyItems[1].getAttribute("style") ?? "").not.toContain(
-      "background-color",
-    );
+    expect(historyItems[1]).not.toHaveClass("sidebar-row-selected");
   });
 
   it("uses the same sidebar tokens in the loading skeleton", () => {
@@ -99,11 +95,8 @@ describe("ChatHistoryList", () => {
 
     const skeletonItem = getAllByTestId("chat-history-skeleton-item")[0];
 
-    expect(skeletonItem).toHaveStyle({
-      minHeight: "var(--theme-spacing-sidebar-row-height)",
-      borderRadius: "var(--theme-radius-shell)",
-      backgroundColor: "var(--theme-shell-sidebar-selected)",
-    });
+    expect(skeletonItem).toHaveClass("sidebar-row-geometry");
+    expect(skeletonItem).toHaveClass("sidebar-row-selected");
     expect(screen.getByTestId("chat-history-skeleton")).toHaveStyle({
       padding:
         "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -20,14 +20,6 @@ import {
 import type { ChatSession } from "@/types/chat";
 
 const logger = createLogger("UI", "ChatHistoryList");
-const sidebarRowStyle = {
-  minHeight: "var(--theme-spacing-sidebar-row-height)",
-  borderRadius: "var(--theme-radius-shell)",
-} as const;
-const activeSidebarRowStyle = {
-  ...sidebarRowStyle,
-  backgroundColor: "var(--theme-shell-sidebar-selected)",
-} as const;
 const sidebarListStyle = {
   padding:
     "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
@@ -107,8 +99,6 @@ const ChatHistoryListItem = memo<{
     onShowDetails,
     showTimestamps = true,
   }) => {
-    const rowStyle = isActive ? activeSidebarRowStyle : sidebarRowStyle;
-
     return (
       <a
         href={getChatUrl(session.id, session.assistantId)}
@@ -129,11 +119,12 @@ const ChatHistoryListItem = memo<{
           useDiv={true}
           showFocusRing={false}
           className={clsx(
-            "theme-transition flex flex-col px-3 py-1.5 pb-3.5 pr-1.5 text-left",
-            !isActive && "hover:bg-[var(--theme-shell-sidebar-hover)]",
+            "sidebar-row-geometry theme-transition flex flex-col px-3 py-1.5 pb-3.5 pr-1.5 text-left",
+            isActive
+              ? "sidebar-row-selected"
+              : "hover:bg-[var(--theme-shell-sidebar-hover)]",
             layout === "compact" ? "gap-0.5" : "gap-1",
           )}
-          style={rowStyle}
           data-chat-id={session.id}
           data-ui="chat-history-item"
         >
@@ -359,8 +350,7 @@ export const ChatHistoryListSkeleton = ({
       <div
         key={i}
         data-testid="chat-history-skeleton-item"
-        className="w-full px-4 py-3"
-        style={activeSidebarRowStyle}
+        className="sidebar-row-geometry sidebar-row-selected w-full px-4 py-3"
       >
         <div className="flex w-full items-center justify-between gap-2">
           <div className="h-5 w-2/3 animate-pulse rounded bg-theme-bg-accent" />

--- a/frontend/src/components/ui/Controls/AnchoredPopover.test.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.test.tsx
@@ -17,8 +17,9 @@ describe("AnchoredPopover", () => {
 
     const panel = screen.getByText("Panel content").parentElement;
 
-    expect(panel).toHaveStyle({
-      borderColor: "var(--theme-border-dropdown)",
-    });
+    // The surface comes from a class, not an inline style, so a theme.css
+    // rule on [data-ui="dropdown-panel"] can override it.
+    expect(panel).toHaveClass("anchored-popover-skin");
+    expect(panel?.getAttribute("style") ?? "").not.toContain("border-color");
   });
 });

--- a/frontend/src/components/ui/Controls/AnchoredPopover.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.tsx
@@ -339,19 +339,19 @@ export function AnchoredPopover({
       ref={setPanelElement}
       id={panelId}
       className={clsx(
-        "theme-transition fixed z-[9999] border focus:outline-none",
+        "anchored-popover-skin theme-transition fixed z-[9999] border focus:outline-none",
         panelClassName,
       )}
       // Focusable container so a pointer-open can hold focus without any item
       // looking pre-selected; roving arrow-key nav then works from here.
       tabIndex={-1}
+      // Only runtime values belong here. The panel's surface lives in
+      // .anchored-popover-skin: an inline style outranks every author rule, so
+      // holding it here made `[data-ui="dropdown-panel"]` — a hook the theming
+      // docs advertise as overridable — silently inert for background, border
+      // and radius. Positioning is written directly to the node in
+      // updatePosition(), so it is unaffected.
       style={{
-        backgroundColor: "var(--theme-shell-dropdown)",
-        borderColor: "var(--theme-border-dropdown)",
-        borderRadius: "var(--theme-radius-base)",
-        boxSizing: "border-box",
-        boxShadow: "var(--theme-elevation-dropdown)",
-        maxWidth: "calc(100vw - 16px)",
         ...panelStyle,
         visibility: isPositioned ? "visible" : "hidden",
       }}

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -28,15 +28,23 @@ describe("DropdownMenu", () => {
       "data-ui",
       "dropdown-panel",
     );
-    expect(screen.getByRole("menu")).toHaveStyle({
-      backgroundColor: "var(--theme-shell-dropdown)",
-      borderColor: "var(--theme-border-divider)",
-      borderRadius: "var(--theme-radius-base)",
-      boxShadow: "var(--theme-elevation-dropdown)",
+    const panel = screen.getByRole("menu");
+    // Surface from the class; only consumer-supplied sizing stays inline.
+    expect(panel).toHaveClass("anchored-popover-skin");
+    expect(panel).toHaveStyle({
       maxWidth:
         "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
       minWidth: "var(--theme-layout-dropdown-min-width)",
     });
+    const inlineStyle = panel.getAttribute("style") ?? "";
+    for (const property of [
+      "background-color",
+      "border-color",
+      "border-radius",
+      "box-shadow",
+    ]) {
+      expect(inlineStyle).not.toContain(property);
+    }
     // Active row uses the soft light highlight, not the old 2px dark ring.
     expect(menuItem.className).not.toContain("focus-ring-inset");
     expect(menuItem.className).toContain("focus:bg-theme-bg-hover");

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -620,6 +620,33 @@ body {
   @apply transition-[background-color,border-color,color,fill,stroke,opacity,box-shadow,transform] duration-150 ease-in-out motion-reduce:transition-none;
 }
 
+/* Sidebar chat rows. Same reasoning as .anchored-popover-skin: held inline,
+   the radius made `[data-ui="chat-history-item"]` unoverridable. The row's <a>
+   wrapper reads --theme-radius-shell too, so a theme that moves the token keeps
+   the focus ring and the row in step; a direct border-radius rule on the hook
+   only reaches the row, since the hook sits on the inner element. */
+.sidebar-row-geometry {
+  min-height: var(--theme-spacing-sidebar-row-height);
+  border-radius: var(--theme-radius-shell);
+}
+
+.sidebar-row-selected {
+  background-color: var(--theme-shell-sidebar-selected);
+}
+
+/* Surface for AnchoredPopover panels (dropdown menus, the chat "+" menu).
+   Deliberately declared here, after @tailwind utilities and outside
+   @layer components: it must still outrank a utility a caller passes through
+   `panelClassName`, while remaining overridable from a customer theme.css,
+   which loads later still. */
+.anchored-popover-skin {
+  background-color: var(--theme-shell-dropdown);
+  border-color: var(--theme-border-dropdown);
+  border-radius: var(--theme-radius-base);
+  box-shadow: var(--theme-elevation-dropdown);
+  max-width: calc(100vw - 16px);
+}
+
 .docx-preview-theme {
   --docx-preview-surface-bg: #f3f4f6;
   --docx-preview-page-bg: #ffffff;


### PR DESCRIPTION
`theming.mdx` advertises `data-ui` attributes as overridable hooks, but an inline style outranks every author rule. So a `theme.css` rule against `[data-ui="dropdown-panel"]` or `[data-ui="chat-history-item"]` silently did nothing for background, border and radius — the theme author writes a correct rule against a documented hook and gets no error and no effect.

A theme in the wild already hit this and worked around it by overriding the underlying tokens instead.

## Change

- `AnchoredPopover`'s panel surface → `.anchored-popover-skin`
- the sidebar row's → `.sidebar-row-geometry` / `.sidebar-row-selected`

Both are declared **after `@tailwind utilities` and outside `@layer components`**. That placement is load-bearing: it keeps them outranking a utility a caller passes through `panelClassName`, while staying overridable from `theme.css`, which `ThemeProvider` appends later still.

Positioning is written straight to the node in `updatePosition()` and is untouched. `boxSizing` is dropped — preflight already sets it.

## Tests

They asserted the inline values, i.e. they enforced the defect. They now assert the class is applied and that the skin longhands are **absent** from the inline style.

Worth noting one was already vacuous: it expected `--theme-border-divider` where the component set `--theme-border-dropdown`, and passed anyway, because jsdom cannot resolve `var()` and both sides normalise to empty. A green run on these was never evidence the skin applied.

## Verification

Built a stylesheet from this branch and loaded it in a browser with a theme rule appended after it, as `ThemeProvider` does. The theme now moves the dark panel border to `rgba(255,255,255,0.08)` and the row radius to `0.75rem` — **both inert before**. Also confirmed the new rules sit after the utility block, and that preflight still supplies `box-sizing`.

829 → 840 tests pass, `eslint .` and typecheck clean.

## Scope

This is the first of several: **13 of the 16 documented `data-ui` hooks** carry inline skin. These two were picked because they are the only ones with observably wrong pixels today. The remainder (`modal-shell`, `modal-overlay`, `chat-input-shell`, `sidebar`, `chat-body`, `chat-header`, `app-shell`, `chat-message`, …) follow the same pattern and can go in follow-ups, after which a contract test asserting no skin longhand appears inline on any documented hook becomes worth adding.

One nuance left as-is: the row's `<a>` wrapper reads `--theme-radius-shell` through a class, so a token override keeps it in step with the row, but a direct `border-radius` rule on the hook reaches only the row — the hook sits on the inner element.