### PR TITLE
feat(office-addin): add the Teams personal app route

### DIFF
--- a/backend/erato/src/frontend_environment.rs
+++ b/backend/erato/src/frontend_environment.rs
@@ -88,6 +88,18 @@ const OUTLOOK_OFFICE_FRAME_ANCESTORS: &[&str] = &[
     "https://outlook.office.com",
     "https://outlook.cloud.microsoft",
 ];
+/// Hosts that frame the Teams personal tab, per the Microsoft tab requirements
+/// table. `*.cloud.microsoft` is additive to the legacy origins, not a replacement.
+const TEAMS_M365_FRAME_ANCESTORS: &[&str] = &[
+    "https://teams.microsoft.com",
+    "https://*.teams.microsoft.com",
+    "https://*.microsoft365.com",
+    "https://*.office.com",
+    "https://*.cloud.microsoft",
+    // Outlook web also serves the tab from office365.com, which no wildcard above matches.
+    "https://outlook.office365.com",
+    "https://outlook-sdf.office365.com",
+];
 
 #[derive(Debug, Clone, Default)]
 /// Map of values that will be provided as environment-variable-like global variables to the frontend.
@@ -475,6 +487,7 @@ fn build_content_security_policy(config: &AppConfig) -> Option<HeaderValue> {
         frame_ancestors.extend(
             OUTLOOK_OFFICE_FRAME_ANCESTORS
                 .iter()
+                .chain(TEAMS_M365_FRAME_ANCESTORS.iter())
                 .map(ToString::to_string),
         );
     }
@@ -1571,15 +1584,19 @@ mod tests {
     }
 
     #[test]
