### PR TITLE
Layer sendFirstMessage failure diagnosis; widen mcp-auth first-response margin

### DIFF
--- a/e2e-tests/tests/mcp-auth.many-models.spec.ts
+++ b/e2e-tests/tests/mcp-auth.many-models.spec.ts
@@ -27,7 +27,10 @@ const runMcpAuthFlow = async (
   await textbox.press("Enter");
 
   const latestAssistantMessage = page.getByTestId("message-assistant").last();
-  await expect(latestAssistantMessage).toBeVisible();
+  // First turn for a cold user plus an MCP tool round-trip regularly exceeds
+  // the 5s default under parallel workers; match the 15s the sibling asserts
+  // in this helper already use.
+  await expect(latestAssistantMessage).toBeVisible({ timeout: 15000 });
 
   // Tool calls render inline in the trace timeline as <ToolCallItem> cards
   // tagged with data-tool-name. The card exists in the DOM whether the trace

--- a/e2e-tests/tests/shared.ts
+++ b/e2e-tests/tests/shared.ts
@@ -191,12 +191,50 @@ export const chatIdFromUrl = (page: Page): string => {
 /**
  * Send the first message of a new chat and return its id. Navigation happens at
  * `chat_created`, so the id is known long before the turn ends.
+ *
+ * The send is verified in layers so a failure names the broken link instead of
+ * a generic navigation timeout: the submitstream request opened a 2xx stream →
+ * the optimistic user bubble rendered → navigation or an explicit send error,
+ * whichever surfaces first. Deliberate-failure tests must not use this helper
+ * for the turn they break.
  */
 export const sendFirstMessage = async (page: Page, message: string) => {
   const textbox = page.getByRole("textbox", { name: "Type a message..." });
   await textbox.fill(message);
+  const submitResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1beta/me/messages/submitstream"),
+    { timeout: 10000 },
+  );
   await textbox.press("Enter");
-  await expect(page).toHaveURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 });
+  const response = await submitResponse;
+  expect(
+    response.ok(),
+    `submitstream should open a 2xx stream, got ${response.status()}`,
+  ).toBe(true);
+  // The optimistic bubble commits on submit, before any stream frame arrives;
+  // its absence means the client dropped the send.
+  await expect(page.getByTestId("message-user").last()).toBeVisible({
+    timeout: 5000,
+  });
+  const sendError = page.getByTestId("chat-send-error");
+  const outcome = await Promise.race([
+    page.waitForURL(/\/chat\/[0-9a-fA-F-]+/, { timeout: 15000 }).then(
+      () => "navigated" as const,
+      () => "timeout" as const,
+    ),
+    sendError.waitFor({ state: "visible", timeout: 15000 }).then(
+      () => "send-error" as const,
+      () => "timeout" as const,
+    ),
+  ]);
+  if (outcome === "send-error") {
+    throw new Error(`send failed: ${await sendError.textContent()}`);
+  }
+  expect(
+    outcome,
+    "chat_created never navigated and no send error was shown",
+  ).toBe("navigated");
   return chatIdFromUrl(page);
 };
 

--- a/e2e-tests/tests/sidebar-generation-status.many-models.spec.ts
+++ b/e2e-tests/tests/sidebar-generation-status.many-models.spec.ts
@@ -204,10 +204,12 @@ test(
           '[data-testid="chat-generation-status"][data-status="running"]',
         ),
     ).toHaveCount(0, { timeout: 60000 });
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- settle beat between the terminal transition and the idle measurement window below
     await page.waitForTimeout(2000);
 
     // The poll must be disabled while idle, not merely slowed down.
     const idleStart = Date.now();
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded measurement window: proves an idle client sends zero /me/generating requests
     await page.waitForTimeout(8000);
     const idleCount = generatingAt.filter((t) => t >= idleStart).length;
     expect(
@@ -317,6 +319,7 @@ test(
     // The stale snapshot must not consume the running status.
     await expect.poll(() => staleReplayed, { timeout: 15000 }).toBe(true);
     for (let i = 0; i < 4; i += 1) {
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded absence window: proves the stale replay does not flip the status within it
       await page.waitForTimeout(1000);
       await expect(indicator).toHaveAttribute("data-status", "running");
     }

--- a/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
+++ b/e2e-tests/tests/sidebar-new-chat.basic.spec.ts
@@ -320,6 +320,7 @@ test(
       // Archiving edits the cached list in place rather than refetching, so
       // releasing just lets any parked request land.
       listHold.release();
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- additive grace recheck after the event-bounded absence assertion above
       await page.waitForTimeout(1000);
 
       await expect(row).toHaveCount(0);


### PR DESCRIPTION
Fast-follow A from the deflake initiative — the adversarially-reviewed hardening of `sendFirstMessage` (used by ~15 first-send tests):

1. **submitstream response asserted `ok()`**, registered before the Enter press — separates "send rejected" from everything downstream
2. **Optimistic user-bubble visibility** — its absence means the client dropped the send (the failure shape of the firefox "send never started" family)
3. **Navigation raced against `chat-send-error`** — an explicit send failure now throws with the error text instead of a generic 15s URL timeout

Also: `mcp-auth`'s first-assistant-bubble assert gets the same 15s margin its sibling asserts already use (it was the 5s default — the source of the retry-recovered firefox failures in recent runs)