### PR TITLE
Never let a progress observer break the observed request

### DIFF
--- a/desktop-sidecar-protocol/tests/client.test.ts
+++ b/desktop-sidecar-protocol/tests/client.test.ts
@@ -344,6 +344,30 @@ describe("DesktopSidecarClient", () => {
     expect(client.getSnapshot().state).toBe("ready");
   });
 
+  it("delivers the result even when the progress observer throws", async () => {
+    const { client } = await setup();
+    await client.discover();
+
+    let observations = 0;
+    await expect(
+      client.invoke(
+        "diagnostics.echo.v1",
+        { message: "sturdy", delayMs: 200 },
+        {
+          progress: {
+            intervalMs: 50,
+            onProgress: () => {
+              observations += 1;
+              throw new Error("observer bug");
+            },
+          },
+        },
+      ),
+    ).resolves.toMatchObject({ message: "sturdy" });
+    expect(observations).toBeGreaterThan(0);
+    expect(client.getSnapshot().state).toBe("ready");
+  });
+
   it("cancels a timed-out delayed echo and leaves its final trace observable", async () => {
     const { client } = await setup();
     await client.discover();

--- a/desktop-sidecar-protocol/typescript/src/client.ts
+++ b/desktop-sidecar-protocol/typescript/src/client.ts
@@ -555,7 +555,13 @@ export class DesktopSidecarClient {
       return;
     }
     if (validateSidecarProgressV1Result(result)) {
-      onProgress(result as SidecarProgressV1Result);
+      try {
+        onProgress(result as SidecarProgressV1Result);
+      } catch {
+        // A throwing observer callback must never reject the polling chain:
+        // that would surface inside invoke's cleanup and replace the observed
+        // request's real outcome with the observer's error.
+      }
     }
   }
 


### PR DESCRIPTION
sidecar.progress.v1 polling documents that observation cannot affect the invoked request. In practice, an exception thrown by the caller's onProgress callback rejected the polling chain, and that rejection surfaced inside invoke's cleanup, replacing the request's real outcome with the observer's error. Observer errors are now caught and dropped at the callback boundary, per the documented contract. A faulty observer still sees every progress step it can handle, and the observed request settles with its own result or error.