### PR TITLE
Pin a type scale per button size

### DIFF
--- a/frontend/src/components/ui/Controls/Button.test.tsx
+++ b/frontend/src/components/ui/Controls/Button.test.tsx
@@ -80,6 +80,23 @@ describe("Button", () => {
     expect(button.getAttribute("data-variant")).toBe("secondary");
   });
 
+  it("pins a type scale per size so it cannot inherit from the container", () => {
+    const { rerender } = render(<Button size="sm">Small</Button>);
+    expect(screen.getByRole("button", { name: "Small" }).className).toContain(
+      "text-sm",
+    );
+
+    rerender(<Button size="md">Medium</Button>);
+    expect(screen.getByRole("button", { name: "Medium" }).className).toContain(
+      "text-base",
+    );
+
+    rerender(<Button size="lg">Large</Button>);
+    expect(screen.getByRole("button", { name: "Large" }).className).toContain(
+      "text-lg",
+    );
+  });
+
   it("reads the pill radius from the theme token, not a hardcoded value", () => {
     render(
       <Button variant="secondary" shape="pill">

--- a/frontend/src/components/ui/Controls/Button.tsx
+++ b/frontend/src/components/ui/Controls/Button.tsx
@@ -82,10 +82,14 @@ const VARIANT_STYLES = {
 
 // Size geometry classes defined in globals.css @layer components
 // so consumer Tailwind utilities (e.g. p-0) can override them.
+// Each size pins its own type scale. Leaving md/lg unset made a button's font
+// size depend on whatever container it happened to land in rather than on its
+// own size prop, so a default-size button next to a size="sm" one disagreed —
+// visible wherever the two sit together, e.g. dialog footers.
 const CONTROL_SIZE_STYLES = {
   sm: "btn-geometry-sm text-sm",
-  md: "btn-geometry-md",
-  lg: "btn-geometry-lg",
+  md: "btn-geometry-md text-base",
+  lg: "btn-geometry-lg text-lg",
 } as const;
 
 const ICON_SIZE_STYLES = {


### PR DESCRIPTION
Only `sm` declared a font size:

```js
const CONTROL_SIZE_STYLES = {
  sm: "btn-geometry-sm text-sm",   // pins 0.875rem
  md: "btn-geometry-md",           // nothing — inherits ambient
  lg: "btn-geometry-lg",           // nothing — inherits ambient
};
```

So a button's text size came from whatever container it landed in rather than from its own `size` prop. Since `md` is the default, roughly a third of buttons float. Wherever the two kinds sit together they visibly disagree — "Refresh devices" (`size="sm"`) at 0.875rem beside "Archive all chats" (default `md`) at 1rem, and the preferences dialog contains both kinds in one file.

**It is not variant-driven.** No colour variant sets a font size; only `list-item` does, for menu rows.

## md -> text-base is a no-op

I walked the JSX ancestor chain of all **42** `md`/`lg` call sites — not proximity, actual open-tag nesting. **None** has an ancestor that sets a text size, so every one already inherits `1rem` from body. This makes that explicit and stops it depending on context.

(An initial proximity scan suggested 14 sites might grow; all were false positives where the `text-sm` was on a sibling `<p>`, e.g. `ConfirmationDialog.tsx:43`. Worth mentioning because it's the obvious way to get this wrong.)

## lg -> text-lg is the one visible change

1.125rem instead of the inherited 1rem, on the single production `lg` button — the assistant hub "Start chat" CTA (`assistantHubUtils.tsx:452`). It follows the `sm`/`base`/`lg` scale. **Drop it to `text-base` if that CTA shouldn't grow** — the md fix stands on its own either way.