### PR TITLE
Emit chat_created before the policy rebuild (ERMAIN-494)

### DIFF
--- a/backend/erato/src/policy/engine.rs
+++ b/backend/erato/src/policy/engine.rs
@@ -16,7 +16,7 @@ use sea_orm::{DatabaseConnection, EntityTrait, FromQueryResult, QuerySelect};
 use serde_json::{Value as JsonValue, json};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::instrument;
 
 const BACKEND_POLICY: &str = include_str!("../../../policy/backend/backend.rego");
@@ -340,6 +340,10 @@ pub(crate) use authorize;
 pub struct PolicyEngine {
     engine: Arc<RwLock<Engine>>,
     data_needs_rebuild: Arc<RwLock<bool>>,
+    /// Serializes rebuilds process-wide (shared by request-scoped clones):
+    /// concurrent stale observers queue here and re-check staleness after
+    /// acquiring, so they coalesce into a single rebuild.
+    rebuild_lock: Arc<Mutex<()>>,
 }
 
 impl Default for PolicyEngine {
@@ -360,6 +364,7 @@ impl PolicyEngine {
         Self {
             engine: Arc::new(RwLock::new(engine)),
             data_needs_rebuild: Arc::new(RwLock::new(true)),
+            rebuild_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -371,6 +376,7 @@ impl PolicyEngine {
         Self {
             engine: self.engine.clone(),
             data_needs_rebuild: Arc::new(RwLock::new(false)),
+            rebuild_lock: self.rebuild_lock.clone(),
         }
     }
 
@@ -391,6 +397,15 @@ impl PolicyEngine {
 
     #[instrument(skip_all)]
     pub async fn rebuild_data(
+        &self,
+        db: &DatabaseConnection,
+        config: &AppConfig,
+    ) -> Result<(), Report> {
+        let _rebuild_guard = self.rebuild_lock.lock().await;
+        self.rebuild_data_locked(db, config).await
+    }
+
+    async fn rebuild_data_locked(
         &self,
         db: &DatabaseConnection,
         config: &AppConfig,
@@ -448,12 +463,16 @@ impl PolicyEngine {
         db: &DatabaseConnection,
         config: &AppConfig,
     ) -> Result<(), Report> {
-        let data_needs_rebuild = { *self.data_needs_rebuild.read().await };
-        tracing::trace!(data_needs_rebuild = data_needs_rebuild);
-        if data_needs_rebuild {
-            self.rebuild_data(db, config).await?;
+        if !*self.data_needs_rebuild.read().await {
+            return Ok(());
         }
-        Ok(())
+        let _rebuild_guard = self.rebuild_lock.lock().await;
+        // Re-check after acquiring: a rebuild that finished while we waited on
+        // the lock already covers this invalidation.
+        if !*self.data_needs_rebuild.read().await {
+            return Ok(());
+        }
+        self.rebuild_data_locked(db, config).await
     }
 
     pub async fn rebuild_data_if_needed_req(

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -4523,8 +4523,6 @@ async fn bg_stream_update_assistant_message_completion(
     .await
     .map_err(Report::msg)?;
 
-    app_state.global_policy_engine.invalidate_data().await;
-
     Ok(())
 }
 
@@ -4572,8 +4570,6 @@ async fn stream_update_assistant_message_completion<
         .send_event_report(tx.clone())
         .in_current_span()
         .await?;
-
-    app_state.global_policy_engine.invalidate_data().await;
 
     Ok(())
 }
@@ -7190,21 +7186,27 @@ async fn run_message_submit_task(
 ) -> Result<(), Report> {
     tracing::info!("run_message_submit_task started for chat_id: {}", chat_id);
 
-    // Rebuild policy data FIRST if a new chat was created (before trying to fetch the chat)
-    if chat_was_created {
-        tracing::info!("Rebuilding policy data for newly created chat");
-        policy
-            .rebuild_data(&app_state.db, &app_state.config)
-            .await
-            .wrap_err("Failed to rebuild policy data after chat creation")?;
-    }
-
-    // Send ChatCreated event if the chat was just created
+    // Send ChatCreated before the policy rebuild so client navigation is not
+    // serialized behind it. This is authz-safe: the chat row is committed and
+    // the global engine invalidated before this task was spawned, so the
+    // client's post-navigation requests wait on (or perform) the same
+    // single-flight rebuild in the middleware and can never observe
+    // pre-create policy data. A rebuild failure no longer suppresses
+    // navigation; it surfaces as an error frame in the created chat.
     if chat_was_created {
         tracing::info!("Sending ChatCreated event for chat_id: {}", chat_id);
         task.send_event(StreamingEvent::ChatCreated { chat_id })
             .await
             .map_err(Report::msg)?;
+
+        tracing::info!("Rebuilding policy data for newly created chat");
+        // Via the global engine: `policy` is a request-scoped clone whose
+        // severed staleness flag cannot see the handler's invalidation.
+        app_state
+            .global_policy_engine
+            .rebuild_data_if_needed(&app_state.db, &app_state.config)
+            .await
+            .wrap_err("Failed to rebuild policy data after chat creation")?;
     }
 
     tracing::info!("Fetching chat for chat_id: {}", chat_id);

--- a/backend/erato/src/server/api/v1beta/message_streaming_file_extraction.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming_file_extraction.rs
@@ -410,6 +410,10 @@ async fn process_mcp_file_outputs(
 
     replace_mcp_file_fields(output_value, &replacements)?;
 
+    // The new file_upload rows must enter the policy data before the client
+    // fetches their previews after the turn completes.
+    app_state.global_policy_engine.invalidate_data().await;
+
     Ok(image_pointers)
 }
 

--- a/backend/erato/src/state.rs
+++ b/backend/erato/src/state.rs
@@ -60,16 +60,6 @@ impl GlobalPolicyEngine {
         }
     }
 
-    /// Check if the policy data needs rebuilding based on time threshold
-    /// Returns true if data has never been built or if more than the specified duration has passed
-    async fn needs_time_based_rebuild(&self, threshold: Duration) -> bool {
-        let last_rebuild = self.last_rebuild_time.read().await;
-        match *last_rebuild {
-            None => true, // Never been rebuilt
-            Some(instant) => instant.elapsed() > threshold,
-        }
-    }
-
     /// Rebuild data if needed based on time threshold or explicit invalidation
     /// Returns a request-scoped PolicyEngine clone for use in the request handler
     #[instrument(skip_all)]
@@ -79,21 +69,43 @@ impl GlobalPolicyEngine {
         config: &AppConfig,
         time_threshold: Duration,
     ) -> Result<PolicyEngine, Report> {
-        let needs_time_rebuild = self.needs_time_based_rebuild(time_threshold).await;
-
-        if needs_time_rebuild {
-            tracing::debug!("Policy data needs time-based rebuild, rebuilding...");
-            self.engine.rebuild_data(db, config).await?;
-            *self.last_rebuild_time.write().await = Some(Instant::now());
-        } else {
-            // Even if time hasn't elapsed, check if data was explicitly invalidated
-            self.engine.rebuild_data_if_needed(db, config).await?;
+        // The periodic refresh is expressed as an invalidation so it funnels
+        // through the same single-flight rebuild as explicit invalidations.
+        // Claiming the time slot under the write lock keeps concurrent requests
+        // from each scheduling their own refresh.
+        let time_based_refresh_due = {
+            let mut last_rebuild = self.last_rebuild_time.write().await;
+            let due = match *last_rebuild {
+                None => true,
+                Some(instant) => instant.elapsed() > time_threshold,
+            };
+            if due {
+                *last_rebuild = Some(Instant::now());
+            }
+            due
+        };
+        if time_based_refresh_due {
+            tracing::debug!("Policy data due for time-based refresh");
+            self.engine.invalidate_data().await;
         }
+
+        self.engine.rebuild_data_if_needed(db, config).await?;
 
         // Use clone_for_request to create an independent data_needs_rebuild state
         // This prevents invalidate_data() on the global engine from affecting
         // request-scoped clones during request processing
         Ok(self.engine.clone_for_request())
+    }
+
+    /// Rebuild after an invalidation, coalescing with any concurrent rebuild.
+    /// For background tasks, whose request-scoped engine clones cannot observe
+    /// invalidations of the global engine.
+    pub async fn rebuild_data_if_needed(
+        &self,
+        db: &DatabaseConnection,
+        config: &AppConfig,
+    ) -> Result<(), Report> {
+        self.engine.rebuild_data_if_needed(db, config).await
     }
 
     /// Invalidate the policy data, forcing a rebuild on next access

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -1937,6 +1937,7 @@ async fn test_message_submit_with_completed_audio_transcription(pool: Pool<Postg
     let (app_config, _server) = setup_mock_llm_server(Some(mock_config)).await;
     let app_state = test_app_state(app_config, pool).await;
     let db = app_state.db.clone();
+    let global_policy_engine = app_state.global_policy_engine.clone();
 
     let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
         .await
@@ -2009,6 +2010,10 @@ async fn test_message_submit_with_completed_audio_transcription(pool: Pool<Postg
         .await
         .expect("Failed to link audio file upload to chat");
 
+    // The rows were inserted directly; the upload endpoint would have
+    // invalidated the policy data after creating them.
+    global_policy_engine.invalidate_data().await;
+
     let summarize_response = server
         .post("/api/v1beta/me/messages/submitstream")
         .with_bearer_token(TEST_JWT_TOKEN)
@@ -2066,6 +2071,7 @@ async fn test_chat_summary_generated_for_audio_only_first_message(pool: Pool<Pos
     let (app_config, _server) = setup_mock_llm_server(None).await;
     let app_state = test_app_state(app_config, pool).await;
     let db = app_state.db.clone();
+    let global_policy_engine = app_state.global_policy_engine.clone();
 
     let _user = get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
         .await
@@ -2125,6 +2131,10 @@ async fn test_chat_summary_generated_for_audio_only_first_message(pool: Pool<Pos
         .insert(&db)
         .await
         .expect("Failed to link audio file to preliminary chat");
+
+    // The rows were inserted directly; the upload endpoint would have
+    // invalidated the policy data after creating them.
+    global_policy_engine.invalidate_data().await;
 
     // Submit the audio file as the first (and only content) in a BRAND NEW chat.
     // No `user_message` text and no `previous_message_id` — the audio-only first-message


### PR DESCRIPTION
New-chat navigation no longer waits on the policy-data rebuild, and a rebuild failure no longer strands the user outside the created chat.

Kept deliberately minimal — the existing `data_needs_rebuild` flag and `clone_for_request` semantics are unchanged. The generation-counter mechanism rewrite is split out into the stacked follow-up PR.

- The submit task sends `chat_created` first, then rebuilds via the global engine (its request-scoped clone's severed staleness flag cannot see the handler's invalidation). Post-navigation requests wait on the same rebuild in the middleware, so they cannot observe pre-create policy data.
- A single-flight rebuild lock (shared by request clones) with a double-check in `rebuild_data_if_needed`: concurrent stale observers — the submit task and the navigating client's middleware requests — coalesce into one rebuild instead of stampeding.
- Drop the completion-time invalidations: nothing in the policy dataset changes at completion. MCP-extracted files now invalidate at creation.
- The periodic 60s refresh claims its time slot up front, so only one worker per window performs the time-based refresh.