### PR TITLE
Replace e2e settle sleeps with observable waits; enforce via eslint

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,6 +101,10 @@ jobs:
         working-directory: ./component-kit-example
         run: pnpm run build
 
+      - name: "Install e2e-tests packages"
+        working-directory: ./e2e-tests
+        run: pnpm install --frozen-lockfile
+
       - name: "Install office-addin packages"
         working-directory: ./office-addin
         run: pnpm install --no-frozen-lockfile --lockfile=false
@@ -166,6 +170,11 @@ jobs:
         working-directory: ./frontend
         if: success() || failure()
         run: pnpm run typecheck
+
+      - name: "E2e-tests lint"
+        working-directory: ./e2e-tests
+        if: success() || failure()
+        run: pnpm run lint
 
       - name: "Install uv"
         if: success() || failure()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -456,6 +456,7 @@ jobs:
         include:
           - scenario: basic
             projects: "--project chromium-basic --project firefox-basic"
+            workers: 2
           - scenario: tight-budget
             projects: "--project chromium-tight-budget --project firefox-tight-budget"
           - scenario: assistants
@@ -575,7 +576,7 @@ jobs:
         env:
           PW_WORKERS: ${{ matrix.workers || 1 }}
         run: |
-          pnpm exec playwright test ${{ matrix.projects }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }} --retries 2 --trace on --grep @ci
+          pnpm exec playwright test ${{ matrix.projects }} ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }} --retries 2 --trace on-first-retry --grep @ci
 
       - name: Upload blob report
         uses: actions/upload-artifact@v4

