### PR TITLE
Allow users to retract message feedback

### DIFF
--- a/backend/erato/src/models/message_feedback.rs
+++ b/backend/erato/src/models/message_feedback.rs
@@ -139,6 +139,94 @@ pub async fn submit_or_update_feedback(
     Ok(feedback)
 }
 
+/// Delete feedback for a message
+///
+/// Removes the feedback record for the given message. Authorization mirrors
+/// `submit_or_update_feedback`, and the same edit time limit applies. If Langfuse
+/// feedback forwarding is enabled, the corresponding score is deleted as well.
+pub async fn delete_feedback(
+    conn: &DatabaseConnection,
+    policy: &PolicyEngine,
+    subject: &Subject,
+    message_id: &Uuid,
+    langfuse_client: &LangfuseClient,
+    enable_feedback: bool,
+    edit_time_limit_seconds: Option<u64>,
+) -> Result<(), Report> {
+    let message = Messages::find_by_id(*message_id)
+        .one(conn)
+        .await?
+        .ok_or_else(|| eyre!("Message with ID {} not found", message_id))?;
+
+    authorize!(
+        policy,
+        subject,
+        &Resource::Chat(message.chat_id.as_hyphenated().to_string()),
+        Action::Read
+    )
+    .map_err(|e| eyre!("Not authorized to delete feedback for this message: {}", e))?;
+
+    authorize!(
+        policy,
+        subject,
+        &Resource::MessageFeedback(message_id.as_hyphenated().to_string()),
+        Action::SubmitFeedback
+    )
+    .map_err(|e| eyre!("Not authorized to delete feedback: {}", e))?;
+
+    let existing = MessageFeedbacks::find()
+        .filter(message_feedbacks::Column::MessageId.eq(*message_id))
+        .one(conn)
+        .await?
+        .ok_or_else(|| eyre!("Feedback for message {} not found", message_id))?;
+
+    if let Some(time_limit_seconds) = edit_time_limit_seconds {
+        let elapsed = chrono::Utc::now().signed_duration_since(existing.created_at);
+        if elapsed.num_seconds() > time_limit_seconds as i64 {
+            return Err(eyre!(
+                "Feedback editing time limit exceeded. Feedback can only be removed within {} seconds of creation.",
+                time_limit_seconds
+            ));
+        }
+    }
+
+    existing.delete(conn).await?;
+
+    if enable_feedback {
+        let langfuse_trace_id = message
+            .generation_metadata
+            .as_ref()
+            .and_then(|metadata_json| {
+                serde_json::from_value::<GenerationMetadata>(metadata_json.clone()).ok()
+            })
+            .and_then(|metadata| metadata.langfuse_trace_id);
+
+        if let Some(trace_id) = langfuse_trace_id {
+            let score_id = format!("{}-user-feedback", trace_id);
+
+            // Delete score asynchronously - don't fail the feedback removal if Langfuse fails
+            let langfuse_client_clone = langfuse_client.clone();
+            tokio::spawn(async move {
+                if let Err(e) = langfuse_client_clone.delete_score(&score_id).await {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to delete feedback score in Langfuse"
+                    );
+                } else {
+                    tracing::debug!("Successfully deleted feedback score in Langfuse");
+                }
+            });
+        } else {
+            tracing::debug!(
+                message_id = %message_id,
+                "No Langfuse trace_id found in message metadata, skipping score deletion"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Get feedbacks for multiple messages efficiently
 ///
 /// This function bulk fetches feedback records for a list of message IDs,

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -200,7 +200,7 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         .route("/chats/{chat_id}/archive", post(archive_chat_endpoint))
         .route(
             "/messages/{message_id}/feedback",
-            put(submit_message_feedback),
+            put(submit_message_feedback).delete(delete_message_feedback),
         )
         .route("/files/{file_id}", get(get_file))
         .route("/files/{file_id}/preview", get(get_file_preview))
@@ -345,6 +345,7 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         starter_prompts,
         chat_messages,
         submit_message_feedback,
+        delete_message_feedback,
         recent_chats,
         frequent_assistants,
         upload_file,
@@ -2135,6 +2136,64 @@ pub async fn submit_message_feedback(
     };
 
     Ok(Json(response))
+}
+
+/// Delete feedback for a message
+#[utoipa::path(
+    delete,
+    path = "/messages/{message_id}/feedback",
+    params(
+        ("message_id" = String, Path, description = "The ID of the message to delete feedback for")
+    ),
+    responses(
+        (status = NO_CONTENT, description = "Feedback successfully deleted"),
+        (status = BAD_REQUEST, description = "Invalid message ID"),
+        (status = NOT_FOUND, description = "Message or feedback not found"),
+        (status = FORBIDDEN, description = "User does not have permission to delete feedback for this message, or the editing time limit has been exceeded"),
+        (status = INTERNAL_SERVER_ERROR, description = "Server error while deleting feedback")
+    ),
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+pub async fn delete_message_feedback(
+    State(app_state): State<AppState>,
+    Extension(me_user): Extension<MeProfile>,
+    Extension(policy): Extension<PolicyEngine>,
+    Path(message_id): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    let message_id = Uuid::parse_str(&message_id).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    policy
+        .rebuild_data_if_needed_req(&app_state.db, &app_state.config)
+        .await?;
+
+    models::message_feedback::delete_feedback(
+        &app_state.db,
+        &policy,
+        &me_user.to_subject(),
+        &message_id,
+        &app_state.langfuse_client,
+        app_state.config.integrations.langfuse.enable_feedback,
+        app_state
+            .config
+            .frontend
+            .message_feedback_edit_time_limit_seconds,
+    )
+    .await
+    .map_err(|e| {
+        let error_msg = e.to_string().to_lowercase();
+        if error_msg.contains("not found") {
+            StatusCode::NOT_FOUND
+        } else if error_msg.contains("not authorized") || error_msg.contains("time limit exceeded")
+        {
+            StatusCode::FORBIDDEN
+        } else {
+            log_internal_server_error(e)
+        }
+    })?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[utoipa::path(get, path = "/messages", responses((status = OK, body = Vec<Message>)))]

--- a/backend/erato/src/services/langfuse.rs
+++ b/backend/erato/src/services/langfuse.rs
@@ -583,6 +583,65 @@ impl LangfuseClient {
         self.send_ingestion_batch(batch).await
     }
 
+    /// Delete a score (retracted user feedback) in Langfuse.
+    ///
+    /// Score deletion is not part of the ingestion API, so this issues a direct
+    /// `DELETE /api/public/scores/{scoreId}` request.
+    pub async fn delete_score(&self, score_id: &str) -> Result<()> {
+        if !self.enabled {
+            tracing::debug!("Langfuse client is disabled, skipping score deletion");
+            return Ok(());
+        }
+
+        let mut url = reqwest::Url::parse(&format!("{}/api/public/scores", self.base_url))
+            .map_err(|e| eyre!("Failed to build Langfuse score URL: {}", e))?;
+        url.path_segments_mut()
+            .map_err(|_| eyre!("Failed to build Langfuse score URL: base URL cannot be a base"))?
+            .push(score_id);
+
+        tracing::debug!(
+            score_id = %score_id,
+            url = %url.as_str(),
+            "Deleting Langfuse score"
+        );
+
+        let response = self
+            .client
+            .delete(url.clone())
+            .basic_auth(&self.public_key, Some(&self.secret_key))
+            .send()
+            .await
+            .map_err(|e| eyre!("Failed to delete score in Langfuse: {}", e))?;
+
+        let status = response.status();
+
+        // The score may legitimately not exist, e.g. when its ingestion event is
+        // still queued or the feedback predates score forwarding.
+        if status == reqwest::StatusCode::NOT_FOUND {
+            tracing::debug!(
+                score_id = %score_id,
+                "Langfuse score not found, nothing to delete"
+            );
+            return Ok(());
+        }
+
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Failed to read response body".to_string());
+            return Err(eyre!(
+                "Failed to delete score '{}' in Langfuse with status {}: {}",
+                score_id,
+                status,
+                body
+            ));
+        }
+
+        tracing::debug!(score_id = %score_id, "Successfully deleted Langfuse score");
+        Ok(())
+    }
+
     /// Get a prompt from Langfuse by name
     pub async fn get_prompt(&self, prompt_name: &str) -> Result<LangfusePrompt> {
         let prompt = self

--- a/backend/erato/tests/integration_tests/api/message_feedback.rs
+++ b/backend/erato/tests/integration_tests/api/message_feedback.rs
@@ -684,3 +684,298 @@ async fn test_create_feedback_ignores_time_limit(pool: Pool<Postgres>) {
     assert_eq!(feedback["sentiment"], "positive");
     assert_eq!(feedback["comment"], "New feedback creation");
 }
+
+/// Test deleting feedback for a message.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// Verifies that feedback can be deleted, disappears from the messages list,
+/// and that new feedback can be submitted afterwards as a fresh record.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delete_feedback(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let (chat_id, message_id) = create_chat_with_message(&server).await;
+
+    // Submit feedback
+    let feedback_body = json!({
+        "sentiment": "negative",
+        "comment": "Not helpful"
+    });
+
+    let response = server
+        .put(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&feedback_body)
+        .await;
+
+    response.assert_status_ok();
+    let first_feedback: serde_json::Value = response.json();
+    let first_feedback_id = first_feedback["id"].as_str().unwrap().to_string();
+
+    // Delete the feedback
+    let response = server
+        .delete(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::NO_CONTENT);
+
+    // The messages list no longer contains feedback for the message
+    let response = server
+        .get(&format!("/api/v1beta/chats/{}/messages", chat_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status_ok();
+    let messages_response: serde_json::Value = response.json();
+    let messages = messages_response["messages"].as_array().unwrap();
+    let message = messages
+        .iter()
+        .find(|m| m["id"] == message_id)
+        .expect("Message not found");
+    assert!(message["feedback"].is_null());
+
+    // Submitting feedback again creates a fresh record
+    let feedback_body = json!({
+        "sentiment": "positive"
+    });
+
+    let response = server
+        .put(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&feedback_body)
+        .await;
+
+    response.assert_status_ok();
+    let new_feedback: serde_json::Value = response.json();
+    assert_eq!(new_feedback["sentiment"], "positive");
+    assert_ne!(new_feedback["id"].as_str().unwrap(), first_feedback_id);
+}
+
+/// Test that users cannot delete feedback for messages in chats they don't own.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `authorization`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// Verifies that authorization prevents users from deleting feedback for other users' messages.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delete_feedback_authorization(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let user1_subject = TEST_USER_SUBJECT;
+    let _user1 = get_or_create_user(&app_state.db, TEST_USER_ISSUER, user1_subject, None)
+        .await
+        .expect("Failed to create user 1");
+
+    let user2_subject = "user-2-subject";
+    let _user2 = get_or_create_user(&app_state.db, TEST_USER_ISSUER, user2_subject, None)
+        .await
+        .expect("Failed to create user 2");
+
+    let user2_token = JwtTokenBuilder::new()
+        .issuer(TEST_USER_ISSUER)
+        .subject(user2_subject)
+        .build();
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // User 1 creates a message and submits feedback
+    let (_chat_id, message_id) = create_chat_with_message(&server).await;
+
+    let feedback_body = json!({
+        "sentiment": "positive"
+    });
+
+    server
+        .put(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&feedback_body)
+        .await
+        .assert_status_ok();
+
+    // User 2 tries to delete user 1's feedback
+    let response = server
+        .delete(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(&user2_token)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::FORBIDDEN);
+}
+
+/// Test that deleting non-existent feedback returns 404.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// Verifies that deleting feedback returns 404 when the message has no feedback,
+/// and when the message itself does not exist.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delete_nonexistent_feedback(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    // Message without any feedback
+    let (_chat_id, message_id) = create_chat_with_message(&server).await;
+
+    let response = server
+        .delete(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::NOT_FOUND);
+
+    // Non-existent message
+    let fake_message_id = "00000000-0000-0000-0000-000000000000";
+
+    let response = server
+        .delete(&format!(
+            "/api/v1beta/messages/{}/feedback",
+            fake_message_id
+        ))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::NOT_FOUND);
+}
+
+/// Test deleting feedback within the configured time limit.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// Verifies that feedback can be deleted when within the configured edit time limit.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delete_feedback_within_time_limit(pool: Pool<Postgres>) {
+    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+    app_config.frontend.message_feedback_edit_time_limit_seconds = Some(60);
+
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let (_chat_id, message_id) = create_chat_with_message(&server).await;
+
+    let feedback_body = json!({
+        "sentiment": "positive"
+    });
+
+    server
+        .put(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&feedback_body)
+        .await
+        .assert_status_ok();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let response = server
+        .delete(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::NO_CONTENT);
+}
+
+/// Test deleting feedback after the configured time limit has expired.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `uses-mocked-llm`
+///
+/// # Test Behavior
+/// Verifies that feedback cannot be deleted after the configured edit time limit,
+/// returning 403 FORBIDDEN.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delete_feedback_after_time_limit(pool: Pool<Postgres>) {
+    let (mut app_config, _server) = setup_mock_llm_server(None).await;
+    app_config.frontend.message_feedback_edit_time_limit_seconds = Some(2);
+
+    let app_state = test_app_state(app_config, pool).await;
+
+    let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state);
+
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let (_chat_id, message_id) = create_chat_with_message(&server).await;
+
+    let feedback_body = json!({
+        "sentiment": "positive"
+    });
+
+    server
+        .put(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&feedback_body)
+        .await
+        .assert_status_ok();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let response = server
+        .delete(&format!("/api/v1beta/messages/{}/feedback", message_id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+
+    response.assert_status(axum::http::StatusCode::FORBIDDEN);
+}

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2649,6 +2649,44 @@
             "bearer_auth": []
           }
         ]
