### PR TITLE
Parallelize e2e CI: shard many-models, worker knob, raise e2e backend memory

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -441,13 +441,18 @@ jobs:
         run: pnpm exec vitest run
 
   test-e2e:
-    name: "test e2e (${{ matrix.scenario }})"
+    name: "test e2e (${{ matrix.scenario }}${{ matrix.shard_name || '' }})"
     needs: [build-and-push-amd64]
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
+        # many-models dominates the e2e critical path, so it runs sharded and
+        # with 2 Playwright workers per shard. The other scenarios keep a
+        # single sequential worker: entra_id talks to a real AAD tenant and
+        # tight-budget consumes a shared per-user budget, and the remaining
+        # jobs are too short for parallelism to pay off.
         include:
           - scenario: basic
             projects: "--project chromium-basic --project firefox-basic"
@@ -457,6 +462,14 @@ jobs:
             projects: "--project chromium-assistants --project firefox-assistants"
           - scenario: many-models
             projects: "--project chromium-many-models --project firefox-many-models"
+            shard: "1/2"
+            shard_name: "-1of2"
+            workers: 2
+          - scenario: many-models
+            projects: "--project chromium-many-models --project firefox-many-models"
+            shard: "2/2"
+            shard_name: "-2of2"
+            workers: 2
           - scenario: entra_id
             projects: "--project chromium-entra-id --project firefox-entra-id"
     permissions:
@@ -559,16 +572,57 @@ jobs:
 
       - name: Run e2e tests
         working-directory: ./e2e-tests
+        env:
+          PW_WORKERS: ${{ matrix.workers || 1 }}
         run: |
-          pnpm exec playwright test ${{ matrix.projects }} --retries 2 --trace on --grep @ci
+          pnpm exec playwright test ${{ matrix.projects }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }} --retries 2 --trace on --grep @ci
 
-      - name: Upload Playwright report
+      - name: Upload blob report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-${{ matrix.scenario }}
+          name: e2e-blob-report-${{ matrix.scenario }}${{ matrix.shard_name || '' }}
+          path: e2e-tests/blob-report/
+          retention-days: 30
+
+  merge-e2e-reports:
+    name: "merge e2e reports"
+    needs: [test-e2e]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.8.0
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.22.2'
+          cache: 'pnpm'
+          cache-dependency-path: './e2e-tests/pnpm-lock.yaml'
+      - name: Install e2e dependencies
+        working-directory: ./e2e-tests
+        run: pnpm install --frozen-lockfile
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: e2e-blob-report-*
+          path: e2e-tests/all-blob-reports
+          merge-multiple: true
+      - name: Merge into HTML report
+        working-directory: ./e2e-tests
+        run: pnpm exec playwright merge-reports --reporter html ./all-blob-reports
+      - name: Upload merged Playwright report
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
           path: e2e-tests/playwright-report/
-          retention-days: 30 
+          retention-days: 30
 
   build-and-push-helm-chart-dev:
     runs-on: ubuntu-24.04 # blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -585,6 +585,21 @@ jobs:
           path: e2e-tests/blob-report/
           retention-days: 30
 
