### PR TITLE
Expose Erato in Outlook organizer appointment compose

### DIFF
--- a/office-addin/.gitignore
+++ b/office-addin/.gitignore
@@ -4,4 +4,4 @@
 /manifests/manifest-funnel-onprem.xml
 src/locales/**/*.json
 src/locales/**/*.ts
-public/locales/**/*.json
+/public/locales/

--- a/office-addin/manifests/manifest-local.xml
+++ b/office-addin/manifests/manifest-local.xml
@@ -5,7 +5,7 @@
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xsi:type="MailApp">
   <Id>a106a734-c891-4e05-9739-eb9b5a39786e</Id>
-  <Version>1.0.0.4</Version>
+  <Version>1.0.0.5</Version>
   <ProviderName>Erato</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Erato Office Extension (Local)" />
@@ -33,6 +33,7 @@
   <Rule xsi:type="RuleCollection" Mode="Or">
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read" />
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Edit" />
+    <Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Edit" />
   </Rule>
   <DisableEntityHighlighting>false</DisableEntityHighlighting>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
@@ -71,6 +72,28 @@
               <Group id="eratoComposeGroup">
                 <Label resid="groupLabel" />
                 <Control xsi:type="Button" id="eratoComposeButton">
+                  <Label resid="buttonLabel" />
+                  <Supertip>
+                    <Title resid="buttonLabel" />
+                    <Description resid="buttonDesc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="icon16" />
+                    <bt:Image size="32" resid="icon32" />
+                    <bt:Image size="80" resid="icon80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="taskPaneUrl" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+            <OfficeTab id="TabDefault">
+              <Group id="eratoOrganizerGroup">
+                <Label resid="groupLabel" />
+                <Control xsi:type="Button" id="eratoOrganizerButton">
                   <Label resid="buttonLabel" />
                   <Supertip>
                     <Title resid="buttonLabel" />
@@ -159,6 +182,28 @@
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="taskPaneUrl" />
                       <SupportsPinning>true</SupportsPinning>
+                    </Action>
+                  </Control>
+                </Group>
+              </OfficeTab>
+            </ExtensionPoint>
+            <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+              <OfficeTab id="TabDefault">
+                <Group id="eratoOrganizerGroup">
+                  <Label resid="groupLabel" />
+                  <Control xsi:type="Button" id="eratoOrganizerButton">
+                    <Label resid="buttonLabel" />
+                    <Supertip>
+                      <Title resid="buttonLabel" />
+                      <Description resid="buttonDesc" />
+                    </Supertip>
+                    <Icon>
+                      <bt:Image size="16" resid="icon16" />
+                      <bt:Image size="32" resid="icon32" />
+                      <bt:Image size="80" resid="icon80" />
+                    </Icon>
+                    <Action xsi:type="ShowTaskpane">
+                      <SourceLocation resid="taskPaneUrl" />
                     </Action>
                   </Control>
                 </Group>