-    fn content_security_policy_includes_outlook_when_office_addin_is_enabled() {
+    fn content_security_policy_includes_outlook_and_teams_when_office_addin_is_enabled() {
         let mut config = AppConfig::default();
         config.integrations.ms_office.addin.enabled = true;
 
         assert_eq!(
             content_security_policy_str(&config).as_deref(),
-            Some(
-                "frame-ancestors 'self' https://outlook.office.com https://outlook.cloud.microsoft"
-            )
+            Some(concat!(
+                "frame-ancestors 'self'",
+                " https://outlook.office.com https://outlook.cloud.microsoft",
+                " https://teams.microsoft.com https://*.teams.microsoft.com",
+                " https://*.microsoft365.com https://*.office.com https://*.cloud.microsoft",
+                " https://outlook.office365.com https://outlook-sdf.office365.com"
+            ))
         );
     }
 

--- a/frontend/src/config/__tests__/themeConfig.test.ts
+++ b/frontend/src/config/__tests__/themeConfig.test.ts
@@ -5,8 +5,13 @@ vi.mock("@/app/env", () => ({
   env: vi.fn(),
 }));
 
-// eslint-disable-next-line import/order
+vi.mock("@/utils/debugLogger", () => ({
+  debugLog: vi.fn(),
+}));
+
 import { env } from "@/app/env";
+import { debugLog } from "@/utils/debugLogger";
+
 import {
   defaultThemeConfig,
   loadThemeConfig,
@@ -18,6 +23,7 @@ import type { Env } from "@/app/env";
 import type { CustomThemeConfig } from "@/utils/themeUtils";
 
 const mockEnv = env as ReturnType<typeof vi.fn>;
+const mockDebugLog = debugLog as ReturnType<typeof vi.fn>;
 
 describe("themeConfig", () => {
   // Default env mock
@@ -501,6 +507,7 @@ describe("themeConfig", () => {
 
     beforeEach(() => {
       global.fetch = vi.fn();
+      mockDebugLog.mockClear();
       vi.spyOn(console, "log").mockImplementation(() => {});
       vi.spyOn(console, "error").mockImplementation(() => {});
     });
@@ -625,7 +632,8 @@ describe("themeConfig", () => {
 
       expect(result).toEqual(mockTheme);
       expect(global.fetch).toHaveBeenCalledTimes(2);
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockDebugLog).toHaveBeenCalledWith(
+        "UI",
         "Theme not found at /custom/theme.json, trying next location",
       );
     });
@@ -640,7 +648,8 @@ describe("themeConfig", () => {
       const result = await loadThemeConfig();
 
       expect(result).toBeNull();
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockDebugLog).toHaveBeenCalledWith(
+        "UI",
         "No custom theme found, using default theme",
       );
     });
@@ -667,10 +676,12 @@ describe("themeConfig", () => {
       const result = await loadThemeConfig();
 
       expect(result).toBeNull();
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockDebugLog).toHaveBeenCalledWith(
+        "UI",
         "Theme not found at /custom/theme.json, trying next location",
       );
-      expect(console.log).toHaveBeenCalledWith(
+      expect(mockDebugLog).toHaveBeenCalledWith(
+        "UI",
         "No custom theme found, using default theme",
       );
     });

--- a/frontend/src/config/themeConfig.ts
+++ b/frontend/src/config/themeConfig.ts
@@ -3,6 +3,7 @@
  * Defines how custom themes are loaded and configured
  */
 import { env } from "@/app/env";
+import { debugLog } from "@/utils/debugLogger";
 
 import type { CustomThemeConfig } from "@/utils/themeUtils";
 
@@ -392,11 +393,11 @@ export async function loadResolvedThemeConfig(
         }
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (error) {
-        console.log(`Theme not found at ${path}, trying next location`);
+        debugLog("UI", `Theme not found at ${path}, trying next location`);
       }
     }
 
-    console.log("No custom theme found, using default theme");
+    debugLog("UI", "No custom theme found, using default theme");
     return null;
   } catch (error) {
     console.error("Failed to load any theme", error);

--- a/office-addin/ARCHITECTURE.md
+++ b/office-addin/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Office add-in architecture
 
 One host-neutral core drives the whole add-in chat experience; each Microsoft
-host (Outlook today; Teams, Word, Excel, PowerPoint later) is a thin
+host (Outlook and Teams today; Word, Excel, PowerPoint later) is a thin
 composition root that injects host behavior through a fixed set of seams.
 Adding a host is meant to be mechanical: compose the core with host providers,
 implement the seams listed below, and never modify the core itself.
@@ -17,6 +17,11 @@ implement the seams listed below, and never modify the core itself.
   `OutlookAddinSessionController.tsx`, `OutlookAddinChat.tsx` (the Outlook
   chat host), `installOutlookComponentRegistrations.ts`, and all Outlook-only
   code in `components/`, `hooks/`, `providers/`, `utils/`, `sessionPolicy/`.
+- `src/teams` — the Teams personal tab composition, a peer of `src/outlook`:
+  `TeamsApp.tsx` (root, served at `/office-addin/teams`), `teamsSession.ts`,
+  `providers/` (the TeamsJS lifecycle, theme and auth roots) and
+  `auth/isTeamsNestedAppAuthSupported.ts`. `@microsoft/teams-js` is imported
+  here and nowhere else.
 - The shared Office.js ring — stays in `src/providers`, `src/hooks`,
   `src/utils`: `OfficeProvider`, `OfficeThemeProvider`, `useOfficeTheme`,
   `utils/officeTheme/`, `officeAsync.ts`, the drag-drop broker
@@ -41,7 +46,9 @@ implement the seams listed below, and never modify the core itself.
    yields an `AddinSessionController`. The default
    `NeutralAddinSessionController` has no anchor policy and persists under
    isolated storage (`erato.addin.neutral.currentChat.v1`). Outlook supplies
-   `OutlookAddinSessionController` (mail-item anchor + session policy).
+   `OutlookAddinSessionController` (mail-item anchor + session policy); Teams
+   supplies `createNeutralAddinSessionController` bound to
+   `erato.addin.teams.currentChat.v1`, so its selection is independent of both.
 3. **Auth** — a host auth provider mounts `SessionAuthProvider`
    (`src/core/SessionAuthProvider.tsx`) with an `AuthSource`; `AuthGate` reads
    only the `SessionAuthCore` fields. The NAA source
@@ -56,13 +63,15 @@ implement the seams listed below, and never modify the core itself.
    host-module eval: `src/outlook/OutlookApp.tsx` calls
    `installOutlookComponentRegistrations()` at module scope, before React
    renders. The registry is a mutable global, so exactly one host per loaded
-   document. Component-kit registrations are re-applied at the entry point via
-   `applyComponentKitRegistrations()` in `src/main.tsx`.
+   document — contributions stay route-local because only the matched lazy
+   route module is evaluated. Teams installs none. Component-kit registrations
+   are re-applied at the entry point via `applyComponentKitRegistrations()` in
+   `src/main.tsx`.
 6. **Platform identifier** — stamped explicitly per host, never inferred from
    a host SDK: the `platform` prop on `AddinChatProviderCore` flows into
    messaging and is sent as the `X-Erato-Platform` request header. Values:
-   `web` (shared-frontend default), `outlook`, `addin-neutral`
-   (`NeutralAddinChatPage` default), future `teams`/`word`/`excel`.
+   `web` (shared-frontend default), `outlook`, `teams`, `addin-neutral`
+   (`NeutralAddinChatPage` default), future `word`/`excel`.
 
 ## Boundary enforcement (`eslint.config.mjs`)
 
@@ -70,14 +79,21 @@ implement the seams listed below, and never modify the core itself.
   import anything under `src/` outside `./core`. Backed by
   `no-restricted-globals` for `Office`/`OfficeRuntime` and a name-based
   `no-restricted-imports` denylist (`**/OfficeProvider`, `**/Outlook*`,
-  `**/outlook/**`, `**/sessionPolicy/**`, `**/useOutlook*`).
+  `**/outlook/**`, `**/sessionPolicy/**`, `**/useOutlook*`, `**/Teams*`,
+  `**/teams/**`, `@microsoft/teams-js`).
+- Host peer fence — `src/outlook/**` and `src/teams/**` may not import each
+  other: one host SDK and one set of registry overrides per document. The
+  Teams block also carries the `Office`/`OfficeRuntime` global ban.
 - Residue-ring guard — `src/hooks`, `src/providers`, `src/utils`, `src/auth`
-  may not import `**/outlook/**` (test mocks excepted): shared code must not
-  depend on the Outlook host module; move it out or invert the dependency.
+  may not import `**/outlook/**` or `**/teams/**` (test mocks excepted):
+  shared code must not depend on a host module; move it out or invert the
+  dependency.
 - Characterization tests —
   `src/core/__tests__/NeutralAddinChatPage.test.tsx` renders the full neutral
   page with the `Office` global deleted and asserts no office.js CDN script
   (`appsforoffice.microsoft.com`) is appended;
+  `src/teams/__tests__/TeamsApp.test.tsx` makes the same assertions for the
+  Teams route and pins its storage key, registry emptiness and MSAL ordering;
   `src/core/__tests__/AddinSettingsDialogCore.test.tsx` asserts the settings
   core shows no host tab without a contribution.
 
@@ -109,30 +125,37 @@ feature-specific overrides inline in `SharedAddinShell`.
 - Only one host SDK per loaded document: host SDKs patch globals, and the
   component registry holds exactly one host's overrides.
 
-## Adding a host: Teams walkthrough
+## The Teams host
 
-1. Create `src/teams/` with `TeamsApp.tsx`, composing outside-in:
-   `SharedAddinShell` → a teams-js provider (`app.initialize()` +
-   `app.getContext()`) → a Teams theme provider mapping
-   `default`/`dark`/`contrast` and subscribing via
-   `app.registerOnThemeChangeHandler` → a Teams auth provider reusing the NAA
-   `AuthSource` → `AuthGate` → `NeutralAddinChatPage` with
-   `platform="teams"`.
-   - Initialize teams-js BEFORE MSAL; the NAA redirect URI is
-     `brk-multihub://<origin>`.
-   - Write a Teams-side NAA-support probe: `isNestedAppAuthSupported` is
-     Office-gated and always false outside an Office host.
-2. Register a lazy route in `src/main.tsx` and regenerate served routes
-   (`pnpm generate:served-routes`).
-3. Install any Teams registry contributions at module eval, mirroring
-   `installOutlookComponentRegistrations`.
-4. Ship a separate Teams app manifest alongside `manifests/` — the unified
-   manifest cannot replace the Outlook manifest today (it excludes Outlook
-   Mac/mobile installs).
-5. Infra: extend CSP `frame-ancestors` (`frontend.extra_frame_ancestors` in
-   `erato.toml`) with `*.cloud.microsoft` plus `teams.microsoft.com`,
-   `*.teams.microsoft.com`, `*.microsoft365.com`, `*.office.com` and the
-   Outlook web hosts — the same personal tab also surfaces in Outlook and the
-   Microsoft 365 app.
-6. Split any diverging lingui copy into `.teams` ids and use
-   `erato.addin.teams.*` storage keys.
+`TeamsApp.tsx` composes outside-in: `SharedAddinShell` → `TeamsProvider` →
+`TeamsThemeProvider` → `TeamsAuthProvider` → `AuthGate` →
+`NeutralAddinChatPage` with `platform="teams"` and the Teams session
+controller. It loads no office.js, so unlike the Outlook route it is free to
+use the router.
+
+- `TeamsProvider` owns the TeamsJS lifecycle and nothing else: `app.initialize`,
+  `app.getContext`, the single-slot `app.registerOnThemeChangeHandler`,
+  and `app.notifySuccess`/`notifyFailure`. It gates children on the handshake,
+  which is what orders TeamsJS before MSAL — MSAL reads the NAA bridge exactly
+  once and otherwise degrades to a non-nested client for the life of the page,
+  silently. Only the handshake is fatal; a rejected `notifySuccess` is logged,
+  never surfaced, because the tab is already usable by then.
+- `isTeamsNestedAppAuthSupported` reads the `nestedAppAuthBridge` TeamsJS
+  installs. `src/auth/isNestedAppAuthSupported.ts` cannot be reused: it is
+  Office-gated, and `Office` does not exist in a tab. `TeamsAuthProvider` probes
+  it per source rebuild rather than caching a verdict, so the `AuthGate` retry
+  re-runs mode detection. TeamsJS skips its default bridge injection in a nested
+  iframe, so the absent-bridge case is logged with the host identity.
+- Auth is NAA-only, reusing `createEntraNaaAuthSource` and
+  `SessionAuthProvider` unchanged, with the login hint from the Teams context.
+  There is no Exchange or oauth2-proxy fallback on this route. The Entra app
+  registration needs the SPA redirect URI `brk-multihub://<origin>` (origin
+  only, no path).
+- Serving: `frame-ancestors` for the Teams and Microsoft 365 hosts is emitted
+  by `build_content_security_policy` in
+  `backend/erato/src/frontend_environment.rs` whenever the add-in integration
+  is enabled; deployments needing more origins still use
+  `frontend.extra_frame_ancestors`. Emit no `X-Frame-Options` — any value a
+  modern browser understands overrides the CSP and blanks the tab.
+- Not shipped: production manifest distribution (`manifests/manifest.json` is
+  the local unified package), Graph access, and Teams-specific chat surfaces.

--- a/office-addin/eslint.config.mjs
+++ b/office-addin/eslint.config.mjs
@@ -152,6 +152,9 @@ const eslintConfig = [
                 "**/outlook/**",
                 "**/sessionPolicy/**",
                 "**/useOutlook*",
+                "**/Teams*",
+                "**/teams/**",
+                "@microsoft/teams-js",
               ],
               message:
                 "Host-neutral core files must receive host behavior through explicit components or props.",
@@ -188,9 +191,67 @@ const eslintConfig = [
         {
           patterns: [
             {
-              group: ["**/outlook/**", "!**/test/mocks/outlook/**"],
+              group: [
+                "**/outlook/**",
+                "!**/test/mocks/outlook/**",
+                "**/teams/**",
+                "!**/test/mocks/teams/**",
+              ],
               message:
-                "The shared ring must not depend on the Outlook host module; move shared code out or invert the dependency.",
+                "The shared ring must not depend on a host module; move shared code out or invert the dependency.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/teams/**/*.ts", "src/teams/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "**/OfficeProvider",
+                "**/OfficeThemeProvider",
+                "**/Outlook*",
+                "**/outlook/**",
+                "**/sessionPolicy/**",
+                "**/useOffice*",
+                "**/useOutlook*",
+              ],
+              message:
+                "The Teams composition is a peer of the Outlook one: only one host SDK and one set of registry overrides per document.",
+            },
+          ],
+        },
+      ],
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "Office",
+          message: "Office.js is owned by the Outlook composition.",
+        },
+        {
+          name: "OfficeRuntime",
+          message: "Office.js is owned by the Outlook composition.",
+        },
+      ],
+    },
+  },
+  {
+    files: ["src/outlook/**/*.ts", "src/outlook/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/Teams*", "**/teams/**", "@microsoft/teams-js"],
+              message:
+                "The Outlook composition is a peer of the Teams one: only one host SDK and one set of registry overrides per document.",
             },
           ],
         },