+  # Aggregate gate over the sharded e2e matrix. The "main - Tests pass" repo
+  # ruleset requires a check with this exact name; reporting it from a gate
+  # (instead of a matrix job) means shard-count changes never need a ruleset
+  # edit.
+  test-e2e-gate:
+    name: "test e2e (many-models)"
+    needs: [test-e2e]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    permissions: {}
+    steps:
+      - name: Verify e2e matrix succeeded
+        run: |
+          test "${{ needs.test-e2e.result }}" = "success"
+
   merge-e2e-reports:
     name: "merge e2e reports"
     needs: [test-e2e]

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -82,10 +82,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  /* In CI the worker count comes from the workflow matrix; scenarios whose
+   * tests share mutable state (entra-id: real AAD tenant, tight-budget:
+   * shared per-user budget) must stay at 1. */
+  workers: process.env.CI ? Number(process.env.PW_WORKERS ?? "1") : undefined,
+  /* Blob reporter on CI so sharded jobs can be merged into one HTML report. */
+  reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -160,8 +160,12 @@ export const selectModel = async (page: Page, modelDisplayName: string) => {
     .getByRole("menuitem", { name: modelDisplayName, exact: true })
     .click();
 
-  // Wait a moment for the selection to take effect
-  await page.waitForTimeout(500);
+  // Selection is synchronous client state, and the trigger label re-renders in
+  // the same commit as the value the send path reads — so the label is the
+  // authoritative signal that the selection took effect. The hidden menu
+  // additionally guarantees the overlay no longer intercepts clicks.
+  await expect(modelSelector).toContainText(modelDisplayName);
+  await expect(menu).toBeHidden();
 };
 
 export const ensureOpenSidebar = async (page: Page) => {

--- a/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, Page, Response } from "@playwright/test";
 import { TAG_CI } from "./tags";
 import {
   chatIsReadyToChat,
@@ -180,32 +180,30 @@ test(
 
     const sidebar = page.getByRole("complementary");
 
-    // Resolve once the gated refetch has listed this chat, so its sidebar row is
-    // backed by recent_chats and survives the New Chat below — which clears only
-    // the placeholder. Registered before the send so the refetch cannot be
-    // missed; the `chatId` guard skips list responses that predate the id.
-    let chatId = "";
-    const firstChatListed = page.waitForResponse(
-      async (response) => {
-        if (!response.url().includes(RECENT_CHATS_URL) || !chatId) {
-          return false;
-        }
-        try {
-          const body = (await response.json()) as { chats?: { id?: string }[] };
-          return (
-            Array.isArray(body.chats) &&
-            body.chats.some((entry) => entry.id === chatId)
-          );
-        } catch {
-          return false;
-        }
-      },
-      { timeout: 30000 },
-    );
+    // The chat's row must be backed by recent_chats before the New Chat below —
+    // which clears only the placeholder. The gated refetch can land before
+    // sendFirstMessage's URL poll has resolved the id, and no further list
+    // request happens until the turn completes; a waitForResponse predicate
+    // keyed on the id would discard that only mid-stream listing and eat the
+    // whole paced-stream budget. Buffer every body from before the send
+    // instead, and match once the id is known.
+    const recentChatsBodies: { chats?: { id?: string }[] }[] = [];
+    const onRecentChats = (response: Response) => {
+      if (!response.url().includes(RECENT_CHATS_URL)) {
+        return;
+      }
+      response
+        .json()
+        .then((body: { chats?: { id?: string }[] }) =>
+          recentChatsBodies.push(body),
+        )
+        .catch(() => {});
+    };
+    page.on("response", onRecentChats);
 
     // A long paced turn, so the return below attaches a resumestream to a task
     // that is provably still generating rather than one that already 404s.
-    chatId = await sendFirstMessage(page, "long running 20");
+    const chatId = await sendFirstMessage(page, "long running 20");
     const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
     const rowLink = sidebar.locator(`a:has([data-chat-id="${chatId}"])`);
     await expect(row).toBeVisible({ timeout: 5000 });
@@ -215,7 +213,18 @@ test(
     });
     await expect(page.getByTestId("chat-input-stop-generation")).toBeVisible();
 
-    await firstChatListed;
+    await expect
+      .poll(
+        () =>
+          recentChatsBodies.some(
+            (body) =>
+              Array.isArray(body.chats) &&
+              body.chats.some((entry) => entry.id === chatId),
+          ),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+    page.off("response", onRecentChats);
 
     // Abandon the still-streaming chat by starting a new one. This is the
     // load-bearing step: New Chat aborts the live SSE socket (abortAllSSE), so
@@ -360,7 +369,7 @@ test(
     const listExclude = await excludeOpenChatFromRecentChats(page);
 
     try {
-      const chatId = await sendFirstMessage(page, "long running 2");
+      const chatId = await sendFirstMessage(page, "long running 6");
       const row = sidebar.locator(`[data-chat-id="${chatId}"]`);
       await expect(row).toBeVisible({ timeout: 5000 });
       // The placeholder is shown while the first turn is still in flight.

--- a/infrastructure/k3d/erato-local/values.yaml
+++ b/infrastructure/k3d/erato-local/values.yaml
@@ -39,6 +39,16 @@ erato:
       repository: registry.eratolabs.com/erato/app
       tag: "adff59a50e3b78d0221a8a5bbb818a249fffb45a"
       pullPolicy: Always
+    # The chart default (500m/512Mi) OOMs under parallel e2e load: the backend's
+    # in-memory file caches (3x100MB default) plus up to 4 concurrent file
+    # parses (~100MB each) exceed 512Mi. Give e2e/dev clusters real headroom.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
     metrics:
       enabled: true
       host: 0.0.0.0


### PR DESCRIPTION
## What

- **Shard `many-models` into 2 matrix jobs** (`--shard=1/2`, `2/2`), each running **2 Playwright workers** (`PW_WORKERS` env → `playwright.config.ts`). All other scenarios keep today's sequential behavior.
- **Raise the e2e/dev backend pod to 2 CPU / 2Gi** in `infrastructure/k3d/erato-local/values.yaml` (product chart defaults untouched — `charts/erato` there is a symlink, this is subchart values scoped to dev/CI).
- **Blob reporter on CI + a `merge-e2e-reports` job** producing one merged HTML report artifact (`playwright-report`), replacing per-scenario HTML artifacts.

## Why

`many-models` is the e2e critical path: ~22 min of its 25.6 min job is test execution at `workers: 1`. Expected effect: pipeline ~46 min → ~30 min, with e2e no longer the long pole after the image build.

The resource bump is what makes workers>1 possible. Measured on a local replica of this exact CI environment (same image `55083e43`, same charts/scenario/secrets flow, chromium `@ci` suite):

| Workers | 512Mi (chart default) | 2Gi |
|---|---|---|
| 1 | 8.8 min | 7.6 min |
| 2 | 5.1 min (marginal failures) | 4.0 min |
| 4 | **collapse: 29/61 failed, backend OOMKilled ×4** | 2.2 min, 0 restarts |
| 6 | — | 1.7 min |

Root cause of the collapse: the backend's in-memory file caches (3×100MB by default) plus up to 4 concurrent file parses (~100M each, `pdf_oxide` on the 100k-word PDF fixture) exceed 512Mi; the OOM kill then cascades into arbitrary test timeouts. The failure set was otherwise **identical at every worker count** (zero parallelism-induced flakes), including a heavy-PDF-isolation control run — isolation alone still OOMs, the resource bump is required.

Conservative rollout on purpose: only `many-models` gets shards/workers here. `basic` at `workers: 2` is a likely cheap follow-up after this proves out; `entra_id` (real AAD tenant) and `tight-budget` (shared per-user budget) stay sequential by design.

## Follow-ups (not in this PR)

- `basic` → `workers: 2`; consider `--trace on-first-retry`
- Product-level: chart default 512Mi is smaller than the backend's own default config wants (caches + parallelism) — same latent OOM exposure exists for customer deployments under concurrent uploads
- 6 spec files have no `@ci` tag and never run in CI
- `sidebar-new-chat.many-models` :168/:344 fail deterministically on fast machines (latent timing races, pass on CI's slower runners