--- a/office-addin/manifests/manifest.json
+++ b/office-addin/manifests/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "id": "ee94d041-bd77-446c-8854-421648f50e7c",
   "developer": {
     "name": "Erato",
@@ -56,7 +56,7 @@
       ],
       "ribbons": [
         {
-          "contexts": ["mailRead", "mailCompose"],
+          "contexts": ["mailRead", "mailCompose", "meetingDetailsOrganizer"],
           "tabs": [
             {
               "builtInTabId": "TabDefault",

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -328,7 +328,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-oFB9k9Pdt4V7cRRCm8ZdPksGcpflUqO6DufN4cULAz6jyRcGBU7uifURak/ANw+oLtJLX3nVl5pQrQLfMPzn+Q==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-sm2SvV9RRPgKxXa/LFp7mSRtLmtbYzkCx2G24BgcjLYEGATRbRC4AdIyxEkQk8p3j9k2/e8lcSd0cD0X8Q+NQg==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -162,7 +162,7 @@ msgstr "Zeitüberschreitung bei der Anmeldung. Versuche es erneut."
 #. js-lingui-explicit-id
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signIn"
-msgstr ""
+msgstr "Anmelden"
 
 #. js-lingui-explicit-id
 #: src/App.tsx
@@ -174,7 +174,7 @@ msgstr ""
 #: src/core/SessionAuthProvider.tsx
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signInToContinue"
-msgstr ""
+msgstr "Melde dich an, um fortzufahren"
 
 #. js-lingui-explicit-id
 #: src/auth/UnsupportedAuthSource.ts
@@ -205,6 +205,16 @@ msgstr "Zum Hochladen ablegen"
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Neuer Chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.appointmentContext"
+msgstr "Termindetails werden als Kontext einbezogen"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.dismissAppointmentContext"
+msgstr "Termindetails nicht einbeziehen"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx
@@ -309,22 +319,22 @@ msgstr "Allen Empfängern antworten"
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
-msgstr ""
+msgstr "Angemeldet. Füge die E-Mail erneut hinzu, um sie anzuhängen."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.action"
-msgstr ""
+msgstr "Anmelden"
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.description"
-msgstr ""
+msgstr "Diese E-Mail wurde nicht angehängt, da zum Lesen eine kurze Anmeldung nötig ist."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
-msgstr ""
+msgstr "Anmelden, um die E-Mail zu laden"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -208,6 +208,16 @@ msgstr "New Chat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.appointmentContext"
+msgstr "Appointment details are included as context"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.dismissAppointmentContext"
+msgstr "Don't include appointment details"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
 msgid "officeAddin.chatInput.dismissDraftContext"
 msgstr "Don't include draft"
 

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -162,7 +162,7 @@ msgstr "Se agotó el tiempo de espera del inicio de sesión. Inténtalo de nuevo
 #. js-lingui-explicit-id
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signIn"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #. js-lingui-explicit-id
 #: src/App.tsx
@@ -174,7 +174,7 @@ msgstr ""
 #: src/core/SessionAuthProvider.tsx
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signInToContinue"
-msgstr ""
+msgstr "Inicia sesión para continuar"
 
 #. js-lingui-explicit-id
 #: src/auth/UnsupportedAuthSource.ts
@@ -205,6 +205,16 @@ msgstr "Suelta para subir"
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nuevo chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.appointmentContext"
+msgstr "Los detalles de la cita se incluyen como contexto"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.dismissAppointmentContext"
+msgstr "No incluir los detalles de la cita"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx
@@ -309,22 +319,22 @@ msgstr "Responder a todos los destinatarios"
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
-msgstr ""
+msgstr "Sesión iniciada. Vuelve a añadir el correo para adjuntarlo."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.action"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.description"
-msgstr ""
+msgstr "Este correo no se adjuntó porque leerlo requiere un inicio de sesión rápido."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
-msgstr ""
+msgstr "Inicia sesión para cargar el correo"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -162,7 +162,7 @@ msgstr "Le délai de connexion a expiré. Réessayez."
 #. js-lingui-explicit-id
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signIn"
-msgstr ""
+msgstr "Se connecter"
 
 #. js-lingui-explicit-id
 #: src/App.tsx
@@ -174,7 +174,7 @@ msgstr ""
 #: src/core/SessionAuthProvider.tsx
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signInToContinue"
-msgstr ""
+msgstr "Connectez-vous pour continuer"
 
 #. js-lingui-explicit-id
 #: src/auth/UnsupportedAuthSource.ts
@@ -205,6 +205,16 @@ msgstr "Déposez pour téléverser"
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nouveau chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.appointmentContext"
+msgstr "Les détails du rendez-vous sont inclus comme contexte"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.dismissAppointmentContext"
+msgstr "Ne pas inclure les détails du rendez-vous"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx
@@ -309,22 +319,22 @@ msgstr "Répondre à tous les destinataires"
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
-msgstr ""
+msgstr "Connecté. Ajoutez à nouveau l'e-mail pour le joindre."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.action"
-msgstr ""
+msgstr "Se connecter"
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.description"
-msgstr ""
+msgstr "Cet e-mail n'a pas été joint, car sa lecture nécessite une connexion rapide."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
-msgstr ""
+msgstr "Connectez-vous pour charger l'e-mail"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -162,7 +162,7 @@ msgstr "Upłynął limit czasu logowania. Spróbuj ponownie."
 #. js-lingui-explicit-id
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signIn"
-msgstr ""
+msgstr "Zaloguj się"
 
 #. js-lingui-explicit-id
 #: src/App.tsx
@@ -174,7 +174,7 @@ msgstr ""
 #: src/core/SessionAuthProvider.tsx
 #: src/core/SharedAddinShell.tsx
 msgid "officeAddin.auth.signInToContinue"
-msgstr ""
+msgstr "Zaloguj się, aby kontynuować"
 
 #. js-lingui-explicit-id
 #: src/auth/UnsupportedAuthSource.ts
@@ -205,6 +205,16 @@ msgstr "Upuść, aby przesłać"
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nowy czat"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.appointmentContext"
+msgstr "Szczegóły terminu są dołączone jako kontekst"
+
+#. js-lingui-explicit-id
+#: src/outlook/components/AddinChatInput.tsx
+msgid "officeAddin.chatInput.dismissAppointmentContext"
+msgstr "Nie dołączaj szczegółów terminu"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx
@@ -309,22 +319,22 @@ msgstr "Odpowiedz wszystkim odbiorcom"
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signedIn.title"
-msgstr ""
+msgstr "Zalogowano. Dodaj e-mail ponownie, aby go załączyć."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.action"
-msgstr ""
+msgstr "Zaloguj się"
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.description"
-msgstr ""
+msgstr "Ten e-mail nie został załączony, ponieważ jego odczytanie wymaga szybkiego zalogowania."
 
 #. js-lingui-explicit-id
 #: src/outlook/providers/EntraGraphTokenProvider.tsx
 msgid "officeAddin.email.signInToLoad.title"
-msgstr ""
+msgstr "Zaloguj się, aby załadować e-mail"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoEmailRenderer.tsx

--- a/office-addin/src/outlook/components/AddinChatInput.tsx
+++ b/office-addin/src/outlook/components/AddinChatInput.tsx
@@ -23,11 +23,19 @@ import { useOutlookComposeSelection } from "../hooks/useOutlookComposeSelection"
 import { useOutlookEmailSource } from "../providers/OutlookEmailSourceProvider";
 import {
   NO_ITEM_SEND_IDENTITY,
+  readAppointmentComposeSnapshot,
   useOutlookMailItem,
 } from "../providers/OutlookMailItemProvider";
+import {
+  isAppointmentCompose as isAppointmentComposeItem,
+  resolveSupportedMailboxItem,
+} from "../sessionPolicy";
 import { resolveOutlookActionFacet } from "../utils/outlookActionFacet";
 import { OUTLOOK_REPLY_FROM_READ_FACET_ID } from "../utils/outlookClientActions";
-import { getComposeBodyType } from "../utils/outlookComposeWrite";
+import {
+  getComposeBodyType,
+  type BodyFormat,
+} from "../utils/outlookComposeWrite";
 import {
   OUTLOOK_SCHEDULE_FACET_ID,
   isSchedulingThreadFresh,
@@ -153,6 +161,12 @@ export const AddinChatInput = forwardRef<
   const { host } = useOffice();
   const availableFacetIds = useAvailableActionFacetIds();
   const composeEmailAvailable = availableFacetIds.has("compose_email");
+  const appointmentRewriteAvailable = availableFacetIds.has(
+    "outlook_rewrite_appointment_selection",
+  );
+  const appointmentContextAvailable = availableFacetIds.has(
+    "outlook_review_appointment",
+  );
   const replyFromReadAvailable = availableFacetIds.has(
     OUTLOOK_REPLY_FROM_READ_FACET_ID,
   );
@@ -163,9 +177,16 @@ export const AddinChatInput = forwardRef<
   const [isUploadingEmail, setIsUploadingEmail] = useState(false);
   const composeSelection = useOutlookComposeSelection();
   const { mailItem, itemIdentity } = useOutlookMailItem();
+  const isAppointmentCompose = mailItem?.itemKind === "appointment";
   const [isSelectionDismissed, setIsSelectionDismissed] = useState(false);
+  // Appointment facets are config-defined (subscription content, not
+  // builtins): when the backend doesn't advertise them, the resolver would
+  // drop the facet — so the selection/draft context must not count as
+  // included, or the chips would promise context the send doesn't carry.
   const hasActiveSelection =
-    composeSelection.data.length > 0 && !isSelectionDismissed;
+    composeSelection.data.length > 0 &&
+    !isSelectionDismissed &&
+    (!isAppointmentCompose || appointmentRewriteAvailable);
 
   // Draft-as-context (#1): a non-empty compose body is eligible to ride along
   // as `outlook_review_draft`, but the user can switch it off via the draft
@@ -180,16 +201,21 @@ export const AddinChatInput = forwardRef<
     setIsSelectionDismissed(false);
   }
   const isDraftContextIncluded =
-    !!mailItem?.isComposeMode && draftBodyText.length > 0 && !isDraftDismissed;
+    !!mailItem?.isComposeMode &&
+    (draftBodyText.length > 0 || isAppointmentCompose) &&
+    !isDraftDismissed &&
+    (!isAppointmentCompose || appointmentContextAvailable);
   // Show the draft chip only when it's actually what we'd send: a live
   // selection takes priority (rewrite wins over review), so hide it then.
   const hasDraftContextChip =
     host === "Outlook" && isDraftContextIncluded && !hasActiveSelection;
 
-  // Draft de-dup marker (#4): the body we last sent as `review_draft` in this
-  // chat. Client-side by design — the backend is action-facet toggle-stateless.
-  // Reset when the chat changes so a fresh chat re-sends the draft.
-  const lastSentDraftBodyRef = useRef<string | null>(null);
+  // Draft de-dup marker (#4): the fingerprint of the draft context we last
+  // sent in this chat (raw body for message drafts, metadata fingerprint for
+  // appointments). Client-side by design — the backend is action-facet
+  // toggle-stateless. Reset when the chat changes so a fresh chat re-sends
+  // the draft.
+  const lastSentDraftFingerprintRef = useRef<string | null>(null);
   const lastDraftChatIdRef = useRef(chatId);
   if (chatId !== lastDraftChatIdRef.current) {
     // Reset the dedup marker when the chat genuinely changes — but NOT when a
@@ -200,7 +226,7 @@ export const AddinChatInput = forwardRef<
       lastDraftChatIdRef.current == null && chatId != null;
     lastDraftChatIdRef.current = chatId;
     if (!isNewChatGettingItsId) {
-      lastSentDraftBodyRef.current = null;
+      lastSentDraftFingerprintRef.current = null;
     }
   }
 
@@ -646,6 +672,28 @@ export const AddinChatInput = forwardRef<
       // executors treat it as a mismatch and fail closed.
       const sendItemIdentity = itemIdentity ?? NO_ITEM_SEND_IDENTITY;
 
+      // Appointment fields are re-read from the LIVE item at send time:
+      // editing an appointment form fires no ItemChanged, so the provider's
+      // bind-time state is frozen at pane-open and would ship a stale (often
+      // empty) snapshot — and poison the de-dup fingerprint with it. Reads
+      // are bounded and fall back per-field to the provider state, so a
+      // wedged host degrades to the old behavior instead of losing the send.
+      const liveItem = resolveSupportedMailboxItem(Office.context.mailbox.item);
+      const appointmentSnapshot =
+        isAppointmentCompose && liveItem && isAppointmentComposeItem(liveItem)
+          ? await readAppointmentComposeSnapshot(liveItem, {
+              subject: mailItem?.subject ?? "",
+              organizer: mailItem?.organizer ?? null,
+              requiredAttendees: mailItem?.requiredAttendees ?? [],
+              optionalAttendees: mailItem?.optionalAttendees ?? [],
+              location: mailItem?.location ?? "",
+              start: mailItem?.start ?? null,
+              end: mailItem?.end ?? null,
+              bodyText: mailItem?.bodyText ?? null,
+              bodyHtml: mailItem?.bodyHtml ?? null,
+            })
+          : null;
+
       // Build the action facet (selection rewrite vs. draft review) via a pure
       // resolver so the selection-priority and draft de-dup rules stay testable.
       //
@@ -656,31 +704,86 @@ export const AddinChatInput = forwardRef<
       // no value to a writing-review prompt and blow the backend's per-arg size
       // cap; text coercion still preserves quoted history (`>` lines), bullet
       // lists, and link URLs, so the model keeps the full conversation context.
-      const bodyFormat = mailItem ? await getComposeBodyType() : undefined;
-      const { facet: actionFacet, sentDraftBody } = resolveOutlookActionFacet({
-        hasActiveSelection,
-        selectionData: composeSelection.data,
-        selectionSource: composeSelection.sourceProperty,
-        draftContextIncluded: isDraftContextIncluded,
-        draftBody: draftBodyText,
-        lastSentDraftBody: lastSentDraftBodyRef.current,
-        bodyFormat,
-        isComposeMode: !!mailItem?.isComposeMode,
-        composeEmailAvailable,
-        isReadMode: !!mailItem && !mailItem.isComposeMode,
-        replyFromReadAvailable,
-        scheduleFacetAvailable,
-        calendarAvailable: calendarFetcher !== null,
-        schedulingThreadActive: isSchedulingThreadFresh(
-          lastSchedulingSignalAt,
-          Date.now(),
-        ),
-        nowIso: toLocalOffsetIso(new Date().toISOString()),
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      });
-      if (sentDraftBody !== null) {
+      let bodyFormat: BodyFormat | undefined;
+      if (mailItem?.isComposeMode) {
+        try {
+          bodyFormat = await getComposeBodyType();
+        } catch {
+          // The live item can race away from compose (pinned pane, the user
+          // clicked a received email mid-send). The message must still go
+          // out — just without a compose body format.
+          bodyFormat = undefined;
+        }
+      }
+      const draftBody = appointmentSnapshot
+        ? (appointmentSnapshot.bodyText ?? appointmentSnapshot.bodyHtml ?? "")
+        : draftBodyText;
+      const draftContextFingerprint = appointmentSnapshot
+        ? JSON.stringify({
+            subject: appointmentSnapshot.subject,
+            body: draftBody,
+            requiredAttendees: appointmentSnapshot.requiredAttendees,
+            optionalAttendees: appointmentSnapshot.optionalAttendees,
+            location: appointmentSnapshot.location,
+            start: appointmentSnapshot.start?.toISOString() ?? "",
+            end: appointmentSnapshot.end?.toISOString() ?? "",
+          })
+        : undefined;
+      const formatAttendees = (
+        attendees: { displayName: string; emailAddress: string }[] | undefined,
+      ) =>
+        attendees
+          ?.map((attendee) => attendee.emailAddress || attendee.displayName)
+          .join(", ");
+      const { facet: actionFacet, sentDraftFingerprint } =
+        resolveOutlookActionFacet({
+          itemKind: mailItem?.itemKind ?? null,
+          hasActiveSelection,
+          selectionData: composeSelection.data,
+          selectionSource: composeSelection.sourceProperty,
+          draftContextIncluded: isDraftContextIncluded,
+          draftBody,
+          lastSentDraftFingerprint: lastSentDraftFingerprintRef.current,
+          draftContextFingerprint,
+          bodyFormat,
+          isComposeMode: !!mailItem?.isComposeMode,
+          composeEmailAvailable,
+          appointmentRewriteAvailable,
+          appointmentContextAvailable,
+          appointmentSubject: appointmentSnapshot?.subject,
+          appointmentRequiredAttendees: formatAttendees(
+            appointmentSnapshot?.requiredAttendees,
+          ),
+          appointmentOptionalAttendees: formatAttendees(
+            appointmentSnapshot?.optionalAttendees,
+          ),
+          appointmentLocation: appointmentSnapshot?.location,
+          // Local wall time with offset — the template tells the model these
+          // are the user's local times; raw UTC would misreport the meeting
+          // time for every non-UTC user.
+          appointmentStart: appointmentSnapshot?.start
+            ? toLocalOffsetIso(appointmentSnapshot.start.toISOString())
+            : undefined,
+          appointmentEnd: appointmentSnapshot?.end
+            ? toLocalOffsetIso(appointmentSnapshot.end.toISOString())
+            : undefined,
+          isReadMode:
+            !!mailItem &&
+            mailItem.itemKind === "message" &&
+            !mailItem.isComposeMode,
+          replyFromReadAvailable,
+          scheduleFacetAvailable,
+          calendarAvailable: calendarFetcher !== null,
+          schedulingThreadActive: isSchedulingThreadFresh(
+            lastSchedulingSignalAt,
+            Date.now(),
+          ),
+          nowIso: toLocalOffsetIso(new Date().toISOString()),
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
+      if (sentDraftFingerprint !== null) {
         // Remember what we sent so an unchanged follow-up de-dupes (#4).
-        lastSentDraftBodyRef.current = sentDraftBody;
+        lastSentDraftFingerprintRef.current = sentDraftFingerprint;
       }
 
       // Snapshot the dropped emails staged for this send. They are cleared only
@@ -783,10 +886,13 @@ export const AddinChatInput = forwardRef<
       chatId,
       chatInputProps,
       composeEmailAvailable,
+      appointmentContextAvailable,
+      appointmentRewriteAvailable,
       composeSelection.data,
       composeSelection.sourceProperty,
       draftBodyText,
       hasActiveSelection,
+      isAppointmentCompose,
       isDraftContextIncluded,
       itemIdentity,
       lastSchedulingSignalAt,
@@ -885,19 +991,31 @@ export const AddinChatInput = forwardRef<
           <div className="flex items-center gap-2 rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary px-3 py-1.5 text-xs text-theme-fg-secondary">
             <span className="shrink-0">&#x1F4DD;</span>
             <span className="min-w-0 truncate">
-              {t({
-                id: "officeAddin.chatInput.draftContext",
-                message: "Your draft is included as context",
-              })}
+              {isAppointmentCompose
+                ? t({
+                    id: "officeAddin.chatInput.appointmentContext",
+                    message: "Appointment details are included as context",
+                  })
+                : t({
+                    id: "officeAddin.chatInput.draftContext",
+                    message: "Your draft is included as context",
+                  })}
             </span>
             <button
               type="button"
               onClick={() => setIsDraftDismissed(true)}
               className="ml-auto shrink-0 rounded-[var(--theme-radius-control)] p-0.5 hover:bg-theme-bg-tertiary"
-              aria-label={t({
-                id: "officeAddin.chatInput.dismissDraftContext",
-                message: "Don't include draft",
-              })}
+              aria-label={
+                isAppointmentCompose
+                  ? t({
+                      id: "officeAddin.chatInput.dismissAppointmentContext",
+                      message: "Don't include appointment details",
+                    })
+                  : t({
+                      id: "officeAddin.chatInput.dismissDraftContext",
+                      message: "Don't include draft",
+                    })
+              }
             >
               &#x2715;
             </button>

--- a/office-addin/src/outlook/components/OutlookEratoEmailRenderer.tsx
+++ b/office-addin/src/outlook/components/OutlookEratoEmailRenderer.tsx
@@ -68,7 +68,10 @@ export function OutlookEratoEmailRenderer({
   const hasSelection = composeSelection.data.length > 0;
   const { mailItem, itemIdentity } = useOutlookMailItem();
   const artifact = useOutlookArtifact();
-  const isReadMode = !!mailItem && !mailItem.isComposeMode;
+  const isReadMode =
+    !!mailItem &&
+    mailItem.itemKind !== "appointment" &&
+    !mailItem.isComposeMode;
   // Identity of the Outlook item open when the user SENT the request that
   // produced this draft (stamped on fresh completions only). When it no
   // longer matches the currently open item, the draft must not open a reply

--- a/office-addin/src/outlook/hooks/__tests__/useOutlookComposeSelection.test.ts
+++ b/office-addin/src/outlook/hooks/__tests__/useOutlookComposeSelection.test.ts
@@ -293,20 +293,18 @@ describe("useOutlookComposeSelection", () => {
     expect(result.current).toEqual({ data: "", sourceProperty: "body" });
   });
 
-  it("clears the held selection when the item becomes an appointment (grace elapsed)", () => {
+  it("clears the held selection when the item becomes an appointment attendee item", () => {
     setComposeItem({ data: "held text", sourceProperty: "body" });
 
     const { result, rerender } = renderHook(() => useOutlookComposeSelection());
 
     expect(result.current.data).toBe("held text");
 
-    // The pane leaks into the calendar module: an AppointmentCompose replaces
-    // the message. It must clear like a lost item — before the shared guard,
-    // the grace re-check saw a non-null non-read item and held the stale
-    // selection chip forever.
+    // Appointment attendee/read mode remains unsupported and must clear like
+    // a lost item rather than retaining a compose selection.
     const mailbox = installMockMailbox();
     mailbox.item = {
-      subject: { getAsync: vi.fn() },
+      subject: "Standup",
       itemType: "appointment",
     };
     mockUseOutlookMailItem.mockReturnValue({ mailItem: null });
@@ -322,6 +320,38 @@ describe("useOutlookComposeSelection", () => {
     });
 
     expect(result.current).toEqual({ data: "", sourceProperty: "body" });
+  });
+
+  it("reads selected description text from appointment organizer compose", () => {
+    const mailbox = installMockMailbox();
+    mailbox.item = {
+      itemType: "appointment",
+      subject: { getAsync: vi.fn() },
+      getSelectedDataAsync: vi.fn((_coercionType, callback) =>
+        callback(
+          createMockAsyncResult({
+            data: "<p>Agenda item</p>",
+            sourceProperty: "body",
+          }),
+        ),
+      ),
+    };
+    mockUseOutlookMailItem.mockReturnValue({
+      itemIdentity: "appointment:1",
+      mailItem: {
+        itemKind: "appointment",
+        subject: "Standup",
+        conversationId: null,
+        isComposeMode: true,
+      },
+    });
+
+    const { result } = renderHook(() => useOutlookComposeSelection());
+
+    expect(result.current).toEqual({
+      data: "Agenda item",
+      sourceProperty: "body",
+    });
   });
 
   it("clears interval and ignores callbacks after unmount", () => {

--- a/office-addin/src/outlook/hooks/useOutlookComposeSelection.ts
+++ b/office-addin/src/outlook/hooks/useOutlookComposeSelection.ts
@@ -64,7 +64,7 @@ const NULL_GRACE_MS = 2500;
  * draft), or once the item is still gone after {@link NULL_GRACE_MS}.
  */
 export function useOutlookComposeSelection(): OutlookComposeSelection {
-  const { mailItem } = useOutlookMailItem();
+  const { itemIdentity, mailItem } = useOutlookMailItem();
   const [selection, setSelection] =
     useState<OutlookComposeSelection>(EMPTY_SELECTION);
   const lastDataRef = useRef("");
@@ -74,6 +74,8 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
   const selectionSurfaceRef = useRef<{
     conversationId: string | null;
     isCompose: boolean;
+    itemKind: "message" | "appointment";
+    appointmentIdentity: string | null;
   } | null>(null);
   // In-flight guard state — must SURVIVE effect re-runs (the effect re-runs on
   // every `mailItem` identity churn). It tracks the HOST's serialized API slot,
@@ -87,7 +89,6 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
   const lastRawHtmlRef = useRef<string | null>(null);
 
   useEffect(() => {
-    // Appointments resolve to null and clear like a lost item below.
     const item = resolveSupportedMailboxItem(Office.context.mailbox.item);
 
     const commitEmpty = () => {
@@ -108,7 +109,7 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
     // Transient/unknown context: the provider's `mailItem` or the raw Office
     // item is momentarily null. Clearing here is what made the chip flicker, so
     // instead hold the last selection and only clear if the context is STILL
-    // gone (or has become a read/appointment item) after a short grace period. If a valid
+    // gone (or has become a read item) after a short grace period. If a valid
     // compose item returns first, this effect re-runs and cancels the timer.
     if (!mailItem || !item) {
       const graceTimer = setTimeout(() => {
@@ -134,12 +135,18 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
     const currentSurface = {
       conversationId: mailItem.conversationId,
       isCompose: mailItem.isComposeMode,
+      itemKind: mailItem.itemKind,
+      appointmentIdentity:
+        mailItem.itemKind === "appointment" ? itemIdentity : null,
     };
     const previousSurface = selectionSurfaceRef.current;
     const isSameSurface =
       previousSurface !== null &&
       previousSurface.conversationId === currentSurface.conversationId &&
-      previousSurface.isCompose === currentSurface.isCompose;
+      previousSurface.isCompose === currentSurface.isCompose &&
+      previousSurface.itemKind === currentSurface.itemKind &&
+      previousSurface.appointmentIdentity ===
+        currentSurface.appointmentIdentity;
     selectionSurfaceRef.current = currentSurface;
 
     // Same surface: keep the dedup refs so the held selection survives a
@@ -161,8 +168,10 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
 
       const composeItem = resolveSupportedMailboxItem(
         Office.context.mailbox.item,
-      ) as Office.MessageCompose | null;
-      if (!composeItem) return;
+      );
+      if (!composeItem || isMessageRead(composeItem)) {
+        return;
+      }
 
       if (inFlightSeqRef.current !== null) {
         // A call is still outstanding — issuing another risks 5100. Skip this
@@ -265,7 +274,7 @@ export function useOutlookComposeSelection(): OutlookComposeSelection {
       clearInterval(intervalId);
       unsubscribeImmediate();
     };
-  }, [mailItem]);
+  }, [itemIdentity, mailItem]);
 
   return selection;
 }

--- a/office-addin/src/outlook/hooks/useOutlookSessionAnchor.ts
+++ b/office-addin/src/outlook/hooks/useOutlookSessionAnchor.ts
@@ -20,15 +20,18 @@ const ANCHOR_DEBOUNCE_MS = 400;
  * context yet) or when no Outlook item is available.
  */
 export function useOutlookSessionAnchor(): OutlookSessionAnchor | null {
-  const { mailItem, isLoading } = useOutlookMailItem();
+  const { itemIdentity, mailItem, isLoading } = useOutlookMailItem();
 
   const liveAnchor = useMemo<OutlookSessionAnchor | null>(() => {
     if (isLoading || !mailItem) return null;
     return {
       conversationId: mailItem.conversationId,
       isCompose: mailItem.isComposeMode,
+      itemKind: mailItem.itemKind,
+      itemIdentity:
+        mailItem.itemKind === "appointment" ? itemIdentity : undefined,
     };
-  }, [isLoading, mailItem]);
+  }, [isLoading, itemIdentity, mailItem]);
 
   // Leading-edge: the first observation passes through without waiting, so
   // cold-open lands the anchor instantly and the session policy can fire

--- a/office-addin/src/outlook/providers/OutlookEmailSourceProvider.tsx
+++ b/office-addin/src/outlook/providers/OutlookEmailSourceProvider.tsx
@@ -211,9 +211,15 @@ export function OutlookEmailSourceProvider({
     useState<StagedEmailDismissalsMap>(() => new Map());
   const [droppedEmails, setDroppedEmails] = useState<DroppedEmailEntry[]>([]);
 
-  const itemId = mailItem?.itemId ?? null;
-  const conversationId = mailItem?.conversationId ?? null;
-  const isComposeMode = mailItem?.isComposeMode ?? false;
+  // This provider is intentionally email-only. Appointment descriptions ride
+  // through their action facet and must never appear as an email/thread card.
+  // The source is nulled ONCE here so every derivation below is
+  // appointment-blind by construction — never gate individual values.
+  const emailItem = mailItem?.itemKind === "appointment" ? null : mailItem;
+  const itemId = emailItem?.itemId ?? null;
+  const conversationId = emailItem?.conversationId ?? null;
+  const isComposeMode = emailItem?.isComposeMode ?? false;
+  const isLoadingEmailAttachments = emailItem ? isLoadingAttachments : false;
 
   // Conversation fetch lives in its own hook so it can be unit-tested in
   // isolation against an injected transport.
@@ -381,8 +387,10 @@ export function OutlookEmailSourceProvider({
   const isEmailBodyIncluded = !!emailBodyFile && !isEmailBodyDismissed;
 
   const selectableAttachments = useMemo(() => {
-    return attachments.filter((attachment) => !attachment.isInline);
-  }, [attachments]);
+    return emailItem
+      ? attachments.filter((attachment) => !attachment.isInline)
+      : [];
+  }, [attachments, emailItem]);
 
   const selectedAttachmentItems = useMemo<LocalFilePreviewItem[]>(() => {
     return selectableAttachments
@@ -561,7 +569,7 @@ export function OutlookEmailSourceProvider({
 
   const value = useMemo<OutlookEmailSourceContextValue>(
     () => ({
-      emailSubject: mailItem?.subject ?? "",
+      emailSubject: emailItem?.subject ?? "",
       isEmailBodyIncluded,
       emailBodyFile,
       isThreadEmlStale,
@@ -576,7 +584,7 @@ export function OutlookEmailSourceProvider({
       addDroppedEmail,
       removeDroppedEmail,
       selectedAttachmentItems,
-      isLoadingAttachments,
+      isLoadingAttachments: isLoadingEmailAttachments,
       removeEmailBody,
       removeAttachment,
       restoreEmailBody,
@@ -602,10 +610,10 @@ export function OutlookEmailSourceProvider({
       isEmailBodyDismissed,
       emailThreadLoadError,
       isEmailBodyIncluded,
-      isLoadingAttachments,
+      isLoadingEmailAttachments,
       isLoadingEmailBody,
       isLoadingParentReplyContext,
-      mailItem?.subject,
+      emailItem?.subject,
       parentReplyContext,
       removeAttachment,
       removeDroppedEmail,

--- a/office-addin/src/outlook/providers/OutlookMailItemProvider.tsx
+++ b/office-addin/src/outlook/providers/OutlookMailItemProvider.tsx
@@ -8,7 +8,15 @@ import {
 } from "react";
 
 import { callOfficeAsync } from "../../utils/officeAsync";
-import { isMessageRead, resolveSupportedMailboxItem } from "../sessionPolicy";
+import {
+  UNSAVED_APPOINTMENT_IDENTITY_PREFIX,
+  UNSAVED_COMPOSE_IDENTITY_PREFIX,
+  getOrMintItemIdentity,
+  isAppointmentCompose,
+  isMessageRead,
+  resolveSupportedMailboxItem,
+  type SupportedOutlookItem,
+} from "../sessionPolicy";
 
 interface EmailAddress {
   displayName: string;
@@ -25,10 +33,17 @@ export interface OutlookAttachmentData {
 }
 
 export interface OutlookMailItemData {
+  itemKind: "message" | "appointment";
   subject: string;
   from: EmailAddress | null;
   to: EmailAddress[];
   cc: EmailAddress[];
+  organizer: EmailAddress | null;
+  requiredAttendees: EmailAddress[];
+  optionalAttendees: EmailAddress[];
+  location: string;
+  start: Date | null;
+  end: Date | null;
   dateTimeCreated: Date | null;
   conversationId: string | null;
   internetMessageId: string | null;
@@ -101,7 +116,7 @@ function parseRecipients(
 export const NO_ITEM_SEND_IDENTITY = "no-item";
 
 function buildMailItemIdentity(
-  item: Office.MessageRead | Office.MessageCompose | null,
+  item: SupportedOutlookItem | null,
 ): string | null {
   if (!item) {
     return null;
@@ -115,19 +130,27 @@ function buildMailItemIdentity(
     );
   }
 
+  if (isAppointmentCompose(item)) {
+    // Never `seriesId` — it names the whole recurring series, so every
+    // occurrence would share an identity (and the insert gate would allow
+    // cross-occurrence inserts). Must agree with `outlookAnchorFromItem`.
+    return getOrMintItemIdentity(item, UNSAVED_APPOINTMENT_IDENTITY_PREFIX);
+  }
+
   return (
     item.conversationId ??
     `${UNSAVED_COMPOSE_IDENTITY_PREFIX}${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`
   );
 }
 
-const UNSAVED_COMPOSE_IDENTITY_PREFIX = "compose:";
-
-// Minted fallbacks differ on every resolve of the SAME unsaved draft, so
-// comparing two of them can't prove a navigation happened.
+// Minted fallbacks differ on every resolve of the SAME unsaved draft (a host
+// may hand out a fresh item object at any time), so comparing two of them
+// can't prove a navigation happened.
 function isStableItemIdentity(identity: string | null): identity is string {
   return (
-    identity !== null && !identity.startsWith(UNSAVED_COMPOSE_IDENTITY_PREFIX)
+    identity !== null &&
+    !identity.startsWith(UNSAVED_COMPOSE_IDENTITY_PREFIX) &&
+    !identity.startsWith(UNSAVED_APPOINTMENT_IDENTITY_PREFIX)
   );
 }
 
@@ -227,10 +250,17 @@ function readMailItemSync(item: Office.MessageRead): OutlookMailItemData {
     : null;
 
   return {
+    itemKind: "message",
     subject: item.subject ?? "",
     from,
     to: parseRecipients(item.to),
     cc: parseRecipients(item.cc),
+    organizer: null,
+    requiredAttendees: [],
+    optionalAttendees: [],
+    location: "",
+    start: null,
+    end: null,
     dateTimeCreated: item.dateTimeCreated ?? null,
     conversationId: item.conversationId ?? null,
     internetMessageId: item.internetMessageId ?? null,
@@ -248,10 +278,17 @@ function readMailItemCompose(
   canCommit: () => boolean,
 ) {
   setMailItem({
+    itemKind: "message",
     subject: "",
     from: null,
     to: [],
     cc: [],
+    organizer: null,
+    requiredAttendees: [],
+    optionalAttendees: [],
+    location: "",
+    start: null,
+    end: null,
     dateTimeCreated: null,
     conversationId: item.conversationId ?? null,
     internetMessageId: null,
@@ -324,6 +361,177 @@ function readMailItemCompose(
   });
 }
 
+/**
+ * Every appointment-compose field the add-in uses, read in one awaitable
+ * sweep. Editing an appointment form fires no ItemChanged, so any state
+ * captured at bind time goes stale — the send path re-reads a fresh snapshot
+ * of the live item instead of trusting provider state.
+ */
+export interface AppointmentComposeSnapshot {
+  subject: string;
+  organizer: EmailAddress | null;
+  requiredAttendees: EmailAddress[];
+  optionalAttendees: EmailAddress[];
+  location: string;
+  start: Date | null;
+  end: Date | null;
+  bodyText: string | null;
+  bodyHtml: string | null;
+}
+
+export const EMPTY_APPOINTMENT_SNAPSHOT: AppointmentComposeSnapshot = {
+  subject: "",
+  organizer: null,
+  requiredAttendees: [],
+  optionalAttendees: [],
+  location: "",
+  start: null,
+  end: null,
+  bodyText: null,
+  bodyHtml: null,
+};
+
+// Bounds each property read so a wedged host (classic Win32 was seen dropping
+// callbacks entirely, ERMAIN-431) degrades to the fallback value instead of
+// hanging the caller — at send time that would hold the user's message.
+const APPOINTMENT_READ_TIMEOUT_MS = 5_000;
+
+function readOptionalProperty<TRaw, TValue>(
+  property:
+    | {
+        getAsync?: (
+          callback: (result: Office.AsyncResult<TRaw>) => void,
+        ) => void;
+      }
+    | undefined,
+  map: (value: TRaw) => TValue,
+  fallback: TValue,
+): Promise<TValue> {
+  if (typeof property?.getAsync !== "function") {
+    return Promise.resolve(fallback);
+  }
+  return callOfficeAsync<TRaw>((callback) => property.getAsync!(callback), {
+    timeoutMs: APPOINTMENT_READ_TIMEOUT_MS,
+  })
+    .then(map)
+    .catch(() => fallback);
+}
+
+/**
+ * Read a fresh snapshot of an appointment compose item. Individual reads that
+ * fail, time out, or aren't supported by the host resolve to the matching
+ * `fallback` field, so the result is always complete and the promise never
+ * rejects.
+ */
+export async function readAppointmentComposeSnapshot(
+  item: Office.AppointmentCompose,
+  fallback: AppointmentComposeSnapshot = EMPTY_APPOINTMENT_SNAPSHOT,
+): Promise<AppointmentComposeSnapshot> {
+  const readBody = (
+    coercionType: Office.CoercionType,
+    bodyFallback: string | null,
+  ): Promise<string | null> =>
+    callOfficeAsync<string>(
+      (callback) => item.body.getAsync(coercionType, callback),
+      { timeoutMs: APPOINTMENT_READ_TIMEOUT_MS },
+    ).catch(() => bodyFallback);
+
+  const [
+    subject,
+    organizer,
+    requiredAttendees,
+    optionalAttendees,
+    location,
+    start,
+    end,
+    bodyText,
+    bodyHtml,
+  ] = await Promise.all([
+    readOptionalProperty(
+      item.subject,
+      (value: string) => value,
+      fallback.subject,
+    ),
+    readOptionalProperty(
+      item.organizer,
+      (details: Office.EmailAddressDetails): EmailAddress | null =>
+        details
+          ? {
+              displayName: details.displayName,
+              emailAddress: details.emailAddress,
+            }
+          : null,
+      fallback.organizer,
+    ),
+    readOptionalProperty(
+      item.requiredAttendees,
+      parseRecipients,
+      fallback.requiredAttendees,
+    ),
+    readOptionalProperty(
+      item.optionalAttendees,
+      parseRecipients,
+      fallback.optionalAttendees,
+    ),
+    readOptionalProperty(
+      item.location,
+      (value: string) => value,
+      fallback.location,
+    ),
+    readOptionalProperty(item.start, (value: Date) => value, fallback.start),
+    readOptionalProperty(item.end, (value: Date) => value, fallback.end),
+    readBody(Office.CoercionType.Text, fallback.bodyText),
+    readBody(Office.CoercionType.Html, fallback.bodyHtml),
+  ]);
+
+  return {
+    subject,
+    organizer,
+    requiredAttendees,
+    optionalAttendees,
+    location,
+    start,
+    end,
+    bodyText,
+    bodyHtml,
+  };
+}
+
+function readAppointmentCompose(
+  item: Office.AppointmentCompose,
+  setMailItem: React.Dispatch<React.SetStateAction<OutlookMailItemData | null>>,
+  canCommit: () => boolean,
+) {
+  setMailItem({
+    itemKind: "appointment",
+    subject: "",
+    from: null,
+    to: [],
+    cc: [],
+    organizer: null,
+    requiredAttendees: [],
+    optionalAttendees: [],
+    location: "",
+    start: null,
+    end: null,
+    dateTimeCreated: null,
+    conversationId: null,
+    internetMessageId: null,
+    itemId: null,
+    bodyText: null,
+    bodyHtml: null,
+    isLoadingBody: true,
+    isComposeMode: true,
+  });
+
+  void readAppointmentComposeSnapshot(item).then((snapshot) => {
+    if (!canCommit()) return;
+    setMailItem((previous) =>
+      previous ? { ...previous, ...snapshot, isLoadingBody: false } : previous,
+    );
+  });
+}
+
 export function useOutlookMailItem() {
   return useContext(OutlookMailItemContext);
 }
@@ -340,9 +548,7 @@ export function OutlookMailItemProvider({
   const [isLoadingAttachments, setIsLoadingAttachments] = useState(true);
   const [hasItemChangedFired, setHasItemChangedFired] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
-  const currentItemRef = useRef<
-    Office.MessageRead | Office.MessageCompose | null
-  >(null);
+  const currentItemRef = useRef<SupportedOutlookItem | null>(null);
   const selectionVersionRef = useRef(0);
   // Identity of the last resolved item — lets us tell a real navigation (the
   // pin-hint tracking signal) from the host's initial same-item selection
@@ -378,9 +584,8 @@ export function OutlookMailItemProvider({
   );
 
   useEffect(() => {
-    // Appointments resolve to the neutral no-item context: a host leaking the
-    // pane into the calendar module (no manifest surface declares one) must
-    // not crash this effect — it runs above every error boundary.
+    // Organizer appointment compose is a first-class surface. Appointment
+    // attendee/read items still resolve to neutral context and fail closed.
     const item = resolveSupportedMailboxItem(Office.context.mailbox.item);
     const selectionVersion = selectionVersionRef.current + 1;
     selectionVersionRef.current = selectionVersion;
@@ -417,6 +622,15 @@ export function OutlookMailItemProvider({
     }
 
     setAttachments([]);
+    if (isAppointmentCompose(item)) {
+      // Appointment attachments must never surface as email context — the
+      // '+' menu and the email-source provider both read this state, so the
+      // isolation has to hold at the source.
+      setIsLoadingAttachments(false);
+      readAppointmentCompose(item, setMailItem, canCommit);
+      setIsLoading(false);
+      return;
+    }
     setIsLoadingAttachments(true);
     void readAttachmentMetadata(item)
       .then((nextAttachments) => {

--- a/office-addin/src/outlook/providers/OutlookMailItemProvider.tsx
+++ b/office-addin/src/outlook/providers/OutlookMailItemProvider.tsx
@@ -139,7 +139,7 @@ function buildMailItemIdentity(
 
   return (
     item.conversationId ??
-    `${UNSAVED_COMPOSE_IDENTITY_PREFIX}${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`
+    `${UNSAVED_COMPOSE_IDENTITY_PREFIX}${globalThis.crypto.randomUUID()}`
   );
 }
 

--- a/office-addin/src/outlook/providers/__tests__/OutlookEmailSourceProvider.test.tsx
+++ b/office-addin/src/outlook/providers/__tests__/OutlookEmailSourceProvider.test.tsx
@@ -23,7 +23,7 @@ vi.mock("../OutlookMailItemProvider", () => ({
 }));
 
 vi.mock("../../hooks/useCurrentThread", () => ({
-  useCurrentThread: () => mockUseCurrentThread(),
+  useCurrentThread: (...args: unknown[]) => mockUseCurrentThread(...args),
 }));
 
 vi.mock("../../hooks/useOutlookMessageFetcher", () => ({
@@ -274,5 +274,57 @@ describe("OutlookEmailSourceProvider — compose reply-context via the dispatche
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(captured!.isLoadingParentReplyContext).toBe(false);
+  });
+});
+
+describe("OutlookEmailSourceProvider — appointment isolation", () => {
+  it("does not present an appointment description or attachments as email context", async () => {
+    const getAttachmentFile = vi.fn();
+    const fetchParentMessageInConversation = vi.fn();
+    mockUseOutlookMailItem.mockReturnValue({
+      itemIdentity: "appointment:1",
+      mailItem: {
+        itemKind: "appointment",
+        itemId: "saved-appointment",
+        conversationId: "must-not-be-used",
+        subject: "Planning session",
+        isComposeMode: true,
+      },
+      attachments: [
+        {
+          id: "agenda",
+          name: "agenda.pdf",
+          isInline: false,
+          attachmentType: "file",
+        },
+      ],
+      isLoadingAttachments: true,
+      getAttachmentFile,
+    });
+    mockUseCurrentThread.mockReturnValue({
+      thread: null,
+      isLoading: false,
+      error: false,
+    });
+    mockUseOutlookMessageFetcher.mockReturnValue({
+      fetcher: { fetchParentMessageInConversation },
+      unavailableReason: null,
+    });
+
+    renderProvider();
+
+    expect(mockUseCurrentThread).toHaveBeenCalledWith(null, null, null);
+    expect(captured!.emailSubject).toBe("");
+    expect(captured!.selectedAttachmentItems).toEqual([]);
+    expect(captured!.isLoadingAttachments).toBe(false);
+    expect(captured!.parentReplyContext).toBeNull();
+    expect(fetchParentMessageInConversation).not.toHaveBeenCalled();
+
+    let files: File[] = [];
+    await act(async () => {
+      files = await captured!.resolveSelectedFilesForSend();
+    });
+    expect(files).toEqual([]);
+    expect(getAttachmentFile).not.toHaveBeenCalled();
   });
 });

--- a/office-addin/src/outlook/providers/__tests__/OutlookMailItemProvider.test.tsx
+++ b/office-addin/src/outlook/providers/__tests__/OutlookMailItemProvider.test.tsx
@@ -55,6 +55,41 @@ function makeComposeItem(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeAppointmentCompose(overrides: Record<string, unknown> = {}) {
+  const asyncField = (value: unknown) => ({
+    getAsync: (cb: (r: unknown) => void) => cb(createMockAsyncResult(value)),
+  });
+  return {
+    itemType: "appointment",
+    seriesId: null,
+    subject: asyncField("Planning session"),
+    organizer: asyncField({
+      displayName: "Ana",
+      emailAddress: "ana@x",
+    }),
+    requiredAttendees: asyncField([
+      { displayName: "Bob", emailAddress: "bob@x" },
+    ]),
+    optionalAttendees: asyncField([]),
+    location: asyncField("Room 3"),
+    start: asyncField(new Date("2026-08-10T08:00:00Z")),
+    end: asyncField(new Date("2026-08-10T09:00:00Z")),
+    body: {
+      getAsync: (coercion: Office.CoercionType, cb: (r: unknown) => void) =>
+        cb(
+          createMockAsyncResult(
+            coercion === Office.CoercionType.Html
+              ? "<p>Discuss roadmap</p>"
+              : "Discuss roadmap",
+          ),
+        ),
+    },
+    getAttachmentsAsync: (cb: (r: unknown) => void) =>
+      cb(createMockAsyncResult([])),
+    ...overrides,
+  };
+}
+
 let mailbox: Mailbox;
 let captured: ContextValue | null;
 
@@ -100,14 +135,56 @@ describe("OutlookMailItemProvider", () => {
     expect(captured?.mailItem).toBeNull();
   });
 
-  // A host leaking the pane into the calendar module: an AppointmentRead has a
-  // string subject too, so without the guard it would masquerade as a read
-  // message instead of resolving to the neutral no-item context.
-  it("treats an appointment item as no item", async () => {
+  it("treats an appointment attendee/read item as no item", async () => {
     mailbox.item = makeReadItem({ itemType: "appointment" });
     await renderProvider();
     expect(captured?.mailItem).toBeNull();
     expect(captured?.itemIdentity).toBeNull();
+  });
+
+  it("loads organizer appointment fields and description", async () => {
+    mailbox.item = makeAppointmentCompose();
+    await renderProvider();
+
+    expect(captured?.mailItem).toMatchObject({
+      itemKind: "appointment",
+      subject: "Planning session",
+      organizer: { displayName: "Ana", emailAddress: "ana@x" },
+      requiredAttendees: [{ displayName: "Bob", emailAddress: "bob@x" }],
+      optionalAttendees: [],
+      location: "Room 3",
+      bodyText: "Discuss roadmap",
+      bodyHtml: "<p>Discuss roadmap</p>",
+      isLoadingBody: false,
+      isComposeMode: true,
+    });
+    expect(captured?.itemIdentity).toMatch(/^appointment:/);
+  });
+
+  it("never reads appointment attachments (isolation from email context)", async () => {
+    const getAttachmentsAsync = vi.fn((cb: (r: unknown) => void) =>
+      cb(createMockAsyncResult([{ id: "a1", name: "agenda.pdf" }])),
+    );
+    mailbox.item = makeAppointmentCompose({ getAttachmentsAsync });
+    await renderProvider();
+
+    expect(getAttachmentsAsync).not.toHaveBeenCalled();
+    expect(captured?.attachments).toEqual([]);
+    expect(captured?.isLoadingAttachments).toBe(false);
+  });
+
+  it("keeps the same per-window identity for an unsaved appointment", async () => {
+    mailbox.item = makeAppointmentCompose();
+    await renderProvider();
+    const firstIdentity = captured?.itemIdentity;
+
+    const handler = mailbox.addHandlerAsync.mock.calls[0][1] as () => void;
+    await act(async () => {
+      handler();
+    });
+
+    expect(captured?.itemIdentity).toBe(firstIdentity);
+    expect(captured?.hasItemChangedFired).toBe(false);
   });
 
   // Drives the "pin this add-in" hint: stays false on the host's initial

--- a/office-addin/src/outlook/sessionPolicy/__tests__/outlookAnchor.test.ts
+++ b/office-addin/src/outlook/sessionPolicy/__tests__/outlookAnchor.test.ts
@@ -21,6 +21,13 @@ const compose = (conv: string | null): OutlookSessionAnchor => ({
   isCompose: true,
 });
 
+const appointment = (identity: string | null): OutlookSessionAnchor => ({
+  conversationId: null,
+  isCompose: true,
+  itemKind: "appointment",
+  itemIdentity: identity,
+});
+
 describe("strictAnchorsEqual", () => {
   it("equal when both null", () => {
     expect(strictAnchorsEqual(null, null)).toBe(true);
@@ -41,6 +48,17 @@ describe("strictAnchorsEqual", () => {
 
   it("not equal when both have null conversationId (treated as distinct)", () => {
     expect(strictAnchorsEqual(compose(null), compose(null))).toBe(false);
+  });
+
+  it("compares appointments by their non-null item identity", () => {
+    expect(strictAnchorsEqual(appointment("A1"), appointment("A1"))).toBe(true);
+    expect(strictAnchorsEqual(appointment("A1"), appointment("A2"))).toBe(
+      false,
+    );
+    expect(strictAnchorsEqual(appointment(null), appointment(null))).toBe(
+      false,
+    );
+    expect(strictAnchorsEqual(appointment("T1"), compose("T1"))).toBe(false);
   });
 });
 
@@ -95,27 +113,28 @@ const composeItem = (conv: string | null) =>
     conversationId: conv ?? undefined,
   }) as unknown as Office.MessageCompose;
 
+const appointmentComposeItem = (seriesId: string | null) =>
+  ({
+    subject: { getAsync: () => undefined },
+    itemType: "appointment",
+    seriesId,
+  }) as unknown as Office.AppointmentCompose;
+
 describe("resolveSupportedMailboxItem", () => {
   it("returns null for a missing item", () => {
     expect(resolveSupportedMailboxItem(null)).toBeNull();
     expect(resolveSupportedMailboxItem(undefined)).toBeNull();
   });
 
-  it("treats appointment items as absent (read and compose shapes)", () => {
-    // AppointmentRead also has a string subject, AppointmentCompose an object
-    // one — both would pass the isMessageRead shape check if let through.
+  it("rejects appointment attendee/read mode but accepts organizer compose", () => {
     expect(
       resolveSupportedMailboxItem({
         subject: "Standup",
         itemType: "appointment",
       }),
     ).toBeNull();
-    expect(
-      resolveSupportedMailboxItem({
-        subject: { getAsync: () => undefined },
-        itemType: "appointment",
-      }),
-    ).toBeNull();
+    const compose = appointmentComposeItem(null);
+    expect(resolveSupportedMailboxItem(compose)).toBe(compose);
   });
 
   it("passes message items through, including without itemType (mocks/hosts omit it)", () => {
@@ -167,5 +186,33 @@ describe("outlookAnchorFromItem", () => {
       conversationId: null,
       isCompose: true,
     });
+  });
+
+  it("mints a per-item appointment identity and never uses seriesId", () => {
+    // seriesId names the PARENT series — every occurrence of a recurring
+    // series shares it, so it must never become the anchor identity.
+    const item = appointmentComposeItem("series-1");
+    const anchor = outlookAnchorFromItem(item);
+    expect(anchor).toMatchObject({
+      conversationId: null,
+      isCompose: true,
+      itemKind: "appointment",
+    });
+    expect(anchor?.itemIdentity).toMatch(/^appointment:/);
+    expect(anchor?.itemIdentity).not.toContain("series-1");
+  });
+
+  it("keeps the minted appointment identity stable for the same item object", () => {
+    const item = appointmentComposeItem(null);
+    expect(outlookAnchorFromItem(item)?.itemIdentity).toBe(
+      outlookAnchorFromItem(item)?.itemIdentity,
+    );
+  });
+
+  it("mints distinct identities for distinct appointment items of one series", () => {
+    const first = outlookAnchorFromItem(appointmentComposeItem("series-1"));
+    const second = outlookAnchorFromItem(appointmentComposeItem("series-1"));
+    expect(first?.itemIdentity).not.toBe(second?.itemIdentity);
+    expect(strictAnchorsEqual(first, second)).toBe(false);
   });
 });

--- a/office-addin/src/outlook/sessionPolicy/index.ts
+++ b/office-addin/src/outlook/sessionPolicy/index.ts
@@ -1,11 +1,16 @@
 export {
+  UNSAVED_APPOINTMENT_IDENTITY_PREFIX,
+  UNSAVED_COMPOSE_IDENTITY_PREFIX,
   anchorsEqualForPreferences,
   composeInheritsAnchorsEqual,
+  getOrMintItemIdentity,
+  isAppointmentCompose,
   isMessageRead,
   outlookAnchorFromItem,
   resolveSupportedMailboxItem,
   strictAnchorsEqual,
 } from "./outlookAnchor";
+export type { SupportedOutlookItem } from "./outlookAnchor";
 export {
   DEFAULT_OUTLOOK_SESSION,
   DEFAULT_OUTLOOK_SESSION_PREFERENCES,

--- a/office-addin/src/outlook/sessionPolicy/outlookAnchor.ts
+++ b/office-addin/src/outlook/sessionPolicy/outlookAnchor.ts
@@ -1,37 +1,77 @@
 import type { OutlookSessionAnchor, OutlookSessionPreferences } from "./types";
 
 /**
- * Type-guard distinguishing read mode from compose mode using the only
- * synchronously-available property of the compose surface that's a non-string
- * (`subject` is `Office.SubjectCompose` for compose, `string` for read).
+ * Type-guard for read-mode messages using the only synchronously-available
+ * property that distinguishes the surfaces: `subject` is a `string` on
+ * `MessageRead` and a subject accessor object on every compose surface
+ * (message and appointment alike), so this returns `false` for both compose
+ * modes.
  *
  * Pure; safe to call during render or in a `useState` initializer.
  */
 export function isMessageRead(
-  item: Office.MessageRead | Office.MessageCompose,
+  item: SupportedOutlookItem,
 ): item is Office.MessageRead {
   return typeof (item as Office.MessageRead).subject === "string";
 }
 
+export type SupportedOutlookItem =
+  | Office.MessageRead
+  | Office.MessageCompose
+  | Office.AppointmentCompose;
+
+export const UNSAVED_COMPOSE_IDENTITY_PREFIX = "compose:";
+export const UNSAVED_APPOINTMENT_IDENTITY_PREFIX = "appointment:";
+
+const mintedItemIdentities = new WeakMap<object, string>();
+
 /**
- * Narrow a raw `Office.context.mailbox.item` to the message shapes the add-in
- * supports; appointment items resolve to `null` ("no item"). `isMessageRead`
- * keys on the subject SHAPE (string vs object), which appointment items also
- * satisfy — an AppointmentRead leaking past this guard masquerades as a read
- * message (attaching the reply facet / reply form to a meeting) and an
- * AppointmentCompose crashes message-only consumers (`item.to` is undefined).
- * Compared against the literal value (`ItemType.Appointment`) so an absent
- * `itemType` keeps meaning "message" — mocks and some hosts omit it.
+ * Page-load-scoped identity for compose surfaces that expose no durable id
+ * (unsaved appointment/message composes). Keyed on the host's item object, so
+ * repeated resolves of the same object agree; a reload (or a host that hands
+ * out a fresh object) mints a new identity, which fails toward "different
+ * item" — the safe direction for the anchor policy and the insert guard.
+ *
+ * Idempotent per item object; safe to call during render.
+ */
+export function getOrMintItemIdentity(item: object, prefix: string): string {
+  const existing = mintedItemIdentities.get(item);
+  if (existing) return existing;
+  const identity = `${prefix}${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+  mintedItemIdentities.set(item, identity);
+  return identity;
+}
+
+export function isAppointmentCompose(
+  item: SupportedOutlookItem,
+): item is Office.AppointmentCompose {
+  return (
+    String((item as { itemType?: string }).itemType).toLowerCase() ===
+      "appointment" &&
+    typeof (item as unknown as { subject?: unknown }).subject !== "string"
+  );
+}
+
+/**
+ * Narrow a raw `Office.context.mailbox.item` to the surfaces the add-in
+ * supports. Organizer appointment compose is supported; attendee/read mode is
+ * deliberately rejected so it can never masquerade as a read email. An absent
+ * `itemType` keeps meaning "message" because mocks and some hosts omit it.
  *
  * Pure; safe to call during render or in a `useState` initializer.
  */
 export function resolveSupportedMailboxItem(
   item: unknown,
-): Office.MessageRead | Office.MessageCompose | null {
-  if (!item || (item as { itemType?: string }).itemType === "appointment") {
-    return null;
-  }
-  return item as Office.MessageRead | Office.MessageCompose;
+): SupportedOutlookItem | null {
+  if (!item) return null;
+
+  const candidate = item as SupportedOutlookItem;
+  const isAppointment =
+    String((candidate as { itemType?: string }).itemType).toLowerCase() ===
+    "appointment";
+  if (isAppointment && !isAppointmentCompose(candidate)) return null;
+
+  return candidate;
 }
 
 /**
@@ -42,9 +82,25 @@ export function resolveSupportedMailboxItem(
  * Pure; safe to call during render or in a `useState` initializer.
  */
 export function outlookAnchorFromItem(
-  item: Office.MessageRead | Office.MessageCompose | null,
+  item: SupportedOutlookItem | null,
 ): OutlookSessionAnchor | null {
   if (!item) return null;
+  if (isAppointmentCompose(item)) {
+    // Deliberately NOT `seriesId`: Office.js reports the PARENT series id on
+    // every occurrence of a recurring series, so two different occurrences
+    // would share an anchor (and a chat, and the insert gate). The minted
+    // identity is page-load-scoped — appointment chats never resume across a
+    // task-pane reload, exactly like a brand-new message compose.
+    return {
+      conversationId: null,
+      isCompose: true,
+      itemKind: "appointment",
+      itemIdentity: getOrMintItemIdentity(
+        item,
+        UNSAVED_APPOINTMENT_IDENTITY_PREFIX,
+      ),
+    };
+  }
   return {
     conversationId: item.conversationId ?? null,
     isCompose: !isMessageRead(item),
@@ -62,6 +118,13 @@ export function strictAnchorsEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
+  const aKind = a.itemKind ?? "message";
+  const bKind = b.itemKind ?? "message";
+  if (aKind !== bKind) return false;
+  if (aKind === "appointment") {
+    if (!a.itemIdentity || !b.itemIdentity) return false;
+    return a.itemIdentity === b.itemIdentity && a.isCompose === b.isCompose;
+  }
   if (a.conversationId === null || b.conversationId === null) return false;
   return a.conversationId === b.conversationId && a.isCompose === b.isCompose;
 }
@@ -79,6 +142,12 @@ export function composeInheritsAnchorsEqual(
 ): boolean {
   if (strictAnchorsEqual(a, b)) return true;
   if (!a || !b) return false;
+  if (
+    (a.itemKind ?? "message") !== "message" ||
+    (b.itemKind ?? "message") !== "message"
+  ) {
+    return false;
+  }
   if (a.conversationId === null || b.conversationId === null) return false;
   return a.conversationId === b.conversationId;
 }

--- a/office-addin/src/outlook/sessionPolicy/outlookAnchor.ts
+++ b/office-addin/src/outlook/sessionPolicy/outlookAnchor.ts
@@ -37,7 +37,7 @@ const mintedItemIdentities = new WeakMap<object, string>();
 export function getOrMintItemIdentity(item: object, prefix: string): string {
   const existing = mintedItemIdentities.get(item);
   if (existing) return existing;
-  const identity = `${prefix}${Date.now().toString(36)}:${Math.random().toString(36).slice(2, 8)}`;
+  const identity = `${prefix}${globalThis.crypto.randomUUID()}`;
   mintedItemIdentities.set(item, identity);
   return identity;
 }

--- a/office-addin/src/outlook/sessionPolicy/persistence.ts
+++ b/office-addin/src/outlook/sessionPolicy/persistence.ts
@@ -24,9 +24,15 @@ const isStringOrNull = (value: unknown): value is string | null =>
 const isAnchor = (value: unknown): value is OutlookSessionAnchor => {
   if (value === null || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
+  const itemKind = candidate.itemKind;
+  const itemIdentity = candidate.itemIdentity;
   return (
     isStringOrNull(candidate.conversationId) &&
-    typeof candidate.isCompose === "boolean"
+    typeof candidate.isCompose === "boolean" &&
+    (itemKind === undefined ||
+      itemKind === "message" ||
+      itemKind === "appointment") &&
+    (itemIdentity === undefined || isStringOrNull(itemIdentity))
   );
 };
 

--- a/office-addin/src/outlook/sessionPolicy/types.ts
+++ b/office-addin/src/outlook/sessionPolicy/types.ts
@@ -10,6 +10,16 @@
 export interface OutlookSessionAnchor {
   conversationId: string | null;
   isCompose: boolean;
+  /** Defaults to `message` for anchors persisted by older add-in builds. */
+  itemKind?: "message" | "appointment";
+  /**
+   * Minted identity for appointment composes, which have no durable id before
+   * save (`seriesId` is unusable — it names the whole recurring series, not
+   * the occurrence). Page-load-scoped: a persisted appointment anchor never
+   * matches after a task-pane reload, so appointment chats don't resume
+   * across reloads by design.
+   */
+  itemIdentity?: string | null;
 }
 
 export interface OutlookSessionPreferences {

--- a/office-addin/src/outlook/utils/__tests__/outlookActionFacet.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/outlookActionFacet.test.ts
@@ -6,12 +6,13 @@ import {
 } from "../outlookActionFacet";
 
 const base: OutlookActionFacetInput = {
+  itemKind: null,
   hasActiveSelection: false,
   selectionData: "",
   selectionSource: "body",
   draftContextIncluded: false,
   draftBody: "",
-  lastSentDraftBody: null,
+  lastSentDraftFingerprint: null,
   bodyFormat: undefined,
   isComposeMode: false,
   composeEmailAvailable: false,
@@ -39,7 +40,7 @@ describe("resolveOutlookActionFacet", () => {
   it("returns no facet with nothing selected and no draft included", () => {
     expect(resolveOutlookActionFacet(base)).toEqual({
       facet: undefined,
-      sentDraftBody: null,
+      sentDraftFingerprint: null,
     });
   });
 
@@ -64,7 +65,7 @@ describe("resolveOutlookActionFacet", () => {
       },
     });
     // Selection sends never touch the draft dedup marker.
-    expect(result.sentDraftBody).toBeNull();
+    expect(result.sentDraftFingerprint).toBeNull();
   });
 
   it("omits body_format from rewrite args when the format is unknown", () => {
@@ -81,19 +82,54 @@ describe("resolveOutlookActionFacet", () => {
     });
   });
 
+  it("uses the appointment-specific rewrite facet for organizer selections", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      itemKind: "appointment",
+      isComposeMode: true,
+      appointmentRewriteAvailable: true,
+      hasActiveSelection: true,
+      selectionData: "Old agenda",
+      selectionSource: "body",
+      bodyFormat: "html",
+    });
+
+    expect(result.facet).toEqual({
+      id: "outlook_rewrite_appointment_selection",
+      args: {
+        selected_text: "Old agenda",
+        source_property: "body",
+        body_format: "html",
+      },
+    });
+  });
+
+  it("does not send an appointment selection to the email rewrite facet", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      itemKind: "appointment",
+      isComposeMode: true,
+      appointmentRewriteAvailable: false,
+      hasActiveSelection: true,
+      selectionData: "Old agenda",
+    });
+
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
+  });
+
   it("sends review_draft for an included, non-empty, changed draft", () => {
     const result = resolveOutlookActionFacet({
       ...base,
       draftContextIncluded: true,
       draftBody: "Dear Bob, ...",
-      lastSentDraftBody: null,
+      lastSentDraftFingerprint: null,
     });
 
     expect(result.facet).toEqual({
       id: "outlook_review_draft",
       args: { full_body: "Dear Bob, ...", body_format: "text" },
     });
-    expect(result.sentDraftBody).toBe("Dear Bob, ...");
+    expect(result.sentDraftFingerprint).toBe("Dear Bob, ...");
   });
 
   it("does NOT send review_draft when the draft chip is dismissed (#1 toggle off)", () => {
@@ -103,7 +139,7 @@ describe("resolveOutlookActionFacet", () => {
       draftBody: "Dear Bob, ...",
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
   });
 
   it("de-dupes: skips review_draft when the body is unchanged since the last send (#4)", () => {
@@ -111,10 +147,10 @@ describe("resolveOutlookActionFacet", () => {
       ...base,
       draftContextIncluded: true,
       draftBody: "same body",
-      lastSentDraftBody: "same body",
+      lastSentDraftFingerprint: "same body",
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
   });
 
   it("re-sends review_draft after the draft body changes", () => {
@@ -122,11 +158,11 @@ describe("resolveOutlookActionFacet", () => {
       ...base,
       draftContextIncluded: true,
       draftBody: "edited body",
-      lastSentDraftBody: "old body",
+      lastSentDraftFingerprint: "old body",
     });
 
     expect(result.facet?.id).toBe("outlook_review_draft");
-    expect(result.sentDraftBody).toBe("edited body");
+    expect(result.sentDraftFingerprint).toBe("edited body");
   });
 
   it("skips an empty draft body even when included", () => {
@@ -136,12 +172,66 @@ describe("resolveOutlookActionFacet", () => {
       draftBody: "",
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
+  });
+
+  it("sends explicit appointment context, including an empty description", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      itemKind: "appointment",
+      isComposeMode: true,
+      appointmentContextAvailable: true,
+      draftContextIncluded: true,
+      draftBody: "",
+      draftContextFingerprint: "appointment-v1",
+      appointmentSubject: "Planning session",
+      appointmentRequiredAttendees: "bob@example.com",
+      appointmentOptionalAttendees: "ana@example.com",
+      appointmentLocation: "Room 3",
+      appointmentStart: "2026-08-10T08:00:00.000Z",
+      appointmentEnd: "2026-08-10T09:00:00.000Z",
+    });
+
+    expect(result.facet).toEqual({
+      id: "outlook_review_appointment",
+      args: {
+        subject: "Planning session",
+        full_body: "",
+        required_attendees: "bob@example.com",
+        optional_attendees: "ana@example.com",
+        location: "Room 3",
+        start: "2026-08-10T08:00:00.000Z",
+        end: "2026-08-10T09:00:00.000Z",
+        body_format: "text",
+        timezone: "Europe/Berlin",
+      },
+    });
+    expect(result.sentDraftFingerprint).toBe("appointment-v1");
+  });
+
+  it("never falls through to email-only compose or reply facets for appointments", () => {
+    expect(
+      resolveOutlookActionFacet({
+        ...base,
+        itemKind: "appointment",
+        isComposeMode: true,
+        composeEmailAvailable: true,
+      }).facet,
+    ).toBeUndefined();
+    expect(
+      resolveOutlookActionFacet({
+        ...base,
+        itemKind: "appointment",
+        isReadMode: true,
+        replyFromReadAvailable: true,
+      }).facet,
+    ).toBeUndefined();
   });
 
   it("sends compose_email for an empty compose draft when the facet is available", () => {
     const result = resolveOutlookActionFacet({
       ...base,
+      itemKind: "message",
       isComposeMode: true,
       draftBody: "   ",
       bodyFormat: "html",
@@ -150,12 +240,13 @@ describe("resolveOutlookActionFacet", () => {
 
     expect(result.facet?.id).toBe("compose_email");
     expect(result.facet?.args).toEqual({ body_format: "html" });
-    expect(result.sentDraftBody).toBeNull();
+    expect(result.sentDraftFingerprint).toBeNull();
   });
 
   it("defaults compose_email body_format to text when unknown", () => {
     const result = resolveOutlookActionFacet({
       ...base,
+      itemKind: "message",
       isComposeMode: true,
       composeEmailAvailable: true,
     });
@@ -170,7 +261,7 @@ describe("resolveOutlookActionFacet", () => {
       composeEmailAvailable: false,
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
   });
 
   it("prefers review_draft over compose_email once the draft has content", () => {
@@ -200,6 +291,7 @@ describe("resolveOutlookActionFacet", () => {
   it("sends outlook_reply_from_read in read mode when the facet is available", () => {
     const result = resolveOutlookActionFacet({
       ...base,
+      itemKind: "message",
       isReadMode: true,
       replyFromReadAvailable: true,
     });
@@ -208,7 +300,7 @@ describe("resolveOutlookActionFacet", () => {
       id: "outlook_reply_from_read",
       args: { body_format: "html" },
     });
-    expect(result.sentDraftBody).toBeNull();
+    expect(result.sentDraftFingerprint).toBeNull();
   });
 
   it("does NOT send outlook_reply_from_read when the facet is unavailable (avoids a 400)", () => {
@@ -218,7 +310,7 @@ describe("resolveOutlookActionFacet", () => {
       replyFromReadAvailable: false,
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
   });
 
   it("does NOT send outlook_reply_from_read outside read mode", () => {
@@ -228,7 +320,7 @@ describe("resolveOutlookActionFacet", () => {
       replyFromReadAvailable: true,
     });
 
-    expect(result).toEqual({ facet: undefined, sentDraftBody: null });
+    expect(result).toEqual({ facet: undefined, sentDraftFingerprint: null });
   });
 
   it("attaches outlook_schedule ambiently in a NEUTRAL context (no item)", () => {
@@ -238,7 +330,7 @@ describe("resolveOutlookActionFacet", () => {
       id: "outlook_schedule",
       args: scheduleArgs,
     });
-    expect(result.sentDraftBody).toBeNull();
+    expect(result.sentDraftFingerprint).toBeNull();
   });
 
   it("does NOT attach outlook_schedule ambiently in read or compose contexts", () => {
@@ -255,7 +347,7 @@ describe("resolveOutlookActionFacet", () => {
         isComposeMode: true,
         draftContextIncluded: true,
         draftBody: "same body",
-        lastSentDraftBody: "same body",
+        lastSentDraftFingerprint: "same body",
       }).facet,
     ).toBeUndefined();
   });
@@ -322,9 +414,25 @@ describe("resolveOutlookActionFacet", () => {
     ).toBe("outlook_rewrite_selection");
   });
 
+  it("sticky never claims an appointment compose — the review facet owns it", () => {
+    const result = resolveOutlookActionFacet({
+      ...base,
+      ...scheduleReady,
+      schedulingThreadActive: true,
+      itemKind: "appointment",
+      isComposeMode: true,
+      appointmentContextAvailable: true,
+      draftContextIncluded: true,
+      draftContextFingerprint: "appointment-v1",
+    });
+
+    expect(result.facet?.id).toBe("outlook_review_appointment");
+  });
+
   it("sticky does not fire without an available facet or calendar backend", () => {
     const result = resolveOutlookActionFacet({
       ...base,
+      itemKind: "message",
       schedulingThreadActive: true,
       scheduleFacetAvailable: true,
       calendarAvailable: false,

--- a/office-addin/src/outlook/utils/__tests__/outlookComposeWrite.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/outlookComposeWrite.test.ts
@@ -23,6 +23,19 @@ describe("outlookComposeWrite", () => {
     uninstallMockMailbox();
   });
 
+  function createAppointmentCompose(body: {
+    getAsync: ReturnType<typeof vi.fn>;
+    getTypeAsync?: ReturnType<typeof vi.fn>;
+    setSelectedDataAsync: ReturnType<typeof vi.fn>;
+    prependAsync: ReturnType<typeof vi.fn>;
+  }) {
+    return {
+      itemType: "appointment",
+      subject: { getAsync: vi.fn() },
+      body,
+    };
+  }
+
   describe("getComposeBodyType", () => {
     it("returns 'html' when body type is Html", async () => {
       const item = createMockMessageCompose({
@@ -124,6 +137,28 @@ describe("outlookComposeWrite", () => {
   });
 
   describe("replaceComposeSelection", () => {
+    it("writes into an appointment organizer description", async () => {
+      const setSelectedDataAsync = vi.fn((_data, _options, callback) =>
+        callback(createMockAsyncResult(undefined)),
+      );
+      mailbox.item = createAppointmentCompose({
+        getAsync: vi.fn(),
+        getTypeAsync: vi.fn((callback) =>
+          callback(createMockAsyncResult(Office.CoercionType.Html)),
+        ),
+        setSelectedDataAsync,
+        prependAsync: vi.fn(),
+      });
+
+      await replaceComposeSelection("Updated agenda");
+
+      expect(setSelectedDataAsync).toHaveBeenCalledWith(
+        "Updated agenda",
+        { coercionType: Office.CoercionType.Html },
+        expect.any(Function),
+      );
+    });
+
     it("converts plain text to HTML with line breaks for html body", async () => {
       const setSelectedDataAsync = vi.fn((_data, _options, callback) =>
         callback(createMockAsyncResult(undefined)),
@@ -267,6 +302,28 @@ describe("outlookComposeWrite", () => {
   });
 
   describe("prependComposeBody", () => {
+    it("prepends an appointment organizer description", async () => {
+      const prependAsync = vi.fn((_data, _options, callback) =>
+        callback(createMockAsyncResult(undefined)),
+      );
+      mailbox.item = createAppointmentCompose({
+        getAsync: vi.fn(),
+        getTypeAsync: vi.fn((callback) =>
+          callback(createMockAsyncResult(Office.CoercionType.Text)),
+        ),
+        setSelectedDataAsync: vi.fn(),
+        prependAsync,
+      });
+
+      await prependComposeBody("Important: agenda updated");
+
+      expect(prependAsync).toHaveBeenCalledWith(
+        "Important: agenda updated",
+        { coercionType: Office.CoercionType.Text },
+        expect.any(Function),
+      );
+    });
+
     it("calls prependAsync with matching coercion type", async () => {
       const prependAsync = vi.fn((_data, _options, callback) =>
         callback(createMockAsyncResult(undefined)),

--- a/office-addin/src/outlook/utils/outlookActionFacet.ts
+++ b/office-addin/src/outlook/utils/outlookActionFacet.ts
@@ -9,6 +9,8 @@ import type { ActionFacetRequest } from "@erato/frontend/library";
  * priority and the draft de-duplication are unit-testable in isolation.
  */
 export interface OutlookActionFacetInput {
+  /** Current Outlook item kind; null for the pinned neutral surface. */
+  itemKind: "message" | "appointment" | null;
   /** A compose selection is active and not dismissed. */
   hasActiveSelection: boolean;
   /** The selected text (only meaningful when `hasActiveSelection`). */
@@ -25,13 +27,17 @@ export interface OutlookActionFacetInput {
   /** Plain-text coercion of the draft body. */
   draftBody: string;
   /**
-   * The draft body last sent as `outlook_review_draft` in this chat, or `null`
-   * if none yet. Encodes change #4 — client-side de-dup. (The backend is
-   * intentionally action-facet toggle-stateless and strips prior-turn facet
-   * directives on replay, so the "did we already send this?" memory must live
-   * on the client.)
+   * The draft-context fingerprint last sent in this chat, or `null` if none
+   * yet: the raw body for message drafts, the JSON metadata+description
+   * fingerprint for appointments (see `draftContextFingerprint`). Encodes
+   * change #4 — client-side de-dup. (The backend is intentionally
+   * action-facet toggle-stateless and strips prior-turn facet directives on
+   * replay, so the "did we already send this?" memory must live on the
+   * client.)
    */
-  lastSentDraftBody: string | null;
+  lastSentDraftFingerprint: string | null;
+  /** De-dup key for appointment metadata + description; defaults to draftBody. */
+  draftContextFingerprint?: string;
   /** Compose body format; included in the rewrite facet args when known. */
   bodyFormat?: string;
   /** The user is in an Outlook compose context (reply/new mail), body may be empty. */
@@ -44,6 +50,16 @@ export interface OutlookActionFacetInput {
    * false and the empty-draft case simply sends no facet (today's behavior).
    */
   composeEmailAvailable: boolean;
+  /** Backend advertises the appointment-specific selection facet. */
+  appointmentRewriteAvailable?: boolean;
+  /** Backend advertises the appointment-specific context facet. */
+  appointmentContextAvailable?: boolean;
+  appointmentSubject?: string;
+  appointmentRequiredAttendees?: string;
+  appointmentOptionalAttendees?: string;
+  appointmentLocation?: string;
+  appointmentStart?: string;
+  appointmentEnd?: string;
   /** The user is reading a received email (read mode, not compose). */
   isReadMode: boolean;
   /**
@@ -82,11 +98,12 @@ export interface OutlookActionFacetResult {
   /** The facet to attach, or `undefined` when none applies. */
   facet: ActionFacetRequest | undefined;
   /**
-   * When a `review_draft` facet was produced, the body to remember so the next
-   * unchanged send de-dupes. `null` means "leave the dedup marker untouched" —
-   * i.e. selection sends and skipped/unchanged drafts.
+   * When a review facet was produced, the fingerprint to remember so the next
+   * unchanged send de-dupes (raw body for message drafts, metadata fingerprint
+   * for appointments). `null` means "leave the dedup marker untouched" — i.e.
+   * selection sends and skipped/unchanged drafts.
    */
-  sentDraftBody: string | null;
+  sentDraftFingerprint: string | null;
 }
 
 /**
@@ -102,6 +119,8 @@ export interface OutlookActionFacetResult {
 export function resolveOutlookActionFacet(
   input: OutlookActionFacetInput,
 ): OutlookActionFacetResult {
+  const { itemKind } = input;
+  const draftFingerprint = input.draftContextFingerprint ?? input.draftBody;
   const scheduleReady = input.scheduleFacetAvailable && input.calendarAvailable;
   const scheduleFacet = (): OutlookActionFacetResult => ({
     facet: {
@@ -109,13 +128,19 @@ export function resolveOutlookActionFacet(
       args: { now_iso: input.nowIso, timezone: input.timezone },
     },
     // A scheduling send never touches the draft dedup marker.
-    sentDraftBody: null,
+    sentDraftFingerprint: null,
   });
 
   if (input.hasActiveSelection) {
+    if (itemKind === "appointment" && !input.appointmentRewriteAvailable) {
+      return { facet: undefined, sentDraftFingerprint: null };
+    }
     return {
       facet: {
-        id: "outlook_rewrite_selection",
+        id:
+          itemKind === "appointment"
+            ? "outlook_rewrite_appointment_selection"
+            : "outlook_rewrite_selection",
         args: {
           selected_text: input.selectionData,
           source_property: input.selectionSource,
@@ -123,7 +148,7 @@ export function resolveOutlookActionFacet(
         },
       },
       // A selection send never touches the draft dedup marker.
-      sentDraftBody: null,
+      sentDraftFingerprint: null,
     };
   }
 
@@ -139,15 +164,48 @@ export function resolveOutlookActionFacet(
   // draft — the draft body only ever rides as the review facet's `full_body`
   // arg, so the model doesn't just lose the review template, it never sees
   // the draft at all.
-  if (scheduleReady && input.schedulingThreadActive) {
+  //
+  // Never on appointment composes: the schedule facet's confirm path opens a
+  // NEW appointment, which is never the right continuation while the user is
+  // already editing one — and each proposal it produces would refresh the
+  // stickiness window, locking the chat into scheduling. The review facet
+  // owns this surface; calendar reads stay reachable mid-turn through its
+  // tool allowlist.
+  if (
+    scheduleReady &&
+    input.schedulingThreadActive &&
+    itemKind !== "appointment"
+  ) {
     return scheduleFacet();
   }
 
   if (
     input.draftContextIncluded &&
-    input.draftBody.length > 0 &&
-    input.draftBody !== input.lastSentDraftBody
+    (itemKind === "appointment" || input.draftBody.length > 0) &&
+    draftFingerprint !== input.lastSentDraftFingerprint
   ) {
+    if (itemKind === "appointment") {
+      if (!input.appointmentContextAvailable) {
+        return { facet: undefined, sentDraftFingerprint: null };
+      }
+      return {
+        facet: {
+          id: "outlook_review_appointment",
+          args: {
+            subject: input.appointmentSubject ?? "",
+            full_body: input.draftBody,
+            required_attendees: input.appointmentRequiredAttendees ?? "",
+            optional_attendees: input.appointmentOptionalAttendees ?? "",
+            location: input.appointmentLocation ?? "",
+            start: input.appointmentStart ?? "",
+            end: input.appointmentEnd ?? "",
+            body_format: "text",
+            timezone: input.timezone,
+          },
+        },
+        sentDraftFingerprint: draftFingerprint,
+      };
+    }
     return {
       facet: {
         id: "outlook_review_draft",
@@ -156,7 +214,7 @@ export function resolveOutlookActionFacet(
           body_format: "text",
         },
       },
-      sentDraftBody: input.draftBody,
+      sentDraftFingerprint: draftFingerprint,
     };
   }
 
@@ -166,6 +224,7 @@ export function resolveOutlookActionFacet(
   // availability because the unknown-facet path hard-400s the send.
   if (
     input.composeEmailAvailable &&
+    itemKind === "message" &&
     input.isComposeMode &&
     !input.hasActiveSelection &&
     input.draftBody.trim().length === 0
@@ -175,7 +234,7 @@ export function resolveOutlookActionFacet(
         id: "compose_email",
         args: { body_format: input.bodyFormat ?? "text" },
       },
-      sentDraftBody: null,
+      sentDraftFingerprint: null,
     };
   }
 
@@ -184,13 +243,17 @@ export function resolveOutlookActionFacet(
   // reply-vs-reply-all via the backend's `propose_client_action` tool when —
   // and only when — the user actually asks for a reply; other requests are
   // answered normally. The reply form prefill is HTML, so request html output.
-  if (input.replyFromReadAvailable && input.isReadMode) {
+  if (
+    input.replyFromReadAvailable &&
+    itemKind === "message" &&
+    input.isReadMode
+  ) {
     return {
       facet: {
         id: OUTLOOK_REPLY_FROM_READ_FACET_ID,
         args: { body_format: "html" },
       },
-      sentDraftBody: null,
+      sentDraftFingerprint: null,
     };
   }
 
@@ -206,5 +269,5 @@ export function resolveOutlookActionFacet(
     return scheduleFacet();
   }
 
-  return { facet: undefined, sentDraftBody: null };
+  return { facet: undefined, sentDraftFingerprint: null };
 }

--- a/office-addin/src/outlook/utils/outlookComposeWrite.ts
+++ b/office-addin/src/outlook/utils/outlookComposeWrite.ts
@@ -7,6 +7,7 @@ import {
   requestImmediateComposeSelectionPoll,
   resumeComposeSelectionPolling,
 } from "../hooks/composeSelectionStore";
+import { isMessageRead, resolveSupportedMailboxItem } from "../sessionPolicy";
 
 // A compose write (setSelectedDataAsync/prependAsync) drops a callback ~never,
 // but on a wedged host it could hang the whole insert forever — bound it.
@@ -38,7 +39,7 @@ interface ComposeWriteAttempt {
 }
 
 async function tryReadComposeBody(
-  item: Office.MessageCompose,
+  item: Office.MessageCompose | Office.AppointmentCompose,
   coercionType: Office.CoercionType,
 ): Promise<string | null> {
   const body = item.body as {
@@ -60,6 +61,16 @@ async function tryReadComposeBody(
   } catch {
     return null;
   }
+}
+
+function getActiveComposeItem():
+  | Office.MessageCompose
+  | Office.AppointmentCompose {
+  const item = resolveSupportedMailboxItem(Office.context.mailbox.item);
+  if (!item || isMessageRead(item)) {
+    throw new Error("No compose item available");
+  }
+  return item;
 }
 
 async function tryComposeWrite(
@@ -88,10 +99,7 @@ async function tryComposeWrite(
  * inspecting body reads instead of throwing.
  */
 export async function getComposeBodyType(): Promise<BodyFormat> {
-  const item = Office.context.mailbox.item as Office.MessageCompose | null;
-  if (!item) {
-    throw new Error("No compose item available");
-  }
+  const item = getActiveComposeItem();
 
   const body = item.body as {
     getTypeAsync?: (
@@ -142,10 +150,7 @@ export async function replaceComposeSelection(
   data: string,
   isHtml = false,
 ): Promise<void> {
-  const item = Office.context.mailbox.item as Office.MessageCompose | null;
-  if (!item) {
-    throw new Error("No compose item available");
-  }
+  const item = getActiveComposeItem();
 
   const bodyFormat = await getComposeBodyType();
   const writeAttempts: ComposeWriteAttempt[] = isHtml
@@ -199,10 +204,7 @@ export async function replaceComposeSelection(
  * Prepends content to the beginning of the compose body.
  */
 export async function prependComposeBody(data: string): Promise<void> {
-  const item = Office.context.mailbox.item as Office.MessageCompose | null;
-  if (!item) {
-    throw new Error("No compose item available");
-  }
+  const item = getActiveComposeItem();
 
   const bodyFormat = await getComposeBodyType();
   const writeAttempts: ComposeWriteAttempt[] =

--- a/office-addin/src/outlook/utils/outlookReadReply.ts
+++ b/office-addin/src/outlook/utils/outlookReadReply.ts
@@ -49,8 +49,9 @@ export function isReplyFormBodyTooLarge(body: string): boolean {
 }
 
 function getReadModeItem(): Office.MessageRead | null {
-  // Appointments fail closed via the shared guard — a "reply" on an
-  // AppointmentRead would open a meeting reply form.
+  // Appointments fail closed — `isMessageRead` is false for every compose
+  // surface, and a "reply" on an AppointmentRead would open a meeting reply
+  // form (those never pass `resolveSupportedMailboxItem` anyway).
   const item = resolveSupportedMailboxItem(Office.context?.mailbox?.item);
   if (!item || !isMessageRead(item)) {
     return null;


### PR DESCRIPTION
Makes the appointment organizer window a first-class add-in surface and hardens the appointment↔email partition throughout.

## What's in here

**Surface**
- Manifest activation rule (`ItemIs Appointment/Edit`) + `AppointmentOrganizerCommandSurface` button in both override generations of the local XML manifest; `meetingDetailsOrganizer` context in the unified manifest.

**Facet pipeline**
- Appointment context/rewrite ride two **config-defined** facets (`outlook_review_appointment`, `outlook_rewrite_appointment_selection`) delivered as a configuration package (companion PR: EratoLab/erato-subscription-content#6). Sends *and* the context chips are gated on `GET /me/facets`, so the UI never claims context a send wouldn't carry.
- Appointment fields are re-read from the live item at send time — editing an appointment form fires no `ItemChanged`, so bind-time state goes stale; reads are bounded with per-field fallback so a wedged host degrades instead of losing the send. Start/end go out as local-offset ISO plus a `timezone` arg.
- Sticky scheduling never claims appointment-compose turns: the schedule facet's confirm path opens a *new* appointment, which is never right while editing one, and each proposal would refresh the stickiness window. Calendar reads stay reachable via the review facet's tool allowlist.
- `getComposeBodyType()` failures on a compose→read race no longer reject the send.

**Identity & isolation**
- Appointment identity is a page-load-scoped mint shared by the provider and anchor paths — never `seriesId`, which Office.js sets to the parent series id on every occurrence (two occurrences would share a chat and pass the insert gate). Minted identities don't count as navigation evidence.
- Appointment attachments never surface as email context (provider skips reading them; email-source provider nulls its source once via an `emailItem` alias).
- `isMessageRead` widened to `SupportedOutlookItem`, deleting eight compound guards; `itemKind` is now required in the facet resolver; dedup markers renamed to `…DraftFingerprint` to match their broadened semantics.