### PR TITLE
Show the user message when returning to a streaming chat

### DIFF
--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -2915,6 +2915,121 @@ async fn test_resume_stream_full_replay(pool: Pool<Postgres>) {
     server_handle.abort();
 }
 
+/// Test that a mid-generation `GET /chats/{id}/messages` returns the user
+/// message of the in-flight turn.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// 1. Starts a slow generation and lets it run for a couple of seconds
+/// 2. Fetches the chat history while that generation is still streaming
+/// 3. Verifies the user message is already listed
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_get_chat_messages_returns_in_flight_user_message(pool: Pool<Postgres>) {
+    use crate::test_utils::MockLlmConfig;
+    use std::time::Duration;
+
+    const USER_MESSAGE: &str = "In-flight history probe";
+
+    // ~4 seconds of generation, so the fetch below lands mid-stream.
+    let mock_config = MockLlmConfig {
+        chunks: (1..=20).map(|i| format!("Message {:02}", i)).collect(),
+        delay_ms: 200,
+        provider_id: "mock-llm".to_string(),
+        model_name: "gpt-3.5-turbo".to_string(),
+        ..Default::default()
+    };
+
+    let (app_config, _server) = setup_mock_llm_server(Some(mock_config)).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    // A real TCP server: axum_test waits for the full response, leaving no
+    // window to fetch in.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let app: axum::Router = erato::server::router::router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state.clone());
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{}", server_addr);
+
+    let client_clone = client.clone();
+    let base_url_clone = base_url.clone();
+    let submit_handle = tokio::spawn(async move {
+        client_clone
+            .post(format!(
+                "{}/api/v1beta/me/messages/submitstream",
+                base_url_clone
+            ))
+            .header("Authorization", format!("Bearer {}", TEST_JWT_TOKEN))
+            .header("Content-Type", "application/json")
+            .json(&json!({ "user_message": USER_MESSAGE }))
+            .send()
+            .await
+            .expect("Failed to send submitstream request")
+            .text()
+            .await
+            .expect("Failed to read submitstream body")
+    });
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let chat_id = {
+        let tasks = app_state.background_tasks.tasks.read().await;
+        tasks.keys().next().copied()
+    }
+    .expect("Expected to find an active background task");
+
+    let messages_response = client
+        .get(format!(
+            "{}/api/v1beta/chats/{}/messages",
+            base_url, chat_id
+        ))
+        .header("Authorization", format!("Bearer {}", TEST_JWT_TOKEN))
+        .send()
+        .await
+        .expect("Failed to fetch chat messages");
+
+    assert_eq!(
+        messages_response.status(),
+        reqwest::StatusCode::OK,
+        "Mid-generation message fetch should succeed"
+    );
+
+    let body: Value = messages_response
+        .json()
+        .await
+        .expect("Failed to parse chat messages response");
+
+    let user_message = body["messages"]
+        .as_array()
+        .expect("Expected a messages array")
+        .iter()
+        .find(|message| message["role"] == "user")
+        .expect("Expected the in-flight user message to be listed");
+
+    assert_eq!(
+        user_message["content"][0]["text"], USER_MESSAGE,
+        "Listed user message should carry the submitted text"
+    );
+
+    submit_handle.abort();
+    server_handle.abort();
+}
+
 #[sqlx::test(migrator = "crate::MIGRATOR")]
 async fn test_abort_stream_persists_partial_message(pool: Pool<Postgres>) {
     use crate::test_utils::MockLlmConfig;

--- a/e2e-tests/tests/mock-flows.many-models.spec.ts
+++ b/e2e-tests/tests/mock-flows.many-models.spec.ts
@@ -322,6 +322,14 @@ test(
     await expect(page.getByText("Second 5 passed")).toBeVisible({
       timeout: 20000,
     });
+
+    // The in-flight user message must survive the reload/resume, not only the
+    // assistant reply.
+    await expect(page.getByTestId("message-user")).toHaveCount(1);
+    await expect(page.getByTestId("message-user")).toContainText(
+      "long running 15",
+    );
+
     await expect(page.getByText("Complete!")).toHaveCount(0);
 
     await expect(page.getByTestId("message-assistant").last()).toContainText(

--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -468,12 +468,11 @@ test.describe("Streaming composer + message queue", () => {
       await sidebarEntry.click();
       await expect(page).toHaveURL(new RegExp(`/chat/${streamingChatId}$`));
 
-      // The queued payload came back as a draft. (No message-count assert
-      // here: while the resumed stream is still in flight the history can
-      // render without the mid-stream user message — a pre-existing resume
-      // quirk unrelated to the queue. The count is checked after completion.)
+      // The queued payload came back as a draft, and the resumed stream still
+      // shows both sent messages.
       await expect(messageBox(page)).toHaveValue("fast");
       await expect(queuedChip(page)).toHaveCount(0);
+      await expect(page.getByTestId("message-user")).toHaveCount(2);
 
       // "Never background-sends" can only be asserted after the abandoned
       // turn has demonstrably completed — before that, the drain this guards

--- a/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
@@ -166,6 +166,120 @@ test(
 );
 
 test(
+  "returning to an abandoned new chat via the sidebar shows its in-flight user message",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    // A paced turn that must outlive the abandon, the sidebar round-trip, the
+    // resume, and completion runs past the default per-test budget.
+    test.setTimeout(120000);
+
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+    await selectModel(page, MOCK_MODEL);
+
+    const sidebar = page.getByRole("complementary");
+
+    // Resolve once the gated refetch has listed this chat, so its sidebar row is
+    // backed by recent_chats and survives the New Chat below — which clears only
+    // the placeholder. Registered before the send so the refetch cannot be
+    // missed; the `chatId` guard skips list responses that predate the id.
+    let chatId = "";
+    const firstChatListed = page.waitForResponse(
+      async (response) => {
+        if (!response.url().includes(RECENT_CHATS_URL) || !chatId) {
+          return false;
+        }
+        try {
+          const body = (await response.json()) as { chats?: { id?: string }[] };
+          return (
+            Array.isArray(body.chats) &&
+            body.chats.some((entry) => entry.id === chatId)
+          );
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30000 },
+    );
+
+    // A long paced turn, so the return below attaches a resumestream to a task
+    // that is provably still generating rather than one that already 404s.
+    chatId = await sendFirstMessage(page, "long running 20");
+    const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+    const rowLink = sidebar.locator(`a:has([data-chat-id="${chatId}"])`);
+    await expect(row).toBeVisible({ timeout: 5000 });
+    // The first paced token confirms the turn is genuinely streaming.
+    await expect(page.getByText("Second 1 passed")).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId("chat-input-stop-generation")).toBeVisible();
+
+    await firstChatListed;
+
+    // Abandon the still-streaming chat by starting a new one. This is the
+    // load-bearing step: New Chat aborts the live SSE socket (abortAllSSE), so
+    // the return has to re-attach via resumestream and replay chat_created +
+    // user_message_saved, which is what puts the user message back. Clicking a
+    // different existing chat instead would preserve the socket and never resume.
+    await page.getByRole("button", { name: "New Chat" }).click();
+    await expect(page).toHaveURL(/\/chat\/new$/);
+
+    // Register before the row click triggers the resume.
+    const resumeResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/v1beta/me/messages/resumestream"),
+      { timeout: 30000 },
+    );
+
+    // Return to the abandoned chat through its (now listed) sidebar row.
+    await ensureOpenSidebar(page);
+    await expect(rowLink).toBeVisible();
+    await rowLink.click();
+    await expect(page).toHaveURL(new RegExp(`/chat/${chatId}$`));
+
+    const resumeResponse = await resumeResponsePromise;
+    // A live task replays into a 2xx SSE stream; a finished/absent one 404s, so
+    // 2xx proves the turn was genuinely resumed rather than already complete.
+    expect(
+      resumeResponse.ok(),
+      `resumestream should replay a live task with a 2xx status, got ${resumeResponse.status()}`,
+    ).toBe(true);
+
+    // The replayed user message is shown exactly once, ahead of the resuming
+    // assistant reply.
+    await expect(page.getByTestId("message-user")).toHaveCount(1);
+    await expect(page.getByTestId("message-user")).toContainText(
+      "long running 20",
+    );
+    await page.waitForFunction(
+      () => {
+        const user = document.querySelector('[data-testid="message-user"]');
+        const assistant = document.querySelector(
+          '[data-testid="message-assistant"]',
+        );
+        return (
+          !!user &&
+          !!assistant &&
+          (user.compareDocumentPosition(assistant) &
+            Node.DOCUMENT_POSITION_FOLLOWING) !==
+            0
+        );
+      },
+      undefined,
+      { timeout: 15000 },
+    );
+
+    // The turn finishes cleanly and the user message is still the only one.
+    await chatIsReadyToChat(page, {
+      expectAssistantResponse: true,
+      loadingTimeoutMs: 60000,
+    });
+    await expect(page.getByTestId("message-user")).toHaveCount(1);
+  },
+);
+
+test(
   "the list refetch fires on a new chat's first turn but not on a listed chat's next turn",
   { tag: TAG_CI },
   async ({ page }) => {

--- a/frontend/src/hooks/chat/__tests__/chatHooksIntegration.test.ts
+++ b/frontend/src/hooks/chat/__tests__/chatHooksIntegration.test.ts
@@ -15,6 +15,9 @@ import { useChatHistory, useChatHistoryStore } from "../useChatHistory";
 import { useChatMessaging } from "../useChatMessaging";
 
 const mockUseInfiniteQuery = vi.hoisted(() => vi.fn());
+const mockInvalidateQueries = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
 
 // Mock SSE Client
 vi.mock("@/utils/sse/sseClient", () => ({
@@ -53,7 +56,7 @@ vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
 vi.mock("@tanstack/react-query", () => ({
   useInfiniteQuery: mockUseInfiniteQuery,
   useQueryClient: () => ({
-    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    invalidateQueries: mockInvalidateQueries,
     clear: vi.fn(),
   }),
 }));
@@ -299,6 +302,24 @@ describe("Chat hooks integration", () => {
         messagingResult2.current.messageOrder[0]
       ].content,
     ).toEqual([{ content_type: "text", text: "Different chat message" }]);
+  });
+
+  it("should mark the left chat's messages stale when starting a new chat", async () => {
+    mockLocation = { pathname: "/chat/chat1" };
+    mockParams = { id: "chat1" };
+
+    const { result: historyResult } = renderHook(() => useChatHistory());
+    expect(historyResult.current.currentChatId).toBe("chat1");
+
+    await act(async () => {
+      await historyResult.current.createNewChat();
+    });
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["chatMessages", { chatId: "chat1" }],
+      }),
+    );
   });
 
   it("should create a new chat and send a message", async () => {

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1476,6 +1476,111 @@ describe("useChatMessaging", () => {
     expect(orderedMessages[1].role).toBe("assistant");
   });
 
+  it("should render the replayed user message when re-entering a streaming chat", async () => {
+    // The previous turn only: entering from /chat/new there is no optimistic
+    // message and no refetch, so the replay is the only source.
+    mockUseChatMessages.mockReturnValue({
+      data: {
+        messages: [
+          {
+            id: "msg-earlier-user",
+            content: [{ content_type: "text", text: "First question" }],
+            role: "user",
+            created_at: "2026-02-18T12:00:00.000Z",
+            chat_id: "chat-resume-1",
+            updated_at: "2026-02-18T12:00:00.000Z",
+            is_message_in_active_thread: true,
+          },
+          {
+            id: "msg-earlier-assistant",
+            content: [{ content_type: "text", text: "First answer" }],
+            role: "assistant",
+            created_at: "2026-02-18T12:00:01.000Z",
+            chat_id: "chat-resume-1",
+            updated_at: "2026-02-18T12:00:01.000Z",
+            is_message_in_active_thread: true,
+          },
+        ],
+        stats: {
+          total_count: 2,
+          returned_count: 2,
+          current_offset: 0,
+          has_more: false,
+        },
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue({}),
+    });
+
+    let resumeCallbacks: {
+      onMessage?: (event: SSEEvent) => void;
+    } = {};
+    mockCreateSSEConnection.mockImplementation((url, callbacks) => {
+      if (url.includes("/resumestream")) {
+        resumeCallbacks = callbacks;
+      }
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useChatMessaging("chat-resume-1"), {
+      wrapper: TestWrapper,
+    });
+
+    expect(resumeCallbacks.onMessage).toBeDefined();
+
+    const replay = async (eventData: Record<string, unknown>) => {
+      await act(async () => {
+        resumeCallbacks.onMessage?.({
+          data: JSON.stringify(eventData),
+          type: "message",
+        });
+      });
+    };
+
+    // Server clock ahead of the browser's: ordering must not depend on which
+    // clock stamped which message.
+    const serverNow = new Date(Date.now() + 60_000).toISOString();
+    await replay({
+      message_type: "user_message_saved",
+      message_id: "msg-inflight-user",
+      message: {
+        id: "msg-inflight-user",
+        role: "user",
+        created_at: serverNow,
+        updated_at: serverNow,
+        content: [{ content_type: "text", text: "Second question" }],
+        input_files_ids: [],
+        is_message_in_active_thread: true,
+      },
+    });
+    await replay({
+      message_type: "assistant_message_started",
+      message_id: "msg-inflight-assistant",
+    });
+    await replay({
+      message_type: "text_delta",
+      message_id: "msg-inflight-assistant",
+      new_text: "Streaming",
+    });
+
+    const orderedMessages = result.current.messageOrder.map(
+      (id) => result.current.messages[id],
+    );
+    const inflightUserIndex = orderedMessages.findIndex(
+      (message) => message.id === "msg-inflight-user",
+    );
+    const inflightAssistantIndex = orderedMessages.findIndex(
+      (message) => message.id === "msg-inflight-assistant",
+    );
+
+    expect(inflightUserIndex).toBeGreaterThanOrEqual(0);
+    expect(inflightAssistantIndex).toBeGreaterThan(inflightUserIndex);
+    expect(
+      orderedMessages.filter((message) => message.id === "msg-inflight-user"),
+    ).toHaveLength(1);
+  });
+
   it("should remove the replaced user message and every later turn on edit submit", async () => {
     const { result } = renderHook(() => useChatMessaging("chat1"), {
       wrapper: TestWrapper,

--- a/frontend/src/hooks/chat/handlers/handleUserMessageSaved.test.ts
+++ b/frontend/src/hooks/chat/handlers/handleUserMessageSaved.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { handleUserMessageSaved } from "./handleUserMessageSaved";
+import {
+  NEW_CHAT_STREAM_KEY,
+  useMessagingStore,
+} from "../store/messagingStore";
+
+import type { MessageSubmitStreamingResponseUserMessageSaved } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { Message } from "@/types/chat";
+
+const STREAM_KEY = "chat-1";
+const SERVER_ID = "11111111-1111-1111-1111-111111111111";
+const CREATED_AT = "2026-07-21T10:00:00.000Z";
+
+function savedEvent(text = "hello") {
+  return {
+    message_type: "user_message_saved",
+    message_id: SERVER_ID,
+    message: {
+      id: SERVER_ID,
+      chat_id: STREAM_KEY,
+      role: "user",
+      content: [{ content_type: "text", text }],
+      created_at: CREATED_AT,
+    },
+  } as unknown as MessageSubmitStreamingResponseUserMessageSaved & {
+    message_type: "user_message_saved";
+  };
+}
+
+function seedUserMessages(messages: Message[]) {
+  useMessagingStore.setState({
+    userMessagesByKey: {
+      [STREAM_KEY]: Object.fromEntries(messages.map((m) => [m.id, m])),
+    },
+  });
+}
+
+function userMessagesForKey() {
+  return useMessagingStore.getState().userMessagesByKey[STREAM_KEY] ?? {};
+}
+
+describe("handleUserMessageSaved", () => {
+  beforeEach(() => {
+    useMessagingStore.setState({
+      activeStreamKey: STREAM_KEY,
+      streamKeyAliases: {},
+      userMessages: {},
+      userMessagesByKey: {},
+      streamingByKey: {},
+    });
+  });
+
+  it("replaces the optimistic message with the server copy", () => {
+    seedUserMessages([
+      {
+        id: "temp-user-1",
+        content: [{ content_type: "text", text: "hello" }],
+        role: "user",
+        createdAt: "2026-07-21T09:59:59.000Z",
+        status: "sending",
+      },
+    ]);
+
+    handleUserMessageSaved(savedEvent(), STREAM_KEY);
+
+    const userMessages = userMessagesForKey();
+    expect(Object.keys(userMessages)).toEqual([SERVER_ID]);
+    expect(userMessages[SERVER_ID]).toMatchObject({
+      status: "complete",
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it("inserts the server copy when there is no optimistic message to reconcile", () => {
+    handleUserMessageSaved(savedEvent(), STREAM_KEY);
+
+    const userMessages = userMessagesForKey();
+    expect(Object.keys(userMessages)).toEqual([SERVER_ID]);
+    expect(userMessages[SERVER_ID]).toMatchObject({
+      role: "user",
+      status: "complete",
+      createdAt: CREATED_AT,
+    });
+    expect(useMessagingStore.getState().userMessages).toEqual(userMessages);
+  });
+
+  it("does not duplicate when the same event is delivered twice", () => {
+    handleUserMessageSaved(savedEvent(), STREAM_KEY);
+    handleUserMessageSaved(savedEvent(), STREAM_KEY);
+
+    expect(Object.keys(userMessagesForKey())).toEqual([SERVER_ID]);
+  });
+
+  it("leaves the active-key mirror alone for a background stream", () => {
+    useMessagingStore.setState({ activeStreamKey: NEW_CHAT_STREAM_KEY });
+
+    handleUserMessageSaved(savedEvent(), STREAM_KEY);
+
+    expect(Object.keys(userMessagesForKey())).toEqual([SERVER_ID]);
+    expect(useMessagingStore.getState().userMessages).toEqual({});
+  });
+});

--- a/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
+++ b/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
@@ -20,7 +20,8 @@ const logger = createLogger("EVENT", "handleUserMessageSaved");
  * 2. Finding the corresponding temporary message in the Zustand store, typically by
  *    matching content and its 'sending' status.
  * 3. If a match is found, the temporary message is removed from the store.
- * 4. The server-confirmed message (with its real ID and details) is then added to the store.
+ * 4. The server-confirmed message (with its real ID and details) is added to the
+ *    store, whether or not a temporary message was found.
  * This ensures the UI reflects the authoritative state from the backend.
  *
  * @param responseData - The data from the 'user_message_saved' SSE event.
@@ -77,6 +78,20 @@ export function handleUserMessageSaved(
       const currentUserMessagesForKey =
         prevState.userMessagesByKey[resolvedStreamKey] ?? {};
       const newUserMessages = { ...currentUserMessagesForKey };
+      const activeResolvedStreamKey = resolveStreamKeyFromState(
+        prevState.activeStreamKey,
+        prevState.streamKeyAliases,
+      );
+
+      const finalUserMessage = {
+        id: serverConfirmedMessage.id,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        content: serverConfirmedMessage.content ?? [],
+        role: serverConfirmedMessage.role as "user", // Role from server, cast as "user"
+        createdAt: serverConfirmedMessage.created_at,
+        status: "complete" as const, // Message is saved, so status is complete
+        input_files_ids: serverConfirmedMessage.input_files_ids,
+      };
 
       // Find the temporary message by content comparison (extract text from ContentPart[])
       const tempMessage = Object.values(newUserMessages).find(
@@ -88,176 +103,88 @@ export function handleUserMessageSaved(
       );
 
       if (tempMessage?.id) {
-        const tempMessageKeyToDelete = tempMessage.id; // This key is the temp-user-id
-        delete newUserMessages[tempMessageKeyToDelete]; // Remove message with temp ID
-
-        // Construct the final message object using server data
-        const finalUserMessage = {
-          id: serverConfirmedMessage.id,
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          content: serverConfirmedMessage.content ?? [],
-          role: serverConfirmedMessage.role as "user", // Role from server, cast as "user"
-          createdAt: serverConfirmedMessage.created_at,
-          status: "complete" as const, // Message is saved, so status is complete
-          input_files_ids: serverConfirmedMessage.input_files_ids,
-        };
-
-        newUserMessages[finalUserMessage.id] = finalUserMessage; // Add message with real ID
-
-        if (process.env.NODE_ENV === "development") {
-          logger.log(
-            `User message ID updated: from ${tempMessageKeyToDelete} to ${finalUserMessage.id}. Content: "${extractTextFromContent(finalUserMessage.content).substring(0, 50)}..."`,
-          );
-        }
-
-        const assistantTimestamp = new Date(
-          new Date(serverConfirmedMessage.created_at).getTime() + 1,
-        ).toISOString();
-        const activeResolvedStreamKey = resolveStreamKeyFromState(
-          prevState.activeStreamKey,
-          prevState.streamKeyAliases,
-        );
-        const nextUserMessagesByKey = {
-          ...prevState.userMessagesByKey,
-          [resolvedStreamKey]: newUserMessages,
-        };
-
-        const currentMessageId = currentStreaming.currentMessageId;
-        const currentAnchoredMessage =
-          typeof currentMessageId === "string"
-            ? newUserMessages[currentMessageId]
-            : undefined;
-        const pointsToUserMessage =
-          (typeof currentMessageId === "string" &&
-            (currentMessageId === tempMessageKeyToDelete ||
-              currentMessageId === finalUserMessage.id ||
-              currentMessageId.startsWith("temp-user-"))) ||
-          currentAnchoredMessage?.role === "user";
-
-        // Only create optimistic assistant if one doesn't already exist
-        // The optimistic assistant is now created immediately in sendMessage()
-        const hasOptimisticAssistant =
-          currentMessageId?.startsWith("temp-assistant-") &&
-          !pointsToUserMessage;
-
-        if (hasOptimisticAssistant) {
-          if (process.env.NODE_ENV === "development") {
-            logger.log(
-              `[OPTIMISTIC] Updating optimistic assistant placeholder timestamp: ${currentStreaming.createdAt} → ${assistantTimestamp} (after user message: ${serverConfirmedMessage.created_at})`,
-            );
-          }
-          const nextStreaming = {
-            ...currentStreaming,
-            createdAt: assistantTimestamp,
-          };
-
-          return {
-            ...prevState,
-            userMessagesByKey: nextUserMessagesByKey,
-            userMessages:
-              activeResolvedStreamKey === resolvedStreamKey
-                ? newUserMessages
-                : prevState.userMessages,
-            streamingByKey: {
-              ...prevState.streamingByKey,
-              [resolvedStreamKey]: nextStreaming,
-            },
-            streaming:
-              activeResolvedStreamKey === resolvedStreamKey
-                ? nextStreaming
-                : prevState.streaming,
-          };
-        }
-
-        // If we already have an assistant anchor (real assistant ID), keep it
-        // and only force ordering behind the confirmed user message.
-        const hasExistingAssistantAnchor =
-          !!currentMessageId && !pointsToUserMessage;
-
-        if (hasExistingAssistantAnchor) {
-          if (process.env.NODE_ENV === "development") {
-            logger.log(
-              `[OPTIMISTIC] Preserving existing assistant stream anchor (${currentMessageId}) and adjusting timestamp to ${assistantTimestamp}.`,
-            );
-          }
-
-          const nextStreaming = {
-            ...currentStreaming,
-            createdAt: assistantTimestamp,
-          };
-
-          return {
-            ...prevState,
-            userMessagesByKey: nextUserMessagesByKey,
-            userMessages:
-              activeResolvedStreamKey === resolvedStreamKey
-                ? newUserMessages
-                : prevState.userMessages,
-            streamingByKey: {
-              ...prevState.streamingByKey,
-              [resolvedStreamKey]: nextStreaming,
-            },
-            streaming:
-              activeResolvedStreamKey === resolvedStreamKey
-                ? nextStreaming
-                : prevState.streaming,
-          };
-        }
-
-        // Fallback: Create/repair optimistic assistant placeholder if stream anchor
-        // points to a user message or is missing.
-        const optimisticAssistantId = `temp-assistant-${Date.now()}`;
-
-        if (process.env.NODE_ENV === "development") {
-          logger.log(
-            `[OPTIMISTIC] Creating/repairing optimistic assistant placeholder with ID: ${optimisticAssistantId}. Previous anchor: ${String(currentMessageId)}`,
-          );
-        }
-
-        const nextStreaming = {
-          ...currentStreaming,
-          currentMessageId: optimisticAssistantId,
-          content: [],
-          createdAt: assistantTimestamp, // Ensure assistant renders after confirmed user
-          isStreaming: false, // Not streaming yet, just a placeholder
-          isFinalizing: false,
-        };
-        return {
-          ...prevState,
-          userMessagesByKey: nextUserMessagesByKey,
-          userMessages:
-            activeResolvedStreamKey === resolvedStreamKey
-              ? newUserMessages
-              : prevState.userMessages,
-          streamingByKey: {
-            ...prevState.streamingByKey,
-            [resolvedStreamKey]: nextStreaming,
-          },
-          streaming:
-            activeResolvedStreamKey === resolvedStreamKey
-              ? nextStreaming
-              : prevState.streaming,
-        };
+        delete newUserMessages[tempMessage.id]; // Remove message with temp ID
       } else {
-        // If no matching temp message found, log a warning.
-        // This could happen if the message was cleared or if there's a mismatch.
-        logger.warn(
-          `No temporary user message found to update for content: "${serverConfirmedMessageContent.substring(0, 100)}...". This might happen if the message was cleared or if there is a data mismatch.`,
+        // `resumestream` replays this event after the optimistic message is
+        // gone. The server id keeps a repeated delivery idempotent, and
+        // mergeDisplayMessages gives the API copy precedence over it.
+        logger.log(
+          `No temporary user message to reconcile; inserting server message ${serverConfirmedMessage.id} directly.`,
           {
-            serverConfirmedMessage,
-            previousUserMessages: currentUserMessagesForKey, // Log the state before attempting update
+            serverContent: serverConfirmedMessageContent,
+            currentMessages: currentUserMessagesForKey,
           },
         );
       }
-      // If no temp message was found to replace, return the previous state unchanged
-      logger.log(
-        "No matching temporary message found, returning previous state.",
-        {
-          serverContent: serverConfirmedMessageContent,
-          currentMessages: currentUserMessagesForKey,
+
+      newUserMessages[finalUserMessage.id] = finalUserMessage; // Add message with real ID
+
+      if (process.env.NODE_ENV === "development") {
+        logger.log(
+          `User message stored under ${finalUserMessage.id} (was ${tempMessage?.id ?? "absent"}). Content: "${extractTextFromContent(finalUserMessage.content).substring(0, 50)}..."`,
+        );
+      }
+
+      // Ordering is by createdAt, and user messages carry the server's clock
+      // while an unanchored assistant falls back to the browser's. Pin the
+      // assistant just behind the confirmed user message so skew between the
+      // two cannot float the answer above its question.
+      const assistantTimestamp = new Date(
+        new Date(serverConfirmedMessage.created_at).getTime() + 1,
+      ).toISOString();
+
+      const currentMessageId = currentStreaming.currentMessageId;
+      const currentAnchoredMessage =
+        typeof currentMessageId === "string"
+          ? newUserMessages[currentMessageId]
+          : undefined;
+      const pointsToUserMessage =
+        (typeof currentMessageId === "string" &&
+          (currentMessageId === tempMessage?.id ||
+            currentMessageId === finalUserMessage.id ||
+            currentMessageId.startsWith("temp-user-"))) ||
+        currentAnchoredMessage?.role === "user";
+      const hasAssistantAnchor = !!currentMessageId && !pointsToUserMessage;
+
+      // Without an assistant anchor, create/repair an optimistic placeholder;
+      // assistant_message_started later swaps in the real id and keeps this
+      // timestamp.
+      const nextStreaming = hasAssistantAnchor
+        ? { ...currentStreaming, createdAt: assistantTimestamp }
+        : {
+            ...currentStreaming,
+            currentMessageId: `temp-assistant-${Date.now()}`,
+            content: [],
+            createdAt: assistantTimestamp,
+            isStreaming: false, // Not streaming yet, just a placeholder
+            isFinalizing: false,
+          };
+
+      if (process.env.NODE_ENV === "development") {
+        logger.log(
+          `[OPTIMISTIC] Assistant anchor ${currentMessageId ?? "none"} → ${nextStreaming.currentMessageId ?? "none"} at ${assistantTimestamp}.`,
+        );
+      }
+
+      return {
+        ...prevState,
+        userMessagesByKey: {
+          ...prevState.userMessagesByKey,
+          [resolvedStreamKey]: newUserMessages,
         },
-      );
-      return prevState;
+        userMessages:
+          activeResolvedStreamKey === resolvedStreamKey
+            ? newUserMessages
+            : prevState.userMessages,
+        streamingByKey: {
+          ...prevState.streamingByKey,
+          [resolvedStreamKey]: nextStreaming,
+        },
+        streaming:
+          activeResolvedStreamKey === resolvedStreamKey
+            ? nextStreaming
+            : prevState.streaming,
+      };
     },
     false,
     "messaging/handleUserMessageSaved",

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -298,6 +298,16 @@ export function useChatHistory() {
     try {
       logger.log("Creating new chat - navigating to /chat/new");
 
+      // Same staleness marking as navigateToChat, which this path bypasses.
+      if (currentChatId) {
+        void queryClient.invalidateQueries({
+          queryKey: chatMessagesQuery({
+            pathParams: { chatId: currentChatId },
+          }).queryKey,
+          refetchType: "none",
+        });
+      }
+
       // CRITICAL: Clear ALL messaging state before navigation.
       // We intentionally clear across all stream keys to avoid resurrecting
       // an older in-flight new-chat stream when user clicks "new chat" again.
@@ -338,7 +348,7 @@ export function useChatHistory() {
       setNewChatPending(false);
       throw error;
     }
-  }, [navigate, setNewChatPending, currentChatId]); // Updated dependency array
+  }, [navigate, setNewChatPending, currentChatId, queryClient]);
 
   // Archive a chat
   const archiveChat = useCallback(


### PR DESCRIPTION
This pull request improves the chat streaming and message reconciliation logic to ensure that user messages created during mid-generation are reliably reflected in the UI and state, even when the optimistic message is gone (e.g., after a page reload or stream resume). It also strengthens test coverage and clarifies the assistant message anchoring logic to prevent ordering issues between user and assistant messages. The main changes are as follows:

**Backend: Streaming and Message Fetching**

* Added a new integration test (`test_get_chat_messages_returns_in_flight_user_message`) to verify that a mid-generation `GET /chats/{id}/messages` correctly returns the user message of the in-flight turn, ensuring backend consistency for streaming scenarios.

**Frontend: Message Reconciliation and Ordering**

* Refactored `handleUserMessageSaved` to always insert the server-confirmed user message into the store, even if no optimistic message is present, and to log when this occurs. This ensures idempotency and correct UI state after stream resumes or repeated events. [[1]](diffhunk://#diff-75e138d166f2bf0f9e669d563df8be4c5830301285f39f06aecda2a5f7f2a82eL23-R24) [[2]](diffhunk://#diff-75e138d166f2bf0f9e669d563df8be4c5830301285f39f06aecda2a5f7f2a82eL80-L94) [[3]](diffhunk://#diff-75e138d166f2bf0f9e669d563df8be4c5830301285f39f06aecda2a5f7f2a82eR96-L123)
* Improved the assistant message anchoring logic: now, after user message confirmation, the assistant placeholder is always ordered immediately after the user message, regardless of client/server clock skew. This prevents the assistant's message from appearing before the user's in the UI.

**Frontend: Testing and Coverage**

* Added a comprehensive unit test for `handleUserMessageSaved` covering reconciliation, direct insertion, idempotency, and background stream handling.
* Added an integration test to verify that starting a new chat marks the previous chat's messages as stale, ensuring correct cache invalidation.
* Added a test to ensure the replayed user message is rendered when re-entering a streaming chat, verifying correct ordering and deduplication.
* Updated the E2E test to assert that both sent messages are shown during a resumed stream, reflecting the improved mid-stream message handling.

**Test Utilities**

* Refactored and hoisted the `mockInvalidateQueries` utility for improved test reliability and clarity. [[1]](diffhunk://#diff-8f20c9eb89fd0dca5bf0f8949a6e3e1ab30a473ae61f32d4358fe5556944a83cR18-R20) [[2]](diffhunk://#diff-8f20c9eb89fd0dca5bf0f8949a6e3e1ab30a473ae61f32d4358fe5556944a83cL56-R59)

These changes collectively ensure that user messages are reliably shown in the UI during streaming and after interruptions, and that assistant messages are always rendered in the correct order.