### PR TITLE
Show a new chat in the sidebar while its first turn runs

### DIFF
--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -171,6 +171,31 @@ export const ensureOpenSidebar = async (page: Page) => {
   }
 };
 
+/** Glob for route interception; substring for request-URL matching. */
+export const RECENT_CHATS_ROUTE = "**/api/v1beta/me/recent_chats*";
+export const RECENT_CHATS_URL = "/api/v1beta/me/recent_chats";
+
+/** The chat id from a `/chat/<id>` URL, or a clear error if there isn't one. */
+export const chatIdFromUrl = (page: Page): string => {
+  const match = /\/chat\/([0-9a-fA-F-]+)/.exec(page.url());
+  if (!match) {
+    throw new Error(`Expected a chat id in the URL, got: ${page.url()}`);
+  }
+  return match[1];
+};
+
+/**
+ * Send the first message of a new chat and return its id. Navigation happens at
+ * `chat_created`, so the id is known long before the turn ends.
+ */
+export const sendFirstMessage = async (page: Page, message: string) => {
+  const textbox = page.getByRole("textbox", { name: "Type a message..." });
+  await textbox.fill(message);
+  await textbox.press("Enter");
+  await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+  return chatIdFromUrl(page);
+};
+
 /**
  * Install a browser-side abort hook that can cancel active streaming requests.
  * Intended for resilience tests that interrupt submitstream/resumestream.

--- a/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
@@ -1,9 +1,14 @@
 import { test, expect, Page } from "@playwright/test";
 import { TAG_CI } from "./tags";
-import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
+import {
+  chatIsReadyToChat,
+  chatIdFromUrl,
+  ensureOpenSidebar,
+  RECENT_CHATS_ROUTE,
+  RECENT_CHATS_URL,
+  sendFirstMessage,
+} from "./shared";
 
-const RECENT_CHATS_ROUTE = "**/api/v1beta/me/recent_chats*";
-const RECENT_CHATS_URL = "/api/v1beta/me/recent_chats";
 /** What ChatHistoryList renders for a chat without a resolved title. */
 const UNTITLED_ROW_LABEL = "New Chat";
 
@@ -133,23 +138,96 @@ const waitForStreamEnd = (page: Page) =>
     });
   });
 
-const chatIdFromUrl = (page: Page): string => {
-  const match = /\/chat\/([0-9a-fA-F-]+)/.exec(page.url());
-  if (!match) {
-    throw new Error(`Expected a chat id in the URL, got: ${page.url()}`);
-  }
-  return match[1];
-};
+/**
+ * Deliver only the `chat_created` frame to the client and then end the stream
+ * on demand, dropping everything after it (so `user_message_saved` is never
+ * processed). Modelled on `holdStreamAfterChatCreated`, but it truncates the
+ * stream at the frame boundary instead of parking the untouched remainder:
+ * even when the backend batches `chat_created` and `user_message_saved` into
+ * one chunk, only `chat_created` reaches the client. Must be installed before
+ * the first navigation; `close()` ends the delivered stream.
+ */
+const closeStreamAfterChatCreated = async (page: Page) => {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    let close: () => void = () => {};
+    const closeRequested = new Promise<void>((resolve) => {
+      close = resolve;
+    });
+    const tapWindow = window as Window & { __closeHeldStream?: () => void };
+    tapWindow.__closeHeldStream = () => close();
 
-const sendFirstMessage = async (page: Page, message: string) => {
-  const textbox = page.getByRole("textbox", { name: "Type a message..." });
-  await textbox.fill(message);
-  await textbox.press("Enter");
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
 
-  // Navigation happens at chat_created, so the id is known long before the
-  // turn ends.
-  await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
-  return chatIdFromUrl(page);
+      const response = await originalFetch(input, init);
+      if (
+        !url.includes("/api/v1beta/me/messages/submitstream") ||
+        !response.body
+      ) {
+        return response;
+      }
+
+      const upstream = response.body.getReader();
+      const decoder = new TextDecoder();
+      const encoder = new TextEncoder();
+      let seen = "";
+      let deliveredChatCreated = false;
+
+      const truncated = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          if (deliveredChatCreated) {
+            // The client has the chat_created frame; end the stream on trigger.
+            await closeRequested;
+            controller.close();
+            void upstream.cancel().catch(() => {});
+            return;
+          }
+          // Read until a complete chat_created frame is buffered, forward just
+          // that frame, and stop reading so nothing after it is delivered.
+          for (;;) {
+            const { done, value } = await upstream.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            seen += decoder.decode(value, { stream: true });
+            const start = seen.indexOf("chat_created");
+            const frameEnd = start !== -1 ? seen.indexOf("\n\n", start) : -1;
+            if (frameEnd !== -1) {
+              controller.enqueue(encoder.encode(seen.slice(0, frameEnd + 2)));
+              deliveredChatCreated = true;
+              return;
+            }
+          }
+        },
+        cancel(reason) {
+          void upstream.cancel(reason).catch(() => {});
+        },
+      });
+
+      return new Response(truncated, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    };
+  });
+
+  return {
+    close: async () => {
+      await page.evaluate(() => {
+        (
+          window as Window & { __closeHeldStream?: () => void }
+        ).__closeHeldStream?.();
+      });
+    },
+  };
 };
 
 test(
@@ -190,8 +268,10 @@ test(
 
       // The placeholder is replaced by the real row, not added alongside it.
       await expect(row).toHaveCount(1);
-      // The summarizer-generated title takes over from the placeholder, which
-      // renders the untitled-chat fallback. It arrives well after the turn.
+      // The aria-label stops being the untitled fallback once the backend row
+      // carries any resolved title. That proves the local placeholder gave way
+      // to the backend-titled row; the label flips for any non-empty title, so
+      // it is not evidence that a summary specifically was generated.
       await expect(rowLink).not.toHaveAttribute(
         "aria-label",
         UNTITLED_ROW_LABEL,
@@ -200,35 +280,6 @@ test(
     } finally {
       await listHold.dispose();
     }
-  },
-);
-
-test(
-  "resuming a stream does not duplicate the new chat's sidebar row",
-  { tag: TAG_CI },
-  async ({ page }) => {
-    await page.goto("/");
-    await chatIsReadyToChat(page);
-    await ensureOpenSidebar(page);
-
-    const chatId = await sendFirstMessage(
-      page,
-      "Please write a long detailed poem about the sun",
-    );
-    const sidebar = page.getByRole("complementary");
-    await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toBeVisible({
-      timeout: 5000,
-    });
-
-    // Only a reload taken while the turn is genuinely in flight resumes a
-    // stream and replays chat_created; the Stop control is present iff a turn
-    // is in flight.
-    await expect(page.getByTestId("chat-input-stop-generation")).toBeVisible();
-    await page.reload();
-    await ensureOpenSidebar(page);
-    await chatIsReadyToChat(page, { loadingTimeoutMs: 60000 });
-
-    await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toHaveCount(1);
   },
 );
 
@@ -281,6 +332,48 @@ test(
       // The turn outlives the removal, so let it end before calling it gone.
       await streamHold.release();
       await streamEnded;
+      await expect(row).toHaveCount(0);
+    } finally {
+      await listHold.dispose();
+    }
+  },
+);
+
+test(
+  "a first turn that ends before its message is saved leaves no ghost row",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    const streamClose = await closeStreamAfterChatCreated(page);
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+
+    const sidebar = page.getByRole("complementary");
+    const listHold = await holdRecentChats(page);
+
+    try {
+      const chatId = await sendFirstMessage(
+        page,
+        "Please write a short poem about the moon",
+      );
+      const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+      await expect(row).toBeVisible({ timeout: 5000 });
+      // Only chat_created has been delivered, so the turn is provably parked
+      // mid-flight with the placeholder showing.
+      await expect(
+        page.getByTestId("chat-input-stop-generation"),
+      ).toBeVisible();
+
+      // End the stream after chat_created and before user_message_saved. The
+      // chat never gets a saved message, so it can never be listed; the only
+      // thing that can take its placeholder away is the terminal
+      // clearPendingChat on the stream's normal close.
+      await streamClose.close();
+
+      await expect(row).toHaveCount(0);
+      // recent_chats is still held, so the removal cannot be the list dropping
+      // the chat — only the close-path clear accounts for it.
+      await page.waitForTimeout(1000);
       await expect(row).toHaveCount(0);
     } finally {
       await listHold.dispose();

--- a/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+import { TAG_CI } from "./tags";
+import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
+
+test(
+  "a new chat is listed in the sidebar as soon as it is created",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+
+    const sidebar = page.getByRole("complementary");
+
+    // Hold the list endpoint back for as long as the assertions below run, so
+    // a row that shows up in that window can only have come from local state.
+    // That is the whole point: a chat has no messages yet when it is created,
+    // so the server would not list it at that moment anyway. The delay is
+    // lifted afterwards — the completion path waits on this same request.
+    let holdList = true;
+    await page.route("**/api/v1beta/me/recent_chats*", async (route) => {
+      while (holdList) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      await route.continue();
+    });
+
+    const textbox = page.getByRole("textbox", { name: "Type a message..." });
+    await textbox.fill("Please write a short poem about the sun");
+    await textbox.press("Enter");
+
+    // Navigation happens at chat_created, so the id is known long before the
+    // turn ends.
+    await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+    const chatId = page.url().split("/").pop();
+
+    const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+    await expect(row).toBeVisible({ timeout: 5000 });
+    // The row renders already highlighted, without waiting for the list to load.
+    await expect(
+      sidebar.locator(`a:has([data-chat-id="${chatId}"])`),
+    ).toHaveAttribute("aria-current", "page");
+
+    holdList = false;
+
+    await chatIsReadyToChat(page, {
+      expectAssistantResponse: true,
+      loadingTimeoutMs: 60000,
+    });
+
+    // The placeholder is replaced by the real row, not added alongside it.
+    await expect(row).toHaveCount(1);
+    // The real title arrives and overwrites the empty placeholder title.
+    await expect(row).not.toBeEmpty();
+  },
+);
+
+test(
+  "resuming a stream does not duplicate the new chat's sidebar row",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+
+    const textbox = page.getByRole("textbox", { name: "Type a message..." });
+    await textbox.fill("Please write a long detailed poem about the sun");
+    await textbox.press("Enter");
+
+    await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+    const chatId = page.url().split("/").pop();
+    const sidebar = page.getByRole("complementary");
+    await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Reloading mid-turn resumes the stream, which replays chat_created.
+    await page.reload();
+    await ensureOpenSidebar(page);
+    await chatIsReadyToChat(page, { loadingTimeoutMs: 60000 });
+
+    await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toHaveCount(1);
+  },
+);

