### PR TITLE
Drop redundant recent-chats refetches on rename

### DIFF
--- a/frontend/src/components/ui/Assistant/AssistantsPageStructure.tsx
+++ b/frontend/src/components/ui/Assistant/AssistantsPageStructure.tsx
@@ -30,7 +30,6 @@ export default function AssistantsPageStructure({
     archiveChat,
     createNewChat: createChat,
     updateChatTitle,
-    refetchHistory,
     fetchNextHistoryPage,
     hasNextHistoryPage,
     isFetchingNextHistoryPage,
@@ -137,14 +136,15 @@ export default function AssistantsPageStructure({
 
       try {
         setIsUpdatingChatTitle(true);
+        // updateChatTitle already invalidates the recent-chats query, which
+        // refetches every loaded page — no extra refetch needed here.
         await updateChatTitle(titleDialogChatId, title);
-        await refetchHistory();
         setTitleDialogChatId(null);
       } finally {
         setIsUpdatingChatTitle(false);
       }
     },
-    [refetchHistory, titleDialogChatId, updateChatTitle],
+    [titleDialogChatId, updateChatTitle],
   );
 
   // Handle creating a new chat

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -505,14 +505,15 @@ export const Chat = ({
 
       try {
         setIsUpdatingChatTitle(true);
+        // updateChatTitle already invalidates the recent-chats query, which
+        // refetches every loaded page — no extra refetch needed here.
         await updateChatTitle(titleDialogChatId, title);
-        await refreshChats();
         setTitleDialogChatId(null);
       } finally {
         setIsUpdatingChatTitle(false);
       }
     },
-    [titleDialogChatId, updateChatTitle, refreshChats],
+    [titleDialogChatId, updateChatTitle],
   );
 
   // Function to capture the scrollToBottom from MessageList

--- a/frontend/src/components/ui/Search/SearchPageStructure.tsx
+++ b/frontend/src/components/ui/Search/SearchPageStructure.tsx
@@ -30,7 +30,6 @@ export default function SearchPageStructure({
     archiveChat,
     createNewChat: createChat,
     updateChatTitle,
-    refetchHistory,
     fetchNextHistoryPage,
     hasNextHistoryPage,
     isFetchingNextHistoryPage,
@@ -136,14 +135,15 @@ export default function SearchPageStructure({
 
       try {
         setIsUpdatingChatTitle(true);
+        // updateChatTitle already invalidates the recent-chats query, which
+        // refetches every loaded page — no extra refetch needed here.
         await updateChatTitle(titleDialogChatId, title);
-        await refetchHistory();
         setTitleDialogChatId(null);
       } finally {
         setIsUpdatingChatTitle(false);
       }
     },
-    [refetchHistory, titleDialogChatId, updateChatTitle],
+    [titleDialogChatId, updateChatTitle],
   );
 
   // Handle creating a new chat

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -19,7 +19,6 @@ import {
   type RecentChatsError,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
-import { deepMerge } from "@/lib/generated/v1betaApi/v1betaApiUtils";
 import { getChatUrl } from "@/utils/chat/urlUtils";
 import { createLogger } from "@/utils/debugLogger";
 
@@ -205,9 +204,6 @@ export function useChatHistory() {
   // Memoize the empty array reference
   const emptyChats = useMemo(() => [], []);
 
-  // Create a stable empty object for fetcherOptions, reflecting what useV1betaApiContext currently returns
-  const stableEmptyFetcherOptions = useMemo(() => ({}), []);
-
   // Extract chats from the paginated response structure, defaulting to a stable empty array reference
   const listedChats = useMemo(
     () => data?.pages.flatMap((page) => page.chats) ?? emptyChats,
@@ -343,13 +339,10 @@ export function useChatHistory() {
   // Archive a chat
   const archiveChat = useCallback(
     async (chatId: string) => {
-      // Replicate the key generation process used by the hook:
-      // 1. Merge stableEmptyFetcherOptions with base variables ({})
-      const mergedVariables = deepMerge(stableEmptyFetcherOptions, {}); // Use stable reference
-      // 2. Get the query definition using the *merged* variables
-      const queryDefinition = recentChatsQuery(mergedVariables);
-      // 3. Extract the queryKey from the definition
-      const queryKey = queryDefinition.queryKey;
+      // Recent-chats query key. Request headers never enter the key
+      // (queryKeyFn only uses path/query/body params), so no fetcherOptions
+      // need to be merged in here.
+      const queryKey = recentChatsQuery({}).queryKey;
 
       try {
         // Call the mutation
@@ -379,23 +372,19 @@ export function useChatHistory() {
         throw error; // Re-throw error for potential handling upstream
       }
     },
-    // fetcherOptions is needed for queryKey generation
     [
       archiveChatMutation,
       queryClient,
       currentChatId,
       // router,
       navigate, // Updated dependency array
-      stableEmptyFetcherOptions, // Use stable reference in dependency array
     ],
   );
 
   // Update chat title_by_user_provided
   const updateChatTitle = useCallback(
     async (chatId: string, titleByUserProvided?: string) => {
-      const mergedVariables = deepMerge(stableEmptyFetcherOptions, {});
-      const queryDefinition = recentChatsQuery(mergedVariables);
-      const queryKey = queryDefinition.queryKey;
+      const queryKey = recentChatsQuery({}).queryKey;
 
       try {
         const trimmedTitle = titleByUserProvided?.trim();
@@ -412,7 +401,7 @@ export function useChatHistory() {
         throw error;
       }
     },
-    [queryClient, stableEmptyFetcherOptions, updateChatMutation],
+    [queryClient, updateChatMutation],
   );
 
   return {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -198,8 +198,11 @@ export default function SearchPage() {
 
     try {
       setIsUpdatingChatTitle(true);
+      // updateChatTitle already invalidates the recent-chats query, which
+      // refetches every loaded page. Only the separate search-results query
+      // still needs an explicit refetch to reflect the new title.
       await updateChatTitle(titleDialogChatId, title);
-      await Promise.all([refetchHistory(), refetchSearchResults()]);
+      await refetchSearchResults();
       setTitleDialogChatId(null);
     } finally {
       setIsUpdatingChatTitle(false);


### PR DESCRIPTION
`updateChatTitle` already awaits `invalidateQueries` on the recent-chats key, which refetches every loaded page of the infinite query. Four call sites then refetched the same list again on top of that, so renaming a chat with N loaded pages issued 2N GETs of the expensive `recent_chats` endpoint.

Removed the extra refetch from `Chat`, `SearchPageStructure`, and `AssistantsPageStructure`. On `SearchPage`, kept only the `refetchSearchResults()` call — that's a separate endpoint the invalidate doesn't cover — and dropped the redundant `refetchHistory()`.

Also cleaned up the dead `deepMerge(stableEmptyFetcherOptions, {})` query-key ceremony in `useChatHistory`: request headers never enter the query key, so it reduced to `recentChatsQuery({}).queryKey`. Removed the now-stale comments too.

Now one rename issues one refetch per loaded page (plus the search-results refetch on the search page), and the new title is still reflected in the sidebar, search page, and `document.title`.