### PR TITLE
Unify the rename dialog's generated-title field with the shared Input

### DIFF
--- a/frontend/src/components/ui/Chat/EditChatTitleDialog.tsx
+++ b/frontend/src/components/ui/Chat/EditChatTitleDialog.tsx
@@ -56,18 +56,26 @@ export const EditChatTitleDialog = ({
     >
       <div className="space-y-4">
         <div>
-          <p className="text-sm font-medium text-theme-fg-primary">
+          <label
+            htmlFor="chat-generated-title"
+            className="mb-1 block text-sm font-medium text-theme-fg-primary"
+          >
             {t({
               id: "chat.history.rename.generated.label",
               message: "Generated title",
             })}
-          </p>
-          <p
-            className="mt-1 rounded-md border border-theme-border bg-theme-bg-secondary px-3 py-2 text-sm text-theme-fg-secondary"
+          </label>
+          <Input
+            id="chat-generated-title"
+            value={generatedTitleFallback}
+            readOnly
+            disabled
             data-testid="generated-chat-title"
-          >
-            {generatedTitleFallback}
-          </p>
+            aria-label={t({
+              id: "chat.history.rename.generated.label",
+              message: "Generated title",
+            })}
+          />
         </div>
 
         <div>


### PR DESCRIPTION
The rename chat dialog rendered the read-only generated title as a hand-styled `<p>` (its own `border-theme-border`, `rounded-md`, `px-3 py-2`, `text-sm`), which diverged from the shared `Input` used for the editable custom title — most noticeably in the border. The disabled field also gave no cursor feedback on hover.

This renders the generated title as a disabled, read-only `Input`, so both fields draw from the same theme tokens (radius, padding, border) and the read-only field shows the `cursor-not-allowed` style on hover for free.