--- a/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
@@ -1,57 +1,205 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { TAG_CI } from "./tags";
 import { chatIsReadyToChat, ensureOpenSidebar } from "./shared";
+
+const RECENT_CHATS_ROUTE = "**/api/v1beta/me/recent_chats*";
+const RECENT_CHATS_URL = "/api/v1beta/me/recent_chats";
+/** What ChatHistoryList renders for a chat without a resolved title. */
+const UNTITLED_ROW_LABEL = "New Chat";
+
+/**
+ * Park every list request until released, so a row that shows up in that window
+ * can only have come from local state. That is the whole point: a chat has no
+ * messages yet when it is created, so the server would not list it at that
+ * moment anyway.
+ */
+const holdRecentChats = async (page: Page) => {
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await page.route(RECENT_CHATS_ROUTE, async (route) => {
+    await released;
+    // The page may have navigated on by now; a dead request is not a failure.
+    await route.continue().catch(() => {});
+  });
+
+  return {
+    release,
+    /** Safe to call twice, and must run even when an assertion threw. */
+    dispose: async () => {
+      release();
+      await page.unroute(RECENT_CHATS_ROUTE).catch(() => {});
+    },
+  };
+};
+
+/**
+ * Park the submitstream response right after the `chat_created` frame, so the
+ * window in which the chat exists but is not listable lasts as long as the test
+ * needs instead of as long as the model happens to take. Must be installed
+ * before the first navigation, and released before the turn can finish.
+ */
+const holdStreamAfterChatCreated = async (page: Page) => {
+  await page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    let release: () => void = () => {};
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tapWindow = window as Window & { __releaseHeldStream?: () => void };
+    tapWindow.__releaseHeldStream = () => release();
+
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      const response = await originalFetch(input, init);
+      if (
+        !url.includes("/api/v1beta/me/messages/submitstream") ||
+        !response.body
+      ) {
+        return response;
+      }
+
+      const upstream = response.body.getReader();
+      const decoder = new TextDecoder();
+      let seen = "";
+      let holding = false;
+
+      const parked = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          if (holding) {
+            await released;
+          }
+          const { done, value } = await upstream.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+          if (!holding) {
+            // Frames can be split across chunks, so match on the running text.
+            seen += decoder.decode(value, { stream: true });
+            holding = seen.includes("chat_created");
+          }
+        },
+        cancel(reason) {
+          void upstream.cancel(reason).catch(() => {});
+        },
+      });
+
+      return new Response(parked, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    };
+  });
+
+  return {
+    release: async () => {
+      await page.evaluate(() => {
+        (
+          window as Window & { __releaseHeldStream?: () => void }
+        ).__releaseHeldStream?.();
+      });
+    },
+  };
+};
+
+/**
+ * Resolves once the submitstream request is over, however it ends. Must be
+ * registered before the turn is started.
+ */
+const waitForStreamEnd = (page: Page) =>
+  new Promise<void>((resolve) => {
+    const isStream = (url: string) =>
+      url.includes("/api/v1beta/me/messages/submitstream");
+    page.on("requestfinished", (request) => {
+      if (isStream(request.url())) {
+        resolve();
+      }
+    });
+    page.on("requestfailed", (request) => {
+      if (isStream(request.url())) {
+        resolve();
+      }
+    });
+  });
+
+const chatIdFromUrl = (page: Page): string => {
+  const match = /\/chat\/([0-9a-fA-F-]+)/.exec(page.url());
+  if (!match) {
+    throw new Error(`Expected a chat id in the URL, got: ${page.url()}`);
+  }
+  return match[1];
+};
+
+const sendFirstMessage = async (page: Page, message: string) => {
+  const textbox = page.getByRole("textbox", { name: "Type a message..." });
+  await textbox.fill(message);
+  await textbox.press("Enter");
+
+  // Navigation happens at chat_created, so the id is known long before the
+  // turn ends.
+  await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+  return chatIdFromUrl(page);
+};
 
 test(
   "a new chat is listed in the sidebar as soon as it is created",
   { tag: TAG_CI },
   async ({ page }) => {
+    const streamHold = await holdStreamAfterChatCreated(page);
     await page.goto("/");
     await chatIsReadyToChat(page);
     await ensureOpenSidebar(page);
 
     const sidebar = page.getByRole("complementary");
+    const listHold = await holdRecentChats(page);
 
-    // Hold the list endpoint back for as long as the assertions below run, so
-    // a row that shows up in that window can only have come from local state.
-    // That is the whole point: a chat has no messages yet when it is created,
-    // so the server would not list it at that moment anyway. The delay is
-    // lifted afterwards — the completion path waits on this same request.
-    let holdList = true;
-    await page.route("**/api/v1beta/me/recent_chats*", async (route) => {
-      while (holdList) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-      await route.continue();
-    });
+    try {
+      const chatId = await sendFirstMessage(
+        page,
+        "Please write a short poem about the sun",
+      );
 
-    const textbox = page.getByRole("textbox", { name: "Type a message..." });
-    await textbox.fill("Please write a short poem about the sun");
-    await textbox.press("Enter");
+      const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+      const rowLink = sidebar.locator(`a:has([data-chat-id="${chatId}"])`);
+      await expect(row).toBeVisible({ timeout: 5000 });
+      // The row renders already highlighted, without waiting for the list.
+      await expect(rowLink).toHaveAttribute("aria-current", "page");
+      // Nothing has a title to offer yet, so the placeholder shows the
+      // untitled-chat fallback.
+      await expect(rowLink).toHaveAttribute("aria-label", UNTITLED_ROW_LABEL);
 
-    // Navigation happens at chat_created, so the id is known long before the
-    // turn ends.
-    await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
-    const chatId = page.url().split("/").pop();
+      // The completion path waits on this same request.
+      listHold.release();
+      await streamHold.release();
 
-    const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
-    await expect(row).toBeVisible({ timeout: 5000 });
-    // The row renders already highlighted, without waiting for the list to load.
-    await expect(
-      sidebar.locator(`a:has([data-chat-id="${chatId}"])`),
-    ).toHaveAttribute("aria-current", "page");
+      await chatIsReadyToChat(page, {
+        expectAssistantResponse: true,
+        loadingTimeoutMs: 60000,
+      });
 
-    holdList = false;
-
-    await chatIsReadyToChat(page, {
-      expectAssistantResponse: true,
-      loadingTimeoutMs: 60000,
-    });
-
-    // The placeholder is replaced by the real row, not added alongside it.
-    await expect(row).toHaveCount(1);
-    // The real title arrives and overwrites the empty placeholder title.
-    await expect(row).not.toBeEmpty();
+      // The placeholder is replaced by the real row, not added alongside it.
+      await expect(row).toHaveCount(1);
+      // The summarizer-generated title takes over from the placeholder, which
+      // renders the untitled-chat fallback. It arrives well after the turn.
+      await expect(rowLink).not.toHaveAttribute(
+        "aria-label",
+        UNTITLED_ROW_LABEL,
+        { timeout: 60000 },
+      );
+    } finally {
+      await listHold.dispose();
+    }
   },
 );
 