+      },
+      "delete": {
+        "tags": [],
+        "summary": "Delete feedback for a message",
+        "operationId": "delete_message_feedback",
+        "parameters": [
+          {
+            "name": "message_id",
+            "in": "path",
+            "description": "The ID of the message to delete feedback for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Feedback successfully deleted"
+          },
+          "400": {
+            "description": "Invalid message ID"
+          },
+          "403": {
+            "description": "User does not have permission to delete feedback for this message, or the editing time limit has been exceeded"
+          },
+          "404": {
+            "description": "Message or feedback not found"
+          },
+          "500": {
+            "description": "Server error while deleting feedback"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
       }
     },
     "/api/v1beta/prompt-optimizer": {

--- a/e2e-tests/tests/feedback.basic.spec.ts
+++ b/e2e-tests/tests/feedback.basic.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { TAG_CI } from "./tags";
+import { chatIsReadyToChat, sendFirstMessage } from "./shared";
+
+const isFeedbackRequest =
+  (method: string) => (r: import("@playwright/test").Response) =>
+    r.url().includes("/feedback") && r.request().method() === method;
+
+test(
+  "Can submit, view, and retract message feedback",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+
+    await sendFirstMessage(page, "Please write a short poem about the sun");
+    await chatIsReadyToChat(page, {
+      expectAssistantResponse: true,
+      loadingTimeoutMs: 15000,
+    });
+
+    const assistantMessage = page.getByTestId("message-assistant").first();
+    const dislikeButton = assistantMessage.getByLabel("Dislike message");
+    const dialog = page.getByRole("dialog");
+
+    // Submit negative feedback; with comments enabled a comment dialog opens
+    await assistantMessage.hover();
+    const submitResponse = page.waitForResponse(isFeedbackRequest("PUT"));
+    await dislikeButton.click();
+    expect((await submitResponse).status()).toBe(200);
+    await dialog.getByRole("button", { name: "Skip" }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // Clicking the active thumb opens the view dialog, which offers Remove
+    await assistantMessage.hover();
+    await dislikeButton.click();
+    await expect(dialog.getByText("Your Feedback")).toBeVisible();
+    await expect(dialog.getByText("You found this unhelpful")).toBeVisible();
+
+    const deleteResponse = page.waitForResponse(isFeedbackRequest("DELETE"));
+    await dialog.getByRole("button", { name: "Remove" }).click();
+    expect((await deleteResponse).status()).toBe(204);
+    await expect(dialog).toHaveCount(0);
+
+    // The thumb unfills once the refetched messages no longer carry feedback
+    await expect(dislikeButton.locator("svg")).not.toHaveClass(
+      /fill-theme-error-fg/,
+    );
+
+    // Clicking the thumb now submits fresh feedback instead of opening the view dialog
+    await assistantMessage.hover();
+    const resubmitResponse = page.waitForResponse(isFeedbackRequest("PUT"));
+    await dislikeButton.click();
+    expect((await resubmitResponse).status()).toBe(200);
+    await dialog.getByRole("button", { name: "Skip" }).click();
+  },
+);

--- a/e2e-tests/tests/feedback.basic.spec.ts
+++ b/e2e-tests/tests/feedback.basic.spec.ts
@@ -31,8 +31,12 @@ test(
     await dialog.getByRole("button", { name: "Skip" }).click();
     await expect(dialog).toHaveCount(0);
 
-    // Clicking the active thumb opens the view dialog, which offers Remove
+    // Clicking the active thumb opens the view dialog, which offers Remove;
+    // wait for the thumb to render as filled so the click doesn't resubmit
     await assistantMessage.hover();
+    await expect(dislikeButton.locator("svg")).toHaveClass(
+      /fill-theme-error-fg/,
+    );
     await dislikeButton.click();
     await expect(dialog.getByText("Your Feedback")).toBeVisible();
     await expect(dialog.getByText("You found this unhelpful")).toBeVisible();

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -569,6 +569,7 @@ export const Chat = ({
     feedbackViewDialogState,
     feedbackConfig,
     handleFeedbackSubmit,
+    handleFeedbackViewDialogRemove,
     closeFeedbackDialog,
     closeFeedbackViewDialog,
     handleFeedbackDialogSubmit,
@@ -866,12 +867,14 @@ export const Chat = ({
           isOpen={feedbackViewDialogState.isOpen}
           onClose={closeFeedbackViewDialog}
           onEdit={switchToEditMode}
+          onRemove={() => void handleFeedbackViewDialogRemove()}
           feedback={feedbackViewDialogState.feedback}
           canEdit={
             feedbackViewDialogState.feedback
               ? canEditFeedback(feedbackViewDialogState.feedback)
               : false
           }
+          error={feedbackViewDialogState.error}
         />
 
         {/* Render the Feedback Comment Dialog */}

--- a/frontend/src/components/ui/Feedback/FeedbackViewDialog.tsx
+++ b/frontend/src/components/ui/Feedback/FeedbackViewDialog.tsx
@@ -15,16 +15,20 @@ interface FeedbackViewDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onEdit: () => void;
+  onRemove?: () => void;
   feedback: MessageFeedback | null;
   canEdit: boolean;
+  error?: string | null;
 }
 
 export const FeedbackViewDialog: React.FC<FeedbackViewDialogProps> = ({
   isOpen,
   onClose,
   onEdit,
+  onRemove,
   feedback,
   canEdit,
+  error,
 }) => {
   const handleEdit = useCallback(() => {
     onEdit();
@@ -44,6 +48,13 @@ export const FeedbackViewDialog: React.FC<FeedbackViewDialogProps> = ({
       contentClassName="max-w-lg"
     >
       <div className="space-y-4">
+        {/* Error message */}
+        {error && (
+          <div className="rounded-md bg-theme-error-bg p-3 text-sm text-theme-error-fg">
+            {error}
+          </div>
+        )}
+
         {/* Sentiment indicator */}
         <div className="flex items-center gap-2 text-sm text-theme-fg-secondary">
           {sentiment === "positive" ? (
@@ -77,6 +88,19 @@ export const FeedbackViewDialog: React.FC<FeedbackViewDialogProps> = ({
 
         {/* Action buttons */}
         <div className="flex justify-end gap-2">
+          {canEdit && onRemove && (
+            <Button
+              variant="danger"
+              onClick={onRemove}
+              className="mr-auto"
+              aria-label={t({
+                id: "feedback.remove",
+                message: "Remove",
+              })}
+            >
+              <Trans id="feedback.remove">Remove</Trans>
+            </Button>
+          )}
           <Button
             variant="secondary"
             onClick={onClose}

--- a/frontend/src/components/ui/Message/DefaultMessageControls.tsx
+++ b/frontend/src/components/ui/Message/DefaultMessageControls.tsx
@@ -70,6 +70,8 @@ export const DefaultMessageControls = memo(function DefaultMessageControls({
       const newState =
         initialFeedback.sentiment === "positive" ? "liked" : "disliked";
       setFeedbackState(newState);
+    } else {
+      setFeedbackState(null);
     }
   }, [initialFeedback]);
 

--- a/frontend/src/hooks/chat/__tests__/useMessageFeedback.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useMessageFeedback.test.ts
@@ -10,6 +10,7 @@ vi.mock("@lingui/react", () => ({
 
 vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
   useSubmitMessageFeedback: vi.fn(),
+  useDeleteMessageFeedback: vi.fn(),
 }));
 
 vi.mock("@/providers/FeatureConfigProvider", () => ({
@@ -23,11 +24,15 @@ vi.mock("@/utils/debugLogger", () => ({
 }));
 
 import { useMessageFeedback } from "@/hooks/chat/useMessageFeedback";
-import { useSubmitMessageFeedback } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import {
+  useDeleteMessageFeedback,
+  useSubmitMessageFeedback,
+} from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useMessageFeedbackFeature } from "@/providers/FeatureConfigProvider";
 
 describe("useMessageFeedback", () => {
   const mockMutateAsync = vi.fn();
+  const mockDeleteMutateAsync = vi.fn();
   const mockFeedbackConfig = {
     enabled: true,
     commentsEnabled: true,
@@ -41,6 +46,25 @@ describe("useMessageFeedback", () => {
     vi.mocked(useSubmitMessageFeedback).mockReturnValue({
       mutateAsync: mockMutateAsync,
       // Add other required mutation properties
+      mutate: vi.fn(),
+      reset: vi.fn(),
+      data: undefined,
+      error: null,
+      isError: false,
+      isIdle: true,
+      isPending: false,
+      isPaused: false,
+      isSuccess: false,
+      status: "idle",
+      variables: undefined,
+      failureCount: 0,
+      failureReason: null,
+      submittedAt: 0,
+      context: undefined,
+    });
+
+    vi.mocked(useDeleteMessageFeedback).mockReturnValue({
+      mutateAsync: mockDeleteMutateAsync,
       mutate: vi.fn(),
       reset: vi.fn(),
       data: undefined,
@@ -275,5 +299,89 @@ describe("useMessageFeedback", () => {
         comment: "Great", // Comment is trimmed and passed through
       },
     });
+  });
+
+  it("should remove feedback successfully", async () => {
+    mockDeleteMutateAsync.mockResolvedValue(undefined);
+    const onFeedbackSuccess = vi.fn();
+
+    const { result } = renderHook(() =>
+      useMessageFeedback({ onFeedbackSuccess }),
+    );
+
+    let removeResult: { success: boolean; errorType?: string } | undefined;
+    await act(async () => {
+      removeResult = await result.current.handleFeedbackRemove("message-123");
+    });
+
+    expect(removeResult?.success).toBe(true);
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({
+      pathParams: { messageId: "message-123" },
+    });
+    expect(onFeedbackSuccess).toHaveBeenCalledWith("message-123");
+  });
+
+  it("should report time limit errors when removing feedback", async () => {
+    mockDeleteMutateAsync.mockRejectedValue({ status: 403 });
+
+    const { result } = renderHook(() => useMessageFeedback());
+
+    let removeResult: { success: boolean; errorType?: string } | undefined;
+    await act(async () => {
+      removeResult = await result.current.handleFeedbackRemove("message-123");
+    });
+
+    expect(removeResult?.success).toBe(false);
+    expect(removeResult?.errorType).toBe("time_limit_exceeded");
+  });
+
+  it("should close the view dialog after removing its feedback", async () => {
+    mockDeleteMutateAsync.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useMessageFeedback());
+
+    act(() => {
+      result.current.openFeedbackViewDialog("message-123", {
+        id: "feedback-id",
+        sentiment: "positive",
+        comment: null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+    });
+
+    expect(result.current.feedbackViewDialogState.isOpen).toBe(true);
+
+    await act(async () => {
+      await result.current.handleFeedbackViewDialogRemove();
+    });
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({
+      pathParams: { messageId: "message-123" },
+    });
+    expect(result.current.feedbackViewDialogState.isOpen).toBe(false);
+  });
+
+  it("should show an error in the view dialog when removal fails", async () => {
+    mockDeleteMutateAsync.mockRejectedValue({ status: 403 });
+
+    const { result } = renderHook(() => useMessageFeedback());
+
+    act(() => {
+      result.current.openFeedbackViewDialog("message-123", {
+        id: "feedback-id",
+        sentiment: "negative",
+        comment: "Some comment",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+    });
+
+    await act(async () => {
+      await result.current.handleFeedbackViewDialogRemove();
+    });
+
+    expect(result.current.feedbackViewDialogState.isOpen).toBe(true);
+    expect(result.current.feedbackViewDialogState.error).toBeTruthy();
   });
 });

--- a/frontend/src/hooks/chat/useMessageFeedback.ts
+++ b/frontend/src/hooks/chat/useMessageFeedback.ts
@@ -2,7 +2,10 @@ import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
 import { useState, useCallback } from "react";
 
-import { useSubmitMessageFeedback } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import {
+  useDeleteMessageFeedback,
+  useSubmitMessageFeedback,
+} from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useMessageFeedbackFeature } from "@/providers/FeatureConfigProvider";
 import { createLogger } from "@/utils/debugLogger";
 
@@ -29,6 +32,7 @@ interface FeedbackViewDialogState {
   isOpen: boolean;
   messageId: string | null;
   feedback: MessageFeedback | null;
+  error: string | null;
 }
 
 /**
@@ -76,6 +80,9 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
   // API mutation for submitting feedback
   const submitFeedbackMutation = useSubmitMessageFeedback();
 
+  // API mutation for removing feedback
+  const deleteFeedbackMutation = useDeleteMessageFeedback();
+
   // State for feedback comment dialog (create or edit)
   const [feedbackDialogState, setFeedbackDialogState] =
     useState<FeedbackDialogState>({
@@ -93,6 +100,7 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
       isOpen: false,
       messageId: null,
       feedback: null,
+      error: null,
     });
 
   /**
@@ -147,6 +155,44 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
   );
 
   /**
+   * Removes previously submitted feedback for a message.
+   *
+   * @param messageId - The ID of the message whose feedback should be removed
+   * @returns Promise<{success: boolean, errorType?: string}> - Success status and optional error type
+   */
+  const handleFeedbackRemove = useCallback(
+    async (
+      messageId: string,
+    ): Promise<{ success: boolean; errorType?: string }> => {
+      try {
+        await deleteFeedbackMutation.mutateAsync({
+          pathParams: { messageId },
+        });
+        logger.log(`Feedback removed successfully for message ${messageId}`);
+        onFeedbackSuccess?.(messageId);
+        return { success: true };
+      } catch (error) {
+        logger.log(
+          `Failed to remove feedback for message ${messageId}:`,
+          error,
+        );
+        if (
+          error &&
+          typeof error === "object" &&
+          "status" in error &&
+          error.status === 403
+        ) {
+          // eslint-disable-next-line lingui/no-unlocalized-strings -- error type identifier, not user-facing
+          return { success: false, errorType: "time_limit_exceeded" };
+        }
+
+        return { success: false, errorType: "unknown" };
+      }
+    },
+    [deleteFeedbackMutation, onFeedbackSuccess],
+  );
+
+  /**
    * Closes the feedback comment dialog and resets state.
    */
   const closeFeedbackDialog = useCallback(() => {
@@ -168,8 +214,52 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
       isOpen: false,
       messageId: null,
       feedback: null,
+      error: null,
     });
   }, []);
+
+  /**
+   * Removes the feedback currently shown in the view dialog.
+   * Closes the dialog on success, shows an error inside it otherwise.
+   */
+  const handleFeedbackViewDialogRemove = useCallback(async () => {
+    if (!feedbackViewDialogState.messageId) {
+      return;
+    }
+
+    const result = await handleFeedbackRemove(
+      feedbackViewDialogState.messageId,
+    );
+
+    if (result.success) {
+      closeFeedbackViewDialog();
+      return;
+    }
+
+    setFeedbackViewDialogState((prev) => ({
+      ...prev,
+      error:
+        result.errorType === "time_limit_exceeded"
+          ? _(
+              msg({
+                id: "feedback.error.time_limit_exceeded",
+                message:
+                  "The editing window has expired. Feedback can no longer be modified.",
+              }),
+            )
+          : _(
+              msg({
+                id: "feedback.error.remove_failed",
+                message: "Failed to remove feedback. Please try again.",
+              }),
+            ),
+    }));
+  }, [
+    feedbackViewDialogState.messageId,
+    handleFeedbackRemove,
+    closeFeedbackViewDialog,
+    _,
+  ]);
 
   /**
    * Handles feedback dialog submission with an optional comment.
@@ -240,6 +330,7 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
         isOpen: true,
         messageId,
         feedback,
+        error: null,
       });
     },
     [],
@@ -296,6 +387,8 @@ export function useMessageFeedback(options: UseMessageFeedbackOptions = {}) {
     feedbackViewDialogState,
     feedbackConfig,
     handleFeedbackSubmit,
+    handleFeedbackRemove,
+    handleFeedbackViewDialogRemove,
     closeFeedbackDialog,
     closeFeedbackViewDialog,
     handleFeedbackDialogSubmit,

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -4906,6 +4906,59 @@ export const useSubmitMessageFeedback = (
   });
 };
 
+export type DeleteMessageFeedbackPathParams = {
+  /**
+   * The ID of the message to delete feedback for
+   */
+  messageId: string;
+};
+
+export type DeleteMessageFeedbackError = Fetcher.ErrorWrapper<undefined>;
+
+export type DeleteMessageFeedbackVariables = {
+  pathParams: DeleteMessageFeedbackPathParams;
+} & V1betaApiContext["fetcherOptions"];
+
+export const fetchDeleteMessageFeedback = (
+  variables: DeleteMessageFeedbackVariables,
+  signal?: AbortSignal,
+) =>
+  v1betaApiFetch<
+    undefined,
+    DeleteMessageFeedbackError,
+    undefined,
+    {},
+    {},
+    DeleteMessageFeedbackPathParams
+  >({
+    url: "/api/v1beta/messages/{messageId}/feedback",
+    method: "delete",
+    ...variables,
+    signal,
+  });
+
+export const useDeleteMessageFeedback = (
+  options?: Omit<
+    reactQuery.UseMutationOptions<
+      undefined,
+      DeleteMessageFeedbackError,
+      DeleteMessageFeedbackVariables
+    >,
+    "mutationFn"
+  >,
+) => {
+  const { fetcherOptions } = useV1betaApiContext();
+  return reactQuery.useMutation<
+    undefined,
+    DeleteMessageFeedbackError,
+    DeleteMessageFeedbackVariables
+  >({
+    mutationFn: (variables: DeleteMessageFeedbackVariables) =>
+      fetchDeleteMessageFeedback(deepMerge(fetcherOptions, variables)),
+    ...options,
+  });
+};
+
 export type PromptOptimizerError = Fetcher.ErrorWrapper<undefined>;
 
 export type PromptOptimizerVariables = {

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1916,6 +1916,11 @@ msgstr "Aktualisieren"
 
 #. js-lingui-explicit-id
 #: src/hooks/chat/useMessageFeedback.ts
+msgid "feedback.error.remove_failed"
+msgstr "Das Feedback konnte nicht entfernt werden. Bitte versuchen Sie es erneut."
+
+#. js-lingui-explicit-id
+#: src/hooks/chat/useMessageFeedback.ts
 msgid "feedback.error.time_limit_exceeded"
 msgstr "Das Bearbeitungsfenster ist abgelaufen. Das Feedback kann nicht mehr geändert werden."
 
@@ -1929,6 +1934,11 @@ msgstr "Sie fanden dies hilfreich"
 #: src/components/ui/Message/DefaultMessageControls.tsx
 msgid "feedback.like.aria"
 msgstr "Nachricht gefällt mir"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Feedback/FeedbackViewDialog.tsx
+msgid "feedback.remove"
+msgstr "Entfernen"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Feedback/FeedbackViewDialog.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1916,6 +1916,11 @@ msgstr "Update"
 
 #. js-lingui-explicit-id
 #: src/hooks/chat/useMessageFeedback.ts
+msgid "feedback.error.remove_failed"
+msgstr "Failed to remove feedback. Please try again."
+
+#. js-lingui-explicit-id
+#: src/hooks/chat/useMessageFeedback.ts
 msgid "feedback.error.time_limit_exceeded"
 msgstr "The editing window has expired. Feedback can no longer be modified."
 
@@ -1929,6 +1934,11 @@ msgstr "You found this helpful"
 #: src/components/ui/Message/DefaultMessageControls.tsx
 msgid "feedback.like.aria"
 msgstr "Like message"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Feedback/FeedbackViewDialog.tsx
+msgid "feedback.remove"
+msgstr "Remove"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Feedback/FeedbackViewDialog.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1916,6 +1916,11 @@ msgstr "Actualizar"
 
 #. js-lingui-explicit-id
 #: src/hooks/chat/useMessageFeedback.ts
+msgid "feedback.error.remove_failed"
+msgstr "No se pudo eliminar la retroalimentación. Por favor, inténtelo de nuevo."
+
+#. js-lingui-explicit-id
+#: src/hooks/chat/useMessageFeedback.ts
 msgid "feedback.error.time_limit_exceeded"
 msgstr "El período de edición ha expirado. La retroalimentación ya no puede ser modificada."
 
@@ -1929,6 +1934,11 @@ msgstr "Encontró esto útil"
 #: src/components/ui/Message/DefaultMessageControls.tsx
 msgid "feedback.like.aria"
 msgstr "Me gusta el mensaje"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Feedback/FeedbackViewDialog.tsx
+msgid "feedback.remove"
+msgstr "Eliminar"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Feedback/FeedbackViewDialog.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1916,6 +1916,11 @@ msgstr "Mettre à jour"
 
 #. js-lingui-explicit-id
 #: src/hooks/chat/useMessageFeedback.ts
+msgid "feedback.error.remove_failed"
+msgstr "Le feedback n'a pas pu être supprimé. Veuillez réessayer."
+
+#. js-lingui-explicit-id
+#: src/hooks/chat/useMessageFeedback.ts
 msgid "feedback.error.time_limit_exceeded"
 msgstr "La fenêtre de modification a expiré. Le feedback ne peut plus être modifié."
 
@@ -1929,6 +1934,11 @@ msgstr "Vous avez trouvé cela utile"
 #: src/components/ui/Message/DefaultMessageControls.tsx
 msgid "feedback.like.aria"
 msgstr "J'aime ce message"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Feedback/FeedbackViewDialog.tsx
+msgid "feedback.remove"
+msgstr "Supprimer"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Feedback/FeedbackViewDialog.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1916,6 +1916,11 @@ msgstr "Aktualizuj"
 
 #. js-lingui-explicit-id
 #: src/hooks/chat/useMessageFeedback.ts
+msgid "feedback.error.remove_failed"
+msgstr "Nie udało się usunąć opinii. Spróbuj ponownie."
+
+#. js-lingui-explicit-id
+#: src/hooks/chat/useMessageFeedback.ts
 msgid "feedback.error.time_limit_exceeded"
 msgstr "Okno edycji wygasło. Opinia nie może być już modyfikowana."
 
@@ -1929,6 +1934,11 @@ msgstr "Uznałeś to za przydatne"
 #: src/components/ui/Message/DefaultMessageControls.tsx
 msgid "feedback.like.aria"
 msgstr "Lubię wiadomość"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Feedback/FeedbackViewDialog.tsx
+msgid "feedback.remove"
+msgstr "Usuń"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Feedback/FeedbackViewDialog.tsx

--- a/infrastructure/k3d/erato-local/config/erato.scenario-basic.toml
+++ b/infrastructure/k3d/erato-local/config/erato.scenario-basic.toml
@@ -4,5 +4,9 @@
 [chat_sharing]
 enabled = true
 
+[frontend]
+enable_message_feedback = true
+enable_message_feedback_comments = true
+
 [frontend.additional_environment]
 K3D_TEST_SCENARIO = "basic"

--- a/office-addin/src/components/AddinChat.tsx
+++ b/office-addin/src/components/AddinChat.tsx
@@ -723,6 +723,7 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
     feedbackViewDialogState,
     feedbackConfig,
     handleFeedbackSubmit,
+    handleFeedbackViewDialogRemove,
     closeFeedbackDialog,
     closeFeedbackViewDialog,
     handleFeedbackDialogSubmit,
@@ -1007,12 +1008,14 @@ export function AddinChat({ assistantId }: AddinChatProps = {}) {
           isOpen={feedbackViewDialogState.isOpen}
           onClose={closeFeedbackViewDialog}
           onEdit={switchToEditMode}
+          onRemove={() => void handleFeedbackViewDialogRemove()}
           feedback={feedbackViewDialogState.feedback}
           canEdit={
             feedbackViewDialogState.feedback
               ? canEditFeedback(feedbackViewDialogState.feedback)
               : false
           }
+          error={feedbackViewDialogState.error}
         />
         <FeedbackCommentDialog
           isOpen={feedbackDialogState.isOpen}


### PR DESCRIPTION
Closes [ERMAIN-488](https://linear.app/erato-labs/issue/ERMAIN-488/allow-users-to-retract-message-feedback-thumbs-updown)

Customer feedback: once thumbs up/down is clicked, there is no way to fully retract it.

## Changes

- **Backend**: new `DELETE /api/v1beta/messages/{message_id}/feedback` (204) with the same authorization and `message_feedback_edit_time_limit_seconds` guard as submit. No DB migration needed.
- **Langfuse**: new `LangfuseClient::delete_score` retracting the forwarded score via direct `DELETE /api/public/scores/{scoreId}` (score deletion is not part of the ingestion API). Fire-and-forget, soft-fail; a 404 (score never ingested) is tolerated.
- **Frontend**: a **Remove** button in the feedback view dialog (reached by clicking the active thumb), gated by the same `canEdit`/time-limit flag as Edit, with an in-dialog error on failure. Translations for de/es/fr/pl.
- Fixes a latent one-way state bug: `DefaultMessageControls` never reset the thumb fill when feedback disappeared after cache invalidation.
- **Office add-in**: wired the new dialog props in `AddinChat.tsx`; the rest arrives via the frontend library.

## Tests

- 5 new backend integration tests: delete happy path (incl. list removal + fresh resubmit), foreign-user 403, missing feedback/message 404, within/after edit time limit.
- 4 new unit tests for the remove flow in `useMessageFeedback`.
- New e2e spec `feedback.basic.spec.ts` covering the full journey (submit → view dialog → Remove → thumb unfills → resubmit), verified against the local stack.