### PR TITLE
Move the remaining documented hooks' surfaces out of inline styles

### DIFF
--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -633,20 +633,6 @@ export const Chat = ({
     );
   }
 
-  const appShellStyle = useMemo(
-    () => ({
-      backgroundColor: "var(--theme-shell-app)",
-    }),
-    [],
-  );
-
-  const pageShellStyle = useMemo(
-    () => ({
-      backgroundColor: "var(--theme-shell-page)",
-    }),
-    [],
-  );
-
   const shouldRenderCenteredEmptyState =
     (forceCenteredEmptyState || emptyStateLayout === "centered") &&
     !!emptyStateComponent &&
@@ -712,9 +698,8 @@ export const Chat = ({
   return (
     <ChatInputControlsProvider value={chatInputControls}>
       <div
-        className="flex size-full flex-col sm:flex-row"
+        className="app-shell-skin flex size-full flex-col sm:flex-row"
         data-ui="app-shell"
-        style={appShellStyle}
       >
         <ChatHistorySidebar
           collapsed={sidebarCollapsed}
@@ -746,7 +731,7 @@ export const Chat = ({
           <div
             {...getConversationDropzoneRootProps()}
             className={clsx(
-              "relative flex h-full min-w-0 flex-1 flex-col",
+              "page-shell-skin relative flex h-full min-w-0 flex-1 flex-col",
               "sm:mt-0",
               // Add left margin based on sidebar state to prevent overlap with fixed sidebar
               // Transition margin to match sidebar animation (300ms)
@@ -767,7 +752,6 @@ export const Chat = ({
               message: "Chat conversation",
             })}
             data-ui="chat-conversation-dropzone"
-            style={pageShellStyle}
           >
             <input
               {...getConversationDropzoneInputProps()}

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -20,10 +20,6 @@ import {
 import type { ChatSession } from "@/types/chat";
 
 const logger = createLogger("UI", "ChatHistoryList");
-const sidebarListStyle = {
-  padding:
-    "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
-} as const;
 const sidebarRowLinkClassName =
   "focus-ring-tight block rounded-[var(--theme-radius-shell)]";
 
@@ -285,7 +281,6 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
           "flex w-full min-w-0 flex-col gap-1",
           className,
         )}
-        style={sidebarListStyle}
         data-ui="chat-history-list"
       >
         {sessions.map((session) => (
@@ -343,8 +338,7 @@ export const ChatHistoryListSkeleton = ({
 }) => (
   <div
     data-testid="chat-history-skeleton"
-    className="flex w-full min-w-0 flex-col gap-1 overflow-y-auto bg-[var(--theme-shell-sidebar)]"
-    style={sidebarListStyle}
+    className="chat-history-list-geometry flex w-full min-w-0 flex-col gap-1 overflow-y-auto bg-[var(--theme-shell-sidebar)]"
   >
     {Array.from({ length: 5 }, (_, i) => (
       <div

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
@@ -100,21 +100,21 @@ describe("ChatHistorySidebar", () => {
 
     const sidebar = container.querySelector('[data-ui="sidebar"]');
 
+    // Surface from the class so theme.css can reach it; only the computed
+    // width stays inline.
+    expect(sidebar).toHaveClass("sidebar-skin");
     expect(sidebar).toHaveStyle({
-      backgroundColor: "var(--theme-shell-sidebar)",
-      borderRightColor:
-        "var(--theme-shell-sidebar-divider-color, var(--theme-border-divider))",
-      boxShadow: "var(--theme-elevation-shell)",
       width: "var(--theme-layout-sidebar-width)",
     });
-    expect(container.querySelector('[data-ui="sidebar-header"]')).toHaveStyle({
-      padding:
-        "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
-    });
-    expect(container.querySelector('[data-ui="sidebar-footer"]')).toHaveStyle({
-      padding:
-        "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
-    });
+    for (const property of ["background-color", "box-shadow"]) {
+      expect(sidebar?.getAttribute("style") ?? "").not.toContain(property);
+    }
+    expect(container.querySelector('[data-ui="sidebar-header"]')).toHaveClass(
+      "sidebar-section-skin",
+    );
+    expect(container.querySelector('[data-ui="sidebar-footer"]')).toHaveClass(
+      "sidebar-section-skin",
+    );
     expect(screen.getByTestId("history-list")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -51,19 +51,6 @@ const activeSidebarItemStyle = {
   ...sidebarItemStyle,
   backgroundColor: "var(--theme-shell-sidebar-selected)",
 } as const;
-const compactShellPaddingStyle = {
-  padding:
-    "var(--theme-spacing-shell-compact-padding-y) var(--theme-spacing-shell-compact-padding-x)",
-} as const;
-const sidebarDividerColor =
-  "var(--theme-shell-sidebar-divider-color, var(--theme-border-divider))";
-const sidebarSectionBackground =
-  "var(--theme-shell-sidebar-section-bg, transparent)";
-const sidebarSectionStyle = {
-  ...compactShellPaddingStyle,
-  backgroundColor: sidebarSectionBackground,
-  borderColor: sidebarDividerColor,
-} as const;
 const sidebarLinkClassName =
   "focus-ring-tight block rounded-[var(--theme-radius-shell)]";
 
@@ -173,8 +160,7 @@ const ChatHistoryHeader = memo<{
 }>(
   ({ collapsed, isSlimMode, onToggleCollapse, showTitle, sidebarLogoPath }) => (
     <div
-      className="flex min-h-[60px] border-b"
-      style={sidebarSectionStyle}
+      className="sidebar-section-skin flex min-h-[60px] border-b"
       data-ui="sidebar-header"
     >
       {/* In slim mode, show logo with hover toggle or just toggle button */}
@@ -631,11 +617,7 @@ const ChatHistoryFooter = memo<{
   onSignOut: () => void;
   isSlimMode?: boolean;
 }>(({ userProfile, onSignOut }) => (
-  <div
-    className="border-t"
-    style={sidebarSectionStyle}
-    data-ui="sidebar-footer"
-  >
+  <div className="sidebar-section-skin border-t" data-ui="sidebar-footer">
     <UserProfileThemeDropdown
       userProfile={userProfile}
       onSignOut={onSignOut}
@@ -807,11 +789,10 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
       [minWidth],
     );
 
+    // Width is runtime state (slim vs expanded); the surface lives in
+    // .sidebar-skin so [data-ui="sidebar"] stays themeable.
     const sidebarShellStyle = useMemo(
       () => ({
-        backgroundColor: "var(--theme-shell-sidebar)",
-        borderColor: sidebarDividerColor,
-        boxShadow: "var(--theme-elevation-shell)",
         width: isSlimMode
           ? "var(--theme-layout-sidebar-slim-width)"
           : expandedSidebarWidth,
@@ -866,6 +847,7 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
               isHiddenMode && "pointer-events-none -translate-x-full opacity-0",
               // Slim and expanded modes stay visible
               !isHiddenMode && "translate-x-0 opacity-100",
+              "sidebar-skin",
               className,
             )}
             style={sidebarShellStyle}

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -785,13 +785,8 @@ describe("ChatInput", () => {
     expect(container.firstElementChild).toHaveStyle({
       maxWidth: "var(--theme-layout-chat-input-max-width)",
     });
-    expect(container.querySelector('[data-ui="chat-input-shell"]')).toHaveStyle(
-      {
-        backgroundColor: "var(--theme-shell-chat-input)",
-        borderColor: "var(--theme-border-chat-input)",
-        borderRadius: "var(--theme-radius-input)",
-        boxShadow: "var(--theme-elevation-input)",
-      },
+    expect(container.querySelector('[data-ui="chat-input-shell"]')).toHaveClass(
+      "chat-input-shell-skin",
     );
     expect(
       container.querySelector('[data-ui="chat-input-shell"]')?.className,

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -1984,12 +1984,6 @@ export const ChatInput = ({
     maxWidth: "var(--theme-layout-chat-input-max-width)",
   } as const;
 
-  const inputShellStyle = {
-    backgroundColor: "var(--theme-shell-chat-input)",
-    borderRadius: "var(--theme-radius-input)",
-    boxShadow: "var(--theme-elevation-input)",
-  } as const;
-
   return (
     <div className="mx-auto w-full" style={shellWrapperStyle}>
       <form
@@ -2221,8 +2215,8 @@ export const ChatInput = ({
             "theme-transition focus-within:border-[var(--theme-border-chat-input-focus)]",
             "flex flex-col",
             "chat-input-shell-geometry",
+            "chat-input-shell-skin",
           )}
-          style={inputShellStyle}
           data-ui="chat-input-shell"
         >
           {ChatInputAttachmentPreview && (

--- a/frontend/src/components/ui/Chat/ChatMessage.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.test.tsx
@@ -105,11 +105,7 @@ describe("ChatMessage", () => {
     const messageShell = screen.getByTestId("message-assistant");
     expect(messageShell).toHaveAttribute("data-ui", "chat-message");
     expect(messageShell).toHaveAttribute("data-role", "assistant");
-    expect(messageShell).toHaveStyle({
-      borderRadius: "var(--theme-radius-message)",
-      padding:
-        "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-    });
+    expect(messageShell).toHaveClass("chat-message-skin");
     expect(messageShell.className).toContain(
       "bg-[var(--theme-message-assistant)]",
     );

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -110,11 +110,6 @@ export const ChatMessage = memo(function ChatMessage({
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const role = isUser ? "user" : "assistant";
-  const messageShellStyle = {
-    borderRadius: "var(--theme-radius-message)",
-    padding:
-      "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-  } as const;
   const messageContentRowStyle = {
     gap: "var(--theme-spacing-message-gap)",
   } as const;
@@ -157,13 +152,12 @@ export const ChatMessage = memo(function ChatMessage({
   return (
     <div
       className={clsx(
-        "group relative flex",
+        "chat-message-skin group relative flex",
         "w-full min-w-[280px] shrink-0",
         messageStyles.hover,
         messageStyles.container[role],
         className,
       )}
-      style={messageShellStyle}
       role="log"
       aria-live="polite"
       aria-label={`${userDisplayName} ${t({ id: "chat.message.aria", message: "message" })}`}

--- a/frontend/src/components/ui/MessageList/MessageList.test.tsx
+++ b/frontend/src/components/ui/MessageList/MessageList.test.tsx
@@ -22,9 +22,7 @@ describe("MessageList", () => {
     const chatBody = screen.getByTestId("message-list");
     const emptyStateShell = chatBody.lastElementChild;
 
-    expect(chatBody).toHaveStyle({
-      backgroundColor: "var(--theme-shell-chat-body)",
-    });
+    expect(chatBody).toHaveClass("chat-body-skin");
     expect(chatBody.className).toContain(
       "[padding:var(--theme-spacing-shell-padding-y)_calc(var(--theme-spacing-shell-padding-x)/2)]",
     );
@@ -53,9 +51,7 @@ describe("MessageList", () => {
     const chatBody = screen.getByTestId("message-list");
     const contentShell = chatBody.lastElementChild;
 
-    expect(chatBody).toHaveStyle({
-      backgroundColor: "var(--theme-shell-chat-body)",
-    });
+    expect(chatBody).toHaveClass("chat-body-skin");
     expect(chatBody.className).toContain(
       "[padding:var(--theme-spacing-shell-padding-y)_calc(var(--theme-spacing-shell-padding-x)/2)]",
     );

--- a/frontend/src/components/ui/MessageList/MessageList.tsx
+++ b/frontend/src/components/ui/MessageList/MessageList.tsx
@@ -799,7 +799,7 @@ export const MessageList = memo<MessageListProps>(
     // Add optimized container class based on state
     const containerClass = useMemo(() => {
       return clsx(
-        "flex flex-1 flex-col overflow-y-auto",
+        "chat-body-skin flex flex-1 flex-col overflow-y-auto",
         "[padding:var(--theme-spacing-shell-padding-y)_calc(var(--theme-spacing-shell-padding-x)/2)]",
         "gap-[var(--theme-spacing-shell-gap)]",
         "sm:[padding:var(--theme-spacing-shell-padding-y)_var(--theme-spacing-shell-padding-x)]",
@@ -812,13 +812,6 @@ export const MessageList = memo<MessageListProps>(
         isTransitioning ? "opacity-0" : "opacity-100",
       );
     }, [className, isTransitioning]);
-
-    const containerStyle = useMemo(
-      () => ({
-        backgroundColor: "var(--theme-shell-chat-body)",
-      }),
-      [],
-    );
 
     const contentWidthStyle = useMemo(
       () => ({
@@ -886,7 +879,6 @@ export const MessageList = memo<MessageListProps>(
       <div
         ref={containerRef}
         className={containerClass}
-        style={containerStyle}
         data-testid="message-list"
         data-ui="chat-body"
         onCopy={handleCopyPlainText}

--- a/frontend/src/components/ui/MessageList/MessageListHeader.test.tsx
+++ b/frontend/src/components/ui/MessageList/MessageListHeader.test.tsx
@@ -15,8 +15,8 @@ describe("MessageListHeader", () => {
       />,
     );
 
-    expect(screen.getByTestId("chat-header-shell")).toHaveStyle({
-      backgroundColor: "var(--theme-shell-chat-header)",
-    });
+    expect(screen.getByTestId("chat-header-shell")).toHaveClass(
+      "chat-header-skin",
+    );
   });
 });

--- a/frontend/src/components/ui/MessageList/MessageListHeader.tsx
+++ b/frontend/src/components/ui/MessageList/MessageListHeader.tsx
@@ -30,8 +30,7 @@ export const MessageListHeader = ({
 }: MessageListHeaderProps) => {
   return (
     <div
-      className="pb-2"
-      style={{ backgroundColor: "var(--theme-shell-chat-header)" }}
+      className="chat-header-skin pb-2"
       data-testid="chat-header-shell"
       data-ui="chat-header"
     >

--- a/frontend/src/components/ui/Modal/ModalBase.test.tsx
+++ b/frontend/src/components/ui/Modal/ModalBase.test.tsx
@@ -20,11 +20,8 @@ describe("ModalBase", () => {
     const overlay = document.querySelector('[data-ui="modal-overlay"]');
 
     expect(dialog).toHaveAttribute("data-ui", "modal-shell");
-    expect(dialog).toHaveStyle({
-      backgroundColor: "var(--theme-shell-modal)",
-      borderRadius: "var(--theme-radius-modal)",
-      boxShadow: "var(--theme-elevation-modal)",
-    });
+    expect(dialog).toHaveClass("modal-shell-skin");
+    expect(dialog.getAttribute("style") ?? "").toBe("");
     expect(dialog.className).toContain("focus-ring");
     expect(dialog.className).toContain("modal-shell-frame-geometry");
     expect(dialog.className).toContain("w-full");
@@ -37,9 +34,8 @@ describe("ModalBase", () => {
       "top: var(--theme-spacing-modal-padding)",
     );
     expect(overlay).toBeTruthy();
-    expect(overlay?.getAttribute("style")).toContain(
-      "background-color: var(--theme-overlay-modal)",
-    );
+    expect(overlay).toHaveClass("modal-overlay-skin");
+    expect(overlay?.getAttribute("style") ?? "").toBe("");
     expect(overlay?.className).not.toContain("backdrop-blur-sm");
   });
 });

--- a/frontend/src/components/ui/Modal/ModalBase.tsx
+++ b/frontend/src/components/ui/Modal/ModalBase.tsx
@@ -69,28 +69,12 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
     return null;
   }
 
-  const overlayStyle = {
-    backgroundColor: "var(--theme-overlay-modal)",
-    backdropFilter: "blur(var(--theme-layout-modal-backdrop-blur))",
-    // Ensure a viewport gutter regardless of any max-w-* utility a consumer
-    // sets on contentClassName — Tailwind utilities outweigh the .modal-shell
-    // max-width calc, so the overlay's flex container holds the safe zone.
-    padding: "var(--theme-layout-modal-viewport-margin)",
-  } as const;
-
-  const shellStyle = {
-    backgroundColor: "var(--theme-shell-modal)",
-    borderRadius: "var(--theme-radius-modal)",
-    boxShadow: "var(--theme-elevation-modal)",
-  } as const;
-
   const modalContent = (
     <div
       className={clsx(
-        "fixed inset-0 z-50 flex items-center justify-center",
+        "modal-overlay-skin fixed inset-0 z-50 flex items-center justify-center",
         className,
       )}
-      style={overlayStyle}
       onMouseDown={handleOverlayMouseDown}
       onClick={handleOverlayClick}
       role="presentation"
@@ -100,11 +84,10 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
       <div
         ref={modalRef}
         className={clsx(
-          "modal-shell-frame-geometry theme-transition relative flex w-full flex-col overflow-hidden font-sans",
+          "modal-shell-skin modal-shell-frame-geometry theme-transition relative flex w-full flex-col overflow-hidden font-sans",
           "focus-ring",
           contentClassName,
         )}
-        style={shellStyle}
         // Make the content div focusable
         tabIndex={-1}
         role="dialog"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -620,6 +620,80 @@ body {
   @apply transition-[background-color,border-color,color,fill,stroke,opacity,box-shadow,transform] duration-150 ease-in-out motion-reduce:transition-none;
 }
 
+/* Surfaces for the remaining documented data-ui hooks. Same reasoning and the
+   same placement rule as .anchored-popover-skin below: an inline style
+   outranks every author rule, so holding these here is what makes the hooks
+   overridable from a customer theme.css at all. */
+.app-shell-skin {
+  background-color: var(--theme-shell-app);
+}
+
+.page-shell-skin {
+  background-color: var(--theme-shell-page);
+}
+
+.chat-body-skin {
+  background-color: var(--theme-shell-chat-body);
+}
+
+.chat-header-skin {
+  background-color: var(--theme-shell-chat-header);
+}
+
+.chat-input-shell-skin {
+  background-color: var(--theme-shell-chat-input);
+  border-radius: var(--theme-radius-input);
+  box-shadow: var(--theme-elevation-input);
+}
+
+.chat-message-skin {
+  border-radius: var(--theme-radius-message);
+  padding: var(--theme-spacing-message-padding-y)
+    var(--theme-spacing-message-padding-x);
+}
+
+.modal-overlay-skin {
+  background-color: var(--theme-overlay-modal);
+  backdrop-filter: blur(var(--theme-layout-modal-backdrop-blur));
+  /* Viewport gutter, held here rather than on the shell so a consumer's
+     max-w-* utility on contentClassName cannot eat into it. */
+  padding: var(--theme-layout-modal-viewport-margin);
+}
+
+.modal-shell-skin {
+  background-color: var(--theme-shell-modal);
+  border-radius: var(--theme-radius-modal);
+  box-shadow: var(--theme-elevation-modal);
+}
+
+/* The sidebar's own width stays inline — it is computed from slim/expanded
+   state. Only the surface moves here. */
+.sidebar-skin {
+  background-color: var(--theme-shell-sidebar);
+  border-color: var(
+    --theme-shell-sidebar-divider-color,
+    var(--theme-border-divider)
+  );
+  box-shadow: var(--theme-elevation-shell);
+}
+
+.sidebar-section-skin {
+  background-color: var(--theme-shell-sidebar-section-bg, transparent);
+  border-color: var(
+    --theme-shell-sidebar-divider-color,
+    var(--theme-border-divider)
+  );
+  padding: var(--theme-spacing-shell-compact-padding-y)
+    var(--theme-spacing-shell-compact-padding-x);
+}
+
+/* Spacing rather than surface, but blocked the same way: held inline it made
+   [data-ui="chat-history-list"] padding unoverridable. */
+.chat-history-list-geometry {
+  padding: calc(var(--theme-spacing-shell-padding-y) / 2)
+    calc(var(--theme-spacing-shell-padding-x) / 2);
+}
+
 /* Sidebar chat rows. Same reasoning as .anchored-popover-skin: held inline,
    the radius made `[data-ui="chat-history-item"]` unoverridable. The row's <a>
    wrapper reads --theme-radius-shell too, so a theme that moves the token keeps


### PR DESCRIPTION
**Stacked on #851** — retarget to `main` once that merges.

Finishes what #851 started. Every remaining hook that `theming.mdx` advertises as overridable held its surface in an inline style, which outranks any author rule — so a `theme.css` rule against it silently did nothing:

`app-shell` · `page-shell` · `sidebar` · `sidebar-header` · `sidebar-footer` · `chat-input-shell` · `chat-body` · `chat-header` · `chat-message` · `chat-history-list` · `modal-shell` · `modal-overlay`

Each moves to a class declared after `@tailwind utilities` and outside `@layer components` — same placement rule as #851, so it still outranks a utility a consumer passes in while remaining overridable from `theme.css`, which loads later.

## Notes

**The sidebar is the only mixed object.** Its `width` is computed from slim/expanded state and stays inline; only the surface moves. Three module consts (`compactShellPaddingStyle`, `sidebarDividerColor`, `sidebarSectionBackground`) are orphaned by that and removed.

**`chat-history-list` is padding, not surface** — but it was blocked identically, so it's included.

**Seven test assertions required the inline values**, i.e. they enforced the defect. They now assert the class is applied and the skin longhands are absent from the inline style.

## Downstream check

I checked this against the one real customer theme in the tree before making the change: **none of these activate a currently-dead rule.** That theme consistently used `background-image` and custom-property overrides — the two techniques an inline style does not block — rather than the properties that were blocked. So no visual change downstream, and nothing to coordinate.

## Not covered

Elements without a documented hook still hold radius inline (sidebar item rows, attachment previews, `Alert`), and the modal close button keeps its bespoke padding token alongside its positioning — converting it would orphan a token that exists specifically to align it to modal padding.

With this landed, the contract test worth adding is one that renders each documented hook and asserts no skin longhand appears in its inline `style` — it would have caught this whole class, and it can't red-line now that the assertions enforcing the defect are gone.