@@ -63,22 +211,79 @@ test(
     await chatIsReadyToChat(page);
     await ensureOpenSidebar(page);
 
-    const textbox = page.getByRole("textbox", { name: "Type a message..." });
-    await textbox.fill("Please write a long detailed poem about the sun");
-    await textbox.press("Enter");
-
-    await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
-    const chatId = page.url().split("/").pop();
+    const chatId = await sendFirstMessage(
+      page,
+      "Please write a long detailed poem about the sun",
+    );
     const sidebar = page.getByRole("complementary");
     await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toBeVisible({
       timeout: 5000,
     });
 
-    // Reloading mid-turn resumes the stream, which replays chat_created.
+    // Only a reload taken while the turn is genuinely in flight resumes a
+    // stream and replays chat_created; the Stop control is present iff a turn
+    // is in flight.
+    await expect(page.getByTestId("chat-input-stop-generation")).toBeVisible();
     await page.reload();
     await ensureOpenSidebar(page);
     await chatIsReadyToChat(page, { loadingTimeoutMs: 60000 });
 
     await expect(sidebar.locator(`[data-chat-id="${chatId}"]`)).toHaveCount(1);
+  },
+);
+
+test(
+  "removing a new chat before it is listed leaves no ghost row",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    const streamHold = await holdStreamAfterChatCreated(page);
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+
+    const sidebar = page.getByRole("complementary");
+    const listHold = await holdRecentChats(page);
+
+    try {
+      const streamEnded = waitForStreamEnd(page);
+      const chatId = await sendFirstMessage(
+        page,
+        "Please write a short poem about the moon",
+      );
+
+      const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+      await expect(row).toBeVisible({ timeout: 5000 });
+      // The turn is parked, so the removal below provably happens inside the
+      // window where only local state accounts for the row.
+      await expect(
+        page.getByTestId("chat-input-stop-generation"),
+      ).toBeVisible();
+
+      // Remove the row while the list still cannot account for it, so nothing
+      // but local state can take it away again.
+      await row.hover();
+      await row.getByRole("button", { name: "Open menu" }).click();
+      await page.getByRole("menuitem", { name: "Remove" }).click();
+      await page.getByRole("button", { name: "Confirm action" }).click();
+
+      await expect(row).toHaveCount(0);
+
+      // Archiving invalidates the list, so releasing lets the answer that
+      // legitimately omits this chat land. The row must not come back with it.
+      const listSettled = page.waitForResponse(
+        (response) => response.url().includes(RECENT_CHATS_URL),
+        { timeout: 30000 },
+      );
+      listHold.release();
+      await listSettled;
+
+      await expect(row).toHaveCount(0);
+      // The turn outlives the removal, so let it end before calling it gone.
+      await streamHold.release();
+      await streamEnded;
+      await expect(row).toHaveCount(0);
+    } finally {
+      await listHold.dispose();
+    }
   },
 );

