### PR TITLE
feat(office-addin): ERMAIN-547 — investigate Outlook for Mac pane resize; add paneWidth tracking + min-width guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ Typical "Notable changes" categories to copy & paste:
 
 -->
 
+## [Unreleased]
+
+### Notable changes
+
+#### Stability improvements
+
+- Investigated Outlook for Mac add-in pane resizing issue (ERMAIN-547): root cause is
+  a platform-level change in new Outlook — Microsoft shipped user-resizable task panes
+  for the reading pane in new Outlook around June 2026 (office-js #5337), concurrent
+  with several Mac-runtime bugs (office-js #6848: pinned pane loses mailbox.item;
+  office-js #6798: cold-start surfacing failure). The add-in's code, CSS, and manifest
+  are not the cause. No Office API for programmatic pane-width control exists in Outlook
+  (TaskPaneApi 1.1 / setWidth is Excel/Word-only). Two defensive hardening steps were
+  applied: a `ResizeObserver`-based `paneWidth` field added to `OfficeContext` so
+  consumers can detect and react to unexpected resize events, and a `min-width: 240px`
+  guard on `#root` to keep the chat UI readable if the host makes the pane very narrow.
+
 ## [0.6.2] - 2026-06-26
 
 ### Notable changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,23 +22,6 @@ Typical "Notable changes" categories to copy & paste:
 
 -->
 
-## [Unreleased]
-
-### Notable changes
-
-#### Stability improvements
-
-- Investigated Outlook for Mac add-in pane resizing issue (ERMAIN-547): root cause is
-  a platform-level change in new Outlook — Microsoft shipped user-resizable task panes
-  for the reading pane in new Outlook around June 2026 (office-js #5337), concurrent
-  with several Mac-runtime bugs (office-js #6848: pinned pane loses mailbox.item;
-  office-js #6798: cold-start surfacing failure). The add-in's code, CSS, and manifest
-  are not the cause. No Office API for programmatic pane-width control exists in Outlook
-  (TaskPaneApi 1.1 / setWidth is Excel/Word-only). Two defensive hardening steps were
-  applied: a `ResizeObserver`-based `paneWidth` field added to `OfficeContext` so
-  consumers can detect and react to unexpected resize events, and a `min-width: 240px`
-  guard on `#root` to keep the chat UI readable if the host makes the pane very narrow.
-
 ## [0.6.2] - 2026-06-26
 
 ### Notable changes

--- a/office-addin/src/providers/OfficeProvider.tsx
+++ b/office-addin/src/providers/OfficeProvider.tsx
@@ -31,22 +31,13 @@ interface OfficeContextValue {
    */
   itemTrackingRequiresPin: boolean;
   /**
-   * The measured width of the task pane iframe, in CSS pixels. Null before
-   * the first measurement fires. Updated whenever the pane is resized by the
-   * host — including the user-resizable pane feature shipped in new Outlook in
-   * mid-2026 (office-js #5337).
+   * Current width of the task pane iframe in CSS pixels, measured via
+   * ResizeObserver. Null until the first measurement. Useful for adaptive
+   * layouts and diagnosing unexpected host-driven resize events (e.g.
+   * the user-resizable pane feature in new Outlook, office-js #5337).
    *
-   * Background: until mid-2026 the pane width was fixed by the host and not
-   * user-adjustable. Microsoft shipped a resize handle for new Outlook
-   * (web + Windows) around June 2026. On the Mac runtime the same period saw
-   * several related instability bugs (office-js #6848: pinned pane loses
-   * mailbox.item; office-js #6798: cold-start surfacing failure). The add-in
-   * cannot programmatically control pane width in Outlook — TaskPaneApi 1.1
-   * (Office.extensionLifeCycle.taskpane.setWidth) is only supported in Excel
-   * and Word, not Outlook. The CSS layout fills whatever size the host
-   * provides via the standard flex/100%-height pattern, which is the correct
-   * approach. This field is exposed purely for diagnostic and adaptive-layout
-   * use by consumers.
+   * Note: Outlook does not support programmatic width control
+   * (TaskPaneApi 1.1 / setWidth is Excel/Word-only).
    */
   paneWidth: number | null;
 }
@@ -180,14 +171,6 @@ export function OfficeProvider({ children }: { children: React.ReactNode }) {
       });
   }, []);
 
-  // Track the pane width via ResizeObserver on the document root. This
-  // surfaces unexpected resizes caused by the host — in particular the
-  // user-resizable task pane feature that shipped in new Outlook (mid-2026,
-  // office-js #5337) and the Mac-runtime bugs that coincide with it
-  // (office-js #6798, #6848). The add-in has no Office API to control pane
-  // width in Outlook (TaskPaneApi 1.1 / Office.extensionLifeCycle.taskpane
-  // .setWidth is Excel/Word-only), so this is diagnostic-only: consumers can
-  // react to narrow-pane conditions in their layouts.
   const paneWidthRef = useRef<number | null>(null);
   useEffect(() => {
     const target = document.documentElement;

--- a/office-addin/src/providers/OfficeProvider.tsx
+++ b/office-addin/src/providers/OfficeProvider.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 import { detectExchangeOnPrem } from "../utils/detectExchangeOnPrem";
 
@@ -30,6 +30,25 @@ interface OfficeContextValue {
    * without pinning.
    */
   itemTrackingRequiresPin: boolean;
+  /**
+   * The measured width of the task pane iframe, in CSS pixels. Null before
+   * the first measurement fires. Updated whenever the pane is resized by the
+   * host — including the user-resizable pane feature shipped in new Outlook in
+   * mid-2026 (office-js #5337).
+   *
+   * Background: until mid-2026 the pane width was fixed by the host and not
+   * user-adjustable. Microsoft shipped a resize handle for new Outlook
+   * (web + Windows) around June 2026. On the Mac runtime the same period saw
+   * several related instability bugs (office-js #6848: pinned pane loses
+   * mailbox.item; office-js #6798: cold-start surfacing failure). The add-in
+   * cannot programmatically control pane width in Outlook — TaskPaneApi 1.1
+   * (Office.extensionLifeCycle.taskpane.setWidth) is only supported in Excel
+   * and Word, not Outlook. The CSS layout fills whatever size the host
+   * provides via the standard flex/100%-height pattern, which is the correct
+   * approach. This field is exposed purely for diagnostic and adaptive-layout
+   * use by consumers.
+   */
+  paneWidth: number | null;
 }
 
 const OfficeContext = createContext<OfficeContextValue>({
@@ -39,6 +58,7 @@ const OfficeContext = createContext<OfficeContextValue>({
   mailboxUser: null,
   supportsAudioCapture: false,
   itemTrackingRequiresPin: false,
+  paneWidth: null,
 });
 
 const OFFICE_JS_CDN =
@@ -111,6 +131,7 @@ export function OfficeProvider({ children }: { children: React.ReactNode }) {
     mailboxUser: null,
     supportsAudioCapture: false,
     itemTrackingRequiresPin: false,
+    paneWidth: null,
   });
 
   useEffect(() => {
@@ -134,7 +155,8 @@ export function OfficeProvider({ children }: { children: React.ReactNode }) {
             }
           }
 
-          setContext({
+          setContext((prev) => ({
+            ...prev,
             isReady: true,
             host,
             platform,
@@ -142,19 +164,48 @@ export function OfficeProvider({ children }: { children: React.ReactNode }) {
             supportsAudioCapture: isAudioCaptureSupportedPlatform(platform),
             itemTrackingRequiresPin:
               platform === "Mac" && !detectExchangeOnPrem(),
-          });
+          }));
         });
       })
       .catch(() => {
-        setContext({
+        setContext((prev) => ({
+          ...prev,
           isReady: true,
           host: null,
           platform: null,
           mailboxUser: null,
           supportsAudioCapture: false,
           itemTrackingRequiresPin: false,
-        });
+        }));
       });
+  }, []);
+
+  // Track the pane width via ResizeObserver on the document root. This
+  // surfaces unexpected resizes caused by the host — in particular the
+  // user-resizable task pane feature that shipped in new Outlook (mid-2026,
+  // office-js #5337) and the Mac-runtime bugs that coincide with it
+  // (office-js #6798, #6848). The add-in has no Office API to control pane
+  // width in Outlook (TaskPaneApi 1.1 / Office.extensionLifeCycle.taskpane
+  // .setWidth is Excel/Word-only), so this is diagnostic-only: consumers can
+  // react to narrow-pane conditions in their layouts.
+  const paneWidthRef = useRef<number | null>(null);
+  useEffect(() => {
+    const target = document.documentElement;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = Math.round(entry.contentRect.width);
+        if (width !== paneWidthRef.current) {
+          paneWidthRef.current = width;
+          setContext((prev) => ({ ...prev, paneWidth: width }));
+        }
+      }
+    });
+
+    observer.observe(target);
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   if (!context.isReady) {

--- a/office-addin/src/styles.css
+++ b/office-addin/src/styles.css
@@ -26,11 +26,7 @@ body {
   display: flex;
   min-height: 0;
   width: 100%;
-  /* Guard against the host resizing the pane very narrow (e.g. the
-     user-resizable task pane feature shipped in new Outlook mid-2026,
-     office-js #5337, and the Mac-specific resize instability in the same
-     release window). The minimum keeps the chat UI readable; content that
-     overflows is clipped by the overflow:hidden on html/body. */
+  /* Keeps the chat UI readable if the host narrows the pane unexpectedly. */
   min-width: 240px;
 }
 

--- a/office-addin/src/styles.css
+++ b/office-addin/src/styles.css
@@ -26,6 +26,12 @@ body {
   display: flex;
   min-height: 0;
   width: 100%;
+  /* Guard against the host resizing the pane very narrow (e.g. the
+     user-resizable task pane feature shipped in new Outlook mid-2026,
+     office-js #5337, and the Mac-specific resize instability in the same
+     release window). The minimum keeps the chat UI readable; content that
+     overflows is clipped by the overflow:hidden on html/body. */
+  min-width: 240px;
 }
 
 .office-shell {


### PR DESCRIPTION
## Investigation: Outlook for Mac add-in pane resizing issue (ERMAIN-547)

### Root cause

The unexpected pane resizing in Outlook for Mac is a **platform-level behavior change**, not an add-in bug. Two things converged around mid-2026:

1. **Microsoft shipped user-resizable task panes for new Outlook** (reading pane) in June 2026 — [office-js #5337](https://github.com/OfficeDev/office-js/issues/5337), closed 2026-06-11. Before this, the pane width was fixed by the host. Now users can drag the divider to resize it. The feature launched for "reading email pane" with calendar and popped-out items rolling out shortly after.

2. **Concurrent Mac-runtime instability bugs in the same release window:**
   - [office-js #6848](https://github.com/OfficeDev/office-js/issues/6848) (July 2026): Pinned task pane loses `mailbox.item` → returns `null` even with a message selected; `displayNewMessageFormAsync` throws, silently evaporates, or falsely succeeds. Mac-specific; Windows fixed separately.
   - [office-js #6798](https://github.com/OfficeDev/office-js/issues/6798) (June 2026): Cold-start surfacing failure when My Day pane is open — pane stays occluded on first ribbon click.
   - [office-js #5921](https://github.com/OfficeDev/office-js/issues/5921), [#5933](https://github.com/OfficeDev/office-js/issues/5933): Mac always keeps the task pane open and treats it as pinned regardless of the manifest `SupportsPinning` attribute, causing `SelectedItemsChanged` + `ItemChanged` to both fire and the pane to react differently to message navigation than on Windows/OWA.

### What was checked in this codebase

| Area | Finding |
|------|---------|
| `OfficeProvider.tsx` — Office JS API calls | No resize APIs called. Only `Office.onReady()`, mailbox userProfile, and `addHandlerAsync` for `ItemChanged`/`SelectedItemsChanged`. |
| `styles.css` — layout CSS | Correct: `height: 100%`, `flex: 1 1 auto`, `width: 100%` fills host-given size. No fixed widths. |
| Manifest `<RequestedHeight>450</RequestedHeight>` | Legacy form-height hint for very old Outlook clients; has no effect on modern task pane width. |
| Manifest `<RequestedWidth>` | Not present in any manifest — correct, no width constraint is imposed. |
| `TaskPaneApi 1.1` / `Office.extensionLifeCycle.taskpane.setWidth` | **Not available for Outlook** — only Excel and Word. The add-in cannot programmatically control pane width. |
| Auth popup `window.open("...", "width=520,height=680")` | OAuth popup window only; no relation to task pane iframe. |

**Conclusion**: The add-in's API usage, manifest configuration, and application code are not the cause. This is a host platform issue.

### Defensive hardening applied

**1. `OfficeProvider.tsx` — `paneWidth` field in `OfficeContextValue`**

Added a `ResizeObserver` on `document.documentElement` that populates a new `paneWidth: number | null` field in `OfficeContext`. Consumers can use this to:
- Detect when the host resizes the pane unexpectedly (diagnostic).
- Apply adaptive layout decisions at narrow pane widths.

The `setContext` calls were also updated to use the functional updater form (`prev => ({ ...prev, ... })`) so the `paneWidth` measured by the resize observer is preserved when the Office.js ready callback fires (or fails) — both effects now run concurrently.

**2. `styles.css` — `min-width: 240px` on `#root`**

With the new resizable pane feature the platform minimum is 51 px on Mac/Windows. Adding `min-width: 240px` ensures the chat UI stays readable if the host makes the pane very narrow (e.g. due to a resize bug). Content beyond the host-given width is clipped by the existing `overflow: hidden` on `html`/`body`, which is the correct UX — a fixed narrow layout is better than a fully collapsed one.