### PR TITLE
Run basic e2e with 2 workers; record traces only on first retry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -456,6 +456,7 @@ jobs:
         include:
           - scenario: basic
             projects: "--project chromium-basic --project firefox-basic"
+            workers: 2
           - scenario: tight-budget
             projects: "--project chromium-tight-budget --project firefox-tight-budget"
           - scenario: assistants
@@ -575,7 +576,7 @@ jobs:
         env:
           PW_WORKERS: ${{ matrix.workers || 1 }}
         run: |
-          pnpm exec playwright test ${{ matrix.projects }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }} --retries 2 --trace on --grep @ci
+          pnpm exec playwright test ${{ matrix.projects }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }} --retries 2 --trace on-first-retry --grep @ci
 
       - name: Upload blob report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-ups from #870:

- **`basic` → `workers: 2`**: after #870, basic (12.6 min) is the longest e2e job. Validated on the local CI-replica cluster (basic scenario): workers=1 = 150s, workers=2 = 90s (1.67×) with an **identical pass/fail set** — the only 2 failures are local-rig DNS artifacts (Node-side `apiRequestContext.get` under the sudo-free browser-DNS config; they pass on CI) and fail identically at workers=1. Expected job time: ~12.6 → ~8 min.
- **`--trace on` → `--trace on-first-retry`**: full-run tracing (DOM snapshots + ~20fps screencast per test) was identified as the largest steady-state CPU tax on the 4vCPU runner during the #870 firefox forensics — CPU contention was the enabling condition for the send-under-open-menu race. Failure evidence is preserved (any failing test retries with tracing on).