--- a/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect, Page } from "@playwright/test";
+import { TAG_CI } from "./tags";
+import {
+  chatIsReadyToChat,
+  chatIdFromUrl,
+  ensureOpenSidebar,
+  RECENT_CHATS_ROUTE,
+  RECENT_CHATS_URL,
+  selectModel,
+  sendFirstMessage,
+} from "./shared";
+
+/**
+ * These tests need a turn that streams and completes on demand, but nothing
+ * about the model's output. Mock-LLM gives that deterministically: `long
+ * running N` streams `Second 1 passed … Second N passed`, one per second, so a
+ * turn is provably in flight for N seconds and finished after — no dependence
+ * on a real model's quota or speed. This is the same mechanism the
+ * queue-and-streaming-composer suite uses. It lives in the many-models
+ * scenario, which is why these tests are here rather than in the basic spec.
+ */
+const MOCK_MODEL = "Mock-LLM";
+
+/**
+ * Resolves once turn `turn` (1-indexed) has rendered its first streamed token:
+ * its assistant reply has left the optimistic placeholder (a real, non-`temp-
+ * assistant-` message id) *and* rendered its first markdown block. That moment
+ * is after `user_message_saved` — so a window ending here captures the gated
+ * refetch — and, for a multi-second reply, long before completion — so it
+ * excludes the end-of-turn refetch. The `real >= turn` guard is load-bearing:
+ * without it the still-present previous reply (already real, already holding a
+ * block) would satisfy the predicate before this turn's reply even begins.
+ */
+const waitForFirstToken = (page: Page, turn: number) =>
+  page.waitForFunction(
+    (expected) => {
+      const bubbles = Array.from(
+        document.querySelectorAll('[data-testid="message-assistant"]'),
+      );
+      const isReal = (el: Element) => {
+        const id = el.getAttribute("data-message-id") ?? "";
+        return id !== "" && !id.startsWith("temp-assistant-");
+      };
+      if (bubbles.filter(isReal).length < expected) {
+        return false;
+      }
+      const last = bubbles[bubbles.length - 1];
+      return (
+        last !== undefined &&
+        isReal(last) &&
+        last.querySelector("p,ul,ol,h1,h2,h3,pre,table") !== null
+      );
+    },
+    turn,
+    { timeout: 60000 },
+  );
+
+/**
+ * Fulfil recent_chats normally but keep whichever chat is (or has been) open in
+ * the URL out of every list response, so a just-created chat is never listable
+ * and its row can only come from the placeholder. Unlike parking the request,
+ * this does not hang the first turn's completion path (which awaits the list
+ * refetch); a hung turn would keep a stream whose close would clear the
+ * placeholder on its own, hiding whether the action under test is what cleared
+ * it.
+ */
+const excludeOpenChatFromRecentChats = async (page: Page) => {
+  const excluded = new Set<string>();
+  await page.route(RECENT_CHATS_ROUTE, async (route) => {
+    const response = await route.fetch();
+    let body: {
+      chats?: { id?: string }[];
+      stats?: { returned_count?: number };
+    };
+    try {
+      body = (await response.json()) as typeof body;
+    } catch {
+      await route.fulfill({ response });
+      return;
+    }
+    const match = /\/chat\/([0-9a-fA-F-]+)/.exec(page.url());
+    if (match) {
+      excluded.add(match[1]);
+    }
+    if (Array.isArray(body.chats) && excluded.size > 0) {
+      const before = body.chats.length;
+      body.chats = body.chats.filter((chat) => !excluded.has(chat.id ?? ""));
+      if (body.stats && typeof body.stats.returned_count === "number") {
+        body.stats.returned_count -= before - body.chats.length;
+      }
+    }
+    await route.fulfill({ json: body });
+  });
+  return {
+    dispose: async () => {
+      await page.unroute(RECENT_CHATS_ROUTE).catch(() => {});
+    },
+  };
+};
+
+test(
+  "resuming an in-flight stream replays chat_created without a duplicate sidebar row",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    // A paced turn plus a reload, resume, and completion runs past the default
+    // per-test budget.
+    test.setTimeout(120000);
+
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+    await selectModel(page, MOCK_MODEL);
+
+    const sidebar = page.getByRole("complementary");
+    // A long paced turn, so the reload below attaches a resumestream to a task
+    // that is provably still generating rather than one that already finished
+    // and 404s.
+    const chatId = await sendFirstMessage(page, "long running 12");
+    const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+    await expect(row).toBeVisible({ timeout: 5000 });
+    // The first paced token confirms the turn is genuinely streaming.
+    await expect(page.getByText("Second 1 passed")).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId("chat-input-stop-generation")).toBeVisible();
+
+    // Register before the reload triggers it.
+    const resumeResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/v1beta/me/messages/resumestream"),
+      { timeout: 30000 },
+    );
+
+    await page.reload();
+    await ensureOpenSidebar(page);
+
+    const resumeResponse = await resumeResponsePromise;
+    // A live task replays into a 2xx SSE stream; a finished/absent one 404s, so
+    // 2xx is what proves the turn was genuinely resumed rather than having
+    // quietly completed before the reload.
+    expect(
+      resumeResponse.ok(),
+      `resumestream should replay a live task with a 2xx status, got ${resumeResponse.status()}`,
+    ).toBe(true);
+
+    // The placeholder that the replayed chat_created re-creates and the now-
+    // listed row are the same chat; the dedup keeps them from rendering as two
+    // rows. This is the assertion the dedup guards.
+    await expect(row).toHaveCount(1);
+
+    // Reading the body drains the resume SSE stream, which closes only when the
+    // backend turn ends, so this doubles as waiting for completion. The stream
+    // replays the whole event history from the start, so its body carries the
+    // chat_created frame that re-created the placeholder.
+    const resumeBody = await resumeResponse.text();
+    expect(resumeBody).toContain("chat_created");
+
+    // With the turn finished, confirm the client settles and the row is still
+    // single, not duplicated by the placeholder outliving the listed row.
+    await chatIsReadyToChat(page, {
+      expectAssistantResponse: true,
+      loadingTimeoutMs: 60000,
+    });
+    await expect(row).toHaveCount(1);
+  },
+);
+
+test(
+  "the list refetch fires on a new chat's first turn but not on a listed chat's next turn",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    // Two paced turns plus their completions run past the default budget.
+    test.setTimeout(180000);
+
+    // Timestamp every list request so each can be attributed to a turn's window.
+    const recentChatsAt: number[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes(RECENT_CHATS_URL)) {
+        recentChatsAt.push(Date.now());
+      }
+    });
+
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+    // A paced reply keeps the reply streaming for many seconds, so the
+    // completion refetch stays well clear of the first-token window.
+    await selectModel(page, MOCK_MODEL);
+
+    const textbox = page.getByRole("textbox", { name: "Type a message..." });
+    const stop = page.getByTestId("chat-input-stop-generation");
+    const countInWindow = (start: number, end: number) =>
+      recentChatsAt.filter((t) => t >= start && t <= end).length;
+
+    // Turn 1 — a brand-new chat. It has no saved message when it is created, so
+    // the sidebar renders it from the local placeholder; the gate must refetch
+    // the list on `user_message_saved` to swap in the real, now-listable row.
+    const start1 = Date.now();
+    await textbox.fill("long running 10");
+    await textbox.press("Enter");
+    await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+    await waitForFirstToken(page, 1);
+    const turn1Count = countInWindow(start1, Date.now());
+
+    // Let turn 1 fully finish so its completion refetch cannot bleed into the
+    // next window.
+    await expect(stop).toHaveCount(0, { timeout: 90000 });
+
+    // Turn 2 — the same chat, now listed and no longer pending. The gate must
+    // skip: no list refetch belongs in the window before the reply streams.
+    const start2 = Date.now();
+    await textbox.fill("long running 10");
+    await textbox.press("Enter");
+    await waitForFirstToken(page, 2);
+    const turn2Count = countInWindow(start2, Date.now());
+
+    await expect(stop).toHaveCount(0, { timeout: 90000 });
+
+    expect(
+      turn1Count,
+      "a new chat's first turn must refetch the list once its user message is saved",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      turn2Count,
+      "a listed chat's next turn must not refetch the list before its reply streams",
+    ).toBe(0);
+  },
+);
+
+test(
+  "starting a new chat drops a finished but still-unlisted chat's placeholder",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    // A paced turn plus its completion runs past the default per-test budget.
+    test.setTimeout(120000);
+
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    await ensureOpenSidebar(page);
+    await selectModel(page, MOCK_MODEL);
+
+    const sidebar = page.getByRole("complementary");
+    // Keep this chat out of every list response so its row can only be the
+    // placeholder, and its removal can only be a placeholder clear rather than
+    // the list dropping it.
+    const listExclude = await excludeOpenChatFromRecentChats(page);
+
+    try {
+      const chatId = await sendFirstMessage(page, "long running 2");
+      const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
+      await expect(row).toBeVisible({ timeout: 5000 });
+      // The placeholder is shown while the first turn is still in flight.
+      await expect(
+        page.getByTestId("chat-input-stop-generation"),
+      ).toBeVisible();
+
+      // Let the turn finish. The chat is now saved on the backend but excluded
+      // from the list, so the placeholder is what still holds its row: the
+      // clearing-on-list effect never fires for a chat that is never listed.
+      await chatIsReadyToChat(page, {
+        expectAssistantResponse: true,
+        loadingTimeoutMs: 60000,
+      });
+      await expect(row).toHaveCount(1);
+
+      // Starting a new chat abandons the finished-but-unlisted chat. Its
+      // placeholder has to be cleared here or it lingers as a ghost row that
+      // nothing else would ever remove.
+      await page.getByRole("button", { name: "New Chat" }).click();
+
+      await expect(row).toHaveCount(0);
+      // The exclusion is still in force, so a late list response cannot be what
+      // took the row away, and cannot bring it back either.
+      await page.waitForTimeout(1000);
+      await expect(row).toHaveCount(0);
+    } finally {
+      await listExclude.dispose();
+    }
+  },
+);

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -353,7 +353,6 @@ export const Chat = ({
       onMessageAction,
     });
 
