### PR TITLE
Fix on-prem detection for hybrid mailboxes; record Windows sidecar qualification

### DIFF
--- a/desktop-sidecar-protocol/TRANSPORT.md
+++ b/desktop-sidecar-protocol/TRANSPORT.md
@@ -203,14 +203,14 @@ As of 2026-07-21, this environment cannot execute the required Outlook desktop
 hosts. No row below is claimed as qualified, so the candidate URL is opt-in and
 there is no built-in production endpoint.
 
-| Platform/host             | Runtime                 | `http://`  | `https://` | Origin observed | Permissions/prerequisites                                      | Status  |
-| ------------------------- | ----------------------- | ---------- | ---------- | --------------- | -------------------------------------------------------------- | ------- |
-| Windows classic Outlook   | embedded Office browser | Not tested | Not tested | Not captured    | WebView2/legacy runtime must be recorded                       | Pending |
-| Windows new Outlook       | WebView2                | Not tested | Not tested | Not captured    | Loopback exemption and private-network prompts must be checked | Pending |
-| macOS Outlook             | WKWebView               | Not tested | Not tested | Not captured    | Local-network permission and certificate trust must be checked | Pending |
-| Office on the web, Edge   | Chromium                | Not tested | Not tested | Not captured    | Mixed-content and private-network policy must be checked       | Pending |
-| Office on the web, Chrome | Chromium                | Not tested | Not tested | Not captured    | Mixed-content and private-network policy must be checked       | Pending |
-| Office on the web, Safari | WebKit                  | Not tested | Not tested | Not captured    | Local-network permission and certificate trust must be checked | Pending |
+| Platform/host             | Runtime                 | `http://`  | `https://` | Origin observed  | Permissions/prerequisites                                      | Status               |
+| ------------------------- | ----------------------- | ---------- | ---------- | ---------------- | -------------------------------------------------------------- | -------------------- |
+| Windows classic Outlook   | WebView2 150.0.4078.105 | Pass       | Not tested | See record below | None: no loopback exemption, no PNA preflight, no prompts      | Qualified 2026-08-03 |
+| Windows new Outlook       | WebView2                | Not tested | Not tested | Not captured     | Loopback exemption and private-network prompts must be checked | Pending              |
+| macOS Outlook             | WKWebView               | Not tested | Not tested | Not captured     | Local-network permission and certificate trust must be checked | Pending              |
+| Office on the web, Edge   | Chromium                | Not tested | Not tested | Not captured     | Mixed-content and private-network policy must be checked       | Pending              |
+| Office on the web, Chrome | Chromium                | Not tested | Not tested | Not captured     | Mixed-content and private-network policy must be checked       | Pending              |
+| Office on the web, Safari | WebKit                  | Not tested | Not tested | Not captured     | Local-network permission and certificate trust must be checked | Pending              |
 
 Qualification records, for every row:
 
@@ -230,3 +230,33 @@ The acceptance outcome is either one loopback profile that passes every row or
 multiple named profiles behind the unchanged request semantics. Results replace
 the `Pending` cells with tested application/runtime/OS versions, date, outcome,
 and installer prerequisites.
+
+### Qualification record: Windows classic Outlook (2026-08-03)
+
+Environment: Windows 11 Pro build 26200; classic Outlook Version 2607
+(Build 20228.20124 Click-to-Run, Current Channel); WebView2 Runtime
+150.0.4078.105 (`Edg/150.0.0.0`); sidecar 0.1.0; add-in task pane served from
+`https://node.tail1f0fbd.ts.net`; sidecar launched with that origin dev-allowed.
+
+1. CORS preflight and RPC: `OPTIONS` answered `204` with exact-origin
+   `Access-Control-Allow-Origin`, methods `POST`, headers `Content-Type`, and
+   `Cache-Control: no-store`; `POST diagnostics.echo.v1` returned a valid
+   result.
+2. Discovery on a fresh connection produced ready data (`protocolVersion 1.0`,
+   server info, instance ID).
+3. Sequential plus three concurrent echoes with distinct UUID request IDs were
+   served by the same instance with no rediscovery.
+4. Restart recovery: after a sidecar restart, discovery returned a new instance
+   ID. Catalogue-change recovery was not separately exercised (same binary).
+5. Exact values: `Origin: https://node.tail1f0fbd.ts.net`,
+   `Host: 127.0.0.1:23123`.
+6. Mixed content: the HTTPS page fetched `http://127.0.0.1:23123` without a
+   warning or block; Chromium treats loopback as potentially trustworthy.
+7. Private-network handling: Chromium 150 sent no
+   `Access-Control-Request-Private-Network` (the PNA preflight scheme was
+   retired upstream) and showed no local-network permission prompt; plain CORS
+   sufficed. Managed-policy controls were not exercised.
+8. WebView2 loopback exemption: not required; no `CheckNetIsolation` change.
+9. Installer-managed certificate trust: not applicable (plain HTTP loopback).
+10. Hostile rejections, all without CORS headers: forged `Host` → `421`;
+    `Origin: null` → `403`; unlisted origin → `403`; absent origin → `403`.