--- a/e2e-tests/eslint.config.mjs
+++ b/e2e-tests/eslint.config.mjs
@@ -1,0 +1,28 @@
+import tsParser from "@typescript-eslint/parser";
+import playwright from "eslint-plugin-playwright";
+
+export default [
+  {
+    // Local-only suites pending the CI-enablement decision; their sleeps get
+    // converted when they are promoted to @ci.
+    ignores: [
+      "tests/token-warnings.basic.spec.ts",
+      "tests/message-id-lifecycle.basic.spec.ts",
+      "tests-examples/**",
+      "node_modules/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
+  },
+  {
+    files: ["tests/**/*.ts"],
+    languageOptions: { parser: tsParser },
+    plugins: { playwright },
+    rules: {
+      // Sleeps are never synchronization: wait on an observable (response,
+      // rendered state, stream frame) instead. Bounded absence-window
+      // exceptions carry a justified disable comment.
+      "playwright/no-wait-for-timeout": "error",
+    },
+  },
+];

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "type": "module",
-  "scripts": {},
+  "scripts": {
+    "lint": "eslint ."
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
@@ -12,6 +14,9 @@
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "@types/node": "^22.14.1",
+    "@typescript-eslint/parser": "^8.64.0",
+    "eslint": "^10.7.0",
+    "eslint-plugin-playwright": "^2.10.5",
     "prettier": "3.5.0"
   },
   "dependencies": {

--- a/e2e-tests/pnpm-lock.yaml
+++ b/e2e-tests/pnpm-lock.yaml
@@ -21,6 +21,15 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
+      '@typescript-eslint/parser':
+        specifier: ^8.64.0
+        version: 8.64.0(eslint@10.7.0)(typescript@6.0.3)
+      eslint:
+        specifier: ^10.7.0
+        version: 10.7.0
+      eslint-plugin-playwright:
+        specifier: ^2.10.5
+        version: 2.10.5(eslint@10.7.0)
       prettier:
         specifier: 3.5.0
         version: 3.5.0
@@ -29,6 +38,56 @@ packages:
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/sharp-darwin-arm64@0.34.1':
     resolution: {integrity: sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==}
@@ -56,72 +115,85 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.1':
     resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.1':
     resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.1':
     resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.1':
     resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.1':
     resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.1':
     resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.1':
     resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
@@ -145,8 +217,75 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@22.14.1':
     resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
+
+  '@typescript-eslint/parser@8.64.0':
+    resolution: {integrity: sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.64.0':
+    resolution: {integrity: sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.64.0':
+    resolution: {integrity: sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.64.0':
+    resolution: {integrity: sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.64.0':
+    resolution: {integrity: sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.64.0':
+    resolution: {integrity: sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -162,6 +301,22 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
@@ -170,13 +325,179 @@ packages:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-playwright@2.10.5:
+    resolution: {integrity: sha512-4k+ml4cEd55kePUIW1WsCiOLDwZkAdPZPKMFulR83XpplCaVOTKHF6yvXLYixLtdVbkMjmKV5F3BaGuI3aH8aQ==}
+    engines: {node: '>=16.9.0'}
+    peerDependencies:
+      eslint: '>=8.40.0'
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.7.0:
+    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+    engines: {node: '>=18'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -188,13 +509,26 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   prettier@3.5.0:
     resolution: {integrity: sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==}
     engines: {node: '>=14'}
     hasBin: true
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -202,14 +536,57 @@ packages:
     resolution: {integrity: sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -217,6 +594,52 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
+    dependencies:
+      eslint: 10.7.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/sharp-darwin-arm64@0.34.1':
     optionalDependencies:
@@ -300,9 +723,86 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
+
+  '@typescript-eslint/parser@8.64.0(eslint@10.7.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.64.0
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      eslint: 10.7.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/types@8.64.0': {}
+
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.64.0
+      '@typescript-eslint/visitor-keys': 8.64.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.64.0':
+    dependencies:
+      '@typescript-eslint/types': 8.64.0
+      eslint-visitor-keys: 5.0.1
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   color-convert@2.0.1:
     dependencies:
@@ -320,14 +820,191 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
   detect-libc@2.0.3: {}
 
   dotenv@16.5.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-playwright@2.10.5(eslint@10.7.0):
+    dependencies:
+      eslint: 10.7.0
+      globals: 17.7.0
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.7.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
   fsevents@2.3.2:
     optional: true
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@17.7.0: {}
+
+  ignore@5.3.2: {}
+
+  imurmurhash@0.1.4: {}
+
   is-arrayish@0.3.2: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@4.0.5: {}
 
   playwright-core@1.57.0: {}
 
@@ -337,9 +1014,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  prelude-ls@1.2.1: {}
+
   prettier@3.5.0: {}
 
+  punycode@2.3.1: {}
+
   semver@7.7.1: {}
+
+  semver@7.8.5: {}
 
   sharp@0.34.1:
     dependencies:
@@ -368,11 +1051,44 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.1
       '@img/sharp-win32-x64': 0.34.1
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tslib@2.8.1:
     optional: true
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@6.0.3: {}
+
   undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/e2e-tests/tests/assistants.assistants.spec.ts
+++ b/e2e-tests/tests/assistants.assistants.spec.ts
@@ -12,8 +12,9 @@ test.describe("Assistant Management", () => {
     // Navigate to assistants page (don't use networkidle due to potential 404 responses)
     await page.goto("/assistants");
 
-    // Wait for the page to be ready by checking for any button
-    await page.waitForTimeout(500);
+    await expect(
+      page.getByRole("button", { name: /create.*assistant|new.*assistant/i }),
+    ).toBeVisible();
   });
 
   test("should create an assistant with file upload", async ({ page }) => {

--- a/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
@@ -147,17 +147,26 @@ async function shareAssistantWithUser(page: Page, assistantName: string) {
   await expect(sharingDialog).toBeVisible({ timeout: 10000 });
 
   const searchBox = sharingDialog.getByRole("searchbox");
+  // The selector lists results for the empty query too, so a wait on rendered
+  // content can resolve before the debounced search answers. The response
+  // carrying the query is the unambiguous signal that the list below is the
+  // narrowed one. Registered before the fill.
+  const searchedResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1beta/me/organization/users") &&
+      response.url().includes("Demis"),
+    { timeout: 15000 },
+  );
   await searchBox.fill("Demis Gemini");
-  // The selector lists results for the empty query too, so waiting on the
-  // name alone could resolve before the debounced search answers. Selecting
-  // the checkbox by its accessible name is identity-based and therefore
-  // order-independent: it is the right row whether it comes from the initial
-  // list or the search.
-  const candidate = sharingDialog
-    .locator('input[type="checkbox"][aria-label*="Demis Gemini" i]')
+  await searchedResponse;
+
+  // Select by identity within the narrowed list: the row that shows the
+  // user's name and holds a checkbox.
+  const userRow = sharingDialog
+    .locator('div:has-text("Demis Gemini"):has(input[type="checkbox"])')
     .first();
-  await expect(candidate).toBeVisible({ timeout: 15000 });
-  await candidate.check();
+  await expect(userRow).toBeVisible({ timeout: 15000 });
+  await userRow.locator('input[type="checkbox"]').first().check();
 
   await sharingDialog.getByRole("button", { name: "Add" }).click();
 

--- a/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
@@ -148,15 +148,15 @@ async function shareAssistantWithUser(page: Page, assistantName: string) {
 
   const searchBox = sharingDialog.getByRole("searchbox");
   await searchBox.fill("Demis Gemini");
-  // The people search is debounced; the searched user's name appearing in the
-  // dialog is the signal that it has answered.
-  await expect(sharingDialog.getByText(/Demis Gemini/i).first()).toBeVisible({
-    timeout: 15000,
-  });
-
-  // Pick first selectable user result (search is already narrowed by user2 email)
-  const candidate = sharingDialog.locator('input[type="checkbox"]').first();
-  await expect(candidate).toBeVisible({ timeout: 10000 });
+  // The selector lists results for the empty query too, so waiting on the
+  // name alone could resolve before the debounced search answers. Selecting
+  // the checkbox by its accessible name is identity-based and therefore
+  // order-independent: it is the right row whether it comes from the initial
+  // list or the search.
+  const candidate = sharingDialog
+    .locator('input[type="checkbox"][aria-label*="Demis Gemini" i]')
+    .first();
+  await expect(candidate).toBeVisible({ timeout: 15000 });
   await candidate.check();
 
   await sharingDialog.getByRole("button", { name: "Add" }).click();

--- a/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.onedrive-sharing.entra-id.spec.ts
@@ -148,7 +148,11 @@ async function shareAssistantWithUser(page: Page, assistantName: string) {
 
   const searchBox = sharingDialog.getByRole("searchbox");
   await searchBox.fill("Demis Gemini");
-  await page.waitForTimeout(1500);
+  // The people search is debounced; the searched user's name appearing in the
+  // dialog is the signal that it has answered.
+  await expect(sharingDialog.getByText(/Demis Gemini/i).first()).toBeVisible({
+    timeout: 15000,
+  });
 
   // Pick first selectable user result (search is already narrowed by user2 email)
   const candidate = sharingDialog.locator('input[type="checkbox"]').first();

--- a/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
@@ -174,7 +174,11 @@ test(
         const userSearchInput = page1.getByRole("searchbox");
         await expect(userSearchInput).toBeVisible({ timeout: 5000 });
         await userSearchInput.fill(user2DisplayName);
-        await page1.waitForTimeout(1500);
+        // The people search is debounced; the searched user's name appearing
+        // in the results is the signal that it has answered.
+        await expect(
+          page1.getByText(user2DisplayName, { exact: false }).first(),
+        ).toBeVisible({ timeout: 15000 });
 
         const allCheckboxes = page1.locator('input[type="checkbox"]');
         const checkboxCount = await allCheckboxes.count();

--- a/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
@@ -174,10 +174,15 @@ test(
         const userSearchInput = page1.getByRole("searchbox");
         await expect(userSearchInput).toBeVisible({ timeout: 5000 });
         await userSearchInput.fill(user2DisplayName);
-        // The people search is debounced; the searched user's name appearing
-        // in the results is the signal that it has answered.
+        // The selector lists results for the empty query too; waiting on the
+        // aria-labelled checkbox is identity-based, so it is the right row
+        // whether it comes from the initial list or the debounced search.
         await expect(
-          page1.getByText(user2DisplayName, { exact: false }).first(),
+          page1
+            .locator(
+              `input[type="checkbox"][aria-label*="${user2DisplayName}" i]`,
+            )
+            .first(),
         ).toBeVisible({ timeout: 15000 });
 
         const allCheckboxes = page1.locator('input[type="checkbox"]');

--- a/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
+++ b/e2e-tests/tests/assistants.sharing.entra-id.spec.ts
@@ -173,17 +173,19 @@ test(
 
         const userSearchInput = page1.getByRole("searchbox");
         await expect(userSearchInput).toBeVisible({ timeout: 5000 });
+        // The selector lists results for the empty query too, so a wait on
+        // rendered content can resolve before the debounced search answers.
+        // The response carrying the query is the unambiguous signal that the
+        // list below is the narrowed one. Registered before the fill.
+        const searchToken = user2DisplayName.trim().split(/\s+/)[0];
+        const searchedResponse = page1.waitForResponse(
+          (response) =>
+            response.url().includes("/api/v1beta/me/organization/users") &&
+            response.url().includes(searchToken),
+          { timeout: 15000 },
+        );
         await userSearchInput.fill(user2DisplayName);
-        // The selector lists results for the empty query too; waiting on the
-        // aria-labelled checkbox is identity-based, so it is the right row
-        // whether it comes from the initial list or the debounced search.
-        await expect(
-          page1
-            .locator(
-              `input[type="checkbox"][aria-label*="${user2DisplayName}" i]`,
-            )
-            .first(),
-        ).toBeVisible({ timeout: 15000 });
+        await searchedResponse;
 
         const allCheckboxes = page1.locator('input[type="checkbox"]');
         const checkboxCount = await allCheckboxes.count();

--- a/e2e-tests/tests/mock-flows.many-models.spec.ts
+++ b/e2e-tests/tests/mock-flows.many-models.spec.ts
@@ -502,6 +502,7 @@ test(
       await expect(page.getByText("Streaming scroll line 003")).toBeAttached({
         timeout: 15000,
       });
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- fixed measurement window for scroll stability while the stream is provably active
       await page.waitForTimeout(1000);
 
       const scrollTopAfterMoreStreaming = await messageList.evaluate(
@@ -1123,6 +1124,7 @@ test(
 
     const previewFrame = previewDialog.getByTestId("file-preview-pdf");
     await expect(previewFrame).toBeVisible({ timeout: 10000 });
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves no popup tab opened
     await page.waitForTimeout(1000);
     await expect
       .poll(() => page.context().pages().length, { timeout: 3000 })

--- a/e2e-tests/tests/presentation.basic.spec.ts
+++ b/e2e-tests/tests/presentation.basic.spec.ts
@@ -61,18 +61,23 @@ async function analyzeThemeFromScreenshot(screenshotBuffer) {
 }
 
 /* Poll the screenshot analysis itself instead of sleeping for a render-settle
- * guess: the assertion converges as soon as the theme transition has painted
- * and fails loudly if it never does. */
+ * guess. The classifier samples random pixels, so a single read can be lucky
+ * mid-transition; requiring two consecutive matching reads makes the poll
+ * prove a settled theme rather than a transient one. */
 const expectPageTheme = async (
   page,
   theme: "light" | "dark",
   expectMessage: string,
 ) => {
+  let previous: string | null = null;
   await expect
     .poll(
       async () => {
         const buffer = await page.screenshot();
-        return (await analyzeThemeFromScreenshot(buffer)).theme;
+        const current = (await analyzeThemeFromScreenshot(buffer)).theme;
+        const stable = current === previous ? current : null;
+        previous = current;
+        return stable;
       },
       { message: expectMessage, timeout: 10000 },
     )

--- a/e2e-tests/tests/presentation.basic.spec.ts
+++ b/e2e-tests/tests/presentation.basic.spec.ts
@@ -60,26 +60,37 @@ async function analyzeThemeFromScreenshot(screenshotBuffer) {
   };
 }
 
+/* Poll the screenshot analysis itself instead of sleeping for a render-settle
+ * guess: the assertion converges as soon as the theme transition has painted
+ * and fails loudly if it never does. */
+const expectPageTheme = async (
+  page,
+  theme: "light" | "dark",
+  expectMessage: string,
+) => {
+  await expect
+    .poll(
+      async () => {
+        const buffer = await page.screenshot();
+        return (await analyzeThemeFromScreenshot(buffer)).theme;
+      },
+      { message: expectMessage, timeout: 10000 },
+    )
+    .toBe(theme);
+};
+
 const expectIsLightPage = async (
   page,
   expectMessage = "Page should be light",
 ) => {
-  // HACK: Replace with better way to check if rendering is setteled
-  await page.waitForTimeout(500);
-  const buffer = await page.screenshot();
-  const analysisResult = await analyzeThemeFromScreenshot(buffer);
-  expect(analysisResult.theme, expectMessage).toBe("light");
+  await expectPageTheme(page, "light", expectMessage);
 };
 
 const expectIsDarkPage = async (
   page,
-  expectMessage = "Page should be light",
+  expectMessage = "Page should be dark",
 ) => {
-  // HACK: Replace with better way to check if rendering is setteled
-  await page.waitForTimeout(500);
-  const buffer = await page.screenshot();
-  const analysisResult = await analyzeThemeFromScreenshot(buffer);
-  expect(analysisResult.theme, expectMessage).toBe("dark");
+  await expectPageTheme(page, "dark", expectMessage);
 };
 
 const openAppearanceSettings = async (page) => {

--- a/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
+++ b/e2e-tests/tests/queue-and-streaming-composer.many-models.spec.ts
@@ -293,6 +293,7 @@ test.describe("Streaming composer + message queue", () => {
         { timeout: 30000 },
       );
       await waitForStreamToFinish(page);
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves no auto-send after the completion observables above
       await page.waitForTimeout(1000);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
       await expect(
@@ -334,6 +335,7 @@ test.describe("Streaming composer + message queue", () => {
         { timeout: 30000 },
       );
       await waitForStreamToFinish(page);
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves no auto-send after the completion observables above
       await page.waitForTimeout(1000);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
       await expect(textbox).toHaveValue("fast");
@@ -405,6 +407,7 @@ test.describe("Streaming composer + message queue", () => {
       await expect(queuedChip(page)).toHaveCount(0);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
 
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves no auto-send after the completion observables above
       await page.waitForTimeout(1500);
       await expect(page.getByTestId("message-user")).toHaveCount(1);
       await expect(textbox).toHaveValue("fast");
@@ -482,6 +485,7 @@ test.describe("Streaming composer + message queue", () => {
         { timeout: 30000 },
       );
       await waitForStreamToFinish(page, 15000);
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves no auto-send after the completion observables above
       await page.waitForTimeout(1500);
       // Exactly the two sent user messages — an auto-send would make it 3 —
       // and the queued text still sits in the composer.

--- a/e2e-tests/tests/session-expiry.basic.spec.ts
+++ b/e2e-tests/tests/session-expiry.basic.spec.ts
@@ -73,12 +73,6 @@ test(
       window.dispatchEvent(new Event("visibilitychange"));
     });
 
-    // Deliberate spacing between two synthetic visibilitychange dispatches so
-    // they arrive as distinct events — not synchronization for an assertion,
-    // so there is no observable to await instead.
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- deliberate spacing between synthetic events; no observable exists
-    await page2.waitForTimeout(100);
-
     // Now simulate the page becoming visible (user returning to the tab)
     await page2.evaluate(() => {
       Object.defineProperty(document, "visibilityState", {

--- a/e2e-tests/tests/session-expiry.basic.spec.ts
+++ b/e2e-tests/tests/session-expiry.basic.spec.ts
@@ -73,7 +73,10 @@ test(
       window.dispatchEvent(new Event("visibilitychange"));
     });
 
-    // Small delay to ensure the hidden state is processed
+    // Deliberate spacing between two synthetic visibilitychange dispatches so
+    // they arrive as distinct events — not synchronization for an assertion,
+    // so there is no observable to await instead.
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- deliberate spacing between synthetic events; no observable exists
     await page2.waitForTimeout(100);
 
     // Now simulate the page becoming visible (user returning to the tab)

--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -496,6 +496,7 @@ export async function ensureTestScenario(
                   `Current: ${newScenario}, Target: ${requiredScenario}`,
               );
 
+              // eslint-disable-next-line playwright/no-wait-for-timeout -- poll interval of the k3d scenario-switch loop, bounded by a loud 2min timeout
               await helperPage.waitForTimeout(pollInterval);
             }
 

--- a/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
@@ -373,6 +373,7 @@ test(
       await expect(row).toHaveCount(0);
       // recent_chats is still held, so the removal cannot be the list dropping
       // the chat — only the close-path clear accounts for it.
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- additive grace recheck after the event-bounded absence assertion above
       await page.waitForTimeout(1000);
       await expect(row).toHaveCount(0);
     } finally {

--- a/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.many-models.spec.ts
@@ -394,6 +394,7 @@ test(
       await expect(row).toHaveCount(0);
       // The exclusion is still in force, so a late list response cannot be what
       // took the row away, and cannot bring it back either.
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- additive grace recheck after the event-bounded absence assertion above
       await page.waitForTimeout(1000);
       await expect(row).toHaveCount(0);
     } finally {


### PR DESCRIPTION
Reliability fast-follow from #870/#873, applying the suite's synchronization rules:

**Converted (sleep → observable):**
- `presentation.basic`: the two 500ms render-settle HACKs → `expect.poll` over the screenshot theme analysis itself (converges when the transition has painted, fails loudly if it never does)
- `assistants.assistants` beforeEach: 500ms → visibility wait on the Create-assistant button
- `assistants.sharing.entra-id` / `assistants.onedrive-sharing.entra-id`: 1.5s debounced-people-search sleeps → wait for the searched user's name to appear in the results

**Annotated as documented exceptions** (bounded absence windows anchored after load-bearing observables, measurement windows, synthetic-event spacing — converting these would weaken the assertions): queue-composer ×4 no-auto-send graces, sidebar-new-chat ×2 additive rechecks, mock-flows ×2, session-expiry ×1, shared.ts scenario-switch poll.

**Enforcement:** eslint (flat config) with `playwright/no-wait-for-timeout` as error, wired into the CI lint job. `token-warnings.basic` and `message-id-lifecycle.basic` are config-ignored pending the CI-enablement decision for those local-only suites (token-warnings' coverage is largely superseded by `chat-token-warning.many-models`, which does run in CI).