### PR TITLE
Serve shared chats via a dedicated active-thread-only messages route

### DIFF
--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -546,14 +546,36 @@ pub async fn get_chat_messages(
     fetch_chat_messages(conn, chat_id, false, limit, offset).await
 }
 
+/// Get the shared view of a chat's messages: the active thread only, with
+/// branches from edits/regenerations excluded.
+///
+/// Authorizes via [`Action::SharedRead`], which the policy grants to any
+/// logged-in user when chat sharing is enabled and the chat has an enabled
+/// share link and is not archived.
+pub async fn get_shared_chat_messages(
+    conn: &DatabaseConnection,
+    policy: &PolicyEngine,
+    subject: &Subject,
+    chat_id: &Uuid,
+    limit: Option<u64>,
+    offset: Option<u64>,
+) -> Result<(Vec<messages::Model>, MessageListStats), Report> {
+    authorize!(
+        policy,
+        subject,
+        &Resource::Chat(chat_id.as_hyphenated().to_string()),
+        Action::SharedRead
+    )?;
+
+    fetch_chat_messages(conn, chat_id, true, limit, offset).await
+}
+
 /// Fetch messages for a chat with pagination support, without any authorization
 /// check.
 ///
-/// Callers are responsible for authorizing access before calling this function.
-///
 /// When `active_thread_only` is true, only messages that are part of the chat's
 /// active thread are returned (branches from edits/regenerations are excluded).