-  // Enhanced sendMessage handler that refreshes the sidebar after sending
   const handleSendMessage = useCallback(
     (
       message: string,
@@ -374,16 +373,11 @@ export const Chat = ({
         modelId,
         assistantId,
         selectedFacetIds,
-      )
-        .then(() => {
-          logger.log("[CHAT_FLOW] Message sent, refreshing chats");
-          return refreshChats();
-        })
-        .catch((error) => {
-          logger.log("[CHAT_FLOW] Error sending message:", error);
-        });
+      ).catch((error) => {
+        logger.log("[CHAT_FLOW] Error sending message:", error);
+      });
     },
-    [baseHandleSendMessage, refreshChats, assistantId],
+    [baseHandleSendMessage, assistantId],
   );
 
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);

--- a/frontend/src/hooks/chat/__tests__/useChatHistory.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatHistory.test.ts
@@ -1,0 +1,195 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+import {
+  useArchiveChatEndpoint,
+  useUpdateChat,
+} from "@/lib/generated/v1betaApi/v1betaApiComponents";
+
+import {
+  useChatHistory,
+  useChatHistoryStore,
+  clearPendingChat,
+  isPendingChat,
+} from "../useChatHistory";
+
+import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+const mockUseInfiniteQuery = vi.hoisted(() => vi.fn());
+
+const mockNavigate = vi.fn();
+let mockLocation = { pathname: "/chat" };
+let mockParams: { id?: string; chatId?: string } = {};
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
+    useParams: () => mockParams,
+  };
+});
+
+vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
+  fetchRecentChats: vi.fn(),
+  useArchiveChatEndpoint: vi.fn(),
+  useUpdateChat: vi.fn(),
+  chatMessagesQuery: vi.fn((variables: { pathParams: { chatId: string } }) => ({
+    queryKey: ["chatMessages", { chatId: variables.pathParams.chatId }],
+  })),
+  recentChatsQuery: vi.fn(() => ({ queryKey: ["recentChats"] })),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useInfiniteQuery: mockUseInfiniteQuery,
+  useQueryClient: () => ({
+    invalidateQueries: vi.fn().mockResolvedValue(undefined),
+    clear: vi.fn(),
+  }),
+}));
+
+const listedChat = (id: string): RecentChat => ({
+  id,
+  title_resolved: `Title of ${id}`,
+  can_edit: true,
+  file_uploads: [],
+  last_message_at: "2026-01-01T12:00:00.000Z",
+  last_selected_facets: ["listed-facet"],
+});
+
+const setListedChats = (chats: RecentChat[]) => {
+  mockUseInfiniteQuery.mockReturnValue({
+    data: {
+      pages: [
+        {
+          chats,
+          stats: {
+            total_count: chats.length,
+            returned_count: chats.length,
+            current_offset: 0,
+            has_more: false,
+          },
+        },
+      ],
+    },
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  });
+};
+
+const PENDING_ID = "11111111-2222-3333-4444-555555555555";
+const pending = { id: PENDING_ID, createdAt: "2026-02-02T08:00:00.000Z" };
+
+describe("useChatHistory pending chat placeholder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation = { pathname: "/chat" };
+    mockParams = {};
+
+    useChatHistoryStore.setState({
+      pendingChat: null,
+      isNewChatPending: false,
+    });
+
+    setListedChats([listedChat("listed-1")]);
+    vi.mocked(useArchiveChatEndpoint).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+    } as unknown as ReturnType<typeof useArchiveChatEndpoint>);
+    vi.mocked(useUpdateChat).mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({}),
+    } as unknown as ReturnType<typeof useUpdateChat>);
+  });
+
+  it("prepends a placeholder row for a chat the list does not have yet", () => {
+    const { result } = renderHook(() => useChatHistory());
+
+    expect(result.current.chats.map((chat) => chat.id)).toEqual(["listed-1"]);
+
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat(pending);
+    });
+
+    expect(result.current.chats.map((chat) => chat.id)).toEqual([
+      PENDING_ID,
+      "listed-1",
+    ]);
+    expect(result.current.chats[0]).toMatchObject({
+      id: PENDING_ID,
+      title_resolved: "",
+      can_edit: false,
+      file_uploads: [],
+      last_message_at: pending.createdAt,
+    });
+  });
+
+  it("does not prepend a placeholder once the chat is listed", () => {
+    const { result, rerender } = renderHook(() => useChatHistory());
+
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat(pending);
+    });
+    expect(result.current.chats).toHaveLength(2);
+
+    setListedChats([listedChat(PENDING_ID), listedChat("listed-1")]);
+    rerender();
+
+    expect(result.current.chats.map((chat) => chat.id)).toEqual([
+      PENDING_ID,
+      "listed-1",
+    ]);
+    expect(result.current.chats[0].title_resolved).toBe(
+      `Title of ${PENDING_ID}`,
+    );
+    // The placeholder is dropped rather than kept around, so it cannot outrank
+    // the list again after the real row leaves it.
+    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
+  });
+
+  it("leaves the first turn's facets and model unresolved on the placeholder", () => {
+    const { result } = renderHook(() => useChatHistory());
+
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat(pending);
+    });
+
+    const placeholder = result.current.chats[0];
+    expect(placeholder.last_selected_facets).toBeUndefined();
+    expect(placeholder.last_model).toBeUndefined();
+  });
+
+  it("carries the assistant id when the chat was started from an assistant", () => {
+    const { result } = renderHook(() => useChatHistory());
+
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat(pending);
+    });
+    expect(result.current.chats[0].assistant_id).toBeUndefined();
+
+    act(() => {
+      useChatHistoryStore
+        .getState()
+        .setPendingChat({ ...pending, assistantId: "assistant-7" });
+    });
+    expect(result.current.chats[0].assistant_id).toBe("assistant-7");
+  });
+
+  it("clears the placeholder only for the chat it is scoped to", () => {
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat(pending);
+    });
+
+    expect(isPendingChat(PENDING_ID)).toBe(true);
+    expect(isPendingChat("some-other-chat")).toBe(false);
+
+    clearPendingChat("some-other-chat");
+    expect(useChatHistoryStore.getState().pendingChat).toEqual(pending);
+
+    clearPendingChat(PENDING_ID);
+    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
+  });
+});

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -5,7 +5,7 @@
  */
 /* eslint-disable lingui/no-unlocalized-strings */
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom"; // Added React Router hooks
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
@@ -25,12 +25,7 @@ import { createLogger } from "@/utils/debugLogger";
 
 import { getStreamKey, useMessagingStore } from "./store/messagingStore";
 
