### PR TITLE
Narrow share-link access: stop granting generic chat read

### DIFF
--- a/backend/erato/tests/integration_tests/api/sharing.rs
+++ b/backend/erato/tests/integration_tests/api/sharing.rs
@@ -119,8 +119,10 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
     assert_eq!(resolve_json["share_link"]["resource_type"], "chat");
     assert_eq!(resolve_json["share_link"]["resource_id"], chat_id);
 
+    // The recipient reads the shared conversation through the dedicated
+    // share-link route, which authorizes via the share link itself.
     let shared_messages_response = server
-        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .get(&format!("/api/v1beta/share-links/{share_link_id}/messages"))
         .with_bearer_token(&recipient_token)
         .await;
     shared_messages_response.assert_status_ok();
@@ -131,6 +133,17 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
             .expect("messages should be array")
             .len()
             >= 2
+    );
+
+    // A share link must NOT grant generic Chat::Read: the recipient cannot reach
+    // the raw messages route (which would expose every edit/regen branch).
+    let generic_route_denied = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(&recipient_token)
+        .await;
+    assert_eq!(
+        generic_route_denied.status_code(),
+        http::StatusCode::NOT_FOUND
     );
 
     let disable_response = server
@@ -165,6 +178,17 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
         .await;
     assert_eq!(
         resolve_after_disable.status_code(),
+        http::StatusCode::NOT_FOUND
+    );
+
+    // The dedicated messages route follows the policy: with the link disabled,
+    // `shared_read` is denied and the shared view disappears.
+    let shared_messages_after_disable = server
+        .get(&format!("/api/v1beta/share-links/{share_link_id}/messages"))
+        .with_bearer_token(&recipient_token)
+        .await;
+    assert_eq!(
+        shared_messages_after_disable.status_code(),
         http::StatusCode::NOT_FOUND
     );
 }

--- a/backend/policy/backend/backend.rego
+++ b/backend/policy/backend/backend.rego
@@ -233,15 +233,6 @@ allow if {
 	data.resource_attributes[resource_kind_chat][input.resource_id].owner_id == input.subject_id
 }
 
-# A logged-in user can read a chat when chat sharing is enabled and the chat has an active share link.
-allow if {
-	input.subject_kind == subject_kind_user
-	input.subject_id != not_logged_in
-	input.resource_kind == resource_kind_chat
-	input.action == action_read
-	can_read_shared_chat(input.resource_id)
-}
-
 # A logged-in user can read the shared view of a chat when chat sharing is
 # enabled and the chat has an active share link.
 allow if {

--- a/backend/policy/backend/backend_test.rego
+++ b/backend/policy/backend/backend_test.rego
@@ -258,8 +258,11 @@ test_user_cannot_read_other_users_chat if {
 		with data.config as chat_sharing_enabled_config
 }
 
-test_user_can_read_shared_chat_when_feature_enabled if {
-	backend.allow with input as {
+# A share link must NOT grant generic chat read. Shared reads go only through the
+# dedicated share-links messages route, which authorizes via the share link itself
+# and serves the active thread only.
+test_share_link_does_not_grant_generic_chat_read if {
+	not backend.allow with input as {
 		"subject_kind": "user",
 		"subject_id": user_2_id,
 		"resource_kind": "chat",

--- a/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
+++ b/e2e-tests/tests/shared-chat-active-thread.many-models.spec.ts
@@ -113,7 +113,7 @@ test(
       createSharingTestContext(browser, "user02@example.com"));
 
     try {
-      const { shareUrl, ownerRoles } = await test.step(
+      const { shareUrl, ownerRoles, chatId } = await test.step(
         "Owner builds a branched chat and shares it",
         async () => {
           // Record the chat's own generic-route messages URL as the owner
@@ -209,7 +209,14 @@ test(
 
           await owner.page.keyboard.press("Escape");
 
-          return { shareUrl, ownerRoles };
+          // chatId (from the owner's own messages URL) lets the recipient step
+          // probe the generic route directly.
+          const chatId = (ownerMessagesUrl as string).match(
+            /\/chats\/([^/?]+)\/messages/,
+          )?.[1];
+          expect(chatId, "chatId parsed from owner messages URL").toBeTruthy();
+
+          return { shareUrl, ownerRoles, chatId };
         },
       );
 
@@ -262,6 +269,14 @@ test(
             .poll(() => chatMessageRoles(recipient.page), { timeout: 15000 })
             .toEqual(ownerRoles);
           await expect(messageBox(recipient.page)).toHaveCount(0);
+
+          // Boundary check: a share link must NOT grant generic Chat::Read.
+          // The recipient hand-crafts the raw messages request; it must be
+          // denied, otherwise every edit/regen branch leaks over that route.
+          const bypass = await recipient.page.request.get(
+            `/api/v1beta/chats/${chatId}/messages`,
+          );
+          expect(bypass.status()).toBe(404);
         },
       );
     } finally {


### PR DESCRIPTION
Follow-up to #866 (ERMAIN-485). The dedicated share-link messages route landed in 485 — now authorized in the policy via `shared_read` — but a share link still also granted any logged-in viewer generic `Chat::Read` on the chat_id, so a viewer could hand-craft `GET /chats/{id}/messages` and receive every edit/regen branch. This removes that grant, closing the leak 485's route alone did not.

## Change
- Remove the chat-read `allow` clause in `backend.rego` that rode on `can_read_shared_chat`. Share-link viewers now hold **only** `shared_read` (modeled in #866), which the dedicated `GET /share-links/{id}/messages` route authorizes against.
- **Keep** the `can_read_shared_chat` helper and the file-upload-via-shared-chat rule — attachments in the shared view still work (the file rule propagates from the same helper `shared_read` derives from).
- Flip the rego test to assert a share-link viewer is **denied** generic chat read; the linked-file rule test stays green.
- Integration test: the viewer reads via the dedicated route (200), the generic route is denied (404), and after the owner disables the link the dedicated route denies too (`shared_read` policy deny → 404).
- e2e: the recipient's hand-crafted `GET /chats/{id}/messages` → 404.

## Effect
The generic messages route, token-usage estimate, and chat metadata now **deny** a share-only viewer (they all check `Chat::Read`); the dedicated route is unaffected (`shared_read`). Attachments keep working via the kept file-upload rule.

Stacks on #866; part of the 485 → 486 → 489 set meant to land together.

Closes ERMAIN-486.

Validated locally: `opa test` 66/66, backend suite green (3 pre-existing local MCP-env failures also fail on main), `test_chat_share_link_enable_disable_flow` green against Postgres.
