### PR TITLE
Default appointment card and sidecar client identity

### DIFF
--- a/frontend/src/components/ui/Message/EratoAppointmentBlock.test.tsx
+++ b/frontend/src/components/ui/Message/EratoAppointmentBlock.test.tsx
@@ -1,0 +1,83 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { componentRegistry } from "@/config/componentRegistry";
+import { messages as enMessages } from "@/locales/en/messages.json";
+
+import {
+  DefaultEratoAppointmentCodeBlock,
+  EratoAppointmentBlock,
+} from "./EratoAppointmentBlock";
+
+import type { EratoAppointmentCodeBlockProps } from "@/config/componentRegistry";
+import type { Messages } from "@lingui/core";
+
+beforeAll(() => {
+  i18n.load("en", enMessages as unknown as Messages);
+  i18n.activate("en");
+});
+
+const renderBlock = (ui: React.ReactElement) =>
+  render(<I18nProvider i18n={i18n}>{ui}</I18nProvider>);
+
+const VALID_PAYLOAD = JSON.stringify({
+  start: "2026-07-09T10:00:00+02:00",
+  end: "2026-07-09T11:00:00+02:00",
+  subject: "Quarterly sync",
+  attendees: ["ada@example.com"],
+  optionalAttendees: ["grace@example.com"],
+  location: "Room 4",
+});
+
+describe("DefaultEratoAppointmentCodeBlock", () => {
+  it("renders a read-only summary card for a valid payload", () => {
+    renderBlock(<DefaultEratoAppointmentCodeBlock content={VALID_PAYLOAD} />);
+
+    expect(screen.getByText("Suggested appointment")).toBeInTheDocument();
+    expect(screen.getByText("Quarterly sync")).toBeInTheDocument();
+    expect(screen.getByText("Room 4")).toBeInTheDocument();
+    expect(
+      screen.getByText("ada@example.com, grace@example.com"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("When")).toBeInTheDocument();
+  });
+
+  it("shows the raw payload muted when it does not parse", () => {
+    renderBlock(
+      <DefaultEratoAppointmentCodeBlock content={'{"start":"2026-07-'} />,
+    );
+
+    expect(screen.getByText(/"start"/)).toBeInTheDocument();
+    expect(screen.queryByText("Suggested appointment")).toBeNull();
+  });
+
+  it("rejects an inverted time range", () => {
+    const inverted = JSON.stringify({
+      start: "2026-07-09T11:00:00+02:00",
+      end: "2026-07-09T10:00:00+02:00",
+    });
+    renderBlock(<DefaultEratoAppointmentCodeBlock content={inverted} />);
+
+    expect(screen.queryByText("Suggested appointment")).toBeNull();
+  });
+});
+
+describe("EratoAppointmentBlock", () => {
+  it("prefers a registered host renderer over the default card", () => {
+    const original = componentRegistry.EratoAppointmentCodeBlock;
+    function HostAppointmentBlock({ content }: EratoAppointmentCodeBlockProps) {
+      return <div data-testid="host-appointment-block">{content}</div>;
+    }
+    componentRegistry.EratoAppointmentCodeBlock = HostAppointmentBlock;
+    try {
+      renderBlock(<EratoAppointmentBlock content={VALID_PAYLOAD} />);
+
+      expect(screen.getByTestId("host-appointment-block")).toBeInTheDocument();
+      expect(screen.queryByText("Suggested appointment")).toBeNull();
+    } finally {
+      componentRegistry.EratoAppointmentCodeBlock = original;
+    }
+  });
+});

--- a/frontend/src/components/ui/Message/EratoAppointmentBlock.tsx
+++ b/frontend/src/components/ui/Message/EratoAppointmentBlock.tsx
@@ -1,0 +1,173 @@
+import { t } from "@lingui/core/macro";
+import { useMemo } from "react";
+
+import {
+  componentRegistry,
+  resolveComponentOverride,
+} from "@/config/componentRegistry";
+
+import type { EratoAppointmentCodeBlockProps } from "@/config/componentRegistry";
+
+interface AppointmentSummary {
+  subject: string;
+  start: Date;
+  end: Date;
+  attendees: string[];
+  location?: string;
+}
+
+const DATE_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "2-digit", // eslint-disable-line lingui/no-unlocalized-strings
+  minute: "2-digit", // eslint-disable-line lingui/no-unlocalized-strings
+};
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+/**
+ * Mirrors the add-in's payload validation (`parseAppointmentDetails` in the
+ * Outlook composition) so web and add-in agree on which fences are renderable:
+ * parseable start/end and a positive duration.
+ */
+function parseAppointmentSummary(fenceBody: string): AppointmentSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fenceBody.trim());
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const raw = parsed as Record<string, unknown>;
+  if (typeof raw.start !== "string" || typeof raw.end !== "string") {
+    return null;
+  }
+  const start = new Date(raw.start);
+  const end = new Date(raw.end);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return null;
+  }
+  if (end.getTime() <= start.getTime()) {
+    return null;
+  }
+
+  const summary: AppointmentSummary = {
+    subject: typeof raw.subject === "string" ? raw.subject : "",
+    start,
+    end,
+    attendees: [
+      ...toStringArray(raw.attendees),
+      ...toStringArray(raw.optionalAttendees),
+    ],
+  };
+  if (typeof raw.location === "string" && raw.location.trim() !== "") {
+    summary.location = raw.location;
+  }
+  return summary;
+}
+
+function formatWhen(summary: AppointmentSummary): string {
+  const startText = summary.start.toLocaleString(undefined, DATE_TIME_FORMAT);
+  const sameDay = summary.start.toDateString() === summary.end.toDateString();
+  const endText = sameDay
+    ? summary.end.toLocaleTimeString(undefined, {
+        hour: "2-digit", // eslint-disable-line lingui/no-unlocalized-strings
+        minute: "2-digit", // eslint-disable-line lingui/no-unlocalized-strings
+      })
+    : summary.end.toLocaleString(undefined, DATE_TIME_FORMAT);
+  return `${startText} – ${endText}`;
+}
+
+/**
+ * Default fallback for erato-appointment code blocks when no host-specific
+ * renderer is registered: a read-only summary card, so a chat produced by the
+ * add-in's scheduling facet stays legible in the web app and on share links.
+ * The Outlook add-in registers a richer renderer that adds the native
+ * open-appointment action. While the fence is still streaming (or the model
+ * emitted malformed JSON) the raw content renders as a muted block, matching
+ * the add-in renderer's behavior.
+ */
+export function DefaultEratoAppointmentCodeBlock({
+  content,
+}: EratoAppointmentCodeBlockProps) {
+  const summary = useMemo(() => parseAppointmentSummary(content), [content]);
+
+  if (!summary) {
+    return (
+      <div className="my-2 whitespace-pre-wrap rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary p-3 text-sm text-theme-fg-muted">
+        {content}
+      </div>
+    );
+  }
+
+  const rows: { label: string; value: string }[] = [
+    {
+      label: t({ id: "chat.message.appointment.when", message: "When" }),
+      value: formatWhen(summary),
+    },
+    ...(summary.location
+      ? [
+          {
+            label: t({
+              id: "chat.message.appointment.where",
+              message: "Where",
+            }),
+            value: summary.location,
+          },
+        ]
+      : []),
+    ...(summary.attendees.length > 0
+      ? [
+          {
+            label: t({
+              id: "chat.message.appointment.attendees",
+              message: "Attendees",
+            }),
+            value: summary.attendees.join(", "),
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <div className="my-2 rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary p-3">
+      <p className="text-xs uppercase tracking-wide text-theme-fg-muted">
+        {t({
+          id: "chat.message.appointment.suggested",
+          message: "Suggested appointment",
+        })}
+      </p>
+      {summary.subject ? (
+        <p className="mt-1 text-sm font-medium text-theme-fg-primary">
+          {summary.subject}
+        </p>
+      ) : null}
+      <dl className="mt-2 space-y-1 text-sm">
+        {rows.map((row) => (
+          <div key={row.label} className="flex gap-2">
+            <dt className="shrink-0 text-theme-fg-muted">{row.label}</dt>
+            <dd className="min-w-0 break-words text-theme-fg-secondary">
+              {row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+/** erato-appointment fence renderer: the host override or the default card. */
+export function EratoAppointmentBlock(props: EratoAppointmentCodeBlockProps) {
+  const Renderer = resolveComponentOverride(
+    componentRegistry.EratoAppointmentCodeBlock,
+    DefaultEratoAppointmentCodeBlock,
+  );
+  return <Renderer {...props} />;
+}

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -1012,7 +1012,23 @@ describe("MessageContent", () => {
     }
   });
 
-  it("keeps erato-appointment fences as plain code blocks without a registered renderer", () => {
+  it("renders the default summary card without a registered renderer", () => {
+    const { container } = renderWithTheme(
+      <MessageContent
+        content={textContent(
+          '```erato-appointment\n{"start":"2026-07-09T10:00:00+02:00","end":"2026-07-09T11:00:00+02:00","subject":"Quarterly sync"}\n```',
+        )}
+      />,
+    );
+
+    expect(screen.getByText("Quarterly sync")).toBeInTheDocument();
+    expect(screen.getByText("Suggested appointment")).toBeInTheDocument();
+    expect(
+      container.querySelector("pre.message-content-code-block"),
+    ).toBeNull();
+  });
+
+  it("shows the raw payload muted while an erato-appointment fence is incomplete", () => {
     const { container } = renderWithTheme(
       <MessageContent
         content={textContent(
@@ -1021,9 +1037,11 @@ describe("MessageContent", () => {
       />,
     );
 
+    expect(screen.getByText(/"start"/)).toBeInTheDocument();
+    expect(screen.queryByText("Suggested appointment")).toBeNull();
     expect(
-      container.querySelector("pre.message-content-code-block code"),
-    ).toHaveTextContent('"start"');
+      container.querySelector("pre.message-content-code-block"),
+    ).toBeNull();
   });
 
   it("does NOT whole-body-fallback for review_draft (feedback stays markdown)", () => {

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -17,11 +17,11 @@ import {
   DEFAULT_LIGHT_CODE_HIGHLIGHT_PRESET,
   resolvePrismCodeTheme,
 } from "@/config/codeHighlightThemes";
-import { componentRegistry } from "@/config/componentRegistry";
 import { useOptionalTranslation } from "@/hooks/i18n";
 import { useTraceFeature } from "@/providers/FeatureConfigProvider";
 import { FileTypeUtil } from "@/utils/fileTypes";
 
+import { EratoAppointmentBlock } from "./EratoAppointmentBlock";
 import { EratoEmailSuggestion } from "./EratoEmailSuggestion";
 import { ImageContentDisplay } from "./ImageContentDisplay";
 import { McpToolApprovalCard } from "./McpToolApprovalCard";
@@ -164,15 +164,12 @@ type MarkdownPreProps = React.ComponentPropsWithoutRef<"pre"> & {
 };
 
 /**
- * The `erato-appointment` fence renders as a card only when a host registered
- * a renderer for it (the Outlook add-in); otherwise it stays a plain code
- * block, exactly like before the registry key existed.
+ * The `erato-appointment` fence (the JSON payload a scheduling facet's
+ * confirm step emits) always renders as a card: a host-registered renderer
+ * when present (the Outlook add-in), otherwise the read-only default summary.
  */
 function isEratoAppointmentLanguage(language: string): boolean {
-  return (
-    language === "erato-appointment" &&
-    componentRegistry.EratoAppointmentCodeBlock !== null
-  );
+  return language === "erato-appointment";
 }
 
 function isCardCodeChild(
@@ -309,9 +306,8 @@ function MarkdownCode({
     );
   }
 
-  const AppointmentBlock = componentRegistry.EratoAppointmentCodeBlock;
-  if (isBlockCode && AppointmentBlock && isEratoAppointmentLanguage(language)) {
-    return <AppointmentBlock content={codeContent} />;
+  if (isBlockCode && isEratoAppointmentLanguage(language)) {
+    return <EratoAppointmentBlock content={codeContent} />;
   }
 
   if (isBlockCode) {

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -189,7 +189,8 @@ export interface ComponentRegistry {
    * Used by the Office addin to render the appointment summary + confirm
    * card that opens a prefilled Outlook appointment form.
    *
-   * When null, `erato-appointment` blocks render as a plain code block.
+   * When null, `erato-appointment` blocks render as the shared read-only
+   * summary card (`DefaultEratoAppointmentCodeBlock`).
    */
   EratoAppointmentCodeBlock: ComponentType<EratoAppointmentCodeBlockProps> | null;
 }

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -42,6 +42,10 @@ export {
   DefaultEratoEmailCodeBlock,
   EratoEmailSuggestion,
 } from "@/components/ui/Message/EratoEmailSuggestion";
+export {
+  DefaultEratoAppointmentCodeBlock,
+  EratoAppointmentBlock,
+} from "@/components/ui/Message/EratoAppointmentBlock";
 export { ImageContentDisplay } from "@/components/ui/Message/ImageContentDisplay";
 export {
   Trace,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -145,7 +145,10 @@ export type {
   OutlookConversationMessage,
   OutlookMessageBody,
   OutlookMessageRecipient,
+  SidecarClientInfo,
 } from "@erato/desktop-sidecar-protocol";
+// Host compositions build their sidecar identity with this.
+export { createBrowserClientInfo } from "@erato/desktop-sidecar-protocol";
 export {
   FileCapabilitiesProvider,
   useFileCapabilitiesContext,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1411,6 +1411,26 @@ msgid "chat.message.action_facet.selection_label"
 msgstr "Auswahl"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.attendees"
+msgstr "Teilnehmer"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.suggested"
+msgstr "Vorgeschlagener Termin"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.when"
+msgstr "Wann"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.where"
+msgstr "Wo"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.aria"
 msgstr "Nachricht"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1411,6 +1411,26 @@ msgid "chat.message.action_facet.selection_label"
 msgstr "Selection"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.attendees"
+msgstr "Attendees"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.suggested"
+msgstr "Suggested appointment"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.when"
+msgstr "When"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.where"
+msgstr "Where"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.aria"
 msgstr "message"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1411,6 +1411,26 @@ msgid "chat.message.action_facet.selection_label"
 msgstr "Selección"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.attendees"
+msgstr "Asistentes"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.suggested"
+msgstr "Cita sugerida"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.when"
+msgstr "Cuándo"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.where"
+msgstr "Dónde"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.aria"
 msgstr "mensaje"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1411,6 +1411,26 @@ msgid "chat.message.action_facet.selection_label"
 msgstr "Sélection"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.attendees"
+msgstr "Participants"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.suggested"
+msgstr "Rendez-vous suggéré"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.when"
+msgstr "Quand"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.where"
+msgstr "Où"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.aria"
 msgstr "message"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1411,6 +1411,26 @@ msgid "chat.message.action_facet.selection_label"
 msgstr "Zaznaczenie"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.attendees"
+msgstr "Uczestnicy"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.suggested"
+msgstr "Proponowany termin"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.when"
+msgstr "Kiedy"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/EratoAppointmentBlock.tsx
+msgid "chat.message.appointment.where"
+msgstr "Gdzie"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
 msgid "chat.message.aria"
 msgstr "wiadomość"

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -164,6 +164,8 @@ export type { ActionConfirmationStatus } from "@/components/ui/Message/ActionCon
 export { ACTION_FACET_ARG_KEYS } from "@/components/ui/Message/ActionFacetContext";
 export { ActionFacetContext } from "@/components/ui/Message/ActionFacetContext";
 export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
+export { DefaultEratoAppointmentCodeBlock } from "@/components/ui/Message/EratoAppointmentBlock";
+export { EratoAppointmentBlock } from "@/components/ui/Message/EratoAppointmentBlock";
 export { DefaultEratoEmailCodeBlock } from "@/components/ui/Message/EratoEmailSuggestion";
 export { EratoEmailSuggestion } from "@/components/ui/Message/EratoEmailSuggestion";
 export { ImageContentDisplay } from "@/components/ui/Message/ImageContentDisplay";

--- a/office-addin/src/core/SharedAddinShell.tsx
+++ b/office-addin/src/core/SharedAddinShell.tsx
@@ -5,6 +5,7 @@ import {
   I18nProvider,
   ThemeProvider,
   Toaster,
+  type SidecarClientInfo,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 
@@ -76,9 +77,19 @@ export const SHARED_ADDIN_FEATURE_CONFIG = {
  * authentication providers are deliberately supplied as children so loading
  * this module never initializes Office.js (or a future Teams SDK).
  */
-export function SharedAddinShell({ children }: { children: ReactNode }) {
+export function SharedAddinShell({
+  children,
+  sidecarClientInfo,
+}: {
+  children: ReactNode;
+  /**
+   * Sidecar identity for this host composition. Without it the provider's
+   * legacy platform sniff reports every add-in host as the Office add-in.
+   */
+  sidecarClientInfo?: SidecarClientInfo;
+}) {
   return (
-    <DesktopSidecarProvider>
+    <DesktopSidecarProvider clientInfo={sidecarClientInfo}>
       <I18nProvider>
         <ThemeProvider enableCustomTheme persistThemeMode={true}>
           <FeatureConfigProvider config={SHARED_ADDIN_FEATURE_CONFIG}>

--- a/office-addin/src/outlook/OutlookApp.tsx
+++ b/office-addin/src/outlook/OutlookApp.tsx
@@ -1,4 +1,7 @@
-import { FeatureConfigProvider } from "@erato/frontend/library";
+import {
+  FeatureConfigProvider,
+  createBrowserClientInfo,
+} from "@erato/frontend/library";
 
 import { OutlookAddinChatPage } from "./OutlookAddinChatPage";
 import { installOutlookComponentRegistrations } from "./installOutlookComponentRegistrations";
@@ -16,6 +19,14 @@ import { OutlookMailItemProvider } from "./providers/OutlookMailItemProvider";
 // The route module resolves before React renders its default export. Registry
 // consumers can therefore memoize safely on their first render.
 installOutlookComponentRegistrations();
+
+// Same identity the sidecar provider's legacy platform sniff produced, so the
+// wire contract to the sidecar is unchanged.
+const OUTLOOK_SIDECAR_CLIENT_INFO = createBrowserClientInfo({
+  name: "erato-office-addin",
+  version: import.meta.env.VITE_APP_VERSION ?? "unversioned",
+  hostApplication: "Microsoft Office add-in",
+});
 
 function OutlookProviders({ children }: { children: React.ReactNode }) {
   const { host } = useOffice();
@@ -49,7 +60,7 @@ function OutlookFeatureConfig({ children }: { children: React.ReactNode }) {
 
 export default function OutlookApp() {
   return (
-    <SharedAddinShell>
+    <SharedAddinShell sidecarClientInfo={OUTLOOK_SIDECAR_CLIENT_INFO}>
       <OfficeProvider>
         <OutlookFeatureConfig>
           <OfficeThemeProvider>


### PR DESCRIPTION
Stacked on #922 — library-side follow-ups from the ERMAIN-540 architecture review (ERMAIN-544, ERMAIN-545).

- **ERMAIN-544**: `erato-appointment` fences now render a read-only default summary card (subject / when / where / attendees) in the web app and share links instead of raw JSON. Validation mirrors the add-in's parser; the Outlook renderer still overrides via the registry; resolution goes through `resolveComponentOverride`. Raw payload renders muted while streaming/malformed.
- **ERMAIN-545**: `SharedAddinShell` gains a `sidecarClientInfo` prop and Outlook passes its identity explicitly (wire-identical to the legacy platform sniff), so a future Teams host can't masquerade as the Office add-in to the desktop sidecar. `createBrowserClientInfo`/`SidecarClientInfo` exported on the library barrel.

Gates: frontend + office-addin lint/typecheck/prettier green, targeted frontend tests (56) and full add-in suite (738) passing, i18n catalogs extracted with translations for all new ids