--- a/office-addin/package.json
+++ b/office-addin/package.json
@@ -34,6 +34,7 @@
     "@erato/frontend-utils": "file:../frontend-utils",
     "@lingui/core": "5.9.4",
     "@lingui/react": "5.9.4",
+    "@microsoft/teams-js": "2.54.0",
     "@remix-run/router": "1.23.2",
     "@tanstack/query-core": "5.100.10",
     "@tanstack/react-query": "5.100.10",

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@lingui/react':
         specifier: 5.9.4
         version: 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(typescript@5.9.3))(react@19.2.7)
+      '@microsoft/teams-js':
+        specifier: 2.54.0
+        version: 2.54.0
       '@remix-run/router':
         specifier: 1.23.2
         version: 1.23.2
@@ -328,7 +331,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-sm2SvV9RRPgKxXa/LFp7mSRtLmtbYzkCx2G24BgcjLYEGATRbRC4AdIyxEkQk8p3j9k2/e8lcSd0cD0X8Q+NQg==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-T7OwCOhqpKZfg1jIxcLLe6ITm65ve83WiXoStQcddQnhAsG/onKutq8/nj10q9aVGT86JSRLpUlyb+wFLFy5xg==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -692,6 +695,9 @@ packages:
 
   '@microsoft/app-manifest@1.0.6':
     resolution: {integrity: sha512-0+abQ2zlrq7VA/Rv/MwBKvN1CPe5FNmfM6a1bsinOXltpGduKDNlvmBTQ6LPUE2rXMA35VCmXMxkXXfn5IoVDw==}
+
+  '@microsoft/teams-js@2.54.0':
+    resolution: {integrity: sha512-d6iflwECR9E1cR55gZ+eLRiDeL01/uL0NJhBHZzbYuXi+H0iQmkKb29dXW8pdOGddyesWQNt8uK01zW0YUbvvg==}
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -4386,6 +4392,13 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       node-fetch: 3.3.2
       strip-bom: 5.0.0
+
+  '@microsoft/teams-js@2.54.0':
+    dependencies:
+      base64-js: 1.5.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:

