### PR TITLE
MCP approval follow-up fixes

### DIFF
--- a/backend/mock-llm-server/src/mocks/mod.rs
+++ b/backend/mock-llm-server/src/mocks/mod.rs
@@ -582,6 +582,26 @@ pub fn get_default_mocks() -> Vec<Mock> {
         },
         // Must precede the "Delay" mock: its "delay" pattern also matches "delayed error"
         Mock {
+            // Ordered before every "delay"-substring mock (its trigger
+            // contains "delay") AND before McpApprovalPolicyToolCall (it
+            // contains "mcp approval probe") — matching is first-match
+            // substring over this list.
+            name: "DelayedMcpApprovalPolicyToolCall".to_string(),
+            description:
+                "Approval-required MCP call after 10s of visible generation, to observe the running -> action-required transition"
+                    .to_string(),
+            match_rules: vec![MatchRule::LastMessageIsUserWithPattern(
+                MatchRuleLastMessageIsUserWithPattern {
+                    pattern: "delayed mcp approval probe".to_string(),
+                },
+            )],
+            response: ResponseConfig::ToolCall(ToolCallResponseConfig {
+                tool_name: "publish_approval_probe".to_string(),
+                arguments: "{}".to_string(),
+                delay_ms: 10_000,
+            }),
+        },
+        Mock {
             name: "DelayedContentFilterError".to_string(),
             description: "Returns the content filter error after a 5 second wait".to_string(),
             match_rules: vec![MatchRule::LastMessageIsUserWithPattern(
@@ -913,24 +933,6 @@ pub fn get_default_mocks() -> Vec<Mock> {
                 tool_name: "auth_forwarded_oidc_probe".to_string(),
                 arguments: "{}".to_string(),
                 delay_ms: 100,
-            }),
-        },
-        Mock {
-            // Ordered before McpApprovalPolicyToolCall: its trigger contains
-            // the shorter phrase and matching is first-match substring.
-            name: "DelayedMcpApprovalPolicyToolCall".to_string(),
-            description:
-                "Approval-required MCP call after 10s of visible generation, to observe the running -> action-required transition"
-                    .to_string(),
-            match_rules: vec![MatchRule::LastMessageIsUserWithPattern(
-                MatchRuleLastMessageIsUserWithPattern {
-                    pattern: "delayed mcp approval probe".to_string(),
-                },
-            )],
-            response: ResponseConfig::ToolCall(ToolCallResponseConfig {
-                tool_name: "publish_approval_probe".to_string(),
-                arguments: "{}".to_string(),
-                delay_ms: 10_000,
             }),
         },
         Mock {

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -102,6 +102,7 @@ vi.mock("@/utils/sse/sseClient", () => {
   };
 });
 
+import { useGenerationStatusStore } from "../store/generationStatusStore";
 import { useMessagingStore } from "../store/messagingStore";
 import { useChatMessaging } from "../useChatMessaging";
 
@@ -927,6 +928,56 @@ describe("useChatMessaging", () => {
       { content_type: "text", text: "final answer" },
     ]);
     expect(result.current.isFinalizing).toBe(false);
+  });
+
+  it("marks the chat action-required instead of finished when the turn parks on a tool approval", async () => {
+    useGenerationStatusStore.setState({
+      statusByChatId: {},
+      currentChatId: null,
+    });
+    // Newer than the local running seed's client-clock timestamp, mirroring
+    // the real ordering (the request part is stamped after the send).
+    const requestedAt = new Date(Date.now() + 60_000).toISOString();
+
+    const { startStreaming, sendSSEEvent } = setupChatMessagingTest();
+
+    await startStreaming("delayed mcp approval probe");
+    await sendSSEEvent({
+      message_type: "assistant_message_started",
+      message_id: "assistant-parked-1",
+    });
+    await sendSSEEvent({
+      message_type: "assistant_message_completed",
+      message_id: "assistant-parked-1",
+      message: {
+        id: "assistant-parked-1",
+        role: "assistant",
+        created_at: "2026-02-18T12:00:01.000Z",
+        updated_at: "2026-02-18T12:00:11.000Z",
+        content: [
+          {
+            content_type: "tool_approval_request",
+            tool_call_id: "call-1",
+            tool_name: "publish_approval_probe",
+            mcp_server_id: "mock_mcp_approval",
+            input: {},
+            requested_at: requestedAt,
+            preset: "restrictive",
+            allow_always: true,
+            annotations: {},
+          },
+        ],
+        input_files_ids: [],
+        is_message_in_active_thread: true,
+      },
+    });
+
+    expect(
+      useGenerationStatusStore.getState().statusByChatId["chat1"],
+    ).toMatchObject({
+      kind: "action_required",
+      startedAt: requestedAt,
+    });
   });
 
   it("should force completion refetch via newly created chat id when hook chatId is null", async () => {

--- a/frontend/src/hooks/chat/store/__tests__/generationStatusStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/generationStatusStore.test.ts
@@ -400,6 +400,25 @@ describe("generationStatusStore", () => {
       });
     });
 
