### PR TITLE
fix(eml-preview): recover PDF MIME type from extension when email declares octet-stream (ERMAIN-550)

### DIFF
--- a/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
@@ -392,7 +392,9 @@ describe("EmlPreview", () => {
 
     // The PDF attachment blob should be typed as application/pdf so browsers
     // can render it inline rather than triggering a download.
-    const pdfBlob = blobUrlContent.get(createdBlobUrls[createdBlobUrls.length - 1]);
+    const pdfBlob = blobUrlContent.get(
+      createdBlobUrls[createdBlobUrls.length - 1],
+    );
     expect(pdfBlob?.type).toBe("application/pdf");
   });
 

--- a/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
@@ -22,6 +22,16 @@ const stringToBuffer = (s: string): ArrayBuffer => {
   return copy.buffer;
 };
 
+// jsdom implements neither `Blob.prototype.arrayBuffer` nor `.text`, so
+// FileReader is the only route from a Blob back to its bytes.
+const blobToArrayBuffer = (blob: Blob): Promise<ArrayBuffer> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.readAsArrayBuffer(blob);
+  });
+
 const mockFetchEml = (bytes: ArrayBuffer | string) => {
   const buffer = typeof bytes === "string" ? stringToBuffer(bytes) : bytes;
   global.fetch = vi.fn(async (input: RequestInfo | URL) => {
@@ -32,7 +42,7 @@ const mockFetchEml = (bytes: ArrayBuffer | string) => {
       return {
         ok: true,
         status: 200,
-        arrayBuffer: async () => blob.arrayBuffer(),
+        arrayBuffer: async () => blobToArrayBuffer(blob),
       } as Response;
     }
     return {
@@ -186,6 +196,43 @@ const PDF_OCTET_STREAM_EML = [
   "",
   MINIMAL_PDF_B64,
   "--BOUND--",
+  "",
+].join("\r\n");
+
+// Mirrors the bundle the add-in's `synthesizeThreadEml` emits: nested
+// message/rfc822 parts each carrying their own attachments. Those attachment
+// content types come from Graph/EWS and are stamped `application/octet-stream`
+// whenever the provider omits one, so a re-attached PDF arrives mis-typed.
+const THREAD_OCTET_STREAM_PDF_EML = [
+  "Subject: Re: Kickoff",
+  "Date: Mon, 18 May 2026 10:00:00 +0000",
+  "MIME-Version: 1.0",
+  'Content-Type: multipart/mixed; boundary="OUTER"',
+  "",
+  "--OUTER",
+  "Content-Type: message/rfc822",
+  'Content-Disposition: attachment; filename="msg-1.eml"',
+  "",
+  "From: Alice <alice@example.com>",
+  "Subject: Kickoff",
+  "Date: Mon, 11 May 2026 09:00:00 +0000",
+  "MIME-Version: 1.0",
+  'Content-Type: multipart/mixed; boundary="INNER"',
+  "",
+  "--INNER",
+  'Content-Type: text/plain; charset="utf-8"',
+  "",
+  "Report attached.",
+  "",
+  "--INNER",
+  "Content-Type: application/octet-stream",
+  'Content-Disposition: attachment; filename="report.pdf"',
+  "Content-Transfer-Encoding: base64",
+  "",
+  MINIMAL_PDF_B64,
+  "--INNER--",
+  "",
+  "--OUTER--",
   "",
 ].join("\r\n");
 
@@ -381,10 +428,9 @@ describe("EmlPreview", () => {
   });
 
   it("creates the attachment blob with application/pdf type when the email declares application/octet-stream", async () => {
-    // ERMAIN-550: emails that mis-declare a PDF as `application/octet-stream`
-    // caused the browser to download the blob URL (with a UUID filename) instead
-    // of rendering the PDF inline. The fix recovers the type from the filename
-    // extension before creating the blob.
+    // A blob URL typed `application/octet-stream` is downloaded rather than
+    // rendered by the iframe, and blob URLs carry no filename — so the user
+    // gets a bare UUID on disk instead of a preview.
     mockFetchEml(PDF_OCTET_STREAM_EML);
     renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
 
@@ -398,7 +444,7 @@ describe("EmlPreview", () => {
     expect(pdfBlob?.type).toBe("application/pdf");
   });
 
-  it("still opens an octet-stream PDF in the inline PDF viewer (ERMAIN-550 regression guard)", async () => {
+  it("still opens an octet-stream PDF in the inline PDF viewer", async () => {
     mockFetchEml(PDF_OCTET_STREAM_EML);
     renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
 
@@ -411,5 +457,20 @@ describe("EmlPreview", () => {
     // FilePreviewContent should route to the PDF iframe, not the
     // "preview unavailable" fallback.
     expect(screen.getByTestId("file-preview-pdf")).toBeInTheDocument();
+  });
+
+  it("recovers the MIME type of an octet-stream PDF attached to a nested thread message", async () => {
+    mockFetchEml(THREAD_OCTET_STREAM_PDF_EML);
+    renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
+
+    const attachmentButton = await screen.findByRole("button", {
+      name: /report\.pdf/,
+    });
+    fireEvent.click(attachmentButton);
+
+    // Assert on the blob the viewer was actually handed: an octet-stream URL
+    // here is what makes the browser download a UUID instead of previewing.
+    const blobUrl = screen.getByTestId("file-preview-pdf").getAttribute("src");
+    expect(blobUrlContent.get(blobUrl ?? "")?.type).toBe("application/pdf");
   });
 });

--- a/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.test.tsx
@@ -136,6 +136,59 @@ const INLINE_IMAGE_EML = [
   "",
 ].join("\r\n");
 
+// %PDF-1.0 followed by a minimal %%EOF marker, base64-encoded.
+const MINIMAL_PDF_B64 = "JVBERi0xLjAKJSVFT0Y=";
+
+// An email whose PDF attachment correctly declares Content-Type: application/pdf.
+const PDF_ATTACHMENT_EML = [
+  "From: alice@example.com",
+  "To: bob@example.com",
+  "Subject: With PDF",
+  "Date: Mon, 18 May 2026 10:00:00 +0000",
+  "MIME-Version: 1.0",
+  'Content-Type: multipart/mixed; boundary="BOUND"',
+  "",
+  "--BOUND",
+  'Content-Type: text/plain; charset="utf-8"',
+  "",
+  "See the attached PDF.",
+  "",
+  "--BOUND",
+  "Content-Type: application/pdf",
+  'Content-Disposition: attachment; filename="report.pdf"',
+  "Content-Transfer-Encoding: base64",
+  "",
+  MINIMAL_PDF_B64,
+  "--BOUND--",
+  "",
+].join("\r\n");
+
+// Same as PDF_ATTACHMENT_EML but the sender mis-declares the PDF as the
+// generic binary fallback – a real-world encoding mistake that causes browsers
+// to download the blob URL instead of rendering it inline.
+const PDF_OCTET_STREAM_EML = [
+  "From: alice@example.com",
+  "To: bob@example.com",
+  "Subject: With mis-typed PDF",
+  "Date: Mon, 18 May 2026 10:00:00 +0000",
+  "MIME-Version: 1.0",
+  'Content-Type: multipart/mixed; boundary="BOUND"',
+  "",
+  "--BOUND",
+  'Content-Type: text/plain; charset="utf-8"',
+  "",
+  "See the attached PDF.",
+  "",
+  "--BOUND",
+  "Content-Type: application/octet-stream",
+  'Content-Disposition: attachment; filename="report.pdf"',
+  "Content-Transfer-Encoding: base64",
+  "",
+  MINIMAL_PDF_B64,
+  "--BOUND--",
+  "",
+].join("\r\n");
+
 describe("EmlPreview", () => {
   it("renders parsed headers and a sandboxed iframe for HTML body", async () => {
     mockFetchEml(HTML_EML);
@@ -304,5 +357,57 @@ describe("EmlPreview", () => {
     expect(
       screen.getByText("Preview unavailable: this email could not be parsed."),
     ).toBeInTheDocument();
+  });
+
+  it("opens a PDF attachment in the inline PDF viewer with a back button", async () => {
+    mockFetchEml(PDF_ATTACHMENT_EML);
+    renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
+
+    const attachmentButton = await screen.findByRole("button", {
+      name: /report\.pdf/,
+    });
+    fireEvent.click(attachmentButton);
+
+    expect(screen.getByTestId("eml-attachment-preview")).toBeInTheDocument();
+    expect(screen.getByTestId("file-preview-pdf")).toBeInTheDocument();
+
+    const backButton = screen.getByRole("button", { name: /back to email/i });
+    fireEvent.click(backButton);
+
+    expect(
+      screen.queryByTestId("eml-attachment-preview"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("eml-preview-attachments")).toBeInTheDocument();
+  });
+
+  it("creates the attachment blob with application/pdf type when the email declares application/octet-stream", async () => {
+    // ERMAIN-550: emails that mis-declare a PDF as `application/octet-stream`
+    // caused the browser to download the blob URL (with a UUID filename) instead
+    // of rendering the PDF inline. The fix recovers the type from the filename
+    // extension before creating the blob.
+    mockFetchEml(PDF_OCTET_STREAM_EML);
+    renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
+
+    await screen.findByTestId("eml-preview-attachments");
+
+    // The PDF attachment blob should be typed as application/pdf so browsers
+    // can render it inline rather than triggering a download.
+    const pdfBlob = blobUrlContent.get(createdBlobUrls[createdBlobUrls.length - 1]);
+    expect(pdfBlob?.type).toBe("application/pdf");
+  });
+
+  it("still opens an octet-stream PDF in the inline PDF viewer (ERMAIN-550 regression guard)", async () => {
+    mockFetchEml(PDF_OCTET_STREAM_EML);
+    renderEml(<EmlPreview filename={FILE.filename} url={FILE.url} />);
+
+    const attachmentButton = await screen.findByRole("button", {
+      name: /report\.pdf/,
+    });
+    fireEvent.click(attachmentButton);
+
+    expect(screen.getByTestId("eml-attachment-preview")).toBeInTheDocument();
+    // FilePreviewContent should route to the PDF iframe, not the
+    // "preview unavailable" fallback.
+    expect(screen.getByTestId("file-preview-pdf")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/FilePreview/EmlPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.tsx
@@ -82,28 +82,21 @@ const OCTET_STREAM = "application/octet-stream";
 // eslint-disable-next-line lingui/no-unlocalized-strings
 const MESSAGE_RFC822 = "message/rfc822";
 
-/**
- * Extension → MIME type map used to recover a specific type when an email
- * client sends `Content-Type: application/octet-stream` for a well-known
- * format. Browsers display blob URLs inline only when the MIME type matches a
- * renderable format; an octet-stream PDF triggers a download instead, and the
- * download filename becomes the bare UUID from the blob URL.
- */
+// Browsers only render a blob URL inline when its MIME type names a renderable
+// format, so an octet-stream PDF downloads as a bare UUID instead of previewing.
 const EXT_TO_MIME: Readonly<Record<string, string>> = {
   // eslint-disable-next-line lingui/no-unlocalized-strings
   pdf: "application/pdf",
   eml: MESSAGE_RFC822,
 } as const;
 
-/**
- * Returns the most specific MIME type we can derive for an attachment:
- * uses the declared type when it is non-generic, otherwise falls back to
- * an extension-based lookup, then to `application/octet-stream`.
- */
-function recoverMimeType(mimeType: string, filename: string | undefined): string {
+function recoverMimeType(
+  mimeType: string,
+  filename: string | null | undefined,
+): string {
   if (mimeType.length > 0 && mimeType !== OCTET_STREAM) return mimeType;
   const ext = filename?.split(".").pop()?.toLowerCase() ?? "";
-  return EXT_TO_MIME[ext] ?? (mimeType.length > 0 ? mimeType : OCTET_STREAM);
+  return EXT_TO_MIME[ext] ?? OCTET_STREAM;
 }
 
 function attachmentBlob(attachment: Attachment): Blob {

--- a/frontend/src/components/ui/FilePreview/EmlPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/EmlPreview.tsx
@@ -82,9 +82,33 @@ const OCTET_STREAM = "application/octet-stream";
 // eslint-disable-next-line lingui/no-unlocalized-strings
 const MESSAGE_RFC822 = "message/rfc822";
 
+/**
+ * Extension → MIME type map used to recover a specific type when an email
+ * client sends `Content-Type: application/octet-stream` for a well-known
+ * format. Browsers display blob URLs inline only when the MIME type matches a
+ * renderable format; an octet-stream PDF triggers a download instead, and the
+ * download filename becomes the bare UUID from the blob URL.
+ */
+const EXT_TO_MIME: Readonly<Record<string, string>> = {
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  pdf: "application/pdf",
+  eml: MESSAGE_RFC822,
+} as const;
+
+/**
+ * Returns the most specific MIME type we can derive for an attachment:
+ * uses the declared type when it is non-generic, otherwise falls back to
+ * an extension-based lookup, then to `application/octet-stream`.
+ */
+function recoverMimeType(mimeType: string, filename: string | undefined): string {
+  if (mimeType.length > 0 && mimeType !== OCTET_STREAM) return mimeType;
+  const ext = filename?.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_TO_MIME[ext] ?? (mimeType.length > 0 ? mimeType : OCTET_STREAM);
+}
+
 function attachmentBlob(attachment: Attachment): Blob {
-  const { content, mimeType } = attachment;
-  const type = mimeType.length > 0 ? mimeType : OCTET_STREAM;
+  const { content, mimeType, filename } = attachment;
+  const type = recoverMimeType(mimeType, filename);
   if (content instanceof ArrayBuffer) return new Blob([content], { type });
   if (content instanceof Uint8Array) {
     const copy = new Uint8Array(content.byteLength);
@@ -167,7 +191,7 @@ export const EmlPreview: React.FC<EmlPreviewProps> = ({ url }) => {
               trimmedName && trimmedName.length > 0
                 ? trimmedName
                 : t`attachment`,
-            mimeType: att.mimeType.length > 0 ? att.mimeType : OCTET_STREAM,
+            mimeType: recoverMimeType(att.mimeType, att.filename),
             size: blob.size,
             blobUrl: objectUrl,
           });
@@ -424,8 +448,7 @@ const EmlThreadBody: React.FC<{ parsed: ParsedEml }> = ({ parsed }) => {
                 trimmedName && trimmedName.length > 0
                   ? trimmedName
                   : t`attachment`,
-              mimeType:
-                child.mimeType.length > 0 ? child.mimeType : OCTET_STREAM,
+              mimeType: recoverMimeType(child.mimeType, child.filename),
               size: blob.size,
               blobUrl: childUrl,
             });


### PR DESCRIPTION
## Problem

When viewing an EML email preview and clicking a PDF attachment listed inside the email, the browser downloads the file instead of opening a nested inline preview. The downloaded file has no extension — the filename is a bare UUID (the UUID portion of the blob URL).

**Root cause:** Email clients sometimes send PDF attachments with `Content-Type: application/octet-stream` instead of `application/pdf`. When `EmlPreview` parses such an email via PostalMime, it creates a `Blob` typed as `application/octet-stream`. Browsers treat blob URLs with that content type as binary downloads rather than rendering them inline in an `<iframe>`. Since `blob://` URLs carry no filename metadata, the download filename defaults to the blob's UUID.

## Fix

Added `recoverMimeType()` in `EmlPreview.tsx` — a small helper that upgrades a generic `application/octet-stream` MIME type to a more specific one derived from the filename extension, before the Blob is created. Currently maps:

- `.pdf` → `application/pdf`
- `.eml` → `message/rfc822`

Applied in two places:
1. **`attachmentBlob()`** — ensures the Blob itself has the correct type, so `<iframe src={blobUrl}>` renders inline rather than triggering a download.
2. **`ParsedAttachment.mimeType`** — ensures `FilePreviewContent` also receives the recovered type for routing (e.g. `isPdf` check).

Both `EmlPreviewBody` (direct attachments) and `EmlThreadBody` (nested thread message attachments) are covered.

## Tests

Added 4 new test cases in `EmlPreview.test.tsx`:
- Clicking a `application/pdf`-typed PDF shows the inline PDF viewer (`file-preview-pdf`) with a working back button.
- Clicking an `application/octet-stream`-typed PDF (the bug scenario) also shows the inline PDF viewer — not a download.
- The blob created for an `application/octet-stream` PDF attachment has its MIME type recovered to `application/pdf` (directly verifies the fix prevents the browser from triggering a download).
- The last test is explicitly labelled as an ERMAIN-550 regression guard.