--- a/office-addin/public/serve.json
+++ b/office-addin/public/serve.json
@@ -1,6 +1,10 @@
 {
   "rewrites": [
     {
+      "source": "/teams",
+      "destination": "index.html"
+    },
+    {
       "source": "/setup",
       "destination": "index.html"
     }

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -84,37 +84,47 @@ const neutralChatPersistedOptions: PersistedStateOptions<string | null> = {
     typeof value === "string" || value === null ? value : null,
 };
 
-/** Neutral session adapter: isolated storage and no anchor/context policy. */
-export function NeutralAddinSessionController({
-  children,
-}: AddinSessionControllerProps) {
-  const [currentChatId, setCurrentChatId] = usePersistedState<string | null>(
-    NEUTRAL_CURRENT_CHAT_KEY,
-    null,
-    neutralChatPersistedOptions,
-  );
-  const [newChatCounter, setNewChatCounter] = useState(0);
-  const clearNewlyCreatedChatIdRef = useRef<() => void>(() => {});
+/**
+ * Neutral session adapter: isolated storage and no anchor/context policy. Each
+ * host passes its own key so one host's selection never moves another's.
+ */
+export function createNeutralAddinSessionController(
+  storageKey: string,
+): ComponentType<AddinSessionControllerProps> {
+  return function NeutralAddinSessionController({
+    children,
+  }: AddinSessionControllerProps) {
+    const [currentChatId, setCurrentChatId] = usePersistedState<string | null>(
+      storageKey,
+      null,
+      neutralChatPersistedOptions,
+    );
+    const [newChatCounter, setNewChatCounter] = useState(0);
+    const clearNewlyCreatedChatIdRef = useRef<() => void>(() => {});
 
-  const beginNewChat = useCallback(() => {
-    setNewChatCounter((value) => value + 1);
-    setCurrentChatId(null);
-  }, [setCurrentChatId]);
-  const selectChat = useCallback(
-    (chatId: string) => setCurrentChatId(chatId),
-    [setCurrentChatId],
-  );
+    const beginNewChat = useCallback(() => {
+      setNewChatCounter((value) => value + 1);
+      setCurrentChatId(null);
+    }, [setCurrentChatId]);
+    const selectChat = useCallback(
+      (chatId: string) => setCurrentChatId(chatId),
+      [setCurrentChatId],
+    );
 
-  return children({
-    currentChatId,
-    effectiveChatId: currentChatId,
-    newChatCounter,
-    beginNewChat,
-    selectChat,
-    adoptNewChatId: selectChat,
-    clearNewlyCreatedChatIdRef,
-  });
+    return children({
+      currentChatId,
+      effectiveChatId: currentChatId,
+      newChatCounter,
+      beginNewChat,
+      selectChat,
+      adoptNewChatId: selectChat,
+      clearNewlyCreatedChatIdRef,
+    });
+  };
 }
+
+export const NeutralAddinSessionController =
+  createNeutralAddinSessionController(NEUTRAL_CURRENT_CHAT_KEY);
 
 function AddinChatDataProvider({
   children,

--- a/office-addin/src/core/NeutralAddinChatPage.tsx
+++ b/office-addin/src/core/NeutralAddinChatPage.tsx
@@ -6,19 +6,28 @@ import {
 import { AddinChatCore } from "./AddinChatCore";
 import { AddinChatProviderCore } from "./AddinChatProviderCore";
 
+import type { AddinSessionControllerProps } from "./AddinChatProviderCore";
+import type { ComponentType } from "react";
+
 /**
  * Ready-to-compose neutral chat surface. The caller owns authentication and
  * the host SDK lifecycle; this component only needs the shared API shell.
  */
 export function NeutralAddinChatPage({
   platform = "addin-neutral",
+  SessionController,
 }: {
   platform?: string;
+  /** Host session adapter; defaults to the neutral storage-only controller. */
+  SessionController?: ComponentType<AddinSessionControllerProps>;
 }) {
   return (
     <ProfileProvider>
       <FileCapabilitiesProvider>
-        <AddinChatProviderCore platform={platform}>
+        <AddinChatProviderCore
+          platform={platform}
+          SessionController={SessionController}
+        >
           <AddinChatCore />
         </AddinChatProviderCore>
       </FileCapabilitiesProvider>

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1096,6 +1096,16 @@ msgstr "Generiertes Manifest hochladen"
 #~ msgid "officeAddin.setup.uploadInstruction"
 #~ msgstr "und laden Sie die heruntergeladene Datei dort hoch."
 
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.initFailed"
+msgstr "Verbindung zu Microsoft Teams nicht möglich."
+
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.loading"
+msgstr "Microsoft Teams-Registerkarte wird geladen..."
+
 # ==============================
 # Unstable IDs
 # ==============================

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1096,6 +1096,16 @@ msgstr "Upload the generated manifest"
 #~ msgid "officeAddin.setup.uploadInstruction"
 #~ msgstr "and upload the downloaded file there."
 
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.initFailed"
+msgstr "Could not connect to Microsoft Teams."
+
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.loading"
+msgstr "Loading Microsoft Teams tab..."
+
 # ==============================
 # Unstable IDs
 # ==============================

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1096,6 +1096,16 @@ msgstr "Cargue el manifiesto generado"
 #~ msgid "officeAddin.setup.uploadInstruction"
 #~ msgstr "y cargue allí el archivo descargado."
 
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.initFailed"
+msgstr "No se pudo conectar con Microsoft Teams."
+
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.loading"
+msgstr "Cargando la pestaña de Microsoft Teams..."
+
 # ==============================
 # Unstable IDs
 # ==============================

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1096,6 +1096,16 @@ msgstr "Téléverser le manifeste généré"
 #~ msgid "officeAddin.setup.uploadInstruction"
 #~ msgstr "et téléversez-y le fichier téléchargé."
 
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.initFailed"
+msgstr "Impossible de se connecter à Microsoft Teams."
+
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.loading"
+msgstr "Chargement de l'onglet Microsoft Teams..."
+
 # ==============================
 # Unstable IDs
 # ==============================

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1096,6 +1096,16 @@ msgstr "Prześlij wygenerowany manifest"
 #~ msgid "officeAddin.setup.uploadInstruction"
 #~ msgstr "i prześlij tam pobrany plik."
 
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.initFailed"
+msgstr "Nie można połączyć się z Microsoft Teams."
+
+#. js-lingui-explicit-id
+#: src/teams/providers/TeamsProvider.tsx
+msgid "officeAddin.teams.loading"
+msgstr "Ładowanie karty Microsoft Teams..."
+
 # ==============================
 # Unstable IDs
 # ==============================

--- a/office-addin/src/main.tsx
+++ b/office-addin/src/main.tsx
@@ -9,6 +9,7 @@ import { injectFrontendEnv } from "./app/env";
 import { AddinSetupRoute } from "./pages/AddinSetupPage";
 
 const OutlookApp = lazy(() => import("./outlook/OutlookApp"));
+const TeamsApp = lazy(() => import("./teams/TeamsApp"));
 
 injectFrontendEnv();
 
@@ -31,6 +32,14 @@ ReactDOM.createRoot(rootElement).render(
           element={
             <Suspense fallback={null}>
               <OutlookApp />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/teams"
+          element={
+            <Suspense fallback={null}>
+              <TeamsApp />
             </Suspense>
           }
         />

--- a/office-addin/src/teams/TeamsApp.tsx
+++ b/office-addin/src/teams/TeamsApp.tsx
@@ -1,0 +1,39 @@
+import { createBrowserClientInfo } from "@erato/frontend/library";
+
+import { TeamsAuthProvider } from "./providers/TeamsAuthProvider";
+import { TeamsProvider } from "./providers/TeamsProvider";
+import { TeamsThemeProvider } from "./providers/TeamsThemeProvider";
+import { TeamsAddinSessionController } from "./teamsSession";
+import { NeutralAddinChatPage } from "../core/NeutralAddinChatPage";
+import { AuthGate, SharedAddinShell } from "../core/SharedAddinShell";
+
+const TEAMS_SIDECAR_CLIENT_INFO = createBrowserClientInfo({
+  name: "erato-office-addin",
+  version: import.meta.env.VITE_APP_VERSION ?? "unversioned",
+  hostApplication: "Microsoft Teams tab",
+});
+
+/**
+ * Installs no component-registry overrides: the Outlook contributions stay
+ * route-local to `OutlookApp`, and this route loads no Office.js.
+ */
+export default function TeamsApp() {
+  return (
+    <SharedAddinShell sidecarClientInfo={TEAMS_SIDECAR_CLIENT_INFO}>
+      <TeamsProvider>
+        <TeamsThemeProvider>
+          <TeamsAuthProvider>
+            <AuthGate>
+              <div className="office-shell">
+                <NeutralAddinChatPage
+                  platform="teams"
+                  SessionController={TeamsAddinSessionController}
+                />
+              </div>
+            </AuthGate>
+          </TeamsAuthProvider>
+        </TeamsThemeProvider>
+      </TeamsProvider>
+    </SharedAddinShell>
+  );
+}

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -1,0 +1,438 @@
+import { componentRegistry } from "@erato/frontend/library";
+import { i18n } from "@lingui/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NEUTRAL_CURRENT_CHAT_KEY } from "../../core/AddinChatProviderCore";
+import {
+  MOCK_TEAMS_LOGIN_HINT,
+  createMockTeamsContext,
+  installMockNestedAppAuthBridge,
+  uninstallMockNestedAppAuthBridge,
+} from "../../test/mocks/teams/context";
+import TeamsApp from "../TeamsApp";
+import { TEAMS_CURRENT_CHAT_KEY } from "../teamsSession";
+
+import type { LoginHintResolver } from "../../core/auth/AuthSource";
+import type { ChatContextValue } from "@erato/frontend/library";
+import type { ReactNode } from "react";
+
+const spies = vi.hoisted(() => ({
+  callLog: [] as string[],
+  initialize: vi.fn(),
+  getContext: vi.fn(),
+  notifySuccess: vi.fn(),
+  notifyFailure: vi.fn(),
+  isNAAChannelRecommended: vi.fn(() => false),
+  themeHandlers: [] as ((theme: string) => void)[],
+  setSystemThemeOverride: vi.fn(),
+  createEntraNaaAuthSource: vi.fn(),
+  sessionAuthSource: vi.fn(),
+  usePersistedState: vi.fn(),
+  messagingStore: {
+    abortActiveSSE: vi.fn(),
+    clearUserMessages: vi.fn(),
+    resetStreaming: vi.fn(),
+    setNavigationTransition: vi.fn(),
+  },
+  useChatMessaging: vi.fn(() => ({
+    messages: {},
+    isLoading: false,
+    isStreaming: false,
+    isPendingResponse: false,
+    isFinalizing: false,
+    streamingContent: null,
+    error: null,
+    sendMessage: vi.fn(async () => undefined),
+    editMessage: vi.fn(async () => undefined),
+    regenerateMessage: vi.fn(async () => undefined),
+    cancelMessage: vi.fn(),
+    refetch: vi.fn(async () => undefined),
+    newlyCreatedChatId: null,
+    clearNewlyCreatedChatId: vi.fn(),
+  })),
+}));
+
+vi.mock("@microsoft/teams-js", () => ({
+  app: {
+    FailedReason: {
+      AuthFailed: "AuthFailed",
+      Timeout: "Timeout",
+      Other: "Other",
+    },
+    initialize: spies.initialize,
+    getContext: () => {
+      spies.callLog.push("app.getContext");
+      return spies.getContext();
+    },
+    registerOnThemeChangeHandler: (handler: (theme: string) => void) => {
+      spies.themeHandlers.push(handler);
+    },
+    notifySuccess: spies.notifySuccess,
+    notifyFailure: spies.notifyFailure,
+  },
+  nestedAppAuth: {
+    isNAAChannelRecommended: spies.isNAAChannelRecommended,
+  },
+}));
+
+vi.mock("../../auth/EntraNaaAuthSource", () => ({
+  createEntraNaaAuthSource: (options: {
+    resolveLoginHint: LoginHintResolver;
+  }) => {
+    spies.callLog.push("createEntraNaaAuthSource");
+    spies.createEntraNaaAuthSource(options);
+    return {
+      mode: "entra-msal",
+      initialize: vi.fn(async () => undefined),
+      acquireBootstrapToken: vi.fn(async () => ({ idToken: "id-token" })),
+      acquireGraphToken: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("../../core/SessionAuthProvider", () => ({
+  SessionAuthProvider: ({
+    authSource,
+    children,
+  }: {
+    authSource: unknown;
+    children?: ReactNode;
+  }) => {
+    spies.sessionAuthSource(authSource);
+    return children;
+  },
+  useSessionAuth: () => ({
+    isInitialized: true,
+    isAuthenticated: true,
+    retryAuthentication: () => Promise.resolve(),
+    error: null,
+  }),
+}));
+
+vi.mock("../../core/AddinChatInputCore", () => ({
+  AddinChatInputCore: () => <div data-testid="teams-chat-input" />,
+}));
+vi.mock("../../core/AddinSettingsDialogCore", () => ({
+  AddinSettingsDialogCore: () => null,
+}));
+
+vi.mock("@erato/frontend/library", async () => {
+  const { createContext, useContext, useState } = await import("react");
+  const ChatContext = createContext<ChatContextValue | null>(null);
+  const passthrough = ({ children }: { children?: ReactNode }) => children;
+
+  return {
+    ApiProvider: passthrough,
+    DesktopSidecarProvider: passthrough,
+    FeatureConfigProvider: passthrough,
+    FileCapabilitiesProvider: passthrough,
+    I18nProvider: passthrough,
+    ProfileProvider: passthrough,
+    ThemeProvider: passthrough,
+    Toaster: () => null,
+    createBrowserClientInfo: (info: unknown) => info,
+    useTheme: () => ({
+      setSystemThemeOverride: spies.setSystemThemeOverride,
+    }),
+
+    ChatContext,
+    useChatContext: () => {
+      const context = useContext(ChatContext);
+      if (!context) {
+        throw new Error("useChatContext must be used within a ChatProvider");
+      }
+      return context;
+    },
+
+    getSupportedFileTypes: () => ({}),
+    mapMessageToUiMessage: (message: unknown) => message,
+    recentChatsQuery: () => ({ queryKey: ["recent-chats"] }),
+    useArchiveChatEndpoint: () => ({
+      mutateAsync: vi.fn(async () => undefined),
+    }),
+    useBudgetStatus: () => undefined,
+    useChatMessaging: spies.useChatMessaging,
+    useFileCapabilitiesContext: () => ({ capabilities: [] }),
+    useFileDropzone: () => ({
+      uploadFiles: vi.fn(async () => []),
+      isUploading: false,
+      uploadedFiles: [],
+      error: null,
+      clearFiles: vi.fn(),
+    }),
+    useFileUploadStore: (
+      selector: (state: { silentChatId: string | null }) => unknown,
+    ) => selector({ silentChatId: null }),
+    useMessagingStore: Object.assign(() => spies.messagingStore, {
+      getState: () => spies.messagingStore,
+    }),
+    useModelHistory: () => ({ currentChatLastModel: null }),
+    usePersistedState: <T,>(key: string, initialValue: T) => {
+      spies.usePersistedState(key);
+      return useState(initialValue);
+    },
+    useRecentChats: () => ({
+      data: { chats: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(async () => undefined),
+    }),
+
+    ChatErrorBoundary: passthrough,
+    ChatInputControlsProvider: passthrough,
+    ChatMessage: () => null,
+    DefaultMessageControls: () => null,
+    DocumentIcon: () => null,
+    DropdownMenu: () => null,
+    FeedbackCommentDialog: () => null,
+    FeedbackViewDialog: () => null,
+    FilePreviewModal: () => null,
+    MessageList: () => <div data-testid="teams-message-list" />,
+    MessageEditProvider: passthrough,
+    chatMessagesQuery: () => ({ queryKey: ["chat-messages"] }),
+    componentRegistry: {},
+    extractTextFromContent: () => "",
+    resolveComponentOverride: (override: unknown, fallback: unknown) =>
+      override ?? fallback,
+    transformEmailFencesForCopy: (value: string) => value,
+    useActiveModelSelection: () => ({
+      availableModels: [],
+      selectedModel: null,
+      setSelectedModel: vi.fn(),
+      isSelectionReady: true,
+    }),
+    useConversationDropzone: () => ({
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      isDragAccept: false,
+    }),
+    useFilePreviewModal: () => ({
+      isPreviewModalOpen: false,
+      fileToPreview: null,
+      openPreviewModal: vi.fn(),
+      closePreviewModal: vi.fn(),
+    }),
+    useFileUploadWithTokenCheck: () => ({
+      uploadFiles: vi.fn(async () => []),
+      uploadError: null,
+      isUploading: false,
+    }),
+    useMessageFeedback: () => ({
+      feedbackDialogState: { isOpen: false },
+      feedbackViewDialogState: { isOpen: false, feedback: null },
+      feedbackConfig: undefined,
+      handleFeedbackSubmit: vi.fn(),
+      handleFeedbackViewDialogRemove: vi.fn(),
+      closeFeedbackDialog: vi.fn(),
+      closeFeedbackViewDialog: vi.fn(),
+      handleFeedbackDialogSubmit: vi.fn(),
+      openFeedbackDialog: vi.fn(),
+      openFeedbackViewDialog: vi.fn(),
+      switchToEditMode: vi.fn(),
+      canEditFeedback: vi.fn(() => false),
+    }),
+    useProfile: () => ({ profile: undefined }),
+    useStandardMessageActions: () => vi.fn(),
+  };
+});
+
+describe("Teams personal tab composition", () => {
+  const originalOffice = Object.getOwnPropertyDescriptor(globalThis, "Office");
+
+  beforeEach(() => {
+    i18n.activate("en");
+    Reflect.deleteProperty(globalThis, "Office");
+    spies.callLog.length = 0;
+    spies.themeHandlers.length = 0;
+    spies.getContext.mockResolvedValue(createMockTeamsContext());
+    spies.initialize.mockImplementation(() => {
+      spies.callLog.push("app.initialize");
+      return Promise.resolve();
+    });
+    spies.notifySuccess.mockResolvedValue({ hasFinishedSuccessfully: true });
+    installMockNestedAppAuthBridge();
+  });
+
+  afterEach(() => {
+    cleanup();
+    uninstallMockNestedAppAuthBridge();
+    vi.clearAllMocks();
+    if (originalOffice) {
+      Object.defineProperty(globalThis, "Office", originalOffice);
+    }
+  });
+
+  const renderTab = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TeamsApp />
+      </QueryClientProvider>,
+    );
+  };
+
+  it("renders the neutral chat surface with no Office global and no office.js script", async () => {
+    const appendChild = vi.spyOn(document.head, "appendChild");
+
+    renderTab();
+
+    expect(await screen.findByTestId("teams-message-list")).toBeInTheDocument();
+    expect(screen.getByTestId("teams-chat-input")).toBeInTheDocument();
+    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(globalThis).not.toHaveProperty("Office");
+    expect(
+      appendChild.mock.calls.some(
+        ([node]) =>
+          node instanceof HTMLScriptElement &&
+          URL.canParse(node.src) &&
+          new URL(node.src).hostname === "appsforoffice.microsoft.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("stamps the teams platform on messaging", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    expect(spies.useChatMessaging).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "teams" }),
+    );
+  });
+
+  it("installs no component-registry overrides, so no Outlook affordances appear", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    expect(Object.keys(componentRegistry)).toHaveLength(0);
+  });
+
+  it("selects chats under the Teams storage key, never the neutral one", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    const keys = spies.usePersistedState.mock.calls.map(([key]) => key);
+    expect(keys).toContain(TEAMS_CURRENT_CHAT_KEY);
+    expect(keys).not.toContain(NEUTRAL_CURRENT_CHAT_KEY);
+  });
+
+  it("builds no auth source at all until the TeamsJS handshake resolves", async () => {
+    let completeHandshake: () => void = () => undefined;
+    spies.initialize.mockImplementation(() => {
+      spies.callLog.push("app.initialize");
+      return new Promise<void>((resolve) => {
+        completeHandshake = resolve;
+      });
+    });
+
+    renderTab();
+
+    expect(
+      await screen.findByText("Loading Microsoft Teams tab..."),
+    ).toBeInTheDocument();
+    expect(spies.sessionAuthSource).not.toHaveBeenCalled();
+    expect(spies.createEntraNaaAuthSource).not.toHaveBeenCalled();
+
+    await act(async () => {
+      completeHandshake();
+    });
+
+    expect(await screen.findByTestId("teams-message-list")).toBeInTheDocument();
+    expect(spies.sessionAuthSource).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "entra-msal" }),
+    );
+    expect(spies.callLog.indexOf("createEntraNaaAuthSource")).toBeGreaterThan(
+      spies.callLog.indexOf("app.getContext"),
+    );
+  });
+
+  it("takes the login hint from the Teams context", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    const options = spies.createEntraNaaAuthSource.mock.calls.at(0)?.at(0) as
+      | { resolveLoginHint: LoginHintResolver }
+      | undefined;
+    await expect(options?.resolveLoginHint()).resolves.toBe(
+      MOCK_TEAMS_LOGIN_HINT,
+    );
+  });
+
+  it("falls back to the unsupported source when the NAA bridge is absent", async () => {
+    uninstallMockNestedAppAuthBridge();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    expect(spies.createEntraNaaAuthSource).not.toHaveBeenCalled();
+    expect(spies.sessionAuthSource).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "unsupported" }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("nested app auth bridge"),
+      expect.objectContaining({ hostName: "Teams", hostClientType: "web" }),
+    );
+  });
+
+  it("maps host themes onto the system theme override", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    expect(spies.setSystemThemeOverride).toHaveBeenLastCalledWith("light");
+
+    act(() => {
+      spies.themeHandlers.forEach((handler) => handler("contrast"));
+    });
+
+    expect(spies.setSystemThemeOverride).toHaveBeenLastCalledWith("dark");
+  });
+
+  it("notifies the host once the tab has loaded", async () => {
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+
+    expect(spies.notifySuccess).toHaveBeenCalled();
+    expect(spies.notifyFailure).not.toHaveBeenCalled();
+  });
+
+  it("keeps a loaded tab alive when the host rejects the load notification", async () => {
+    spies.notifySuccess.mockRejectedValue(new Error("host said no"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    renderTab();
+    await screen.findByTestId("teams-message-list");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId("teams-message-list")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Could not connect to Microsoft Teams."),
+    ).not.toBeInTheDocument();
+    expect(spies.notifyFailure).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Teams notifySuccess failed",
+      expect.any(Error),
+    );
+  });
+
+  it("reports a failed handshake to the host instead of showing a dead frame", async () => {
+    spies.initialize.mockRejectedValue(new Error("host handshake refused"));
+
+    renderTab();
+
+    expect(
+      await screen.findByText("Could not connect to Microsoft Teams."),
+    ).toBeInTheDocument();
+    expect(spies.notifyFailure).toHaveBeenCalledWith({
+      reason: "Other",
+      message: "host handshake refused",
+    });
+    expect(spies.createEntraNaaAuthSource).not.toHaveBeenCalled();
+  });
+});

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -387,7 +387,10 @@ describe("Teams personal tab composition", () => {
     renderTab();
     await screen.findByTestId("teams-message-list");
 
-    expect(spies.setSystemThemeOverride).toHaveBeenLastCalledWith("light");
+    // Set from a passive effect, which can still be pending here.
+    await waitFor(() =>
+      expect(spies.setSystemThemeOverride).toHaveBeenLastCalledWith("light"),
+    );
 
     act(() => {
       spies.themeHandlers.forEach((handler) => handler("contrast"));

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -1,7 +1,7 @@
 import { componentRegistry } from "@erato/frontend/library";
 import { i18n } from "@lingui/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NEUTRAL_CURRENT_CHAT_KEY } from "../../core/AddinChatProviderCore";
@@ -373,10 +373,14 @@ describe("Teams personal tab composition", () => {
     expect(spies.sessionAuthSource).toHaveBeenCalledWith(
       expect.objectContaining({ mode: "unsupported" }),
     );
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("nested app auth bridge"),
-      expect.objectContaining({ hostName: "Teams", hostClientType: "web" }),
-    );
+    // The warning comes from a passive effect, which can still be pending when
+    // the message list is already in the DOM.
+    await waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("nested app auth bridge"),
+        expect.objectContaining({ hostName: "Teams", hostClientType: "web" }),
+      );
+    });
   });
 
   it("maps host themes onto the system theme override", async () => {

--- a/office-addin/src/teams/__tests__/isTeamsNestedAppAuthSupported.test.ts
+++ b/office-addin/src/teams/__tests__/isTeamsNestedAppAuthSupported.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  installMockNestedAppAuthBridge,
+  uninstallMockNestedAppAuthBridge,
+} from "../../test/mocks/teams/context";
+import { isTeamsNestedAppAuthSupported } from "../auth/isTeamsNestedAppAuthSupported";
+
+describe("isTeamsNestedAppAuthSupported", () => {
+  afterEach(() => {
+    uninstallMockNestedAppAuthBridge();
+  });
+
+  it("reports support once TeamsJS installed the bridge", () => {
+    installMockNestedAppAuthBridge();
+
+    expect(isTeamsNestedAppAuthSupported()).toBe(true);
+  });
+
+  it("reports no support without the bridge", () => {
+    expect(isTeamsNestedAppAuthSupported()).toBe(false);
+  });
+
+  it("does not read the Office global", () => {
+    const originalOffice = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "Office",
+    );
+    Reflect.deleteProperty(globalThis, "Office");
+
+    expect(() => isTeamsNestedAppAuthSupported()).not.toThrow();
+
+    if (originalOffice) {
+      Object.defineProperty(globalThis, "Office", originalOffice);
+    }
+  });
+});

--- a/office-addin/src/teams/auth/isTeamsNestedAppAuthSupported.ts
+++ b/office-addin/src/teams/auth/isTeamsNestedAppAuthSupported.ts
@@ -1,0 +1,15 @@
+/**
+ * The Office probe reads `Office.context.requirements`, absent in a Teams tab.
+ * The bridge TeamsJS installs is the only reliable signal here:
+ * `isNAAChannelRecommended()` reports a host preference and is false on hosts
+ * where NAA works.
+ */
+export function isTeamsNestedAppAuthSupported(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const { nestedAppAuthBridge } = window as unknown as {
+    nestedAppAuthBridge?: unknown;
+  };
+  return nestedAppAuthBridge !== undefined;
+}

--- a/office-addin/src/teams/providers/TeamsAuthProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsAuthProvider.tsx
@@ -1,0 +1,67 @@
+import { nestedAppAuth } from "@microsoft/teams-js";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useTeams } from "./TeamsProvider";
+import { createEntraNaaAuthSource } from "../../auth/EntraNaaAuthSource";
+import { UnsupportedAuthSource } from "../../auth/UnsupportedAuthSource";
+import { SessionAuthProvider } from "../../core/SessionAuthProvider";
+import { isTeamsNestedAppAuthSupported } from "../auth/isTeamsNestedAppAuthSupported";
+
+import type { AuthSource, LoginHintResolver } from "../../core/auth/AuthSource";
+
+/** Never throws: a diagnostic must not take down the tree it is explaining. */
+function readNaaChannelRecommendation(): boolean | "unknown" {
+  try {
+    return nestedAppAuth.isNAAChannelRecommended();
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Builds MSAL below `TeamsProvider`: the NAA bridge only exists after the
+ * TeamsJS handshake, and a client built earlier degrades to a non-nested one
+ * permanently. Teams has no Exchange or oauth2-proxy fallback.
+ */
+export function TeamsAuthProvider({ children }: { children: React.ReactNode }) {
+  const { hostName, hostClientType, userPrincipalName } = useTeams();
+  const [rebuildNonce, setRebuildNonce] = useState(0);
+
+  const resolveLoginHint = useCallback<LoginHintResolver>(
+    () => Promise.resolve(userPrincipalName ?? undefined),
+    [userPrincipalName],
+  );
+
+  const source = useMemo<AuthSource>(() => {
+    // Probed per rebuild, so a retry re-runs mode detection instead of being
+    // answered from a verdict frozen at handshake time.
+    if (!isTeamsNestedAppAuthSupported()) {
+      return new UnsupportedAuthSource("unsupported");
+    }
+    return createEntraNaaAuthSource({ resolveLoginHint });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rebuildNonce is a recompute trigger, not read in the body
+  }, [resolveLoginHint, rebuildNonce]);
+
+  useEffect(() => {
+    if (source.mode !== "unsupported") {
+      return;
+    }
+    console.warn(
+      "Teams tab has no nested app auth bridge; sign-in is unavailable",
+      {
+        hostName,
+        hostClientType,
+        isNaaChannelRecommended: readNaaChannelRecommendation(),
+      },
+    );
+  }, [hostClientType, hostName, source]);
+
+  return (
+    <SessionAuthProvider
+      authSource={source}
+      onReinitialize={() => setRebuildNonce((nonce) => nonce + 1)}
+    >
+      {children}
+    </SessionAuthProvider>
+  );
+}

--- a/office-addin/src/teams/providers/TeamsProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsProvider.tsx
@@ -1,0 +1,132 @@
+import { t } from "@lingui/core/macro";
+import { app } from "@microsoft/teams-js";
+import { createContext, useContext, useEffect, useState } from "react";
+
+import type { ReactNode } from "react";
+
+/** Host themes TeamsJS reports; unknown values (e.g. `glass`) map to default. */
+export type TeamsTheme = "default" | "dark" | "contrast";
+
+interface TeamsContextValue {
+  isReady: boolean;
+  hostName: string | null;
+  hostClientType: string | null;
+  theme: TeamsTheme | null;
+  /** MSAL login hint only; TeamsJS identity fields are never proof of identity. */
+  userPrincipalName: string | null;
+}
+
+const EMPTY_TEAMS_CONTEXT: TeamsContextValue = {
+  isReady: false,
+  hostName: null,
+  hostClientType: null,
+  theme: null,
+  userPrincipalName: null,
+};
+
+const TeamsContext = createContext<TeamsContextValue>(EMPTY_TEAMS_CONTEXT);
+
+function normalizeTeamsTheme(theme: string | undefined): TeamsTheme {
+  return theme === "dark" || theme === "contrast" ? theme : "default";
+}
+
+export function useTeams() {
+  return useContext(TeamsContext);
+}
+
+/**
+ * Children render only once `app.initialize()` has resolved, which is what
+ * guarantees the NAA bridge exists before the auth provider builds MSAL.
+ */
+export function TeamsProvider({ children }: { children: ReactNode }) {
+  const [context, setContext] =
+    useState<TeamsContextValue>(EMPTY_TEAMS_CONTEXT);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const bootstrap = async () => {
+      await app.initialize();
+      const teamsContext = await app.getContext();
+      if (cancelled) {
+        return;
+      }
+
+      setContext({
+        isReady: true,
+        hostName: teamsContext.app.host.name || null,
+        hostClientType: teamsContext.app.host.clientType || null,
+        theme: normalizeTeamsTheme(teamsContext.app.theme),
+        userPrincipalName:
+          teamsContext.user?.loginHint ??
+          teamsContext.user?.userPrincipalName ??
+          null,
+      });
+
+      // Single-slot registration with no unregister, so it is claimed once here
+      // rather than per theme-consumer mount.
+      app.registerOnThemeChangeHandler((theme) => {
+        if (cancelled) {
+          return;
+        }
+        setContext((current) => ({
+          ...current,
+          theme: normalizeTeamsTheme(theme),
+        }));
+      });
+
+      // Releasing the host's loading indicator is reported separately from the
+      // handshake: a rejection here must not tear down a tab that is already up.
+      void app.notifySuccess().catch((cause: unknown) => {
+        console.warn("Teams notifySuccess failed", cause);
+      });
+    };
+
+    void bootstrap().catch((cause: unknown) => {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      try {
+        app.notifyFailure({ reason: app.FailedReason.Other, message });
+      } catch {
+        // The host is unreachable, so the panel below is all we can surface.
+      }
+      if (!cancelled) {
+        setError(message);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error !== null) {
+    return (
+      <div className="office-shell office-shell--centered">
+        <p className="office-status office-status--error" role="alert">
+          {t({
+            id: "officeAddin.teams.initFailed",
+            message: "Could not connect to Microsoft Teams.",
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  if (!context.isReady) {
+    return (
+      <div className="office-shell office-shell--centered">
+        <p className="office-status">
+          {t({
+            id: "officeAddin.teams.loading",
+            message: "Loading Microsoft Teams tab...",
+          })}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <TeamsContext.Provider value={context}>{children}</TeamsContext.Provider>
+  );
+}

--- a/office-addin/src/teams/providers/TeamsThemeProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsThemeProvider.tsx
@@ -1,0 +1,23 @@
+/**
+ * Feeds the host theme in as the "system" override, so an explicit Light/Dark
+ * pick in settings still wins. Mirrors `OfficeThemeProvider`.
+ */
+import { useTheme } from "@erato/frontend/library";
+import { useEffect, type ReactNode } from "react";
+
+import { useTeams } from "./TeamsProvider";
+
+export function TeamsThemeProvider({ children }: { children: ReactNode }) {
+  const { theme } = useTeams();
+  const { setSystemThemeOverride } = useTheme();
+
+  useEffect(() => {
+    if (theme === null) {
+      setSystemThemeOverride(null);
+      return;
+    }
+    setSystemThemeOverride(theme === "default" ? "light" : "dark");
+  }, [theme, setSystemThemeOverride]);
+
+  return <>{children}</>;
+}

--- a/office-addin/src/teams/teamsSession.ts
+++ b/office-addin/src/teams/teamsSession.ts
@@ -1,0 +1,11 @@
+import { createNeutralAddinSessionController } from "../core/AddinChatProviderCore";
+
+/**
+ * History is shared server-side but the selection is not: opening the tab must
+ * never move the chat an Outlook task pane has open.
+ */
+export const TEAMS_CURRENT_CHAT_KEY = "erato.addin.teams.currentChat.v1";
+
+export const TeamsAddinSessionController = createNeutralAddinSessionController(
+  TEAMS_CURRENT_CHAT_KEY,
+);

--- a/office-addin/src/test/__tests__/sessionKeys.test.ts
+++ b/office-addin/src/test/__tests__/sessionKeys.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { NEUTRAL_CURRENT_CHAT_KEY } from "../../core/AddinChatProviderCore";
 import { OUTLOOK_SESSION_KEY } from "../../outlook/sessionPolicy";
+import { TEAMS_CURRENT_CHAT_KEY } from "../../teams/teamsSession";
 
 describe("add-in session storage separation", () => {
   it("uses different keys for neutral and Outlook chat selection", () => {
     expect(NEUTRAL_CURRENT_CHAT_KEY).not.toBe(OUTLOOK_SESSION_KEY);
+  });
+
+  it("keeps the Teams selection out of the neutral and Outlook keys", () => {
+    expect(TEAMS_CURRENT_CHAT_KEY).not.toBe(NEUTRAL_CURRENT_CHAT_KEY);
+    expect(TEAMS_CURRENT_CHAT_KEY).not.toBe(OUTLOOK_SESSION_KEY);
   });
 });

--- a/office-addin/src/test/mocks/teams/context.ts
+++ b/office-addin/src/test/mocks/teams/context.ts
@@ -1,0 +1,54 @@
+/**
+ * TeamsJS is a module import, not a global, so consumers replace it with
+ * `vi.mock("@microsoft/teams-js", …)` rather than stubbing it in setup.
+ */
+
+/** The subset of `app.Context` the Teams composition reads. */
+export interface MockTeamsContext {
+  app: {
+    locale: string;
+    theme: string;
+    sessionId: string;
+    host: { name: string; clientType: string; sessionId: string };
+  };
+  page: { id: string; frameContext: string };
+  user?: {
+    id: string;
+    loginHint?: string;
+    userPrincipalName?: string;
+  };
+  dialogParameters: Record<string, string>;
+}
+
+export const MOCK_TEAMS_LOGIN_HINT = "erato.user@contoso.test";
+
+export function createMockTeamsContext(
+  overrides: Partial<MockTeamsContext> = {},
+): MockTeamsContext {
+  return {
+    app: {
+      locale: "en-us",
+      theme: "default",
+      sessionId: "app-session",
+      host: { name: "Teams", clientType: "web", sessionId: "host-session" },
+    },
+    page: { id: "eratoChat", frameContext: "content" },
+    user: {
+      id: "00000000-0000-0000-0000-000000000001",
+      loginHint: MOCK_TEAMS_LOGIN_HINT,
+      userPrincipalName: MOCK_TEAMS_LOGIN_HINT,
+    },
+    dialogParameters: {},
+    ...overrides,
+  };
+}
+
+/** Stands in for the bridge TeamsJS installs while `app.initialize()` resolves. */
+export function installMockNestedAppAuthBridge() {
+  (window as unknown as { nestedAppAuthBridge?: unknown }).nestedAppAuthBridge =
+    {};
+}
+
+export function uninstallMockNestedAppAuthBridge() {
+  Reflect.deleteProperty(window, "nestedAppAuthBridge");
+}


### PR DESCRIPTION
Adds `src/teams/` — TeamsJS lifecycle, NAA auth over the existing Entra source, and the host-neutral chat at `/office-addin/teams` — plus the Teams/M365 `frame-ancestors` origins.

Stacked on #930.

ERMAIN-553