+    it("markApprovalDecided consumes a running continuation entry too", () => {
+      store().seedActionRequired("chat-1", iso(0));
+      // A poll observed the decision's continuation running before the
+      // decide call resolved.
+      store().applyPollSnapshot([
+        { chat_id: "chat-1", state: "running", started_at: iso(5_000) },
+      ]);
+      expect(statusOf("chat-1")).toMatchObject({ kind: "running" });
+
+      store().markApprovalDecided("chat-1");
+      expect(statusOf("chat-1")).toMatchObject({ kind: "cleared" });
+
+      // A stale in-flight poll still carrying the continuation loses.
+      store().applyPollSnapshot([
+        { chat_id: "chat-1", state: "running", started_at: iso(5_000) },
+      ]);
+      expect(statusOf("chat-1")).toMatchObject({ kind: "cleared" });
+    });
+
     it("markApprovalDecided tombstones and blocks re-seeding the same marker", () => {
       store().seedActionRequired("chat-1", iso(0));
       store().markApprovalDecided("chat-1");

--- a/frontend/src/hooks/chat/store/generationStatusStore.ts
+++ b/frontend/src/hooks/chat/store/generationStatusStore.ts
@@ -162,7 +162,15 @@ export const useGenerationStatusStore = create<GenerationStatusStore>()(
         set(
           (prev) => {
             const existing = prev.statusByChatId[chatId];
-            if (existing?.kind !== "action_required") {
+            // The decision resolves only after the continuation's stream
+            // closed, and the server persists the terminal outcome before
+            // closing it — so besides the parked entry, a "running" entry a
+            // poll observed for the continuation is also stale by now and
+            // must not be left for grace-gated cleanup.
+            if (
+              existing?.kind !== "action_required" &&
+              existing?.kind !== "running"
+            ) {
               return prev;
             }
             return {

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1015,9 +1015,24 @@ export function useChatMessaging(
               "[DEBUG_STREAMING] processStreamEvent: assistant_message_completed - calling handleRefetchAndClear.",
             );
             if (activeStreamKey !== NEW_CHAT_STREAM_KEY) {
-              useGenerationStatusStore
-                .getState()
-                .markTerminalLocal(activeStreamKey, "finished");
+              // A turn that stopped on a tool approval is parked, not
+              // finished. The server persists awaiting_approval only after
+              // emitting this event, so a completion-triggered refetch can
+              // read the pre-park row — derive the parked state locally from
+              // the final parts (the same last-part invariant the backend
+              // uses) instead of flashing "finished" and idling the poller.
+              const finalParts =
+                responseData.message?.content ?? responseData.content;
+              const lastPart = finalParts?.at(-1);
+              if (lastPart?.content_type === "tool_approval_request") {
+                useGenerationStatusStore
+                  .getState()
+                  .seedActionRequired(activeStreamKey, lastPart.requested_at);
+              } else {
+                useGenerationStatusStore
+                  .getState()
+                  .markTerminalLocal(activeStreamKey, "finished");
+              }
             }
             recentlyCompletedByKeyRef.current[activeStreamKey] = Date.now();
             void handleRefetchAndClear({

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2841,7 +2841,7 @@ msgstr "Ask before running"
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/McpToolApprovalSettings.tsx
 msgid "preferences.dialog.mcpServers.approvals.description"
-msgstr "Tools you chose to always allow from the in-chat confirmation. Remove an entry to be asked again."
+msgstr "Your decisions from the in-chat confirmation are stored here and can be changed any time. They apply to your account on every device."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/McpToolApprovalSettings.tsx
@@ -2851,12 +2851,12 @@ msgstr "No decisions yet. When you choose \"Always allow\" in a chat, the tool a
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/McpToolApprovalSettings.tsx
 msgid "preferences.dialog.mcpServers.approvals.heading"
-msgstr "Always-allowed tools"
+msgstr "Tool approvals"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/McpToolApprovalSettings.tsx
 msgid "preferences.dialog.mcpServers.approvals.loadError"
-msgstr "Could not load always-allowed tools. Please try again."
+msgstr "Could not load tool approvals. Please try again."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/McpToolApprovalSettings.tsx


### PR DESCRIPTION
Four fixes from manual testing that landed on the #918 branch after it was squash-merged, so they never reached main:

- **Mock precedence**: the "delayed mcp approval probe" trigger contains the substring "delay" and was swallowed by the 5s-delay text mock (matching is first-match over the ordered list); reordered above every delay-substring mock.
- **Green flash on park-while-away**: the completed event is emitted before `remove_task` persists `awaiting_approval`, so the origin tab marked the chat finished (green) and idled the poller. The completion handler now applies the backend's last-part invariant: a turn ending in a `tool_approval_request` seeds `action_required` instead.
- **Stale grey after deciding**: the decision's continuation takes a generation lease, so polls truthfully report `running`; `markApprovalDecided` only consumed `action_required` entries and no-opped on the poll-flipped one, leaving a grey pulse for the grace-gated cleanup (or a reload). The tombstone now also consumes `running` — safe because `decide()` resolves only after the stream closes, which is after the terminal outcome is persisted.
- **Stale en catalog**: lingui extraction never overwrites existing `msgstr` for explicit-id entries; the tool-approval heading/description/loadError still carried pre-rework English. Synced to the source defaults