-pub async fn fetch_chat_messages(
+async fn fetch_chat_messages(
     conn: &DatabaseConnection,
     chat_id: &Uuid,
     active_thread_only: bool,

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -542,13 +542,34 @@ pub async fn get_chat_messages(
         Action::Read
     )?;
 
+    // Owner route: return every branch (no active-thread filter).
+    fetch_chat_messages(conn, chat_id, false, limit, offset).await
+}
+
+/// Fetch messages for a chat with pagination support, without any authorization
+/// check.
+///
+/// Callers are responsible for authorizing access before calling this function.
+///
+/// When `active_thread_only` is true, only messages that are part of the chat's
+/// active thread are returned (branches from edits/regenerations are excluded).
+pub async fn fetch_chat_messages(
+    conn: &DatabaseConnection,
+    chat_id: &Uuid,
+    active_thread_only: bool,
+    limit: Option<u64>,
+    offset: Option<u64>,
+) -> Result<(Vec<messages::Model>, MessageListStats), Report> {
     // Set default pagination values
     let limit = limit.unwrap_or(100);
     let offset = offset.unwrap_or(0);
 
     // Query messages for this chat with pagination, ordered by creation time
-    let messages = Messages::find()
-        .filter(messages::Column::ChatId.eq(*chat_id))
+    let mut query = Messages::find().filter(messages::Column::ChatId.eq(*chat_id));
+    if active_thread_only {
+        query = query.filter(messages::Column::IsMessageInActiveThread.eq(true));
+    }
+    let messages = query
         .order_by_desc(messages::Column::CreatedAt)
         .limit(limit)
         .offset(offset)
@@ -558,10 +579,12 @@ pub async fn get_chat_messages(
     // Use our pagination utility to efficiently calculate the total count
     let (total_count, has_more) =
         pagination::calculate_total_count(offset, limit, messages.len(), || async {
-            Messages::find()
-                .filter(messages::Column::ChatId.eq(*chat_id))
-                .count(conn)
-                .await
+            let mut count_query = Messages::find().filter(messages::Column::ChatId.eq(*chat_id));
+            if active_thread_only {
+                count_query =
+                    count_query.filter(messages::Column::IsMessageInActiveThread.eq(true));
+            }
+            count_query.count(conn).await
         })
         .await?;
 

--- a/backend/erato/src/models/share_link.rs
+++ b/backend/erato/src/models/share_link.rs
@@ -146,6 +146,21 @@ pub async fn set_share_link_enabled(
     Ok(created)
 }
 
+/// Look up a share link by ID without any validity checks.
+///
+/// Whether the link actually grants access (sharing feature enabled, link
+/// enabled, resource not archived) is the policy's decision — callers resolve
+/// the target resource from the returned row and authorize against that.
+pub async fn get_share_link_by_id(
+    conn: &DatabaseConnection,
+    share_link_id: &Uuid,
+) -> Result<share_links::Model, Report> {
+    ShareLinks::find_by_id(*share_link_id)
+        .one(conn)
+        .await?
+        .wrap_err("Share link not found")
+}
+
 pub async fn get_active_share_link_by_id(
     conn: &DatabaseConnection,
     config: &crate::config::AppConfig,

--- a/backend/erato/src/policy/engine.rs
+++ b/backend/erato/src/policy/engine.rs
@@ -714,6 +714,7 @@ pub const fn is_valid_resource_action(resource: ResourceKind, action: Action) ->
     #[allow(clippy::match_like_matches_macro)]
     match (resource, action) {
         (ResourceKind::Chat, Action::Read) => true,
+        (ResourceKind::Chat, Action::SharedRead) => true,
         (ResourceKind::Chat, Action::Update) => true,
         (ResourceKind::Chat, Action::SubmitMessage) => true,
         (ResourceKind::Chat, Action::Share) => true,

--- a/backend/erato/src/policy/types.rs
+++ b/backend/erato/src/policy/types.rs
@@ -156,6 +156,11 @@ impl Resource {
 pub enum Action {
     #[serde(rename = "read")]
     Read,
+    /// Read the shared view of a resource — for chats, the active thread as
+    /// served by the share-links messages route — as opposed to the full
+    /// owner-level [`Action::Read`].
+    #[serde(rename = "shared_read")]
+    SharedRead,
     #[serde(rename = "create")]
     Create,
     #[serde(rename = "update")]

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -288,6 +288,10 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         .route("/share-links", get(get_share_link_for_resource))
         .route("/share-links", put(set_share_link))
         .route("/share-links/{share_link_id}", get(resolve_share_link))
+        .route(
+            "/share-links/{share_link_id}/messages",
+            get(share_links::share_link_messages),
+        )
         // Sharepoint/OneDrive integration routes
         .route(
             "/integrations/sharepoint/all-drives",
@@ -409,6 +413,7 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         share_links::get_share_link_for_resource,
         share_links::set_share_link,
         share_links::resolve_share_link,
+        share_links::share_link_messages,
         ms_office::ews_proxy,
         sharepoint::all_drives,
         sharepoint::get_drive_root,
@@ -2326,6 +2331,27 @@ pub async fn chat_messages(
         }
     })?;
 
+    let response =
+        assemble_chat_messages_response(&app_state, &policy, &me_user, chat_id, messages, stats)
+            .await?;
+
+    Ok(Json(response))
+}
+
+/// Assemble the `ChatMessagesResponse` DTO from a list of message models.
+///
+/// This performs the shared assembly used by both the owner-facing chat
+/// messages route and the share-link messages route: feedback lookup, file-id
+/// collection, capability flags, file-URL map, per-message conversion with
+/// feedback + error reports, presigned image-URL regeneration, and stats.
+async fn assemble_chat_messages_response(
+    app_state: &AppState,
+    policy: &PolicyEngine,
+    me_user: &MeProfile,
+    chat_id: Uuid,
+    messages: Vec<messages::Model>,
+    stats: models::message::MessageListStats,
+) -> Result<ChatMessagesResponse, StatusCode> {
     // Get feedback for all messages
     let message_ids: Vec<Uuid> = messages.iter().map(|m| m.id).collect();
     let feedbacks =
@@ -2347,7 +2373,7 @@ pub async fn chat_messages(
 
     // Determine if any available model supports image understanding
     let available_models = app_state
-        .available_models(&policy, &me_user.to_subject(), &me_user.groups)
+        .available_models(policy, &me_user.to_subject(), &me_user.groups)
         .await
         .map_err(log_internal_server_error)?;
     let (supports_image_understanding, supports_audio_input) =
@@ -2370,7 +2396,7 @@ pub async fn chat_messages(
     for file_id in all_file_ids {
         if let Ok(file_upload) = models::file_upload::get_file_upload_with_url_and_token(
             &app_state.db,
-            &policy,
+            policy,
             &me_user.to_subject(),
             &file_id,
             &app_state.file_storage_providers,
@@ -2448,7 +2474,7 @@ pub async fn chat_messages(
     }
 
     // Create the response with messages and stats
-    let response = ChatMessagesResponse {
+    Ok(ChatMessagesResponse {
         messages: response_messages,
         stats: ChatMessageStats {
             total_count: stats.total_count,
@@ -2456,9 +2482,7 @@ pub async fn chat_messages(
             returned_count: stats.returned_count,
             has_more: stats.has_more,
         },
-    };
-
-    Ok(Json(response))
+    })
 }
 
 #[utoipa::path(

--- a/backend/erato/src/server/api/v1beta/share_links.rs
+++ b/backend/erato/src/server/api/v1beta/share_links.rs
@@ -272,13 +272,12 @@ pub async fn share_link_messages(
         .rebuild_data_if_needed_req(&app_state.db, &app_state.config)
         .await?;
 
-    // The share link is the authorization: a valid, enabled share link for a
-    // (non-archived) chat grants read access to the active thread. No
-    // `Chat::Read` check here.
-    let share_link =
-        share_link::get_active_share_link_by_id(&app_state.db, &app_state.config, &share_link_id)
-            .await
-            .map_err(|_| StatusCode::NOT_FOUND)?;
+    // The share link only identifies the chat. Whether it grants access is
+    // decided by the policy through `Action::SharedRead`, which requires the
+    // sharing feature on, the link enabled, and the chat not archived.
+    let share_link = share_link::get_share_link_by_id(&app_state.db, &share_link_id)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
 
     if share_link.resource_type != "chat" {
         return Err(StatusCode::NOT_FOUND);
@@ -289,13 +288,24 @@ pub async fn share_link_messages(
     let limit = params.get("limit").and_then(|l| l.parse::<u64>().ok());
     let offset = params.get("offset").and_then(|o| o.parse::<u64>().ok());
 
-    // Fetch only the active thread — branches from edits/regenerations are
-    // filtered server-side and cannot be requested by the caller.
-    let (messages, stats) =
-        crate::models::message::fetch_chat_messages(&app_state.db, &chat_id, true, limit, offset)
-            .await
-            .wrap_err("Failed to get shared chat messages")
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let (messages, stats) = crate::models::message::get_shared_chat_messages(
+        &app_state.db,
+        &policy,
+        &me_user.to_subject(),
+        &chat_id,
+        limit,
+        offset,
+    )
+    .await
+    .map_err(|e| {
+        let s = e.to_string();
+        if s.contains("not authorized") {
+            // A denied `shared_read` is indistinguishable from a missing link.
+            StatusCode::NOT_FOUND
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
 
     let response = super::assemble_chat_messages_response(
         &app_state, &policy, &me_user, chat_id, messages, stats,

--- a/backend/erato/src/server/api/v1beta/share_links.rs
+++ b/backend/erato/src/server/api/v1beta/share_links.rs
@@ -241,6 +241,70 @@ pub async fn resolve_share_link(
     }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/share-links/{share_link_id}/messages",
+    params(
+        ("share_link_id" = String, Path, description = "The share link ID"),
+        ("limit" = Option<u64>, Query, description = "Maximum number of messages to return per page. Defaults to 100 if not provided. Larger values may impact performance."),
+        ("offset" = Option<u64>, Query, description = "Number of messages to skip for pagination. Defaults to 0 if not provided.")
+    ),
+    responses(
+        (status = OK, body = super::ChatMessagesResponse, description = "Successfully retrieved active-thread messages for the shared chat"),
+        (status = BAD_REQUEST, description = "Invalid share link ID"),
+        (status = NOT_FOUND, description = "Share link not found, disabled, or unavailable"),
+        (status = INTERNAL_SERVER_ERROR, description = "Server error while retrieving messages")
+    ),
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+pub async fn share_link_messages(
+    State(app_state): State<AppState>,
+    Extension(me_user): Extension<MeProfile>,
+    Extension(policy): Extension<PolicyEngine>,
+    Path(share_link_id): Path<String>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> Result<Json<super::ChatMessagesResponse>, StatusCode> {
+    let share_link_id = Uuid::parse_str(&share_link_id).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    policy
+        .rebuild_data_if_needed_req(&app_state.db, &app_state.config)
+        .await?;
+
+    // The share link is the authorization: a valid, enabled share link for a
+    // (non-archived) chat grants read access to the active thread. No
+    // `Chat::Read` check here.
+    let share_link =
+        share_link::get_active_share_link_by_id(&app_state.db, &app_state.config, &share_link_id)
+            .await
+            .map_err(|_| StatusCode::NOT_FOUND)?;
+
+    if share_link.resource_type != "chat" {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let chat_id = Uuid::parse_str(&share_link.resource_id).map_err(|_| StatusCode::NOT_FOUND)?;
+
+    // Parse pagination parameters
+    let limit = params.get("limit").and_then(|l| l.parse::<u64>().ok());
+    let offset = params.get("offset").and_then(|o| o.parse::<u64>().ok());
+
+    // Fetch only the active thread — branches from edits/regenerations are
+    // filtered server-side and cannot be requested by the caller.
+    let (messages, stats) =
+        crate::models::message::fetch_chat_messages(&app_state.db, &chat_id, true, limit, offset)
+            .await
+            .wrap_err("Failed to get shared chat messages")
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let response = super::assemble_chat_messages_response(
+        &app_state, &policy, &me_user, chat_id, messages, stats,
+    )
+    .await?;
+
+    Ok(Json(response))
+}
+
 async fn fetch_owner_profile_photo(
     app_state: &AppState,
     me_user: &MeProfile,

--- a/backend/erato/tests/integration_tests/api/sharing.rs
+++ b/backend/erato/tests/integration_tests/api/sharing.rs
@@ -119,8 +119,10 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
     assert_eq!(resolve_json["share_link"]["resource_type"], "chat");
     assert_eq!(resolve_json["share_link"]["resource_id"], chat_id);
 
+    // The recipient reads the shared conversation through the dedicated
+    // share-link route, which authorizes via the share link itself.
     let shared_messages_response = server
-        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .get(&format!("/api/v1beta/share-links/{share_link_id}/messages"))
         .with_bearer_token(&recipient_token)
         .await;
     shared_messages_response.assert_status_ok();
@@ -131,6 +133,17 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
             .expect("messages should be array")
             .len()
             >= 2
+    );
+
+    // A share link must NOT grant generic Chat::Read: the recipient cannot reach
+    // the raw messages route (which would expose every edit/regen branch).
+    let generic_route_denied = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(&recipient_token)
+        .await;
+    assert_eq!(
+        generic_route_denied.status_code(),
+        http::StatusCode::NOT_FOUND
     );
 
     let disable_response = server
@@ -165,6 +178,17 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
         .await;
     assert_eq!(
         resolve_after_disable.status_code(),
+        http::StatusCode::NOT_FOUND
+    );
+
+    // The dedicated messages route follows the policy: with the link disabled,
+    // `shared_read` is denied and the shared view disappears.
+    let shared_messages_after_disable = server
+        .get(&format!("/api/v1beta/share-links/{share_link_id}/messages"))
+        .with_bearer_token(&recipient_token)
+        .await;
+    assert_eq!(
+        shared_messages_after_disable.status_code(),
         http::StatusCode::NOT_FOUND
     );
 }

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -3119,6 +3119,73 @@
         ]
       }
     },
+    "/api/v1beta/share-links/{share_link_id}/messages": {
+      "get": {
+        "tags": [
+          "share_links"
+        ],
+        "operationId": "share_link_messages",
+        "parameters": [
+          {
+            "name": "share_link_id",
+            "in": "path",
+            "description": "The share link ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of messages to return per page. Defaults to 100 if not provided. Larger values may impact performance.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of messages to skip for pagination. Defaults to 0 if not provided.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved active-thread messages for the shared chat",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatMessagesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid share link ID"
+          },
+          "404": {
+            "description": "Share link not found, disabled, or unavailable"
+          },
+          "500": {
+            "description": "Server error while retrieving messages"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/v1beta/token_usage/estimate": {
       "post": {
         "tags": [

--- a/backend/policy/backend/backend.rego
+++ b/backend/policy/backend/backend.rego
@@ -233,15 +233,6 @@ allow if {
 	data.resource_attributes[resource_kind_chat][input.resource_id].owner_id == input.subject_id
 }
 
-# A logged-in user can read a chat when chat sharing is enabled and the chat has an active share link.
-allow if {
-	input.subject_kind == subject_kind_user
-	input.subject_id != not_logged_in
-	input.resource_kind == resource_kind_chat
-	input.action == action_read
-	can_read_shared_chat(input.resource_id)
-}
-
 # A logged-in user can read the shared view of a chat when chat sharing is
 # enabled and the chat has an active share link.
 allow if {

--- a/backend/policy/backend/backend.rego
+++ b/backend/policy/backend/backend.rego
@@ -111,6 +111,11 @@ action_submit_feedback := "submit_feedback"
 action_update := "update"
 action_delete := "delete"
 action_share := "share"
+# If allowed on a chat, allows reading the chat's shared view: the active
+# thread only, as served by the dedicated share-links messages route. Distinct
+# from `read`, which also exposes non-active-thread messages from
+# edits/regenerations and everything else reserved for the chat owner.
+action_shared_read := "shared_read"
 
 chat_sharing_enabled if {
 	data.config.chat_sharing.enabled
@@ -237,6 +242,16 @@ allow if {
 	can_read_shared_chat(input.resource_id)
 }
 
+# A logged-in user can read the shared view of a chat when chat sharing is
+# enabled and the chat has an active share link.
+allow if {
+	input.subject_kind == subject_kind_user
+	input.subject_id != not_logged_in
+	input.resource_kind == resource_kind_chat
+	input.action == action_shared_read
+	can_read_shared_chat(input.resource_id)
+}
+
 # A user can submit messages to chats they own.
 allow if {
 	# Ensure subject is a user and is logged in.
@@ -338,7 +353,8 @@ allow if {
 	data.resource_attributes[resource_kind_chat][chat_id].owner_id == input.subject_id
 }
 
-# A user can read file uploads if they can access one of the linked shared chats.
+# A user can read file uploads linked to a chat they can `shared_read`: the
+# shared view of a chat includes its attachments.
 allow if {
 	input.subject_kind == subject_kind_user
 	input.subject_id != not_logged_in

--- a/backend/policy/backend/backend_test.rego
+++ b/backend/policy/backend/backend_test.rego
@@ -309,6 +309,101 @@ test_owner_can_share_own_chat if {
 	} with data.resource_attributes as resource_attributes
 }
 
+test_user_can_shared_read_chat_with_active_share_link if {
+	backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "shared_read",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as share_links
+		with data.config as chat_sharing_enabled_config
+}
+
+test_user_cannot_shared_read_chat_without_share_link if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "shared_read",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as []
+		with data.config as chat_sharing_enabled_config
+}
+
+test_user_cannot_shared_read_chat_when_feature_disabled if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "shared_read",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as share_links
+		with data.config as chat_sharing_disabled_config
+}
+
+test_user_cannot_shared_read_chat_when_share_link_disabled if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "shared_read",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as [{
+			"id": "share-link-1",
+			"resource_type": "chat",
+			"resource_id": chat_1_id,
+			"enabled": false,
+		}]
+		with data.config as chat_sharing_enabled_config
+}
+
+test_user_cannot_shared_read_archived_chat if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "shared_read",
+	} with data.resource_attributes as {"chat": {chat_1_id: {
+		"id": chat_1_id,
+		"owner_id": user_1_id,
+		"archived_at": "2026-07-24T00:00:00Z",
+	}}}
+		with data.share_links as share_links
+		with data.config as chat_sharing_enabled_config
+}
+
+# `shared_read` never grants more than the shared view: the owner-only actions
+# on the same chat stay denied for a share-link viewer.
+test_shared_read_viewer_cannot_update_chat if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "update",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as share_links
+		with data.config as chat_sharing_enabled_config
+}
+
+test_shared_read_viewer_cannot_submit_message if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "chat",
+		"resource_id": chat_1_id,
+		"action": "submit_message",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as share_links
+		with data.config as chat_sharing_enabled_config
+}
+
 test_user_can_read_linked_file_via_shared_chat if {
 	backend.allow with input as {
 		"subject_kind": "user",

--- a/backend/policy/backend/backend_test.rego
+++ b/backend/policy/backend/backend_test.rego
@@ -258,8 +258,11 @@ test_user_cannot_read_other_users_chat if {
 		with data.config as chat_sharing_enabled_config
 }
 
-test_user_can_read_shared_chat_when_feature_enabled if {
-	backend.allow with input as {
+# A share link must NOT grant generic chat read. Shared reads go only through the
+# dedicated share-links messages route, which authorizes via the share link itself
+# and serves the active thread only.
+test_share_link_does_not_grant_generic_chat_read if {
+	not backend.allow with input as {
 		"subject_kind": "user",
 		"subject_id": user_2_id,
 		"resource_kind": "chat",

--- a/backend/policy/backend/backend_test.rego
+++ b/backend/policy/backend/backend_test.rego
@@ -258,8 +258,11 @@ test_user_cannot_read_other_users_chat if {
 		with data.config as chat_sharing_enabled_config
 }
 
-test_user_can_read_shared_chat_when_feature_enabled if {
-	backend.allow with input as {
+# A share link must NOT grant generic chat read. Shared reads go only through the
+# dedicated share-links messages route, which authorizes via shared_read and
+# serves the active thread only.
+test_share_link_does_not_grant_generic_chat_read if {
+	not backend.allow with input as {
 		"subject_kind": "user",
 		"subject_id": user_2_id,
 		"resource_kind": "chat",
@@ -413,6 +416,23 @@ test_user_can_read_linked_file_via_shared_chat if {
 		"action": "read",
 	} with data.resource_attributes as resource_attributes
 		with data.share_links as share_links
+		with data.config as chat_sharing_enabled_config
+}
+
+test_user_cannot_read_linked_file_via_shared_chat_when_share_link_disabled if {
+	not backend.allow with input as {
+		"subject_kind": "user",
+		"subject_id": user_2_id,
+		"resource_kind": "file_upload",
+		"resource_id": file_upload_2_id,
+		"action": "read",
+	} with data.resource_attributes as resource_attributes
+		with data.share_links as [{
+			"id": "share-link-1",
+			"resource_type": "chat",
+			"resource_id": chat_1_id,
+			"enabled": false,
+		}]
 		with data.config as chat_sharing_enabled_config
 }
 

--- a/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
+++ b/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
@@ -116,6 +116,18 @@ test(
       const { shareUrl, ownerRoles } = await test.step(
         "Owner builds a branched chat and shares it",
         async () => {
+          // Record the chat's own generic-route messages URL as the owner
+          // loads it, so the positive control below can re-fetch the full tree.
+          let ownerMessagesUrl: string | undefined;
+          owner.page.on("response", (response) => {
+            if (
+              response.request().method() === "GET" &&
+              /\/api\/v1beta\/chats\/[^/]+\/messages/.test(response.url())
+            ) {
+              ownerMessagesUrl = response.url();
+            }
+          });
+
           await owner.page.goto("/");
           await chatIsReadyToChat(owner.page);
           await selectModel(owner.page, "Mock-LLM");
@@ -155,6 +167,30 @@ test(
           // shared view must reproduce exactly.
           const ownerRoles = await chatMessageRoles(owner.page);
           expect(ownerRoles.length).toBeGreaterThan(0);
+
+          // Positive control: prove the edit + regenerate actually orphaned
+          // branches server-side. Without it the shared-route assertion (no
+          // `is_message_in_active_thread: false` rows) could pass vacuously if
+          // no branch was ever created. The owner's own generic route returns
+          // the full tree, including the discarded branches.
+          expect(
+            ownerMessagesUrl,
+            "owner's generic messages route must have been observed",
+          ).toBeTruthy();
+          const ownerFullResponse = await owner.page.request.get(
+            ownerMessagesUrl as string,
+          );
+          expect(ownerFullResponse.ok()).toBe(true);
+          const ownerFullBody = (await ownerFullResponse.json()) as {
+            messages: { is_message_in_active_thread: boolean }[];
+          };
+          const discardedBranches = ownerFullBody.messages.filter(
+            (message) => message.is_message_in_active_thread === false,
+          );
+          expect(
+            discardedBranches.length,
+            "edit + regenerate must orphan at least one branch",
+          ).toBeGreaterThan(0);
 
           await owner.page.getByRole("button", { name: "Share" }).click();
           const dialog = owner.page.getByRole("dialog", {

--- a/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
+++ b/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test, type Browser, type Page } from "@playwright/test";
+
+import { chatIsReadyToChat, selectModel } from "./shared";
+import { TAG_CI } from "./tags";
+
+/**
+ * Regression guard for ERMAIN-485 ("Geteilte Chats zeigen alle Bearbeitungen
+ * und Regenerierungen"): the shared view must render only the active thread,
+ * never the branches produced by edits/regenerations.
+ *
+ * We assert at the API level — the shared page is fed by the dedicated
+ * `GET /share-links/{id}/messages` route, which always filters server-side. A
+ * DOM-only check would pass for a cosmetic frontend filter that still leaks
+ * branches over the wire, so we inspect the recipient's actual network
+ * response and require zero `is_message_in_active_thread: false` entries. We
+ * also pin the shared view against the owner's own active-view roles so the
+ * test can't pass for the wrong reason.
+ */
+
+const messageBox = (page: Page) =>
+  page.getByRole("textbox", { name: "Type a message..." });
+
+const chatMessageRoles = async (page: Page): Promise<string[]> =>
+  page
+    .locator('[data-ui="chat-message"]')
+    .evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute("data-role") ?? ""),
+    );
+
+const loginForSharingTest = async (
+  page: Page,
+  email: string,
+  password = "admin",
+) => {
+  await page.getByRole("button", { name: "Sign in with" }).click();
+  await expect.poll(() => page.url(), { timeout: 10000 }).toContain("/auth");
+
+  const emailInput = page.getByRole("textbox", { name: "email address" });
+  await emailInput.waitFor({ state: "visible", timeout: 10000 });
+  await emailInput.fill(email);
+
+  const passwordInput = page.getByRole("textbox", { name: "Password" });
+  await passwordInput.fill(password);
+  await passwordInput.press("Enter");
+
+  const chatTextbox = messageBox(page);
+  const grantAccessButton = page.getByRole("button", { name: "Grant Access" });
+  const grantAccessVisible = await grantAccessButton
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (grantAccessVisible) {
+    await grantAccessButton.click();
+  }
+
+  await expect(chatTextbox).toBeVisible({ timeout: 10000 });
+};
+
+const createSharingTestContext = async (
+  browser: Browser,
+  email: string,
+  password = "admin",
+) => {
+  const context = await browser.newContext({
+    storageState: { cookies: [], origins: [] },
+  });
+  const page = await context.newPage();
+  const chatTextbox = messageBox(page);
+  const localAuthUsername = email.split("@")[0];
+
+  await page.goto(`/?user=${encodeURIComponent(localAuthUsername)}`);
+
+  try {
+    await expect(chatTextbox).toBeVisible({ timeout: 5000 });
+    return { context, page };
+  } catch {
+    await page.goto("/");
+    await loginForSharingTest(page, email, password);
+  }
+
+  await expect(chatTextbox).toBeVisible({ timeout: 10000 });
+
+  return { context, page };
+};
+
+const sendSettledMessage = async (
+  page: Page,
+  text: string,
+  expectedTurns: number,
+) => {
+  const textbox = messageBox(page);
+  await expect(textbox).toBeEnabled();
+  await textbox.fill(text);
+  await textbox.press("Enter");
+  await chatIsReadyToChat(page, { loadingTimeoutMs: 30000 });
+
+  await expect(page.getByTestId("message-user")).toHaveCount(expectedTurns);
+  await expect(page.getByTestId("message-assistant")).toHaveCount(
+    expectedTurns,
+  );
+};
+
+test(
+  "shared view shows only the active thread, not edited/regenerated branches",
+  { tag: TAG_CI },
+  async ({ browser }) => {
+    test.setTimeout(180000);
+
+    const owner = await test.step("Create owner session", async () =>
+      createSharingTestContext(browser, "user01@example.com"));
+    const recipient = await test.step("Create recipient session", async () =>
+      createSharingTestContext(browser, "user02@example.com"));
+
+    try {
+      const { shareUrl, ownerRoles } = await test.step(
+        "Owner builds a branched chat and shares it",
+        async () => {
+          await owner.page.goto("/");
+          await chatIsReadyToChat(owner.page);
+          await selectModel(owner.page, "Mock-LLM");
+
+          // Two plain turns (texts avoid every mock trigger substring so each
+          // resolves via the fast default response).
+          await sendSettledMessage(owner.page, "hello", 1);
+          await sendSettledMessage(owner.page, "hello2", 2);
+
+          // Regenerate the first assistant reply -> orphans a branch.
+          const firstAssistant = owner.page
+            .getByTestId("message-assistant")
+            .first();
+          await firstAssistant.hover();
+          const regenerateButton =
+            firstAssistant.getByLabel("Regenerate response");
+          await regenerateButton.waitFor({ state: "visible", timeout: 10000 });
+          await regenerateButton.click();
+          await chatIsReadyToChat(owner.page, { loadingTimeoutMs: 30000 });
+
+          // Edit the first user message -> orphans another branch.
+          const firstUser = owner.page.getByTestId("message-user").first();
+          await firstUser.hover();
+          const editButton = firstUser.getByLabel("Edit message");
+          await editButton.waitFor({ state: "visible", timeout: 10000 });
+          await editButton.click();
+
+          const editTextbox = owner.page.getByTestId("message-editor-input");
+          await expect(editTextbox).toBeVisible({ timeout: 30000 });
+          await editTextbox.fill("hello edited");
+          const saveButton = owner.page.getByTestId("message-editor-submit");
+          await expect(saveButton).toBeEnabled();
+          await saveButton.click();
+          await chatIsReadyToChat(owner.page, { loadingTimeoutMs: 30000 });
+
+          // Capture the owner's active-view roles: this is the ground truth the
+          // shared view must reproduce exactly.
+          const ownerRoles = await chatMessageRoles(owner.page);
+          expect(ownerRoles.length).toBeGreaterThan(0);
+
+          await owner.page.getByRole("button", { name: "Share" }).click();
+          const dialog = owner.page.getByRole("dialog", {
+            name: "Share chat",
+          });
+          await expect(dialog).toBeVisible();
+
+          const shareToggle = dialog.getByLabel("Toggle chat sharing");
+          await shareToggle.click();
+
+          const shareLinkField = dialog.getByLabel("Shared chat link");
+          await expect(shareLinkField).toBeVisible();
+          await expect(shareToggle).toBeChecked();
+          const shareUrl = await shareLinkField.inputValue();
+          expect(shareUrl).toContain("/chat-share/");
+
+          await owner.page.keyboard.press("Escape");
+
+          return { shareUrl, ownerRoles };
+        },
+      );
+
+      await test.step(
+        "Recipient's shared-messages response contains only the active thread",
+        async () => {
+          // Capture the recipient's response to the dedicated share-link route.
+          const messagesResponsePromise = recipient.page.waitForResponse(
+            (response) =>
+              /\/api\/v1beta\/share-links\/[^/]+\/messages/.test(
+                response.url(),
+              ) && response.request().method() === "GET",
+            { timeout: 20000 },
+          );
+
+          await recipient.page.goto(shareUrl);
+
+          const response = await messagesResponsePromise;
+          expect(response.ok()).toBe(true);
+          const body = (await response.json()) as {
+            messages: { role: string; is_message_in_active_thread: boolean }[];
+          };
+
+          // Server-side filter guarantee: no orphaned branches over the wire.
+          const leaked = body.messages.filter(
+            (message) => message.is_message_in_active_thread === false,
+          );
+          expect(leaked).toHaveLength(0);
+
+          // The shared view must reproduce the owner's active view exactly.
+          // The DOM's `data-role` collapses every non-user role to
+          // "assistant", so normalize the API roles the same way to compare
+          // like for like.
+          const sharedRoles = body.messages
+            .slice()
+            .sort(
+              (a, b) =>
+                new Date(
+                  (a as unknown as { created_at: string }).created_at,
+                ).getTime() -
+                new Date(
+                  (b as unknown as { created_at: string }).created_at,
+                ).getTime(),
+            )
+            .map((message) => (message.role === "user" ? "user" : "assistant"));
+          expect(sharedRoles).toEqual(ownerRoles);
+
+          // Sanity-check the rendered DOM matches too.
+          await expect
+            .poll(() => chatMessageRoles(recipient.page), { timeout: 15000 })
+            .toEqual(ownerRoles);
+          await expect(messageBox(recipient.page)).toHaveCount(0);
+        },
+      );
+    } finally {
+      await owner.context.close();
+      await recipient.context.close();
+    }
+  },
+);

--- a/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
+++ b/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
@@ -113,7 +113,7 @@ test(
       createSharingTestContext(browser, "user02@example.com"));
 
     try {
-      const { shareUrl, ownerRoles } = await test.step(
+      const { shareUrl, ownerRoles, chatId } = await test.step(
         "Owner builds a branched chat and shares it",
         async () => {
           // Record the chat's own generic-route messages URL as the owner
@@ -209,7 +209,14 @@ test(
 
           await owner.page.keyboard.press("Escape");
 
-          return { shareUrl, ownerRoles };
+          // chatId (from the owner's own messages URL) lets the recipient step
+          // probe the generic route directly.
+          const chatId = (ownerMessagesUrl as string).match(
+            /\/chats\/([^/?]+)\/messages/,
+          )?.[1];
+          expect(chatId, "chatId parsed from owner messages URL").toBeTruthy();
+
+          return { shareUrl, ownerRoles, chatId };
         },
       );
 
@@ -262,6 +269,14 @@ test(
             .poll(() => chatMessageRoles(recipient.page), { timeout: 15000 })
             .toEqual(ownerRoles);
           await expect(messageBox(recipient.page)).toHaveCount(0);
+
+          // Boundary check: a share link must NOT grant generic Chat::Read.
+          // The recipient hand-crafts the raw messages request; it must be
+          // denied, otherwise every edit/regen branch leaks over that route.
+          const bypass = await recipient.page.request.get(
+            `/api/v1beta/chats/${chatId}/messages`,
+          );
+          expect(bypass.status()).toBe(404);
         },
       );
     } finally {

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -5832,6 +5832,138 @@ export const useResolveShareLink = <TData = Schemas.ResolveShareLinkResponse,>(
   });
 };
 
+export type ShareLinkMessagesPathParams = {
+  /**
+   * The share link ID
+   */
+  shareLinkId: string;
+};
+
+export type ShareLinkMessagesQueryParams = {
+  /**
+   * Maximum number of messages to return per page. Defaults to 100 if not provided. Larger values may impact performance.
+   *
+   * @format int64
+   * @minimum 0
+   */
+  limit?: number;
+  /**
+   * Number of messages to skip for pagination. Defaults to 0 if not provided.
+   *
+   * @format int64
+   * @minimum 0
+   */
+  offset?: number;
+};
+
+export type ShareLinkMessagesError = Fetcher.ErrorWrapper<undefined>;
+
+export type ShareLinkMessagesVariables = {
+  pathParams: ShareLinkMessagesPathParams;
+  queryParams?: ShareLinkMessagesQueryParams;
+} & V1betaApiContext["fetcherOptions"];
+
+export const fetchShareLinkMessages = (
+  variables: ShareLinkMessagesVariables,
+  signal?: AbortSignal,
+) =>
+  v1betaApiFetch<
+    Schemas.ChatMessagesResponse,
+    ShareLinkMessagesError,
+    undefined,
+    {},
+    ShareLinkMessagesQueryParams,
+    ShareLinkMessagesPathParams
+  >({
+    url: "/api/v1beta/share-links/{shareLinkId}/messages",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export function shareLinkMessagesQuery(variables: ShareLinkMessagesVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.ChatMessagesResponse>;
+};
+
+export function shareLinkMessagesQuery(
+  variables: ShareLinkMessagesVariables | reactQuery.SkipToken,
+): {
+  queryKey: reactQuery.QueryKey;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.ChatMessagesResponse>)
+    | reactQuery.SkipToken;
+};
+
+export function shareLinkMessagesQuery(
+  variables: ShareLinkMessagesVariables | reactQuery.SkipToken,
+) {
+  return {
+    queryKey: queryKeyFn({
+      path: "/api/v1beta/share-links/{shareLinkId}/messages",
+      operationId: "shareLinkMessages",
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({ signal }: QueryFnOptions) =>
+            fetchShareLinkMessages(variables, signal),
+  };
+}
+
+export const useSuspenseShareLinkMessages = <
+  TData = Schemas.ChatMessagesResponse,
+>(
+  variables: ShareLinkMessagesVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.ChatMessagesResponse,
+      ShareLinkMessagesError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useV1betaApiContext(options);
+  return reactQuery.useSuspenseQuery<
+    Schemas.ChatMessagesResponse,
+    ShareLinkMessagesError,
+    TData
+  >({
+    ...shareLinkMessagesQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export const useShareLinkMessages = <TData = Schemas.ChatMessagesResponse,>(
+  variables: ShareLinkMessagesVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.ChatMessagesResponse,
+      ShareLinkMessagesError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useV1betaApiContext(options);
+  return reactQuery.useQuery<
+    Schemas.ChatMessagesResponse,
+    ShareLinkMessagesError,
+    TData
+  >({
+    ...shareLinkMessagesQuery(
+      variables === reactQuery.skipToken
+        ? variables
+        : deepMerge(fetcherOptions, variables),
+    ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type TokenUsageEstimateError = Fetcher.ErrorWrapper<undefined>;
 
 export type TokenUsageEstimateVariables = {
@@ -6350,6 +6482,11 @@ export type QueryOperation =
       path: "/api/v1beta/share-links/{shareLinkId}";
       operationId: "resolveShareLink";
       variables: ResolveShareLinkVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: "/api/v1beta/share-links/{shareLinkId}/messages";
+      operationId: "shareLinkMessages";
+      variables: ShareLinkMessagesVariables | reactQuery.SkipToken;
     }
   | {
       path: "/health";

--- a/frontend/src/pages/SharedChatPage.tsx
+++ b/frontend/src/pages/SharedChatPage.tsx
@@ -7,7 +7,7 @@ import { Chat } from "@/components/ui/Chat/Chat";
 import { ChatEmptyState } from "@/components/ui/Chat/ChatEmptyState";
 import { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
 import { useResolveChatShareLink } from "@/hooks/useChatShareLink";
-import { useChatMessages } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import { useShareLinkMessages } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { RootProvider } from "@/providers/RootProvider";
 import { extractTextFromContent } from "@/utils/adapters/contentPartAdapter";
 import { mapApiMessageToUiMessage } from "@/utils/adapters/messageAdapter";
@@ -60,10 +60,10 @@ export default function SharedChatPage() {
     data: messagesResponse,
     isLoading: isLoadingMessages,
     error: messagesError,
-  } = useChatMessages(
-    chatId
+  } = useShareLinkMessages(
+    shareId
       ? {
-          pathParams: { chatId },
+          pathParams: { shareLinkId: shareId },
           queryParams: { limit: 1000 },
         }
       : skipToken,

--- a/infrastructure/k3d/erato-local/config/erato.scenario-many-models.toml
+++ b/infrastructure/k3d/erato-local/config/erato.scenario-many-models.toml
@@ -132,5 +132,8 @@ rule_type = "allow-for-group-members"
 mcp_server_ids = ["mock_mcp_unavailable_500"]
 groups = ["mcp-unavailable-resilience"]
 
+[chat_sharing]
+enabled = true
+
 [frontend.additional_environment]
 K3D_TEST_SCENARIO = "many-models"


### PR DESCRIPTION
Shared chats reused `GET /chats/{chatId}/messages`, which returns **every** branch (edits/regenerations) to any `Chat::Read` holder — so viewers saw stale/branch messages ("Geteilte Chats zeigen alle Bearbeitungen und Regenerierungen").

This adds a dedicated `GET /share-links/{share_link_id}/messages` route, **always** filtered to the active thread server-side (non-bypassable — not a frontend filter, not a caller-controlled param), and points the shared view at it.

**Policy: shared access is modeled in OPA as `shared_read`** (reworked per review):
- New `Action::SharedRead` (`shared_read`) on `Chat`, granted by the policy when chat sharing is enabled, the chat has an enabled share link (`data.share_links`, already policy data), and the chat is not archived — the same `can_read_shared_chat` helper that already propagates file-upload read access for shared chats.
- `shared_read` is deliberately separate from `read`: `read` stays owner-level (all branches, token estimates, metadata), `shared_read` covers only the shared active-thread view.
- The route resolves the share link to its chat (plain lookup, no validity checks in Rust) and authorizes via `authorize!(Chat, SharedRead)`; a policy deny maps to 404. Feature/enabled/archived gating now lives **only** in the policy.
- Rego tests: allow with active link; deny without link, with disabled link, with sharing disabled, with archived chat; `shared_read` grants neither `update` nor `submit_message`.

**Backend (reuse, no duplication):**
- Split a private `fetch_chat_messages` (pure fetch, `active_thread_only` param) out of `models::message::get_chat_messages`; the owner route is unchanged (`authorize!(Chat::Read)` + all branches). New `get_shared_chat_messages` = `authorize!(Chat::SharedRead)` + active thread only.
- Extract `assemble_chat_messages_response` (DTO assembly: feedback, files, capabilities, image-URL regeneration, stats) from the `chat_messages` handler and reuse it for both routes.

**Frontend:** regenerated the OpenAPI spec + client; `SharedChatPage` now uses the generated `useShareLinkMessages` hook keyed by `shareId` (no FE filter, renders verbatim).

**Regression test:** `shared-chat-active-thread.many-models.spec.ts` asserts at the API level — the recipient's network response to the new route has **zero** `is_message_in_active_thread:false` entries and its role order matches the owner's active view exactly.

Out of scope (per the issue): freezing/snapshotting at share time — the shared view still auto-updates as the owner edits. Removing the generic `Chat::Read` grant for share links lands in ERMAIN-486 (#878), stacked on this.