-// Import the correct response type and the RecentChat type from schemas
-// No longer needed after switching to invalidateQueries:
-// import type {
-//   RecentChatsResponse,
-//   RecentChat,
-// } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
 const logger = createLogger("HOOK", "useChatHistory");
 const CHAT_HISTORY_PAGE_SIZE = 30;
@@ -38,6 +33,15 @@ const CHAT_HISTORY_PAGE_SIZE = 30;
 interface ChatHistoryState {
   isNewChatPending: boolean; // Flag to indicate a new chat navigation is in progress
   setNewChatPending: (isPending: boolean) => void;
+  /**
+   * A chat that exists on the backend but is not listable yet, with the moment
+   * it was created. `get_recent_chats` only returns chats that already have a
+   * message, and the backend creates the chat row before it inserts the first
+   * user message, so between `chat_created` and the first list fetch after
+   * `user_message_saved` there is nothing to render a row from.
+   */
+  pendingChat: { id: string; createdAt: string } | null;
+  setPendingChat: (chat: { id: string; createdAt: string } | null) => void;
 }
 
 // Create a store to track the current selected chat
@@ -54,6 +58,9 @@ export const useChatHistoryStore = create<ChatHistoryState>()(
             false,
             "chatHistory/setNewChatPending",
           ),
+        pendingChat: null,
+        setPendingChat: (chat) =>
+          set({ pendingChat: chat }, false, "chatHistory/setPendingChat"),
       };
 
       // Add debugging for state changes
@@ -88,7 +95,8 @@ export function useChatHistory() {
   }, [location.pathname, params.id, params.chatId]);
 
   const { fetcherOptions } = useV1betaApiContext();
