### PR TITLE
Make sm the default button size

### DIFF
--- a/frontend/src/components/ui/Controls/Button.test.tsx
+++ b/frontend/src/components/ui/Controls/Button.test.tsx
@@ -80,6 +80,15 @@ describe("Button", () => {
     expect(button.getAttribute("data-variant")).toBe("secondary");
   });
 
+  it("defaults to the sm house size", () => {
+    render(<Button>Default</Button>);
+
+    const button = screen.getByRole("button", { name: "Default" });
+
+    expect(button).toHaveAttribute("data-geometry", "sm");
+    expect(button.className).toContain("btn-geometry-sm");
+  });
+
   it("pins a type scale per size so it cannot inherit from the container", () => {
     const { rerender } = render(<Button size="sm">Small</Button>);
     expect(screen.getByRole("button", { name: "Small" }).className).toContain(

--- a/frontend/src/components/ui/Controls/Button.tsx
+++ b/frontend/src/components/ui/Controls/Button.tsx
@@ -16,6 +16,10 @@ export type ButtonVariant =
   | "link"
   | "danger";
 
+// "sm" is the house size and the default. It is what the great majority of
+// call sites already pass, so omitting the prop yields the common case rather
+// than an outlier — which is how md buttons ended up scattered among sm ones.
+// Reach for "md"/"lg" only as deliberate emphasis.
 type ButtonSize = "sm" | "md" | "lg";
 
 // Shape controls the corner geometry. "pill" yields a fully rounded button;
@@ -119,7 +123,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       variant = "secondary",
-      size = "md",
+      size = "sm",
       shape = "default",
       geometry = "control",
       icon,

--- a/frontend/src/pages/assistantHubUtils.tsx
+++ b/frontend/src/pages/assistantHubUtils.tsx
@@ -449,7 +449,7 @@ export function AssistantHubVersionOverviewSection({
           </div>
         </div>
         {onStartChat && (
-          <Button variant="primary" size="lg" onClick={onStartChat}>
+          <Button variant="primary" onClick={onStartChat}>
             {t({
               id: "assistantHub.action.startChat",
               message: "Start chat",


### PR DESCRIPTION
**Stacked on #854** — retarget to `main` once that merges. Both touch `Button.tsx` and its test.

`sm` was already the house size everywhere except dialogs, but the *default* was `md` — so omitting the prop produced an outlier rather than the common case:

```
area               sm   md   lg   dominant
settings            8    0    0   sm (100%)
assistant          26    8    1   sm (74%)
chat               20    8    0   sm (71%)
other              30   19    2   sm (58%)
dialogs             3   18    0   md (85%)
TOTAL              87   53    3
```

That is how `md` buttons ended up scattered among `sm` ones — "Archive all chats" (`md`) beside "Refresh devices" (`sm`) in the same dialog, one `md` among eight `sm` siblings in `AssistantHubMyPage`, `Back to Assistants` beside two `sm`, and so on.

## Approach

Changed the **default** rather than adding `size="sm"` to 53 call sites. A call-site sweep leaves the default as a trap: the next `<Button>` written without a size is `md` again and the drift restarts. This way new code inherits the convention.

Result: **all 113 production buttons are `sm`** — 75 explicit, 38 by default. No `md` or `lg` remains in app code. The lone `lg` (assistant hub "Start chat") drops to the default with it.

`md` and `lg` remain available for deliberate emphasis, and the type scale each pins (from #854) is unchanged.

## Downstream

`Button` is exported from `frontend/src/library`, so this is a contract change for consumers that omit `size`. I checked: **2 office-addin buttons** (`UserSettingsTabContent` footer) and **0 component-kit** call sites. Both add-in buttons shrinking to `sm` matches the host, which is the direction that repo has been moving.