### PR TITLE
Fix cargo-deny for erato_config first-party crate

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -120,6 +120,7 @@ exceptions = [
 
     # First-party Erato Labs crates
     { allow = ["AGPL-3.0-or-later"], crate = "erato" },
+    { allow = ["AGPL-3.0-or-later"], crate = "erato_config" },
     { allow = ["AGPL-3.0-or-later"], crate = "mock-llm-server" },
     { allow = ["AGPL-3.0-or-later"], crate = "mock-mcp-server" },
 


### PR DESCRIPTION
Related #894 