-  const { isNewChatPending, setNewChatPending } = useChatHistoryStore();
+  const { isNewChatPending, setNewChatPending, pendingChat, setPendingChat } =
+    useChatHistoryStore();
 
   const {
     data,
@@ -141,10 +149,42 @@ export function useChatHistory() {
   const stableEmptyFetcherOptions = useMemo(() => ({}), []);
 
   // Extract chats from the paginated response structure, defaulting to a stable empty array reference
-  const chats = useMemo(
+  const listedChats = useMemo(
     () => data?.pages.flatMap((page) => page.chats) ?? emptyChats,
     [data?.pages, emptyChats],
   );
+
+  const isPendingChatListed = pendingChat
+    ? listedChats.some((chat) => chat.id === pendingChat.id)
+    : false;
+
+  // Once the backend lists the chat, the placeholder has served its purpose.
+  // Dropping it here also keeps it from resurfacing as a ghost row if the chat
+  // later leaves the list, e.g. by being archived.
+  useEffect(() => {
+    if (isPendingChatListed) {
+      setPendingChat(null);
+    }
+  }, [isPendingChatListed, setPendingChat]);
+
+  const chats = useMemo(() => {
+    if (!pendingChat || isPendingChatListed) {
+      return listedChats;
+    }
+    // Only the fields the sidebar renders. `last_selected_facets` and
+    // `last_model` are deliberately absent: consumers treat a present value as
+    // authoritative and would override what the assistant configured for the
+    // first turn. `can_edit` is false to match what an unlisted chat resolves
+    // to today.
+    const placeholder: RecentChat = {
+      id: pendingChat.id,
+      title_resolved: "",
+      can_edit: false,
+      file_uploads: [],
+      last_message_at: pendingChat.createdAt,
+    };
+    return [placeholder, ...listedChats];
+  }, [listedChats, pendingChat, isPendingChatListed]);
 
   // Navigate to a specific chat (assistant-aware)
   const navigateToChat = useCallback(

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -30,18 +30,36 @@ import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 const logger = createLogger("HOOK", "useChatHistory");
 const CHAT_HISTORY_PAGE_SIZE = 30;
 
+/**
+ * A chat that exists on the backend but is not listable yet, with the moment it
+ * was created. `get_recent_chats` only returns chats that already have a
+ * message, and the backend creates the chat row before it inserts the first
+ * user message, so between `chat_created` and the first list fetch after
+ * `user_message_saved` there is nothing to render a row from.
+ */
+export interface PendingChat {
+  id: string;
+  createdAt: string;
+  /**
+   * Set only when the chat was started from an assistant page. Selecting the
+   * row has to keep the assistant in the URL, and the list response that would
+   * otherwise carry the assistant has not arrived yet.
+   */
+  assistantId?: string;
+}
+
+/**
+ * `T` with its optional fields made mandatory to write but still allowed to be
+ * `undefined`, so a field added to the generated type cannot silently default
+ * to absent here.
+ */
+type Complete<T> = { [K in keyof Required<T>]: T[K] };
+
 interface ChatHistoryState {
   isNewChatPending: boolean; // Flag to indicate a new chat navigation is in progress
   setNewChatPending: (isPending: boolean) => void;
-  /**
-   * A chat that exists on the backend but is not listable yet, with the moment
-   * it was created. `get_recent_chats` only returns chats that already have a
-   * message, and the backend creates the chat row before it inserts the first
-   * user message, so between `chat_created` and the first list fetch after
-   * `user_message_saved` there is nothing to render a row from.
-   */
-  pendingChat: { id: string; createdAt: string } | null;
-  setPendingChat: (chat: { id: string; createdAt: string } | null) => void;
+  pendingChat: PendingChat | null;
+  setPendingChat: (chat: PendingChat | null) => void;
 }
 
 // Create a store to track the current selected chat
@@ -59,8 +77,16 @@ export const useChatHistoryStore = create<ChatHistoryState>()(
             "chatHistory/setNewChatPending",
           ),
         pendingChat: null,
+        // Returning the current state for a no-op write keeps the snapshot
+        // identity, so the redundant clears (one per mounted `useChatHistory`)
+        // do not notify subscribers.
         setPendingChat: (chat) =>
-          set({ pendingChat: chat }, false, "chatHistory/setPendingChat"),
+          set(
+            (state) =>
+              state.pendingChat === chat ? state : { pendingChat: chat },
+            false,
+            "chatHistory/setPendingChat",
+          ),
       };
 
       // Add debugging for state changes
@@ -75,6 +101,34 @@ export const useChatHistoryStore = create<ChatHistoryState>()(
     },
   ),
 );
+
+/**
+ * Drops the placeholder row for a chat whose first turn can no longer make it
+ * listable: nothing else will ever remove it, because the clearing effect below
+ * only fires when the chat shows up in the list, which a chat without a saved
+ * user message never does.
+ *
+ * `chatId` scopes the clear so a concurrent first turn keeps its own
+ * placeholder; pass nothing to clear whichever chat is pending.
+ */
+export function clearPendingChat(chatId?: string) {
+  const { pendingChat, setPendingChat } = useChatHistoryStore.getState();
+  if (!pendingChat) {
+    return;
+  }
+  if (chatId !== undefined && pendingChat.id !== chatId) {
+    return;
+  }
+  setPendingChat(null);
+}
+
+/**
+ * Whether the sidebar is currently rendering `chatId` from the placeholder,
+ * i.e. whether the list is known to be missing a row for it.
+ */
+export function isPendingChat(chatId: string): boolean {
+  return useChatHistoryStore.getState().pendingChat?.id === chatId;
+}
 
 export function useChatHistory() {
   // const router = useRouter(); // Removed Next.js router
@@ -95,8 +149,14 @@ export function useChatHistory() {
   }, [location.pathname, params.id, params.chatId]);
 
   const { fetcherOptions } = useV1betaApiContext();
-  const { isNewChatPending, setNewChatPending, pendingChat, setPendingChat } =
-    useChatHistoryStore();
+  const isNewChatPending = useChatHistoryStore(
+    (state) => state.isNewChatPending,
+  );
+  const setNewChatPending = useChatHistoryStore(
+    (state) => state.setNewChatPending,
+  );
+  const pendingChat = useChatHistoryStore((state) => state.pendingChat);
+  const setPendingChat = useChatHistoryStore((state) => state.setPendingChat);
 
   const {
     data,
@@ -159,29 +219,40 @@ export function useChatHistory() {
     : false;
 
   // Once the backend lists the chat, the placeholder has served its purpose.
-  // Dropping it here also keeps it from resurfacing as a ghost row if the chat
-  // later leaves the list, e.g. by being archived.
+  // Dropping it here is what keeps it from resurfacing later: the placeholder
+  // outranks the list, so a stale one would re-appear as a ghost row the moment
+  // the real row leaves the list, e.g. by being archived. This covers only
+  // chats that do get listed; the paths where that never happens clear the
+  // placeholder themselves.
   useEffect(() => {
     if (isPendingChatListed) {
       setPendingChat(null);
     }
   }, [isPendingChatListed, setPendingChat]);
 
-  const chats = useMemo(() => {
+  const chats = useMemo<RecentChat[]>(() => {
     if (!pendingChat || isPendingChatListed) {
       return listedChats;
     }
-    // Only the fields the sidebar renders. `last_selected_facets` and
-    // `last_model` are deliberately absent: consumers treat a present value as
-    // authoritative and would override what the assistant configured for the
-    // first turn. `can_edit` is false to match what an unlisted chat resolves
-    // to today.
-    const placeholder: RecentChat = {
+    // Everything the sidebar renders, plus `assistant_id` so selecting the row
+    // stays on the assistant route. `last_selected_facets` and `last_model` are
+    // deliberately undefined: consumers treat a present value as authoritative
+    // and would override what the assistant configured for the first turn.
+    // `can_edit` is false to match what an unlisted chat resolves to today.
+    const placeholder: Complete<RecentChat> = {
       id: pendingChat.id,
       title_resolved: "",
+      title_by_summary: undefined,
+      title_by_user_provided: undefined,
       can_edit: false,
       file_uploads: [],
       last_message_at: pendingChat.createdAt,
+      assistant_id: pendingChat.assistantId,
+      assistant_name: undefined,
+      archived_at: undefined,
+      last_chat_provider_id: undefined,
+      last_selected_facets: undefined,
+      last_model: undefined,
     };
     return [placeholder, ...listedChats];
   }, [listedChats, pendingChat, isPendingChatListed]);
@@ -239,6 +310,9 @@ export function useChatHistory() {
       messagingStore.setAwaitingFirstStreamChunkForNewChat(false);
       messagingStore.setSSEAbortCallback(null, getStreamKey(currentChatId));
 
+      // Aborting the streams above abandons any first turn still in flight.
+      clearPendingChat();
+
       // Set the pending flag first to prevent unwanted changes during navigation
       logger.log("Setting isNewChatPending to TRUE");
       setNewChatPending(true);
@@ -283,6 +357,10 @@ export function useChatHistory() {
           pathParams: { chatId },
           body: {}, // Send empty object as body
         });
+
+        // The row offering this action may itself be the placeholder, which no
+        // list response can take away.
+        clearPendingChat(chatId);
 
         // Invalidate the query - React Query will refetch it automatically
         // when components using it are active.

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -50,6 +50,7 @@ import {
   NEW_CHAT_STREAM_KEY,
   useMessagingStore,
 } from "./store/messagingStore";
+import { useChatHistoryStore } from "./useChatHistory";
 import { useExplicitNavigation } from "./useExplicitNavigation";
 
 import type {
@@ -874,6 +875,15 @@ export function useChatMessaging(
                 previousStreamKey,
               );
 
+              if (responseData.chat_id) {
+                // Give the sidebar something to render right away; the chat is
+                // not listable until its first message is saved.
+                useChatHistoryStore.getState().setPendingChat({
+                  id: responseData.chat_id,
+                  createdAt: new Date().toISOString(),
+                });
+              }
+
               if (
                 responseData.chat_id &&
                 previousStreamKey !== responseData.chat_id
@@ -920,6 +930,9 @@ export function useChatMessaging(
               responseData,
             );
             handleUserMessageSaved(responseData, activeStreamKey);
+            // The chat now has a message, so the list query can see it. This
+            // replaces the placeholder row with the real one.
+            void refetchChatHistory();
             break;
 
           case "assistant_message_started":
@@ -1040,6 +1053,7 @@ export function useChatMessaging(
       setNewlyCreatedChatId, // for handleChatCreated
       // External handlers (handleChatCreated, handleUserMessageSaved, etc.) are stable imports
       handleRefetchAndClear, // Added dependency
+      refetchChatHistory,
       explicitNav, // Added explicit navigation dependency
       setError,
       resetStreaming,

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -50,7 +50,11 @@ import {
   NEW_CHAT_STREAM_KEY,
   useMessagingStore,
 } from "./store/messagingStore";
-import { useChatHistoryStore } from "./useChatHistory";
+import {
+  clearPendingChat,
+  isPendingChat,
+  useChatHistoryStore,
+} from "./useChatHistory";
 import { useExplicitNavigation } from "./useExplicitNavigation";
 
 import type {
@@ -881,6 +885,9 @@ export function useChatMessaging(
                 useChatHistoryStore.getState().setPendingChat({
                   id: responseData.chat_id,
                   createdAt: new Date().toISOString(),
+                  ...(explicitNav.currentAssistantId
+                    ? { assistantId: explicitNav.currentAssistantId }
+                    : {}),
                 });
               }
 
@@ -930,9 +937,14 @@ export function useChatMessaging(
               responseData,
             );
             handleUserMessageSaved(responseData, activeStreamKey);
-            // The chat now has a message, so the list query can see it. This
-            // replaces the placeholder row with the real one.
-            void refetchChatHistory();
+            // The chat now has a message, so the list query can see it, which
+            // replaces the placeholder row with the real one. Only the chat
+            // still rendered from a placeholder needs this: for every other
+            // turn the list already has its row, and a refetch here would cost
+            // one request per loaded page mid-stream.
+            if (isPendingChat(activeStreamKey)) {
+              void refetchChatHistory();
+            }
             break;
 
           case "assistant_message_started":
@@ -1025,6 +1037,7 @@ export function useChatMessaging(
 
             setError(new Error(description));
             resetStreaming(activeStreamKey);
+            clearPendingChat(activeStreamKey);
             setSubmittingForKey(activeStreamKey, false);
             void handleRefetchAndClear({
               logContext: `Stream error event (${streamError.error_type})`,
@@ -1175,6 +1188,7 @@ export function useChatMessaging(
             if (stillStreaming) {
               setError(connectionError);
               resetStreaming(resumeStreamKey);
+              clearPendingChat(resumeStreamKey);
               void handleRefetchAndClear({
                 logContext: `Resume stream error (${reason})`,
               });
@@ -1447,6 +1461,7 @@ export function useChatMessaging(
               "[DEBUG_STREAMING] SSE onError: Resetting streaming state.",
             );
             resetStreaming(activeStreamKey);
+            clearPendingChat(activeStreamKey);
 
             // Use the new utility for refetch and clear
             logger.log(
@@ -1495,6 +1510,7 @@ export function useChatMessaging(
               logger.log(
                 "[DEBUG_STREAMING] SSE onClose: Not streaming, calling handleRefetchAndClear.",
               );
+              clearPendingChat(activeStreamKey);
               void handleRefetchAndClear({ logContext: "SSE closed normally" });
             } else if (currentlyStreaming) {
               setSSECleanupForKey(activeStreamKey, null);
@@ -1520,6 +1536,7 @@ export function useChatMessaging(
                 "[DEBUG_STREAMING] SSE onClose (unexpected): Resetting streaming state.",
               );
               resetStreaming(activeStreamKey);
+              clearPendingChat(activeStreamKey);
 
               // Use the new utility for refetch and clear
               logger.log(


### PR DESCRIPTION
This pull request adds comprehensive end-to-end tests for sidebar behavior when creating new chats, especially focusing on the correct handling of optimistic sidebar rows during chat creation, removal, and streaming interruptions. It also introduces several shared test utilities to facilitate these scenarios. Additionally, a redundant sidebar refresh after sending a message has been removed from the chat UI code.

**New end-to-end tests for sidebar chat creation and edge cases:**

* Added `sidebar-new-chat.basic.spec.ts` with tests ensuring that:
  - A new chat appears in the sidebar immediately upon creation, before the backend lists it.
  - Removing a pending chat before it's listed leaves no ghost row.
  - If the first turn ends before the message is saved, no ghost row remains.
* Added `sidebar-new-chat.many-models.spec.ts` with tests ensuring that:
  - Resuming an in-flight stream does not duplicate sidebar rows.
  - The chat list is only refetched at appropriate times for new and existing chats.
  - Starting a new chat clears placeholders for finished but unlisted chats.

**Test utilities and helpers:**

* Introduced shared helpers in `shared.ts` for extracting chat IDs from URLs, sending the first message, and intercepting or manipulating network requests related to chat creation and listing.

**Code simplification:**

* Removed an unnecessary sidebar refresh (`refreshChats()`) after sending a message in the chat UI component, as the sidebar now updates optimistically. [[1]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55L356) [[2]](diffhunk://#diff-1714fae1124df6d25373c8ef59a3f61be88e5a77571e4ecacafddcebb386cf55L377-R380)