### PR TITLE
Withhold owner feedback from share-link viewers

### DIFF
--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -2331,9 +2331,10 @@ pub async fn chat_messages(
         }
     })?;
 
-    let response =
-        assemble_chat_messages_response(&app_state, &policy, &me_user, chat_id, messages, stats)
-            .await?;
+    let response = assemble_chat_messages_response(
+        &app_state, &policy, &me_user, chat_id, messages, stats, true,
+    )
+    .await?;
 
     Ok(Json(response))
 }
@@ -2344,6 +2345,9 @@ pub async fn chat_messages(
 /// messages route and the share-link messages route: feedback lookup, file-id
 /// collection, capability flags, file-URL map, per-message conversion with
 /// feedback + error reports, presigned image-URL regeneration, and stats.
+///
+/// `include_feedback` gates the feedback lookup: feedback is the chat owner's
+/// private signal, so the share-link path passes `false` and returns none.
 async fn assemble_chat_messages_response(
     app_state: &AppState,
     policy: &PolicyEngine,
@@ -2351,14 +2355,18 @@ async fn assemble_chat_messages_response(
     chat_id: Uuid,
     messages: Vec<messages::Model>,
     stats: models::message::MessageListStats,
+    include_feedback: bool,
 ) -> Result<ChatMessagesResponse, StatusCode> {
-    // Get feedback for all messages
+    // Get feedback for all messages (owner-only; empty on the shared path).
     let message_ids: Vec<Uuid> = messages.iter().map(|m| m.id).collect();
-    let feedbacks =
+    let feedbacks = if include_feedback {
         models::message_feedback::get_feedbacks_for_messages(&app_state.db, &message_ids)
             .await
             .wrap_err("Failed to get message feedbacks")
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    } else {
+        std::collections::HashMap::new()
+    };
 
     // Collect all unique file IDs from all messages
     let all_file_ids: std::collections::HashSet<Uuid> = messages

--- a/backend/erato/src/server/api/v1beta/share_links.rs
+++ b/backend/erato/src/server/api/v1beta/share_links.rs
@@ -307,8 +307,10 @@ pub async fn share_link_messages(
         }
     })?;
 
+    // Feedback is the owner's private signal — never surface it to a share-link
+    // viewer.
     let response = super::assemble_chat_messages_response(
-        &app_state, &policy, &me_user, chat_id, messages, stats,
+        &app_state, &policy, &me_user, chat_id, messages, stats, false,
     )
     .await?;
 

--- a/backend/erato/tests/integration_tests/api/sharing.rs
+++ b/backend/erato/tests/integration_tests/api/sharing.rs
@@ -73,6 +73,47 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
     let events = parse_sse_events(&submit_response);
     let chat_id = extract_chat_id(&events).expect("Expected chat_created event");
 
+    // The owner leaves feedback on the assistant reply and sees it on their own
+    // view — the positive control for the shared-view assertion further down.
+    let owner_view: Value = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(&owner_token)
+        .await
+        .json();
+    let assistant_message_id = owner_view["messages"]
+        .as_array()
+        .expect("owner messages array")
+        .iter()
+        .find(|message| message["role"] == "assistant")
+        .and_then(|message| message["id"].as_str())
+        .expect("assistant message id")
+        .to_string();
+    server
+        .put(&format!(
+            "/api/v1beta/messages/{assistant_message_id}/feedback"
+        ))
+        .with_bearer_token(&owner_token)
+        .add_header(http::header::CONTENT_TYPE, "application/json")
+        .json(&json!({ "sentiment": "positive", "comment": "clear answer" }))
+        .await
+        .assert_status_ok();
+
+    let owner_view_with_feedback: Value = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(&owner_token)
+        .await
+        .json();
+    let owner_feedback = owner_view_with_feedback["messages"]
+        .as_array()
+        .expect("owner messages array")
+        .iter()
+        .find(|message| message["id"] == assistant_message_id.as_str())
+        .expect("owner sees the assistant message");
+    assert!(
+        !owner_feedback["feedback"].is_null(),
+        "owner must see their own feedback"
+    );
+
     let before_share_response = server
         .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
         .with_bearer_token(&recipient_token)
@@ -135,6 +176,18 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
             >= 2
     );
 
+    // The owner's feedback must not surface in the shared view.
+    let shared_assistant = shared_messages_json["messages"]
+        .as_array()
+        .expect("shared messages array")
+        .iter()
+        .find(|message| message["id"] == assistant_message_id.as_str())
+        .expect("assistant message in shared view");
+    assert!(
+        shared_assistant["feedback"].is_null(),
+        "share-link viewer must not see the owner's feedback"
+    );
+
     // A share link must NOT grant generic Chat::Read: the recipient cannot reach
     // the raw messages route (which would expose every edit/regen branch).
     let generic_route_denied = server
@@ -144,6 +197,33 @@ async fn test_chat_share_link_enable_disable_flow(pool: Pool<Postgres>) {
     assert_eq!(
         generic_route_denied.status_code(),
         http::StatusCode::NOT_FOUND
+    );
+
+    // A share-link viewer cannot write feedback either — the feedback endpoint
+    // gates on Chat::Read, which the viewer no longer holds.
+    let viewer_feedback_denied = server
+        .put(&format!(
+            "/api/v1beta/messages/{assistant_message_id}/feedback"
+        ))
+        .with_bearer_token(&recipient_token)
+        .add_header(http::header::CONTENT_TYPE, "application/json")
+        .json(&json!({ "sentiment": "negative" }))
+        .await;
+    assert_eq!(
+        viewer_feedback_denied.status_code(),
+        http::StatusCode::FORBIDDEN
+    );
+
+    // Nor retract the owner's feedback — deletion gates on Chat::Read too.
+    let viewer_feedback_delete_denied = server
+        .delete(&format!(
+            "/api/v1beta/messages/{assistant_message_id}/feedback"
+        ))
+        .with_bearer_token(&recipient_token)
+        .await;
+    assert_eq!(
+        viewer_feedback_delete_denied.status_code(),
+        http::StatusCode::FORBIDDEN
     );
 
     let disable_response = server


### PR DESCRIPTION
Follow-up to #878 (ERMAIN-486). After 486 removes the share-link `Chat::Read` grant, a viewer can no longer *write* feedback — but the dedicated share-link route still embedded the **owner's** feedback in its response, because it reuses `assemble_chat_messages_response`, which fetched feedback unconditionally. That read-exposure is independent of the rego change and is what this PR closes.

## Change
- Thread `include_feedback` through `assemble_chat_messages_response`: the owner route passes `true`, the share-link route passes `false`. A share-link viewer never receives the owner's 👍/👎 or free-text comment.
- Integration test (extends `test_chat_share_link_enable_disable_flow`):
  - owner leaves feedback and sees it on their own view — positive control, so the assertion below is not vacuous;
  - the share-link view returns `feedback: null` for that message;
  - the viewer's `PUT /messages/{id}/feedback` is denied (403) — the write-denial that 486 enables;
  - the viewer's `DELETE /messages/{id}/feedback` is denied (403) — retraction (ERMAIN-488 / #865, now on base) gates on `Chat::Read` too.

The read-scope fix here is independent of 486 and could land on its own, but it's kept in the stack to land together.

Stacks on #878; part of the 485 → 486 → 489 set meant to land together.

Closes ERMAIN-489.

Validated locally: the extended integration test is green against Postgres.