--- a/office-addin/src/utils/__tests__/detectExchangeOnPrem.test.ts
+++ b/office-addin/src/utils/__tests__/detectExchangeOnPrem.test.ts
@@ -19,16 +19,25 @@ describe("detectExchangeOnPrem", () => {
   });
 
   it.each(["office365", "outlook", "outlookCom", "gmail"])(
-    "treats accountType %s as not on-prem",
+    "treats accountType %s without on-prem endpoints as not on-prem",
     (accountType) => {
       installMailbox({
         userProfile: { accountType },
-        // The URL fallback must not override the authoritative accountType.
-        ewsUrl: "https://mail.corp.example.com/EWS/Exchange.asmx",
+        ewsUrl: "https://outlook.office365.com/EWS/Exchange.asmx",
       });
       expect(detectExchangeOnPrem()).toBe(false);
     },
   );
+
+  it("trusts a non-Microsoft ewsUrl over a cloud accountType", () => {
+    // New Outlook on Mac reports "office365" for a hybrid account whose
+    // mailbox lives on-prem — the endpoint host is the truthful signal.
+    installMailbox({
+      userProfile: { accountType: "office365" },
+      ewsUrl: "https://mail.corp.example.com/EWS/Exchange.asmx",
+    });
+    expect(detectExchangeOnPrem()).toBe(true);
+  });
 
   it("falls back to a non-Microsoft ewsUrl host when accountType is missing", () => {
     installMailbox({

--- a/office-addin/src/utils/detectExchangeOnPrem.ts
+++ b/office-addin/src/utils/detectExchangeOnPrem.ts
@@ -37,16 +37,6 @@ function isMicrosoftCloudHostname(hostname: string): boolean {
   );
 }
 
-/** `accountType` values that are definitively NOT on-prem Exchange:
- * Microsoft-hosted ("office365", consumer "outlookCom") or a non-Exchange
- * backend entirely ("outlook" = classic-desktop-connected, "gmail"). */
-const NON_ON_PREM_ACCOUNT_TYPES = new Set([
-  "office365",
-  "outlook",
-  "outlookCom",
-  "gmail",
-]);
-
 /**
  * Whether the current mailbox is served by an on-prem Exchange (SE) rather
  * than Exchange Online — i.e. whether mail must be fetched via EWS SOAP
@@ -54,13 +44,15 @@ const NON_ON_PREM_ACCOUNT_TYPES = new Set([
  * Graph (Graph can't reach on-prem mailboxes).
  *
  * Signals, in order of authority:
- * (a) `userProfile.accountType`: "enterprise" ⇒ on-prem; any of the known
- *     cloud/non-Exchange values ⇒ not.
- * (b) `accountType` is officially Mailbox 1.6+ and may be absent (the SE probe
- *     on a 1.5-ceiling OWA empirically still returned "enterprise", but we
- *     don't rely on that): fall back to where the mailbox's service endpoints
- *     (`ewsUrl`/`restUrl`) live — a non-Microsoft host means on-prem.
- * (c) No usable signal ⇒ false. Conservative on purpose: better that a cloud
+ * (a) `userProfile.accountType` "enterprise" ⇒ on-prem. Only the positive
+ *     direction is trusted: new Outlook on Mac reports "office365" for a
+ *     hybrid account whose mailbox lives on-prem (the value tracks the
+ *     signed-in Entra identity, not the mailbox host), so a cloud accountType
+ *     must never veto endpoint evidence. The property is also Mailbox 1.6+ and
+ *     may be absent entirely.
+ * (b) Where the mailbox's service endpoints (`ewsUrl`/`restUrl`) live — a
+ *     non-Microsoft host means on-prem.
+ * (c) No on-prem signal ⇒ false. Conservative on purpose: better that a cloud
  *     host falls through to the Graph path than fetching mail via the on-prem
  *     EWS path its host won't broker or issue callback tokens for.
  */
@@ -74,12 +66,8 @@ export function detectExchangeOnPrem(): boolean {
       return false;
     }
 
-    const accountType = mailbox.userProfile?.accountType;
-    if (accountType === "enterprise") {
+    if (mailbox.userProfile?.accountType === "enterprise") {
       return true;
-    }
-    if (accountType && NON_ON_PREM_ACCOUNT_TYPES.has(accountType)) {
-      return false;
     }
 
     for (const serviceUrl of [mailbox.ewsUrl, mailbox.restUrl]) {


### PR DESCRIPTION
Two independent items split out of the `feature/ermain-503-addin-sidecar-thread-fetcher` branch (#892) so that PR stays focused on the sidecar fetcher. Both surfaced during Outlook-on-Mac testing.

## 1. Bug fix — on-prem detection for hybrid mailboxes (`detectExchangeOnPrem`)

New Outlook on Mac reports `accountType: "office365"` for a **hybrid** account whose mailbox actually lives **on-prem** — the value tracks the signed-in Entra identity, not the mailbox host. The previous logic let a cloud `accountType` veto the endpoint evidence, so these mailboxes were misrouted to the Graph path, which cannot reach an on-prem mailbox.

Fix: only the positive `"enterprise" ⇒ on-prem` signal is trusted; otherwise a non-Microsoft `ewsUrl`/`restUrl` host decides. Added a test asserting a non-Microsoft `ewsUrl` wins over a cloud `accountType`; existing cases updated to use cloud endpoints so they still read as not-on-prem. `vitest` → 11/11 pass.

Independent of the sidecar work; belongs on `main` regardless.

## 2. Docs — Windows classic Outlook transport qualification

Fills the Windows classic Outlook row of the `TRANSPORT.md` qualification matrix from live testing: WebView2 150, no Private-Network-Access preflight, no loopback exemption or permission prompt required. The macOS row stays pending and is tracked separately (WKWebView blocks plain-http loopback as mixed content — ERMAIN-522 adds the HTTPS profile).