### PR TITLE
Treat cloud.microsoft endpoints as Exchange Online

### DIFF
--- a/office-addin/src/utils/__tests__/detectExchangeOnPrem.test.ts
+++ b/office-addin/src/utils/__tests__/detectExchangeOnPrem.test.ts
@@ -29,6 +29,17 @@ describe("detectExchangeOnPrem", () => {
     },
   );
 
+  it("treats the unified cloud.microsoft endpoints as Exchange Online", () => {
+    // Outlook on the web reports outlook.cloud.microsoft service URLs on
+    // migrated tenants; misclassifying them as on-prem vetoes NAA.
+    installMailbox({
+      userProfile: { accountType: "office365" },
+      ewsUrl: "https://outlook.cloud.microsoft/EWS/Exchange.asmx",
+      restUrl: "https://outlook.cloud.microsoft/api",
+    });
+    expect(detectExchangeOnPrem()).toBe(false);
+  });
+
   it("trusts a non-Microsoft ewsUrl over a cloud accountType", () => {
     // New Outlook on Mac reports "office365" for a hybrid account whose
     // mailbox lives on-prem — the endpoint host is the truthful signal.

--- a/office-addin/src/utils/detectExchangeOnPrem.ts
+++ b/office-addin/src/utils/detectExchangeOnPrem.ts
@@ -20,6 +20,9 @@
  * EWS/REST URL on any of these belongs to a cloud mailbox; any other host is
  * treated as customer-hosted (on-prem) Exchange. `.partner.outlook.cn` is
  * already covered by `.outlook.cn` but listed to document the full set.
+ * `.cloud.microsoft` is the unified domain Microsoft is migrating M365
+ * endpoints to; Outlook on the web reports `outlook.cloud.microsoft` service
+ * URLs for EXO mailboxes on migrated tenants.
  */
 const MICROSOFT_CLOUD_HOST_SUFFIXES = [
   ".office.com",
@@ -28,6 +31,7 @@ const MICROSOFT_CLOUD_HOST_SUFFIXES = [
   ".office365.us",
   ".outlook.cn",
   ".partner.outlook.cn",
+  ".cloud.microsoft",
 ];
 
 function isMicrosoftCloudHostname(hostname: string): boolean {


### PR DESCRIPTION
Fixes ERMAIN-548. Live-reproduced on an EXO mailbox in Outlook on the web: `Office.context.mailbox.ewsUrl`/`restUrl` now report `https://outlook.cloud.microsoft/...` — Microsoft's unified `cloud.microsoft` domain rolling out to OWA. `detectExchangeOnPrem()`'s cloud-suffix allowlist didn't include it, so EXO mailboxes in OWA were classified as on-prem, which (a) triggered the #730 NAA veto — the add-in silently fell back to the oauth2-proxy path and `EntraGraphTokenProvider` never mounted — and (b) routed the mail data plane to EWS instead of Graph. Desktop clients still report `outlook.office365.com` endpoints, hence the OWA-only symptom.

One-line allowlist addition plus a regression test. Verified: probe values from the live OWA session (`isSetSupported("NestedAppAuth","1.1") === true`, `accountType === "office365"`, endpoints on `outlook.cloud.microsoft`); 12/12 detection tests green, eslint/prettier/tsc clean