### PR TITLE
feat(office-addin): attach files and images shared in Teams conversations

### DIFF
--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1281,7 +1281,7 @@ msgstr "{chatTitle} öffnen"
 #. placeholder {0}: file.name
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.openSharedFile"
-
+msgstr "{0} öffnen"
 
 #. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1278,6 +1278,12 @@ msgid "officeAddin.teams.picker.openChat"
 msgstr "{chatTitle} öffnen"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: file.name
+#: src/teams/components/TeamsChatPickerDialog.tsx
+msgid "officeAddin.teams.picker.openSharedFile"
+
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.partialBuild"
 msgstr "{chatsCompleted} von {chatsTotal} Unterhaltungen geladen. Das Geladene anhängen?"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1278,6 +1278,12 @@ msgid "officeAddin.teams.picker.openChat"
 msgstr "Open {chatTitle}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: file.name
+#: src/teams/components/TeamsChatPickerDialog.tsx
+msgid "officeAddin.teams.picker.openSharedFile"
+msgstr "Open {0}"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.partialBuild"
 msgstr "Loaded {chatsCompleted} of {chatsTotal} conversations. Attach what was loaded?"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1278,6 +1278,12 @@ msgid "officeAddin.teams.picker.openChat"
 msgstr "Abrir {chatTitle}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: file.name
+#: src/teams/components/TeamsChatPickerDialog.tsx
+msgid "officeAddin.teams.picker.openSharedFile"
+
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.partialBuild"
 msgstr "Se cargaron {chatsCompleted} de {chatsTotal} conversaciones. ¿Adjuntar lo cargado?"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1281,7 +1281,7 @@ msgstr "Abrir {chatTitle}"
 #. placeholder {0}: file.name
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.openSharedFile"
-
+msgstr "Abrir {0}"
 
 #. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1281,7 +1281,7 @@ msgstr "Ouvrir {chatTitle}"
 #. placeholder {0}: file.name
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.openSharedFile"
-
+msgstr "Ouvrir {0}"
 
 #. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1278,6 +1278,12 @@ msgid "officeAddin.teams.picker.openChat"
 msgstr "Ouvrir {chatTitle}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: file.name
+#: src/teams/components/TeamsChatPickerDialog.tsx
+msgid "officeAddin.teams.picker.openSharedFile"
+
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.partialBuild"
 msgstr "{chatsCompleted} conversation(s) sur {chatsTotal} chargée(s). Joindre ce qui a été chargé ?"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1278,6 +1278,12 @@ msgid "officeAddin.teams.picker.openChat"
 msgstr "Otwórz {chatTitle}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: file.name
+#: src/teams/components/TeamsChatPickerDialog.tsx
+msgid "officeAddin.teams.picker.openSharedFile"
+
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.partialBuild"
 msgstr "Wczytano {chatsCompleted} z {chatsTotal} rozmów. Załączyć to, co się wczytało?"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1281,7 +1281,7 @@ msgstr "Otwórz {chatTitle}"
 #. placeholder {0}: file.name
 #: src/teams/components/TeamsChatPickerDialog.tsx
 msgid "officeAddin.teams.picker.openSharedFile"
-
+msgstr "Otwórz {0}"
 
 #. js-lingui-explicit-id
 #: src/teams/components/TeamsChatPickerDialog.tsx

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -188,6 +188,9 @@ vi.mock("@erato/frontend/library", async () => {
       error: null,
       clearFiles: vi.fn(),
     }),
+    useFeatureConfig: () => ({
+      upload: { maxSizeBytes: 10 * 1024 * 1024 },
+    }),
     useFileUploadStore: (
       selector: (state: { silentChatId: string | null }) => unknown,
     ) => selector({ silentChatId: null }),

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -43,6 +43,7 @@ import type {
   ParsedTeamsChat,
   TeamsSharedFileRef,
 } from "../utils/parsedTeamsChat";
+import type { TeamsFileFetcher } from "../utils/teamsChatFetcher";
 import type { TeamsSearchHit } from "../utils/teamsChatGraph";
 import type { TeamsMessageSelection } from "../utils/teamsChatSelection";
 import type {
@@ -402,7 +403,13 @@ function TeamsChatPickerDialogBody({
                 })}
                 title={senderName}
                 subline={message.text}
-                chips={<SharedFileChips files={message.sharedFiles} />}
+                chips={
+                  <SharedFileChips
+                    files={message.sharedFiles}
+                    fileFetcher={picker.fileFetcher}
+                    maxFileBytes={picker.maxFileBytes}
+                  />
+                }
                 createdAt={message.createdAt}
                 senderName={senderName}
               />
@@ -530,7 +537,13 @@ function TeamsChatPickerDialogBody({
                 })}
                 title={senderName}
                 subline={message.text}
-                chips={<SharedFileChips files={message.sharedFiles} />}
+                chips={
+                  <SharedFileChips
+                    files={message.sharedFiles}
+                    fileFetcher={picker.fileFetcher}
+                    maxFileBytes={picker.maxFileBytes}
+                  />
+                }
                 createdAt={message.createdAt}
                 senderName={senderName}
               />
@@ -973,21 +986,57 @@ function BuildProgress({ picker }: { picker: TeamsChatPickerContextValue }) {
 }
 
 /**
- * One compact chip per file shared with the message. Clicking opens the file
- * where it lives — SharePoint's own preview — which costs no download, no
- * consent and no space in this pane.
+ * One compact chip per file shared with the message. With the file grant the
+ * bytes come through our own token into a tab-local blob — no SharePoint
+ * session needed, which a dev browser profile rarely has. Without the grant
+ * the chip falls back to the file's SharePoint page.
  */
-function SharedFileChips({ files }: { files: readonly TeamsSharedFileRef[] }) {
+function SharedFileChips({
+  files,
+  fileFetcher,
+  maxFileBytes,
+}: {
+  files: readonly TeamsSharedFileRef[];
+  fileFetcher: TeamsFileFetcher | null;
+  maxFileBytes: number;
+}) {
   if (files.length === 0) return null;
+
+  const openFile = (file: TeamsSharedFileRef) => {
+    if (!fileFetcher) {
+      window.open(file.contentUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+    // The tab must open synchronously with the click or the popup blocker
+    // eats it; the content streams in afterwards.
+    const viewer = window.open("about:blank", "_blank");
+    if (!viewer) return;
+    void fileFetcher
+      .downloadSharedFile(file.contentUrl, maxFileBytes, {})
+      .then((result) => {
+        if (result.state === "ok") {
+          viewer.location.href = URL.createObjectURL(
+            new Blob([result.content.bytes], {
+              type: result.content.contentType,
+            }),
+          );
+        } else {
+          // Oversized or unresolvable here — let SharePoint have it.
+          viewer.location.href = file.contentUrl;
+        }
+      })
+      .catch(() => {
+        viewer.location.href = file.contentUrl;
+      });
+  };
+
   return (
     <div className="mt-1 flex flex-wrap gap-1">
       {files.map((file) => (
         <button
           key={file.attachmentId}
           type="button"
-          onClick={() =>
-            window.open(file.contentUrl, "_blank", "noopener,noreferrer")
-          }
+          onClick={() => openFile(file)}
           title={file.name}
           aria-label={t({
             id: "officeAddin.teams.picker.openSharedFile",

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -4,11 +4,13 @@ import {
   Button,
   CloseIcon,
   FILE_PREVIEW_STYLES,
+  FilePreviewModal,
   FolderIcon,
   Input,
   ModalBase,
   PageIcon,
   SearchIcon,
+  SpinnerIcon,
 } from "@erato/frontend/library";
 import { plural, t } from "@lingui/core/macro";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -43,17 +45,46 @@ import type {
   ParsedTeamsChat,
   TeamsSharedFileRef,
 } from "../utils/parsedTeamsChat";
-import type { TeamsFileFetcher } from "../utils/teamsChatFetcher";
 import type { TeamsSearchHit } from "../utils/teamsChatGraph";
 import type { TeamsMessageSelection } from "../utils/teamsChatSelection";
 import type {
   TeamsChannelConversationRef,
   TeamsChatConversationRef,
 } from "../utils/teamsConversationRef";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 const SEARCH_DEBOUNCE_MS = 350;
 const SKELETON_ROWS = 5;
+
+interface SharedFilePreview {
+  name: string;
+  /** Object URL of the fetched bytes; null when only SharePoint remains. */
+  url: string | null;
+  mimeType: string | null;
+  contentUrl: string;
+}
+
+type FilePreviewModalFile = NonNullable<
+  ComponentProps<typeof FilePreviewModal>["file"]
+>;
+
+/**
+ * The preview modal wants the backend's upload shape; a Teams shared file has
+ * no upload behind it, so the minimum the modal renders from is faked here.
+ * A null `url` takes the modal's "not previewable" path, whose Download
+ * button then opens SharePoint from a user gesture — no popup blocking.
+ */
+function previewModalFile(preview: SharedFilePreview): FilePreviewModalFile {
+  return {
+    id: "teams-shared-file",
+    filename: preview.name,
+    preview_url: preview.url,
+    download_url: preview.url ?? preview.contentUrl,
+    file_capability: {
+      mime_types: preview.mimeType ? [preview.mimeType] : [],
+    },
+  } as FilePreviewModalFile;
+}
 
 export function TeamsChatPickerDialog() {
   const picker = useTeamsChatPicker();
@@ -93,6 +124,11 @@ function TeamsChatPickerDialogBody({
   );
   const search = useTeamsChatSearch(picker.fetcher, isSearching ? trimmed : "");
   const hitProbe = useTeamsChannelHitProbe(picker.channelFetcher);
+  const [sharedFilePreview, setSharedFilePreview] =
+    useState<SharedFilePreview | null>(null);
+  const [sharedFileLoadingId, setSharedFileLoadingId] = useState<string | null>(
+    null,
+  );
 
   // A probe can resolve after the dialog is gone; a late auto-tick would
   // otherwise plant a selection into the next opening.
@@ -145,80 +181,135 @@ function TeamsChatPickerDialogBody({
     resolvedChats.get(chatId)?.title ??
     null;
 
+  /**
+   * The bytes come through our own token into the same preview modal the chat
+   * uses — a dev browser profile rarely holds a SharePoint session, so a
+   * SharePoint tab would mostly show a login wall. That tab remains the
+   * fallback when the file grant is missing.
+   */
+  const openSharedFile = (file: TeamsSharedFileRef) => {
+    const fileFetcher = picker.fileFetcher;
+    if (!fileFetcher) {
+      window.open(file.contentUrl, "_blank", "noopener,noreferrer");
+      return;
+    }
+    setSharedFileLoadingId(file.attachmentId);
+    void fileFetcher
+      .downloadSharedFile(file.contentUrl, picker.maxFileBytes, {})
+      .then((result) => {
+        if (!aliveRef.current) return;
+        setSharedFilePreview(
+          result.state === "ok"
+            ? {
+                name: file.name,
+                url: URL.createObjectURL(
+                  new Blob([result.content.bytes], {
+                    type: result.content.contentType,
+                  }),
+                ),
+                mimeType: result.content.contentType,
+                contentUrl: file.contentUrl,
+              }
+            : {
+                name: file.name,
+                url: null,
+                mimeType: null,
+                contentUrl: file.contentUrl,
+              },
+        );
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (aliveRef.current) setSharedFileLoadingId(null);
+      });
+  };
+
+  const closeSharedFilePreview = () => {
+    if (sharedFilePreview?.url) URL.revokeObjectURL(sharedFilePreview.url);
+    setSharedFilePreview(null);
+  };
+
   return (
-    <ModalBase
-      isOpen
-      onClose={picker.close}
-      title={dialogTitle}
-      contentClassName="h-[80vh] max-h-[600px] max-w-xl"
-    >
-      <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
-        <div className="flex shrink-0 items-center gap-2">
-          {(activeChat || activeChannel) && !isSearching && (
-            <Button
-              variant="ghost"
-              geometry="icon"
-              icon={<ArrowLeftIcon className="size-4" />}
-              onClick={() => {
-                setActiveChatId(null);
-                setActiveChannel(null);
-              }}
+    <>
+      <ModalBase
+        isOpen
+        onClose={picker.close}
+        title={dialogTitle}
+        contentClassName="h-[80vh] max-h-[600px] max-w-xl"
+      >
+        <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
+          <div className="flex shrink-0 items-center gap-2">
+            {(activeChat || activeChannel) && !isSearching && (
+              <Button
+                variant="ghost"
+                geometry="icon"
+                icon={<ArrowLeftIcon className="size-4" />}
+                onClick={() => {
+                  setActiveChatId(null);
+                  setActiveChannel(null);
+                }}
+                aria-label={t({
+                  id: "officeAddin.teams.picker.back",
+                  message: "Back to chats",
+                })}
+              />
+            )}
+            <SearchIcon
+              className="size-4 shrink-0 text-theme-fg-muted"
+              aria-hidden="true"
+            />
+            <Input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t({
+                id: "officeAddin.teams.picker.searchPlaceholder",
+                message: "Filter chats or search messages",
+              })}
               aria-label={t({
-                id: "officeAddin.teams.picker.back",
-                message: "Back to chats",
+                id: "officeAddin.teams.picker.searchLabel",
+                message: "Filter Teams chats or search messages",
               })}
             />
+            {query.length > 0 && (
+              <Button
+                variant="ghost"
+                geometry="icon"
+                icon={<CloseIcon className="size-4" />}
+                onClick={() => setQuery("")}
+                aria-label={t({
+                  id: "officeAddin.teams.picker.clearSearch",
+                  message: "Clear search",
+                })}
+              />
+            )}
+          </div>
+
+          {activeChat && !isSearching && (
+            <p className="shrink-0 truncate text-sm font-medium text-theme-fg-primary">
+              {activeChat.title}
+            </p>
           )}
-          <SearchIcon
-            className="size-4 shrink-0 text-theme-fg-muted"
-            aria-hidden="true"
-          />
-          <Input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={t({
-              id: "officeAddin.teams.picker.searchPlaceholder",
-              message: "Filter chats or search messages",
-            })}
-            aria-label={t({
-              id: "officeAddin.teams.picker.searchLabel",
-              message: "Filter Teams chats or search messages",
-            })}
-          />
-          {query.length > 0 && (
-            <Button
-              variant="ghost"
-              geometry="icon"
-              icon={<CloseIcon className="size-4" />}
-              onClick={() => setQuery("")}
-              aria-label={t({
-                id: "officeAddin.teams.picker.clearSearch",
-                message: "Clear search",
-              })}
-            />
-          )}
+
+          <div className="min-h-0 flex-1 divide-y divide-theme-border overflow-y-auto">
+            {liveLength > 0
+              ? renderQueryResults()
+              : activeChannel
+                ? renderChannelMessageList(activeChannel)
+                : activeChatId
+                  ? renderMessageList(activeChatId)
+                  : renderChatList()}
+          </div>
+
+          {renderFooter()}
         </div>
-
-        {activeChat && !isSearching && (
-          <p className="shrink-0 truncate text-sm font-medium text-theme-fg-primary">
-            {activeChat.title}
-          </p>
-        )}
-
-        <div className="min-h-0 flex-1 divide-y divide-theme-border overflow-y-auto">
-          {liveLength > 0
-            ? renderQueryResults()
-            : activeChannel
-              ? renderChannelMessageList(activeChannel)
-              : activeChatId
-                ? renderMessageList(activeChatId)
-                : renderChatList()}
-        </div>
-
-        {renderFooter()}
-      </div>
-    </ModalBase>
+      </ModalBase>
+      <FilePreviewModal
+        isOpen={sharedFilePreview !== null}
+        onClose={closeSharedFilePreview}
+        file={sharedFilePreview ? previewModalFile(sharedFilePreview) : null}
+      />
+    </>
   );
 
   function renderQueryResults(): ReactNode {
@@ -406,8 +497,8 @@ function TeamsChatPickerDialogBody({
                 chips={
                   <SharedFileChips
                     files={message.sharedFiles}
-                    fileFetcher={picker.fileFetcher}
-                    maxFileBytes={picker.maxFileBytes}
+                    loadingId={sharedFileLoadingId}
+                    onOpen={openSharedFile}
                   />
                 }
                 createdAt={message.createdAt}
@@ -540,8 +631,8 @@ function TeamsChatPickerDialogBody({
                 chips={
                   <SharedFileChips
                     files={message.sharedFiles}
-                    fileFetcher={picker.fileFetcher}
-                    maxFileBytes={picker.maxFileBytes}
+                    loadingId={sharedFileLoadingId}
+                    onOpen={openSharedFile}
                   />
                 }
                 createdAt={message.createdAt}
@@ -993,61 +1084,46 @@ function BuildProgress({ picker }: { picker: TeamsChatPickerContextValue }) {
  */
 function SharedFileChips({
   files,
-  fileFetcher,
-  maxFileBytes,
+  loadingId,
+  onOpen,
 }: {
   files: readonly TeamsSharedFileRef[];
-  fileFetcher: TeamsFileFetcher | null;
-  maxFileBytes: number;
+  /** Attachment id whose bytes are being fetched for the preview. */
+  loadingId: string | null;
+  onOpen: (file: TeamsSharedFileRef) => void;
 }) {
   if (files.length === 0) return null;
 
-  const openFile = (file: TeamsSharedFileRef) => {
-    if (!fileFetcher) {
-      window.open(file.contentUrl, "_blank", "noopener,noreferrer");
-      return;
-    }
-    // The tab must open synchronously with the click or the popup blocker
-    // eats it; the content streams in afterwards.
-    const viewer = window.open("about:blank", "_blank");
-    if (!viewer) return;
-    void fileFetcher
-      .downloadSharedFile(file.contentUrl, maxFileBytes, {})
-      .then((result) => {
-        if (result.state === "ok") {
-          viewer.location.href = URL.createObjectURL(
-            new Blob([result.content.bytes], {
-              type: result.content.contentType,
-            }),
-          );
-        } else {
-          // Oversized or unresolvable here — let SharePoint have it.
-          viewer.location.href = file.contentUrl;
-        }
-      })
-      .catch(() => {
-        viewer.location.href = file.contentUrl;
-      });
-  };
-
   return (
     <div className="mt-1 flex flex-wrap gap-1">
-      {files.map((file) => (
-        <button
-          key={file.attachmentId}
-          type="button"
-          onClick={() => openFile(file)}
-          title={file.name}
-          aria-label={t({
-            id: "officeAddin.teams.picker.openSharedFile",
-            message: `Open ${file.name}`,
-          })}
-          className="theme-transition flex max-w-44 items-center gap-1 rounded-full border border-theme-border bg-theme-bg-accent px-2 py-0.5 text-[11px] text-theme-fg-muted hover:bg-theme-bg-hover hover:text-theme-fg-primary"
-        >
-          <PageIcon className="size-3 shrink-0" aria-hidden />
-          <span className="truncate">{file.name}</span>
-        </button>
-      ))}
+      {files.map((file) => {
+        const isLoading = loadingId === file.attachmentId;
+        return (
+          <button
+            key={file.attachmentId}
+            type="button"
+            onClick={() => onOpen(file)}
+            disabled={isLoading}
+            aria-busy={isLoading}
+            title={file.name}
+            aria-label={t({
+              id: "officeAddin.teams.picker.openSharedFile",
+              message: `Open ${file.name}`,
+            })}
+            className="theme-transition flex max-w-44 items-center gap-1 rounded-full border border-theme-border bg-theme-bg-accent px-2 py-0.5 text-[11px] text-theme-fg-muted hover:bg-theme-bg-hover hover:text-theme-fg-primary"
+          >
+            {isLoading ? (
+              <SpinnerIcon
+                className="size-3 shrink-0 animate-spin"
+                aria-hidden
+              />
+            ) : (
+              <PageIcon className="size-3 shrink-0" aria-hidden />
+            )}
+            <span className="truncate">{file.name}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -131,14 +131,15 @@ function TeamsChatPickerDialogBody({
   );
 
   // A probe can resolve after the dialog is gone; a late auto-tick would
-  // otherwise plant a selection into the next opening.
+  // otherwise plant a selection into the next opening. Re-armed in the effect
+  // body because StrictMode runs the cleanup once between its double mounts.
   const aliveRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
       aliveRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   const chatMatches = useMemo(
     () => filterTeamsChats(picker.chatList.chats, query),

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -141,6 +141,28 @@ function TeamsChatPickerDialogBody({
     };
   }, []);
 
+  // Closing the dialog aborts an in-flight preview download instead of
+  // letting a multi-megabyte transfer finish for nobody.
+  const previewAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    previewAbortRef.current = controller;
+    return () => controller.abort();
+  }, []);
+
+  // The preview's blob URL must also die with the dialog, not only with the
+  // preview modal's own close button.
+  const previewUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    previewUrlRef.current = sharedFilePreview?.url ?? null;
+  }, [sharedFilePreview]);
+  useEffect(
+    () => () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    },
+    [],
+  );
+
   const chatMatches = useMemo(
     () => filterTeamsChats(picker.chatList.chats, query),
     [picker.chatList.chats, query],
@@ -195,10 +217,11 @@ function TeamsChatPickerDialogBody({
       return;
     }
     setSharedFileLoadingId(file.attachmentId);
+    const signal = previewAbortRef.current?.signal;
     void fileFetcher
-      .downloadSharedFile(file.contentUrl, picker.maxFileBytes, {})
+      .downloadSharedFile(file.contentUrl, picker.maxFileBytes, { signal })
       .then((result) => {
-        if (!aliveRef.current) return;
+        if (signal?.aborted || !aliveRef.current) return;
         setSharedFilePreview(
           result.state === "ok"
             ? {

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -7,6 +7,7 @@ import {
   FolderIcon,
   Input,
   ModalBase,
+  PageIcon,
   SearchIcon,
 } from "@erato/frontend/library";
 import { plural, t } from "@lingui/core/macro";
@@ -38,7 +39,10 @@ import {
 
 import type { TeamsChatPickerContextValue } from "../providers/TeamsChatPickerProvider";
 import type { ParsedTeamsChannel } from "../utils/parsedTeamsChannel";
-import type { ParsedTeamsChat } from "../utils/parsedTeamsChat";
+import type {
+  ParsedTeamsChat,
+  TeamsSharedFileRef,
+} from "../utils/parsedTeamsChat";
 import type { TeamsSearchHit } from "../utils/teamsChatGraph";
 import type { TeamsMessageSelection } from "../utils/teamsChatSelection";
 import type {
@@ -398,6 +402,7 @@ function TeamsChatPickerDialogBody({
                 })}
                 title={senderName}
                 subline={message.text}
+                chips={<SharedFileChips files={message.sharedFiles} />}
                 createdAt={message.createdAt}
                 senderName={senderName}
               />
@@ -525,6 +530,7 @@ function TeamsChatPickerDialogBody({
                 })}
                 title={senderName}
                 subline={message.text}
+                chips={<SharedFileChips files={message.sharedFiles} />}
                 createdAt={message.createdAt}
                 senderName={senderName}
               />
@@ -962,6 +968,37 @@ function BuildProgress({ picker }: { picker: TeamsChatPickerContextValue }) {
           })}
         </p>
       )}
+    </div>
+  );
+}
+
+/**
+ * One compact chip per file shared with the message. Clicking opens the file
+ * where it lives — SharePoint's own preview — which costs no download, no
+ * consent and no space in this pane.
+ */
+function SharedFileChips({ files }: { files: readonly TeamsSharedFileRef[] }) {
+  if (files.length === 0) return null;
+  return (
+    <div className="mt-1 flex flex-wrap gap-1">
+      {files.map((file) => (
+        <button
+          key={file.attachmentId}
+          type="button"
+          onClick={() =>
+            window.open(file.contentUrl, "_blank", "noopener,noreferrer")
+          }
+          title={file.name}
+          aria-label={t({
+            id: "officeAddin.teams.picker.openSharedFile",
+            message: `Open ${file.name}`,
+          })}
+          className="theme-transition flex max-w-44 items-center gap-1 rounded-full border border-theme-border bg-theme-bg-accent px-2 py-0.5 text-[11px] text-theme-fg-muted hover:bg-theme-bg-hover hover:text-theme-fg-primary"
+        >
+          <PageIcon className="size-3 shrink-0" aria-hidden />
+          <span className="truncate">{file.name}</span>
+        </button>
+      ))}
     </div>
   );
 }

--- a/office-addin/src/teams/components/TeamsPickerRow.tsx
+++ b/office-addin/src/teams/components/TeamsPickerRow.tsx
@@ -19,6 +19,8 @@ export interface TeamsPickerRowProps {
   /** Present only for rows that drill in; renders the title as a button. */
   onOpen?: () => void;
   openLabel?: string;
+  /** Compact affordances under the subline, e.g. shared-file chips. */
+  chips?: ReactNode;
   /** Status line under the subline — why this row can't be ticked right now. */
   note?: ReactNode;
   createdAt?: string | null;
@@ -42,6 +44,7 @@ export function TeamsPickerRow({
   subline,
   onOpen,
   openLabel,
+  chips,
   note,
   createdAt,
   senderName,
@@ -86,6 +89,7 @@ export function TeamsPickerRow({
             {subline}
           </div>
         )}
+        {chips}
         {note !== undefined && (
           <div
             className="mt-0.5 text-xs italic text-theme-fg-muted"

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -27,6 +27,7 @@ import type { ParsedTeamsChat } from "../../utils/parsedTeamsChat";
 import type {
   TeamsChannelFetcher,
   TeamsChatFetcher,
+  TeamsFileFetcher,
 } from "../../utils/teamsChatFetcher";
 import type { PageChatMessagesResult } from "../../utils/teamsChatPager";
 import type { ReactNode } from "react";
@@ -139,6 +140,7 @@ function omitStyleProps(props: Record<string, unknown>) {
 const hooks = vi.hoisted(() => ({
   fetcher: null as TeamsChatFetcher | null,
   channelFetcher: null as TeamsChannelFetcher | null,
+  fileFetcher: null as TeamsFileFetcher | null,
   chatList: null as UseTeamsChatListResult | null,
   channelList: null as UseTeamsChannelListResult | null,
   messages: null as UseTeamsChatMessagesResult | null,
@@ -168,8 +170,8 @@ vi.mock("../../hooks/useTeamsChannelFetcher", () => ({
 }));
 vi.mock("../../hooks/useTeamsFileFetcher", () => ({
   useTeamsFileFetcher: () => ({
-    fetcher: null,
-    unavailableReason: "graph-unavailable",
+    fetcher: hooks.fileFetcher,
+    unavailableReason: hooks.fileFetcher ? null : "graph-unavailable",
   }),
 }));
 vi.mock("../../hooks/useTeamsChannelList", () => ({
@@ -421,6 +423,7 @@ describe("TeamsChatPickerDialog", () => {
     hooks.uploadStore = { isUploading: false, error: null };
     hooks.fetcher = fakeFetcher();
     hooks.channelFetcher = null;
+    hooks.fileFetcher = null;
     hooks.chatList = chatListResult();
     hooks.channelList = channelListResult();
     hooks.messages = messagesResult();
@@ -1006,6 +1009,62 @@ describe("TeamsChatPickerDialog", () => {
       "https://contoso.sharepoint.com/multipage-test.pdf",
       "_blank",
       "noopener,noreferrer",
+    );
+  });
+
+  it("previews a shared file through our own token when the grant exists", async () => {
+    const downloadSharedFile = vi.fn(() =>
+      Promise.resolve({
+        state: "ok" as const,
+        content: {
+          bytes: new TextEncoder().encode("pdf").buffer,
+          contentType: "application/pdf",
+        },
+      }),
+    );
+    hooks.fileFetcher = { downloadSharedFile };
+    hooks.messages = messagesResult({
+      messages: [
+        {
+          chatId: MOCK_CHAT_ID,
+          messageId: "1754000000000",
+          senderName: "Max Token",
+          createdAt: "2026-08-10T09:15:00Z",
+          editedAt: null,
+          text: "check this PDF guys",
+          markers: ["[attachment: multipage-test.pdf]"],
+          replyToId: null,
+          deepLink: "https://example.invalid/m",
+          sharedFiles: [
+            {
+              attachmentId: "att-1",
+              name: "multipage-test.pdf",
+              contentUrl: "https://contoso.sharepoint.com/multipage-test.pdf",
+            },
+          ],
+          imageUrls: [],
+        },
+      ],
+    });
+    const viewer = { location: { href: "" }, close: vi.fn() };
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue(viewer as unknown as Window);
+    URL.createObjectURL = vi.fn(() => "blob:preview");
+    renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Product sync" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open multipage-test.pdf" }),
+    );
+
+    // The tab opens synchronously; the bytes stream in behind it.
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+    await waitFor(() => expect(viewer.location.href).toBe("blob:preview"));
+    expect(downloadSharedFile).toHaveBeenCalledWith(
+      "https://contoso.sharepoint.com/multipage-test.pdf",
+      10 * 1024 * 1024,
+      expect.anything(),
     );
   });
 

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -118,6 +118,7 @@ vi.mock("@erato/frontend/library", () => ({
   ArrowLeftIcon: () => null,
   CloseIcon: () => null,
   FolderIcon: () => null,
+  PageIcon: () => null,
   SearchIcon: () => null,
   FILE_PREVIEW_STYLES: { progress: { container: "", bar: "" } },
   useFileUploadStore: { getState: () => hooks.uploadStore },
@@ -964,6 +965,47 @@ describe("TeamsChatPickerDialog", () => {
     expect(getMessage).not.toHaveBeenCalled();
     const text = await uploads[0][0].text();
     expect(text).toContain("Works for me.");
+  });
+
+  it("shows a shared file as a chip that opens the SharePoint preview", () => {
+    hooks.messages = messagesResult({
+      messages: [
+        {
+          chatId: MOCK_CHAT_ID,
+          messageId: "1754000000000",
+          senderName: "Max Token",
+          createdAt: "2026-08-10T09:15:00Z",
+          editedAt: null,
+          text: "check this PDF guys [attachment: multipage-test.pdf]",
+          markers: [],
+          replyToId: null,
+          deepLink: "https://example.invalid/m",
+          sharedFiles: [
+            {
+              attachmentId: "att-1",
+              name: "multipage-test.pdf",
+              contentUrl: "https://contoso.sharepoint.com/multipage-test.pdf",
+            },
+          ],
+          imageUrls: [],
+        },
+      ],
+    });
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue(null) as unknown as ReturnType<typeof vi.fn>;
+    renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Product sync" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open multipage-test.pdf" }),
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://contoso.sharepoint.com/multipage-test.pdf",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 
   it("uploads pasted images beside the transcript", async () => {

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -122,6 +122,7 @@ vi.mock("@erato/frontend/library", () => ({
   SearchIcon: () => null,
   FILE_PREVIEW_STYLES: { progress: { container: "", bar: "" } },
   useFileUploadStore: { getState: () => hooks.uploadStore },
+  useFeatureConfig: () => ({ upload: { maxSizeBytes: 10 * 1024 * 1024 } }),
   // Tag-stripping stand-in; the real block handling has its own unit tests.
   htmlToPlainText: (html: string) => html.replace(/<[^>]+>/g, ""),
 }));

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -121,6 +121,8 @@ vi.mock("@erato/frontend/library", () => ({
   SearchIcon: () => null,
   FILE_PREVIEW_STYLES: { progress: { container: "", bar: "" } },
   useFileUploadStore: { getState: () => hooks.uploadStore },
+  // Tag-stripping stand-in; the real block handling has its own unit tests.
+  htmlToPlainText: (html: string) => html.replace(/<[^>]+>/g, ""),
 }));
 
 function omitStyleProps(props: Record<string, unknown>) {
@@ -309,6 +311,7 @@ function fakeFetcher(
       });
     },
     getMessage: () => Promise.resolve(NEWEST),
+    getHostedContent: () => Promise.resolve(null),
   };
 }
 
@@ -321,6 +324,7 @@ function fakeChannelFetcher(
     listMessagesPage: () =>
       Promise.resolve({ messages: [], nextLink: null, status: 200, ok: true }),
     probeMessage: () => Promise.resolve({ message: null, status: 404 }),
+    getHostedContent: () => Promise.resolve(null),
     getReply: () => Promise.resolve(null),
     pageChannelBackwards: () =>
       Promise.resolve({
@@ -954,6 +958,50 @@ describe("TeamsChatPickerDialog", () => {
     expect(getMessage).not.toHaveBeenCalled();
     const text = await uploads[0][0].text();
     expect(text).toContain("Works for me.");
+  });
+
+  it("uploads pasted images beside the transcript", async () => {
+    const hosted = `https://graph.microsoft.com/v1.0/chats/x/messages/1/hostedContents/aWQ9/$value`;
+    const base = fakeFetcher();
+    hooks.fetcher = {
+      ...base,
+      pageChatBackwards: () =>
+        Promise.resolve({
+          messages: [
+            mockGraphChatMessage({
+              id: "a",
+              body: {
+                contentType: "html",
+                content: `<p>see this</p><img src="${hosted}">`,
+              },
+            }),
+          ],
+          nextLink: null,
+          truncated: false,
+          oldestCreatedDateTime: "2026-03-03T09:14:00Z",
+          state: "ok",
+        }),
+      getHostedContent: () =>
+        Promise.resolve({
+          bytes: new TextEncoder().encode("png-bytes").buffer,
+          contentType: "image/png",
+        }),
+    };
+    renderPicker();
+    fireEvent.click(selectChat());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Attach" }));
+    });
+    await waitFor(() => expect(uploads).toHaveLength(1));
+
+    expect(uploads[0]).toHaveLength(2);
+    const [transcript, image] = uploads[0];
+    expect(transcript.name).toBe("teams-Product_sync.md");
+    expect(image.name).toMatch(/^teams-img-[0-9a-f]{16}\.png$/);
+    await expect(transcript.text()).resolves.toContain(
+      `[image: attached as ${image.name}]`,
+    );
   });
 
   it("never uploads an empty transcript", async () => {

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -1083,9 +1083,59 @@ describe("TeamsChatPickerDialog", () => {
     expect(downloadSharedFile).toHaveBeenCalledWith(
       "https://contoso.sharepoint.com/multipage-test.pdf",
       10 * 1024 * 1024,
-      expect.anything(),
+      // Closing the dialog must be able to abort the transfer.
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("revokes the preview's blob url when the picker unmounts around it", async () => {
+    const downloadSharedFile = vi.fn(() =>
+      Promise.resolve({
+        state: "ok" as const,
+        content: {
+          bytes: new TextEncoder().encode("pdf").buffer,
+          contentType: "application/pdf",
+        },
+      }),
+    );
+    hooks.fileFetcher = { downloadSharedFile };
+    hooks.messages = messagesResult({
+      messages: [
+        {
+          chatId: MOCK_CHAT_ID,
+          messageId: "1754000000000",
+          senderName: "Max Token",
+          createdAt: "2026-08-10T09:15:00Z",
+          editedAt: null,
+          text: "check this PDF guys",
+          markers: [],
+          replyToId: null,
+          deepLink: "https://example.invalid/m",
+          sharedFiles: [
+            {
+              attachmentId: "att-1",
+              name: "multipage-test.pdf",
+              contentUrl: "https://contoso.sharepoint.com/multipage-test.pdf",
+            },
+          ],
+          imageUrls: [],
+        },
+      ],
+    });
+    URL.createObjectURL = vi.fn(() => "blob:preview");
+    const revoke = vi.fn();
+    URL.revokeObjectURL = revoke;
+    const view = renderPicker();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Product sync" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open multipage-test.pdf" }),
+    );
+    await screen.findByRole("dialog", { name: "Preview multipage-test.pdf" });
+
+    view.unmount();
+    expect(revoke).toHaveBeenCalledWith("blob:preview");
   });
 
   it("uploads pasted images beside the transcript", async () => {

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -415,10 +416,14 @@ function Opener() {
 }
 
 function renderPicker() {
+  // StrictMode on purpose: the app runs under it, and its double-mount is what
+  // exposed the alive-ref arming bug the plain renderer never would.
   const view = render(
-    <TeamsChatPickerProvider>
-      <Opener />
-    </TeamsChatPickerProvider>,
+    <StrictMode>
+      <TeamsChatPickerProvider>
+        <Opener />
+      </TeamsChatPickerProvider>
+    </StrictMode>,
   );
   fireEvent.click(screen.getByText("open picker"));
   return view;

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -931,6 +931,8 @@ describe("TeamsChatPickerDialog", () => {
           editedAt: null,
           text: "Works for me.",
           markers: [],
+          sharedFiles: [],
+          imageUrls: [],
           replyToId: null,
           deepLink: "https://example.invalid/m",
         },

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -121,6 +121,19 @@ vi.mock("@erato/frontend/library", () => ({
   FolderIcon: () => null,
   PageIcon: () => null,
   SearchIcon: () => null,
+  SpinnerIcon: () => null,
+  FilePreviewModal: ({
+    isOpen,
+    file,
+  }: {
+    isOpen: boolean;
+    file: { filename: string; preview_url?: string | null } | null;
+  }) =>
+    isOpen && file ? (
+      <div role="dialog" aria-label={`Preview ${file.filename}`}>
+        {file.preview_url}
+      </div>
+    ) : null,
   FILE_PREVIEW_STYLES: { progress: { container: "", bar: "" } },
   useFileUploadStore: { getState: () => hooks.uploadStore },
   useFeatureConfig: () => ({ upload: { maxSizeBytes: 10 * 1024 * 1024 } }),
@@ -1046,10 +1059,9 @@ describe("TeamsChatPickerDialog", () => {
         },
       ],
     });
-    const viewer = { location: { href: "" }, close: vi.fn() };
-    const openSpy = vi
-      .spyOn(window, "open")
-      .mockReturnValue(viewer as unknown as Window);
+    // spyOn returns the previous test's spy when one exists; drop its calls.
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    openSpy.mockClear();
     URL.createObjectURL = vi.fn(() => "blob:preview");
     renderPicker();
 
@@ -1058,14 +1070,17 @@ describe("TeamsChatPickerDialog", () => {
       screen.getByRole("button", { name: "Open multipage-test.pdf" }),
     );
 
-    // The tab opens synchronously; the bytes stream in behind it.
-    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
-    await waitFor(() => expect(viewer.location.href).toBe("blob:preview"));
+    // The in-app preview modal takes the bytes; no tab, no SharePoint login.
+    const preview = await screen.findByRole("dialog", {
+      name: "Preview multipage-test.pdf",
+    });
+    expect(preview).toHaveTextContent("blob:preview");
     expect(downloadSharedFile).toHaveBeenCalledWith(
       "https://contoso.sharepoint.com/multipage-test.pdf",
       10 * 1024 * 1024,
       expect.anything(),
     );
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("uploads pasted images beside the transcript", async () => {

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -164,6 +164,12 @@ vi.mock("../../hooks/useTeamsChannelFetcher", () => ({
     unavailableReason: hooks.channelFetcher ? null : "graph-unavailable",
   }),
 }));
+vi.mock("../../hooks/useTeamsFileFetcher", () => ({
+  useTeamsFileFetcher: () => ({
+    fetcher: null,
+    unavailableReason: "graph-unavailable",
+  }),
+}));
 vi.mock("../../hooks/useTeamsChannelList", () => ({
   useTeamsChannelList: () => hooks.channelList,
 }));

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -139,7 +139,14 @@ vi.mock("@erato/frontend/library", () => ({
   useFileUploadStore: { getState: () => hooks.uploadStore },
   useFeatureConfig: () => ({ upload: { maxSizeBytes: 10 * 1024 * 1024 } }),
   // Tag-stripping stand-in; the real block handling has its own unit tests.
-  htmlToPlainText: (html: string) => html.replace(/<[^>]+>/g, ""),
+  htmlToPlainText: (html: string) => {
+    let text = html;
+    for (let previous = ""; text !== previous; ) {
+      previous = text;
+      text = text.replace(/<[^>]+>/g, "");
+    }
+    return text;
+  },
 }));
 
 function omitStyleProps(props: Record<string, unknown>) {

--- a/office-addin/src/teams/hooks/useTeamsDevProbe.ts
+++ b/office-addin/src/teams/hooks/useTeamsDevProbe.ts
@@ -2,7 +2,17 @@ import { useEffect } from "react";
 
 import { GRAPH_TEAMS_CHANNEL_SCOPES } from "./useTeamsChannelFetcher";
 import { GRAPH_TEAMS_CHAT_SCOPES } from "./useTeamsChatFetcher";
+import { GRAPH_TEAMS_FILE_SCOPES } from "./useTeamsFileFetcher";
 import { useGraphTokenOptional } from "../../core/auth/GraphTokenProvider";
+import { makeGraphTokenSource } from "../../utils/graph/graphClient";
+import {
+  downloadTeamsSharedFile,
+  shareTokenForUrl,
+} from "../utils/teamsSharedFilesGraph";
+import {
+  MAX_SHARED_FILE_BYTES,
+  MAX_IMAGE_BYTES,
+} from "../utils/teamsTranscriptAssets";
 
 const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
 
@@ -112,12 +122,64 @@ export function useTeamsDevProbe(): void {
           GRAPH_TEAMS_CHANNEL_SCOPES,
         ),
       joinedTeams: () => raw("/me/joinedTeams", {}, GRAPH_TEAMS_CHANNEL_SCOPES),
+      /** Is `Files.Read.All` actually in the token this tenant hands out? */
+      fileScopes: async () => {
+        const token = await graph
+          .acquireToken(GRAPH_TEAMS_FILE_SCOPES)
+          .catch((error: unknown) => `FAILED: ${String(error)}`);
+        return token.startsWith("FAILED")
+          ? { requested: GRAPH_TEAMS_FILE_SCOPES.join(" "), granted: token }
+          : {
+              requested: GRAPH_TEAMS_FILE_SCOPES.join(" "),
+              granted: decodeScopes(token),
+            };
+      },
+      /** The `/shares` metadata leg alone — does the driveItem resolve? */
+      share: (contentUrl: string) =>
+        raw(
+          `/shares/${shareTokenForUrl(contentUrl)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+          {},
+          GRAPH_TEAMS_FILE_SCOPES,
+        ),
+      /** The full download — the decisive CORS test for the tempauth URL. */
+      download: async (contentUrl: string) => {
+        const result = await downloadTeamsSharedFile(
+          contentUrl,
+          MAX_SHARED_FILE_BYTES,
+          makeGraphTokenSource((options) =>
+            graph.acquireToken(GRAPH_TEAMS_FILE_SCOPES, options),
+          ),
+        );
+        return result.state === "ok"
+          ? {
+              state: result.state,
+              byteLength: result.content.bytes.byteLength,
+              contentType: result.content.contentType,
+            }
+          : result;
+      },
+      /** A hosted image by its body URL; pass channel scopes for channels. */
+      image: async (url: string, scopes?: string[]) => {
+        const token = await graph.acquireToken(
+          scopes ?? GRAPH_TEAMS_CHAT_SCOPES,
+        );
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const bytes = response.ok ? await response.arrayBuffer() : null;
+        return {
+          status: response.status,
+          byteLength: bytes?.byteLength ?? null,
+          contentType: response.headers.get("Content-Type"),
+          overCap: (bytes?.byteLength ?? 0) > MAX_IMAGE_BYTES,
+        };
+      },
       raw,
     };
 
     (globalThis as unknown as { __eratoTeams?: unknown }).__eratoTeams = probe;
     console.log(
-      "[erato] __eratoTeams ready: scopes() | search(q) | joinedTeams() | channelMessage(teamId, channelId, id)",
+      "[erato] __eratoTeams ready: scopes() | fileScopes() | search(q) | joinedTeams() | channelMessage(teamId, channelId, id) | share(contentUrl) | download(contentUrl) | image(url, scopes?)",
     );
 
     return () => {

--- a/office-addin/src/teams/hooks/useTeamsDevProbe.ts
+++ b/office-addin/src/teams/hooks/useTeamsDevProbe.ts
@@ -137,7 +137,7 @@ export function useTeamsDevProbe(): void {
       /** The `/shares` metadata leg alone — does the driveItem resolve? */
       share: (contentUrl: string) =>
         raw(
-          `/shares/${shareTokenForUrl(contentUrl)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+          `/shares/${shareTokenForUrl(contentUrl)}/driveItem`,
           {},
           GRAPH_TEAMS_FILE_SCOPES,
         ),

--- a/office-addin/src/teams/hooks/useTeamsFileFetcher.ts
+++ b/office-addin/src/teams/hooks/useTeamsFileFetcher.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+import { useSessionAuth } from "../../core/SessionAuthProvider";
+import { useGraphTokenOptional } from "../../core/auth/GraphTokenProvider";
+import { createGraphTeamsFileFetcher } from "../utils/teamsChatFetcher";
+
+import type { AcquireGraphToken } from "../../utils/graph/graphClient";
+import type { TeamsFileFetcher } from "../utils/teamsChatFetcher";
+
+/**
+ * Held apart from the chat and channel scopes: `Files.Read.All` spans the
+ * user's whole OneDrive/SharePoint reach and needs its own admin decision, so
+ * acquiring it together with the others would let a tenant that never granted
+ * it lose messages as well.
+ */
+export const GRAPH_TEAMS_FILE_SCOPES = ["Files.Read.All"];
+
+export type TeamsFileFetcherUnavailableReason =
+  | "graph-unavailable"
+  | "unsupported-mode";
+
+export interface UseTeamsFileFetcherResult {
+  fetcher: TeamsFileFetcher | null;
+  unavailableReason: TeamsFileFetcherUnavailableReason | null;
+}
+
+/**
+ * Never throws, and a non-null fetcher is not proof of consent — the scope is
+ * only exercised on first use, so callers must still handle an error state.
+ */
+export function useTeamsFileFetcher(): UseTeamsFileFetcherResult {
+  const { mode } = useSessionAuth();
+  const graph = useGraphTokenOptional();
+
+  return useMemo<UseTeamsFileFetcherResult>(() => {
+    if (mode !== "entra-msal") {
+      return { fetcher: null, unavailableReason: "unsupported-mode" };
+    }
+    if (!graph) {
+      return { fetcher: null, unavailableReason: "graph-unavailable" };
+    }
+    const acquireGraphToken: AcquireGraphToken = (options) =>
+      graph.acquireToken(GRAPH_TEAMS_FILE_SCOPES, options);
+    return {
+      fetcher: createGraphTeamsFileFetcher(acquireGraphToken),
+      unavailableReason: null,
+    };
+  }, [graph, mode]);
+}

--- a/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   TeamsChannelFetcher,
   TeamsChatFetcher,
+  TeamsFileFetcher,
 } from "../utils/teamsChatFetcher";
 import type { TeamsFetchState } from "../utils/teamsChatGraph";
 import type { TeamsChatSelection } from "../utils/teamsChatSelection";
@@ -68,6 +69,7 @@ const ABORTED_OUTCOME: TeamsTranscriptBuildOutcome = {
 export function useTeamsTranscriptBuild(
   fetcher: TeamsChatFetcher | null,
   channelFetcher: TeamsChannelFetcher | null = null,
+  fileFetcher: TeamsFileFetcher | null = null,
 ): UseTeamsTranscriptBuildResult {
   const [progress, setProgress] = useState<TeamsTranscriptProgress | null>(
     null,
@@ -112,6 +114,7 @@ export function useTeamsTranscriptBuild(
               fetcher,
               selections: args.selections,
               channelFetcher,
+              fileFetcher,
               knownChats: args.knownChats,
               knownChannels: args.knownChannels,
               self: args.self,
@@ -144,7 +147,7 @@ export function useTeamsTranscriptBuild(
         setIsBuilding(false);
       }
     },
-    [channelFetcher, fetcher],
+    [channelFetcher, fetcher, fileFetcher],
   );
 
   return { build, progress, isBuilding, cancel, reset };

--- a/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
@@ -21,6 +21,8 @@ import type { TeamsChatSelection } from "../utils/teamsChatSelection";
 export interface TeamsTranscriptBuildOutcome {
   /** Null when nothing renderable was fetched — never upload an empty file. */
   file: File | null;
+  /** Images fetched from the messages, uploaded beside the transcript. */
+  assets: File[];
   state: TeamsFetchState;
   messageCount: number;
   skippedCount: number;
@@ -44,6 +46,7 @@ export interface UseTeamsTranscriptBuildResult {
 
 const ABORTED_OUTCOME: TeamsTranscriptBuildOutcome = {
   file: null,
+  assets: [],
   state: "error",
   messageCount: 0,
   skippedCount: 0,
@@ -124,6 +127,7 @@ export function useTeamsTranscriptBuild(
             // in UTC would file those same messages under a different day.
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
+          assets: collected.assetFiles,
           state: collected.state,
           messageCount: collected.messageCount,
           skippedCount: collected.skippedCount,

--- a/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
@@ -38,6 +38,7 @@ export interface UseTeamsTranscriptBuildResult {
     knownChannels?: ReadonlyMap<string, ParsedTeamsChannel>;
     self?: TeamsSelfIdentity;
     limit?: number;
+    maxFileBytes?: number;
   }) => Promise<TeamsTranscriptBuildOutcome>;
   progress: TeamsTranscriptProgress | null;
   isBuilding: boolean;
@@ -95,6 +96,7 @@ export function useTeamsTranscriptBuild(
       knownChannels?: ReadonlyMap<string, ParsedTeamsChannel>;
       self?: TeamsSelfIdentity;
       limit?: number;
+      maxFileBytes?: number;
     }): Promise<TeamsTranscriptBuildOutcome> => {
       if (!fetcher || args.selections.length === 0) {
         return ABORTED_OUTCOME;
@@ -119,6 +121,7 @@ export function useTeamsTranscriptBuild(
               knownChannels: args.knownChannels,
               self: args.self,
               limit: args.limit,
+              maxFileBytes: args.maxFileBytes,
               signal,
               onProgress: setProgress,
             }),

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -15,6 +15,7 @@ import { useTeamsChannelList } from "../hooks/useTeamsChannelList";
 import { useTeamsChatFetcher } from "../hooks/useTeamsChatFetcher";
 import { useTeamsChatList } from "../hooks/useTeamsChatList";
 import { useTeamsDevProbe } from "../hooks/useTeamsDevProbe";
+import { useTeamsFileFetcher } from "../hooks/useTeamsFileFetcher";
 import { useTeamsTranscriptBuild } from "../hooks/useTeamsTranscriptBuild";
 import {
   DEFAULT_CHAT_MESSAGE_LIMIT,
@@ -153,6 +154,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const { userPrincipalName, userId } = useTeams();
   const { fetcher } = useTeamsChatFetcher();
   const { fetcher: channelFetcher } = useTeamsChannelFetcher();
+  const { fetcher: fileFetcher } = useTeamsFileFetcher();
   useTeamsDevProbe();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -194,7 +196,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   chatsByIdRef.current = chatList.chatsById;
 
   const { build, progress, isBuilding, cancel, reset } =
-    useTeamsTranscriptBuild(fetcher, channelFetcher);
+    useTeamsTranscriptBuild(fetcher, channelFetcher, fileFetcher);
 
   const messageLimitRef = useRef(messageLimit);
   messageLimitRef.current = messageLimit;

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -1,4 +1,4 @@
-import { useFileUploadStore } from "@erato/frontend/library";
+import { useFeatureConfig, useFileUploadStore } from "@erato/frontend/library";
 import {
   createContext,
   useCallback,
@@ -155,6 +155,8 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const { fetcher } = useTeamsChatFetcher();
   const { fetcher: channelFetcher } = useTeamsChannelFetcher();
   const { fetcher: fileFetcher } = useTeamsFileFetcher();
+  // Shared-file downloads cap at what the deployment's upload limit accepts.
+  const maxFileBytes = useFeatureConfig().upload.maxSizeBytes;
   useTeamsDevProbe();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -316,6 +318,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       knownChannels: channelsByKeyRef.current,
       self,
       limit: messageLimitRef.current,
+      maxFileBytes,
     });
     // A user-initiated cancel is not a failure to report.
     if (cancelledRef.current) return;
@@ -328,7 +331,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       return;
     }
     await deliver([outcome.file, ...outcome.assets], key);
-  }, [build, deliver, self]);
+  }, [build, deliver, maxFileBytes, self]);
 
   const attachPartial = useCallback(async () => {
     const outcome = partialOutcome;

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -181,8 +181,6 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const handoffRef = useRef<((files: File[]) => Promise<void>) | null>(null);
   const cancelledRef = useRef(false);
   const lastBuildRef = useRef<{ key: string; files: File[] } | null>(null);
-  const selectionRef = useRef(selection);
-  selectionRef.current = selection;
 
   // The object id is the reliable match; the login hint can differ from a
   // member's primary SMTP address, which would leave the viewer in their own
@@ -199,16 +197,9 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const channelList = useTeamsChannelList(
     hasEverOpened ? channelFetcher : null,
   );
-  const channelsByKeyRef = useRef(channelList.channelsByKey);
-  channelsByKeyRef.current = channelList.channelsByKey;
-  const chatsByIdRef = useRef(chatList.chatsById);
-  chatsByIdRef.current = chatList.chatsById;
 
   const { build, progress, isBuilding, cancel, reset } =
     useTeamsTranscriptBuild(fetcher, channelFetcher, fileFetcher);
-
-  const messageLimitRef = useRef(messageLimit);
-  messageLimitRef.current = messageLimit;
 
   const open = useCallback(
     (onSelectFiles: (files: File[]) => Promise<void>) => {
@@ -306,13 +297,13 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   );
 
   const attach = useCallback(async () => {
-    const selections = [...selectionRef.current.values()];
+    const selections = [...selection.values()];
     if (selections.length === 0) return;
     cancelledRef.current = false;
     setAttachError(null);
     setPartialOutcome(null);
 
-    const key = teamsSelectionDedupeKey(selections, messageLimitRef.current);
+    const key = teamsSelectionDedupeKey(selections, messageLimit);
     const built = lastBuildRef.current;
     if (built?.key === key) {
       await deliver(built.files, key);
@@ -321,10 +312,10 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
 
     const outcome = await build({
       selections,
-      knownChats: chatsByIdRef.current,
-      knownChannels: channelsByKeyRef.current,
+      knownChats: chatList.chatsById,
+      knownChannels: channelList.channelsByKey,
       self,
-      limit: messageLimitRef.current,
+      limit: messageLimit,
       maxFileBytes,
     });
     // A user-initiated cancel is not a failure to report.
@@ -338,7 +329,16 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       return;
     }
     await deliver([outcome.file, ...outcome.assets], key);
-  }, [build, deliver, maxFileBytes, self]);
+  }, [
+    build,
+    chatList.chatsById,
+    channelList.channelsByKey,
+    deliver,
+    maxFileBytes,
+    messageLimit,
+    selection,
+    self,
+  ]);
 
   const attachPartial = useCallback(async () => {
     const outcome = partialOutcome;

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -40,6 +40,7 @@ import type {
 import type {
   TeamsChannelFetcher,
   TeamsChatFetcher,
+  TeamsFileFetcher,
 } from "../utils/teamsChatFetcher";
 import type { TeamsChatSelection } from "../utils/teamsChatSelection";
 import type { ReactNode } from "react";
@@ -59,6 +60,10 @@ export interface TeamsChatPickerContextValue {
   fetcher: TeamsChatFetcher | null;
   /** Null when the channel scopes were not granted — the picker shows chats only. */
   channelFetcher: TeamsChannelFetcher | null;
+  /** Null when `Files.Read.All` was not granted. */
+  fileFetcher: TeamsFileFetcher | null;
+  /** The deployment's upload limit; also caps chip-preview downloads. */
+  maxFileBytes: number;
   self: TeamsSelfIdentity | undefined;
   chatList: UseTeamsChatListResult;
   channelList: UseTeamsChannelListResult;
@@ -113,6 +118,8 @@ const CLOSED_PICKER: TeamsChatPickerContextValue = {
   close: () => {},
   fetcher: null,
   channelFetcher: null,
+  fileFetcher: null,
+  maxFileBytes: 0,
   self: undefined,
   chatList: EMPTY_CHAT_LIST,
   channelList: EMPTY_CHANNEL_LIST,
@@ -351,6 +358,8 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       close,
       fetcher,
       channelFetcher,
+      fileFetcher,
+      maxFileBytes,
       self,
       chatList,
       channelList,
@@ -380,10 +389,12 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       chatList,
       close,
       fetcher,
+      fileFetcher,
       isBuilding,
       isMessageSelectionFull,
       isOpen,
       isSelected,
+      maxFileBytes,
       messageLimit,
       open,
       partialOutcome,

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -169,7 +169,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
 
   const handoffRef = useRef<((files: File[]) => Promise<void>) | null>(null);
   const cancelledRef = useRef(false);
-  const lastBuildRef = useRef<{ key: string; file: File } | null>(null);
+  const lastBuildRef = useRef<{ key: string; files: File[] } | null>(null);
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
 
@@ -266,10 +266,10 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
    * walking Graph again, which is tens of seconds.
    */
   const deliver = useCallback(
-    async (file: File, retryKey?: string): Promise<boolean> => {
+    async (files: File[], retryKey?: string): Promise<boolean> => {
       const handoff = handoffRef.current;
       const fail = () => {
-        if (retryKey) lastBuildRef.current = { key: retryKey, file };
+        if (retryKey) lastBuildRef.current = { key: retryKey, files };
         setAttachError("upload-failed");
         return false;
       };
@@ -277,7 +277,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
         return fail();
       }
       try {
-        await handoff([file]);
+        await handoff(files);
       } catch (error) {
         console.warn(
           "[TeamsChatPicker] attaching the transcript failed",
@@ -304,7 +304,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     const key = teamsSelectionDedupeKey(selections, messageLimitRef.current);
     const built = lastBuildRef.current;
     if (built?.key === key) {
-      await deliver(built.file, key);
+      await deliver(built.files, key);
       return;
     }
 
@@ -325,7 +325,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       setPartialOutcome(outcome);
       return;
     }
-    await deliver(outcome.file, key);
+    await deliver([outcome.file, ...outcome.assets], key);
   }, [build, deliver, self]);
 
   const attachPartial = useCallback(async () => {
@@ -334,7 +334,9 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     setPartialOutcome(null);
     // Put the offer back if the composer never took it — the partial
     // transcript is the only copy of a walk that already ran.
-    if (!(await deliver(outcome.file))) setPartialOutcome(outcome);
+    if (!(await deliver([outcome.file, ...outcome.assets]))) {
+      setPartialOutcome(outcome);
+    }
   }, [deliver, partialOutcome]);
 
   const value = useMemo<TeamsChatPickerContextValue>(

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -33,6 +33,8 @@ function message(
     editedAt: null,
     text: "Can we move the sync to Thursday?",
     markers: [],
+    sharedFiles: [],
+    imageUrls: [],
     replyToId: null,
     deepLink: buildTeamsMessageDeepLink(MOCK_CHAT_ID, messageId),
     ...overrides,

--- a/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
+++ b/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
@@ -34,6 +34,7 @@ function fakeChannelFetcher(overrides: Partial<TeamsChannelFetcher> = {}) {
       Promise.resolve({ messages: [], nextLink: null, status: 200, ok: true }),
     ),
     probeMessage: vi.fn(() => Promise.resolve({ message: null, status: 404 })),
+    getHostedContent: vi.fn(() => Promise.resolve(null)),
     getReply: vi.fn(() => Promise.resolve(null)),
     pageChannelBackwards: vi.fn(() =>
       Promise.resolve({
@@ -76,6 +77,7 @@ function fakeFetcher(overrides: Partial<TeamsChatFetcher> = {}) {
       }),
     ),
     getMessage: vi.fn(() => Promise.resolve(null)),
+    getHostedContent: vi.fn(() => Promise.resolve(null)),
     ...overrides,
   };
   return fetcher;
@@ -289,6 +291,61 @@ describe("collectTeamsTranscript", () => {
     expect(seen.map((entry) => entry.completed)).toEqual(
       [...seen.map((entry) => entry.completed)].sort((a, b) => a - b),
     );
+  });
+
+  it("fetches pasted images and stamps their markers with the upload name", async () => {
+    const hosted = `https://graph.microsoft.com/v1.0/chats/x/messages/1/hostedContents/aWQ9/$value`;
+    const pageChatBackwards = vi.fn(() =>
+      Promise.resolve({
+        messages: [
+          mockGraphChatMessage({
+            id: "a",
+            body: {
+              contentType: "html" as const,
+              content: `<p>see this</p><img src="${hosted}">`,
+            },
+          }),
+        ],
+        nextLink: null,
+        truncated: false,
+        oldestCreatedDateTime: "2026-03-03T09:14:00Z",
+        state: "ok" as const,
+      }),
+    );
+    const getHostedContent = vi.fn(() =>
+      Promise.resolve({
+        bytes: new TextEncoder().encode("png-bytes").buffer,
+        contentType: "image/png",
+      }),
+    );
+    const totals: number[] = [];
+
+    const result = await collectTeamsTranscript({
+      fetcher: fakeFetcher({ pageChatBackwards, getHostedContent }),
+      selections: [
+        {
+          kind: "conversation",
+          ref: chatRef(MOCK_CHAT_ID),
+          title: "Product sync",
+        },
+      ],
+      knownChats,
+      onProgress: (progress) => totals.push(progress.requestsTotal),
+    });
+
+    expect(getHostedContent).toHaveBeenCalledWith(
+      MOCK_CHAT_ID,
+      hosted,
+      expect.anything(),
+    );
+    expect(result.assetFiles).toHaveLength(1);
+    const name = result.assetFiles[0].name;
+    expect(name).toMatch(/^teams-img-[0-9a-f]{16}\.png$/);
+    expect(result.sections[0].messages[0].text).toContain(
+      `[image: attached as ${name}]`,
+    );
+    // The denominator grows by the image fetch once its count is known.
+    expect(Math.max(...totals)).toBe(Math.min(...totals) + 1);
   });
 
   it("names a conversation while it is being fetched and clears it after", async () => {

--- a/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
+++ b/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
@@ -139,6 +139,8 @@ describe("collectTeamsTranscript", () => {
             editedAt: null,
             text: "the body the picker already showed",
             markers: [],
+            sharedFiles: [],
+            imageUrls: [],
             replyToId: null,
             deepLink: "https://example.invalid/a",
           },

--- a/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
+++ b/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
@@ -348,6 +348,107 @@ describe("collectTeamsTranscript", () => {
     expect(Math.max(...totals)).toBe(Math.min(...totals) + 1);
   });
 
+  it("downloads shared files when the grant exists and stamps their markers", async () => {
+    const pageChatBackwards = vi.fn(() =>
+      Promise.resolve({
+        messages: [
+          mockGraphChatMessage({
+            id: "a",
+            body: { contentType: "text" as const, content: "see the plan" },
+            attachments: [
+              {
+                id: "att-1",
+                contentType: "reference",
+                name: "Q3 Plan.docx",
+                contentUrl: "https://contoso.sharepoint.com/q3",
+              },
+            ],
+          }),
+        ],
+        nextLink: null,
+        truncated: false,
+        oldestCreatedDateTime: "2026-03-03T09:14:00Z",
+        state: "ok" as const,
+      }),
+    );
+    const downloadSharedFile = vi.fn(() =>
+      Promise.resolve({
+        state: "ok" as const,
+        content: {
+          bytes: new TextEncoder().encode("docx-bytes").buffer,
+          contentType: "application/vnd.openxmlformats",
+        },
+      }),
+    );
+
+    const result = await collectTeamsTranscript({
+      fetcher: fakeFetcher({ pageChatBackwards }),
+      fileFetcher: { downloadSharedFile },
+      selections: [
+        {
+          kind: "conversation",
+          ref: chatRef(MOCK_CHAT_ID),
+          title: "Product sync",
+        },
+      ],
+      knownChats,
+    });
+
+    expect(downloadSharedFile).toHaveBeenCalledWith(
+      "https://contoso.sharepoint.com/q3",
+      expect.any(Number),
+      expect.anything(),
+    );
+    expect(result.assetFiles).toHaveLength(1);
+    const name = result.assetFiles[0].name;
+    expect(name).toMatch(/^teams-file-[0-9a-f]{8}-Q3_Plan\.docx$/);
+    expect(result.sections[0].messages[0].markers).toEqual([
+      `[attachment: Q3 Plan.docx — attached as ${name}]`,
+    ]);
+  });
+
+  it("leaves file markers bare without the file grant", async () => {
+    const pageChatBackwards = vi.fn(() =>
+      Promise.resolve({
+        messages: [
+          mockGraphChatMessage({
+            id: "a",
+            body: { contentType: "text" as const, content: "see the plan" },
+            attachments: [
+              {
+                id: "att-1",
+                contentType: "reference",
+                name: "Q3 Plan.docx",
+                contentUrl: "https://contoso.sharepoint.com/q3",
+              },
+            ],
+          }),
+        ],
+        nextLink: null,
+        truncated: false,
+        oldestCreatedDateTime: "2026-03-03T09:14:00Z",
+        state: "ok" as const,
+      }),
+    );
+
+    const result = await collectTeamsTranscript({
+      fetcher: fakeFetcher({ pageChatBackwards }),
+      selections: [
+        {
+          kind: "conversation",
+          ref: chatRef(MOCK_CHAT_ID),
+          title: "Product sync",
+        },
+      ],
+      knownChats,
+    });
+
+    expect(result.assetFiles).toEqual([]);
+    expect(result.sections[0].messages[0].markers).toEqual([
+      "[attachment: Q3 Plan.docx]",
+    ]);
+  });
+
   it("names a conversation while it is being fetched and clears it after", async () => {
     const getMessage = vi.fn((chatId: string, messageId: string) =>
       Promise.resolve(mockGraphChatMessage({ id: messageId, chatId })),

--- a/office-addin/src/teams/utils/__tests__/parsedTeamsChat.test.ts
+++ b/office-addin/src/teams/utils/__tests__/parsedTeamsChat.test.ts
@@ -198,4 +198,51 @@ describe("parseTeamsMessage", () => {
       ),
     ).toBeNull();
   });
+
+  it("keeps a shared file as a structured ref, not only a marker", () => {
+    const parsed = parseTeamsMessage(
+      mockGraphChatMessage({
+        body: { contentType: "text", content: "see the plan" },
+        attachments: [
+          {
+            id: "att-1",
+            contentType: "reference",
+            name: "Q3 Plan.docx",
+            contentUrl: "https://contoso.sharepoint.com/sites/x/Q3%20Plan.docx",
+          },
+          // A card has no file behind it and must not become a ref.
+          {
+            id: "att-2",
+            contentType: "application/vnd.microsoft.card.adaptive",
+            name: null,
+          },
+        ],
+      }),
+      MOCK_CHAT_ID,
+    );
+    expect(parsed?.sharedFiles).toEqual([
+      {
+        attachmentId: "att-1",
+        name: "Q3 Plan.docx",
+        contentUrl: "https://contoso.sharepoint.com/sites/x/Q3%20Plan.docx",
+      },
+    ]);
+  });
+
+  it("keeps hosted image urls aligned with their [image] markers", () => {
+    const hosted = `https://graph.microsoft.com/v1.0/chats/${encodeURIComponent(
+      MOCK_CHAT_ID,
+    )}/messages/1741000000000/hostedContents/aWQ9/$value`;
+    const parsed = parseTeamsMessage(
+      mockGraphChatMessage({
+        body: {
+          contentType: "html",
+          content: `<img src="https://media.example/sticker.gif"><img src="${hosted}">`,
+        },
+      }),
+      MOCK_CHAT_ID,
+    );
+    expect(parsed?.text).toBe("[image][image]");
+    expect(parsed?.imageUrls).toEqual([null, hosted]);
+  });
 });

--- a/office-addin/src/teams/utils/__tests__/teamsChatSelection.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsChatSelection.test.ts
@@ -93,6 +93,8 @@ describe("groupSelectionsByConversation", () => {
       editedAt: null,
       text: "already parsed",
       markers: [],
+      sharedFiles: [],
+      imageUrls: [],
       replyToId: null,
       deepLink: "https://example.invalid/a",
     };

--- a/office-addin/src/teams/utils/__tests__/teamsSharedFilesGraph.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsSharedFilesGraph.test.ts
@@ -75,8 +75,9 @@ describe("downloadTeamsSharedFile", () => {
     expect(new TextDecoder().decode(result.content.bytes)).toBe("pdf-bytes");
     expect(result.content.contentType).toBe("application/pdf");
 
+    // No $select — naming properties suppresses the downloadUrl annotation.
     expect(calls[0].url).toBe(
-      `https://graph.microsoft.com/v1.0/shares/${shareTokenForUrl(CONTENT_URL)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+      `https://graph.microsoft.com/v1.0/shares/${shareTokenForUrl(CONTENT_URL)}/driveItem`,
     );
     expect(
       (calls[0].init?.headers as Record<string, string>).Authorization,

--- a/office-addin/src/teams/utils/__tests__/teamsSharedFilesGraph.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsSharedFilesGraph.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { jsonResponse } from "../../../test/mocks/teams/graph";
+import { makeGraphTokenSource } from "../../../utils/graph/graphClient";
+import {
+  downloadTeamsSharedFile,
+  shareTokenForUrl,
+} from "../teamsSharedFilesGraph";
+
+import type { GraphTransport } from "../../../utils/graph/graphClient";
+
+const tokenSource = () => makeGraphTokenSource(async () => "token");
+
+const CONTENT_URL = "https://contoso.sharepoint.com/sites/x/Q3%20Plan.docx";
+
+function binaryResponse(text: string, contentType: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "",
+    headers: {
+      get: (name: string) => (name === "Content-Type" ? contentType : null),
+    },
+    arrayBuffer: () => Promise.resolve(new TextEncoder().encode(text).buffer),
+  } as unknown as Response;
+}
+
+function driveItemResponse(overrides: Record<string, unknown> = {}): Response {
+  return jsonResponse({
+    name: "Q3 Plan.docx",
+    size: 1234,
+    file: { mimeType: "application/vnd.openxmlformats" },
+    "@microsoft.graph.downloadUrl": "https://download.example/tempauth",
+    ...overrides,
+  });
+}
+
+describe("shareTokenForUrl", () => {
+  it("encodes to the u! base64url form and decodes back to the url", () => {
+    const token = shareTokenForUrl(CONTENT_URL);
+    expect(token.startsWith("u!")).toBe(true);
+    expect(token).not.toMatch(/[+/=]/);
+    const base64 = token
+      .slice(2)
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(Math.ceil((token.length - 2) / 4) * 4, "=");
+    expect(atob(base64)).toBe(CONTENT_URL);
+  });
+});
+
+describe("downloadTeamsSharedFile", () => {
+  it("resolves the share, then downloads pre-authenticated without a token", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const transport: GraphTransport = vi.fn(
+      (url: string, init?: RequestInit) => {
+        calls.push({ url, init });
+        return Promise.resolve(
+          url.includes("/shares/")
+            ? driveItemResponse()
+            : binaryResponse("pdf-bytes", "application/pdf"),
+        );
+      },
+    );
+
+    const result = await downloadTeamsSharedFile(
+      CONTENT_URL,
+      10_000,
+      tokenSource(),
+      { transport },
+    );
+
+    expect(result.state).toBe("ok");
+    if (result.state !== "ok") return;
+    expect(new TextDecoder().decode(result.content.bytes)).toBe("pdf-bytes");
+    expect(result.content.contentType).toBe("application/pdf");
+
+    expect(calls[0].url).toBe(
+      `https://graph.microsoft.com/v1.0/shares/${shareTokenForUrl(CONTENT_URL)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+    );
+    expect(
+      (calls[0].init?.headers as Record<string, string>).Authorization,
+    ).toBe("Bearer token");
+    expect(calls[1].url).toBe("https://download.example/tempauth");
+    expect(calls[1].init?.headers ?? {}).not.toHaveProperty("Authorization");
+  });
+
+  it("refuses an oversized file from metadata without downloading a byte", async () => {
+    const transport = vi.fn(() =>
+      Promise.resolve(driveItemResponse({ size: 50_000 })),
+    );
+
+    const result = await downloadTeamsSharedFile(
+      CONTENT_URL,
+      10_000,
+      tokenSource(),
+      { transport },
+    );
+
+    expect(result).toEqual({ state: "too-large" });
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a shared folder as unattachable", async () => {
+    const transport = vi.fn(() =>
+      Promise.resolve(driveItemResponse({ file: null })),
+    );
+
+    const result = await downloadTeamsSharedFile(
+      CONTENT_URL,
+      10_000,
+      tokenSource(),
+      { transport },
+    );
+
+    expect(result).toEqual({ state: "error" });
+  });
+
+  it("degrades to an error state when the share cannot be resolved", async () => {
+    const transport = vi.fn(() => Promise.resolve(jsonResponse({}, 403)));
+
+    const result = await downloadTeamsSharedFile(
+      CONTENT_URL,
+      10_000,
+      tokenSource(),
+      { transport },
+    );
+
+    expect(result).toEqual({ state: "error" });
+  });
+});

--- a/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
+import {
+  MAX_IMAGE_BYTES,
+  MAX_TRANSCRIPT_IMAGES,
+  collectTeamsImageAssets,
+  planTeamsImageFetches,
+  stampImageMarkers,
+} from "../teamsTranscriptAssets";
+
+import type { TeamsTranscriptSection } from "../buildTeamsTranscriptFile";
+import type { ParsedTeamsChat, ParsedTeamsMessage } from "../parsedTeamsChat";
+
+const chat: ParsedTeamsChat = {
+  chatId: MOCK_CHAT_ID,
+  title: "Product sync",
+  participants: [],
+  participantsTruncated: false,
+  chatType: "group",
+  lastActivityAt: null,
+  previewText: "",
+};
+
+function message(
+  overrides: Partial<ParsedTeamsMessage> = {},
+): ParsedTeamsMessage {
+  return {
+    chatId: MOCK_CHAT_ID,
+    messageId: "m1",
+    senderName: "Ada Lovelace",
+    createdAt: "2026-03-03T09:14:00Z",
+    editedAt: null,
+    text: "[image]",
+    markers: [],
+    replyToId: null,
+    deepLink: "https://example.invalid/m1",
+    sharedFiles: [],
+    imageUrls: [],
+    ...overrides,
+  };
+}
+
+function section(messages: ParsedTeamsMessage[]): TeamsTranscriptSection {
+  return { kind: "chat", chat, messages, selection: "messages" };
+}
+
+const url = (id: string) =>
+  `https://graph.microsoft.com/v1.0/chats/x/messages/1/hostedContents/${id}/$value`;
+
+const bytesOf = (text: string) => new TextEncoder().encode(text).buffer;
+
+describe("stampImageMarkers", () => {
+  it("replaces markers by occurrence index and leaves unfetched ones", () => {
+    expect(
+      stampImageMarkers("a [image] b [image] c", [null, "teams-img-1.png"]),
+    ).toBe("a [image] b [image: attached as teams-img-1.png] c");
+  });
+
+  it("returns the text unchanged with nothing to stamp", () => {
+    expect(stampImageMarkers("[image]", [null])).toBe("[image]");
+  });
+});
+
+describe("planTeamsImageFetches", () => {
+  it("counts unique fetchable urls up to the cap", () => {
+    const many = Array.from({ length: MAX_TRANSCRIPT_IMAGES + 5 }, (_, i) =>
+      url(`u${i}`),
+    );
+    const sections = [
+      section([
+        message({ imageUrls: [url("a"), null, url("a")] }),
+        message({ messageId: "m2", imageUrls: many }),
+      ]),
+    ];
+    expect(planTeamsImageFetches(sections)).toBe(MAX_TRANSCRIPT_IMAGES);
+  });
+});
+
+describe("collectTeamsImageAssets", () => {
+  it("uploads one file per distinct image and stamps every marker", async () => {
+    // The same bytes behind two urls — one upload, two stamps.
+    const fetchImage = vi.fn((_section, requested: string) =>
+      Promise.resolve({
+        bytes: bytesOf(requested.includes("dup") ? "same" : "same"),
+        contentType: "image/jpeg",
+      }),
+    );
+    const sections = [
+      section([
+        message({ text: "[image]", imageUrls: [url("a")] }),
+        message({
+          messageId: "m2",
+          text: "[image]",
+          imageUrls: [url("dup")],
+        }),
+      ]),
+    ];
+
+    const result = await collectTeamsImageAssets({ sections, fetchImage });
+
+    expect(fetchImage).toHaveBeenCalledTimes(2);
+    expect(result.files).toHaveLength(1);
+    const name = result.files[0].name;
+    expect(name).toMatch(/^teams-img-[0-9a-f]{16}\.jpg$/);
+    for (const stamped of result.sections[0].messages) {
+      expect(stamped.text).toBe(`[image: attached as ${name}]`);
+    }
+  });
+
+  it("leaves the marker alone when the fetch fails or the image is oversized", async () => {
+    const fetchImage = vi.fn((_section, requested: string) =>
+      requested.includes("big")
+        ? Promise.resolve({
+            bytes: new ArrayBuffer(MAX_IMAGE_BYTES + 1),
+            contentType: "image/png",
+          })
+        : Promise.resolve(null),
+    );
+    const onFetched = vi.fn();
+    const sections = [
+      section([
+        message({
+          text: "[image] [image]",
+          imageUrls: [url("gone"), url("big")],
+        }),
+      ]),
+    ];
+
+    const result = await collectTeamsImageAssets({
+      sections,
+      fetchImage,
+      onFetched,
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.sections[0].messages[0].text).toBe("[image] [image]");
+    // Progress accounting: exactly once per planned fetch, success or not.
+    expect(onFetched).toHaveBeenCalledTimes(2);
+  });
+});

--- a/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
@@ -255,6 +255,29 @@ describe("shared files", () => {
     );
   });
 
+  it("hands the deployment's upload limit to the download as the per-file cap", async () => {
+    const downloadFile = vi.fn(() => okDownload("x"));
+    const sections = [
+      section([
+        message({
+          sharedFiles: [fileRef("big.pdf", "https://c.sharepoint.com/big")],
+        }),
+      ]),
+    ];
+
+    await collectTeamsMessageAssets({
+      sections,
+      fetchImage: () => Promise.resolve(null),
+      downloadFile,
+      maxFileBytes: 50 * 1024 * 1024,
+    });
+
+    expect(downloadFile).toHaveBeenCalledWith(
+      expect.anything(),
+      50 * 1024 * 1024,
+    );
+  });
+
   it("caps the number of files it will download", async () => {
     const downloadFile = vi.fn(() => okDownload("x"));
     const refs = Array.from({ length: MAX_TRANSCRIPT_FILES + 3 }, (_, i) =>

--- a/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
 import {
   MAX_IMAGE_BYTES,
+  MAX_TRANSCRIPT_FILES,
   MAX_TRANSCRIPT_IMAGES,
-  collectTeamsImageAssets,
-  planTeamsImageFetches,
+  collectTeamsMessageAssets,
+  planTeamsAssetFetches,
   stampImageMarkers,
 } from "../teamsTranscriptAssets";
 
@@ -62,7 +63,7 @@ describe("stampImageMarkers", () => {
   });
 });
 
-describe("planTeamsImageFetches", () => {
+describe("planTeamsAssetFetches", () => {
   it("counts unique fetchable urls up to the cap", () => {
     const many = Array.from({ length: MAX_TRANSCRIPT_IMAGES + 5 }, (_, i) =>
       url(`u${i}`),
@@ -73,11 +74,11 @@ describe("planTeamsImageFetches", () => {
         message({ messageId: "m2", imageUrls: many }),
       ]),
     ];
-    expect(planTeamsImageFetches(sections)).toBe(MAX_TRANSCRIPT_IMAGES);
+    expect(planTeamsAssetFetches(sections, false)).toBe(MAX_TRANSCRIPT_IMAGES);
   });
 });
 
-describe("collectTeamsImageAssets", () => {
+describe("collectTeamsMessageAssets", () => {
   it("uploads one file per distinct image and stamps every marker", async () => {
     // The same bytes behind two urls — one upload, two stamps.
     const fetchImage = vi.fn((_section, requested: string) =>
@@ -97,7 +98,11 @@ describe("collectTeamsImageAssets", () => {
       ]),
     ];
 
-    const result = await collectTeamsImageAssets({ sections, fetchImage });
+    const result = await collectTeamsMessageAssets({
+      sections,
+      fetchImage,
+      downloadFile: null,
+    });
 
     expect(fetchImage).toHaveBeenCalledTimes(2);
     expect(result.files).toHaveLength(1);
@@ -127,9 +132,10 @@ describe("collectTeamsImageAssets", () => {
       ]),
     ];
 
-    const result = await collectTeamsImageAssets({
+    const result = await collectTeamsMessageAssets({
       sections,
       fetchImage,
+      downloadFile: null,
       onFetched,
     });
 
@@ -137,5 +143,131 @@ describe("collectTeamsImageAssets", () => {
     expect(result.sections[0].messages[0].text).toBe("[image] [image]");
     // Progress accounting: exactly once per planned fetch, success or not.
     expect(onFetched).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("shared files", () => {
+  const fileRef = (name: string, contentUrl: string) => ({
+    attachmentId: `att-${name}`,
+    name,
+    contentUrl,
+  });
+  const okDownload = (text: string, contentType = "application/pdf") =>
+    Promise.resolve({
+      state: "ok" as const,
+      content: { bytes: bytesOf(text), contentType },
+    });
+
+  it("counts files in the plan only when the grant exists", () => {
+    const sections = [
+      section([
+        message({
+          imageUrls: [url("a")],
+          sharedFiles: [fileRef("plan.pdf", "https://c.sharepoint.com/p")],
+        }),
+      ]),
+    ];
+    expect(planTeamsAssetFetches(sections, false)).toBe(1);
+    expect(planTeamsAssetFetches(sections, true)).toBe(2);
+  });
+
+  it("stamps the inline marker and the appended marker with the upload name", async () => {
+    const downloadFile = vi.fn(() => okDownload("pdf-bytes"));
+    const sections = [
+      section([
+        message({
+          // Referenced in the body: the marker sits inline.
+          text: "see [attachment: Q3 Plan.docx]",
+          sharedFiles: [fileRef("Q3 Plan.docx", "https://c.sharepoint.com/q3")],
+        }),
+        message({
+          messageId: "m2",
+          // Never referenced: the marker was appended after the text.
+          text: "and this",
+          markers: ["[attachment: notes.pdf]"],
+          sharedFiles: [fileRef("notes.pdf", "https://c.sharepoint.com/notes")],
+        }),
+      ]),
+    ];
+
+    const result = await collectTeamsMessageAssets({
+      sections,
+      fetchImage: () => Promise.resolve(null),
+      downloadFile,
+    });
+
+    // Identical bytes behind both urls dedupe to one upload.
+    expect(result.files).toHaveLength(1);
+    const name = result.files[0].name;
+    expect(name).toMatch(/^teams-file-[0-9a-f]{8}-Q3_Plan\.docx$/);
+    expect(result.sections[0].messages[0].text).toBe(
+      `see [attachment: Q3 Plan.docx — attached as ${name}]`,
+    );
+    expect(result.sections[0].messages[1].markers).toEqual([
+      `[attachment: notes.pdf — attached as ${name}]`,
+    ]);
+  });
+
+  it("discloses a file refused for size instead of staying silent", async () => {
+    const downloadFile = vi.fn(() =>
+      Promise.resolve({ state: "too-large" as const }),
+    );
+    const sections = [
+      section([
+        message({
+          text: "see [attachment: video.mp4]",
+          sharedFiles: [fileRef("video.mp4", "https://c.sharepoint.com/v")],
+        }),
+      ]),
+    ];
+
+    const result = await collectTeamsMessageAssets({
+      sections,
+      fetchImage: () => Promise.resolve(null),
+      downloadFile,
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.sections[0].messages[0].text).toBe(
+      "see [attachment: video.mp4 — too large to attach]",
+    );
+  });
+
+  it("leaves markers untouched without the file grant", async () => {
+    const sections = [
+      section([
+        message({
+          text: "see [attachment: plan.pdf]",
+          sharedFiles: [fileRef("plan.pdf", "https://c.sharepoint.com/p")],
+        }),
+      ]),
+    ];
+
+    const result = await collectTeamsMessageAssets({
+      sections,
+      fetchImage: () => Promise.resolve(null),
+      downloadFile: null,
+    });
+
+    expect(result.files).toEqual([]);
+    expect(result.sections[0].messages[0].text).toBe(
+      "see [attachment: plan.pdf]",
+    );
+  });
+
+  it("caps the number of files it will download", async () => {
+    const downloadFile = vi.fn(() => okDownload("x"));
+    const refs = Array.from({ length: MAX_TRANSCRIPT_FILES + 3 }, (_, i) =>
+      fileRef(`f${i}.pdf`, `https://c.sharepoint.com/f${i}`),
+    );
+    const sections = [section([message({ sharedFiles: refs })])];
+
+    await collectTeamsMessageAssets({
+      sections,
+      fetchImage: () => Promise.resolve(null),
+      downloadFile,
+    });
+
+    expect(downloadFile).toHaveBeenCalledTimes(MAX_TRANSCRIPT_FILES);
   });
 });

--- a/office-addin/src/teams/utils/collectTeamsTranscript.ts
+++ b/office-addin/src/teams/utils/collectTeamsTranscript.ts
@@ -81,6 +81,8 @@ export interface CollectTeamsTranscriptArgs {
   channelFetcher?: TeamsChannelFetcher | null;
   /** Present only where `Files.Read.All` was granted. */
   fileFetcher?: TeamsFileFetcher | null;
+  /** The deployment's configured upload limit, as the per-file cap. */
+  maxFileBytes?: number;
   /** Channel metadata from the browse cache, keyed by `teamId/channelId`. */
   knownChannels?: ReadonlyMap<string, ParsedTeamsChannel>;
   self?: TeamsSelfIdentity;
@@ -322,6 +324,7 @@ export async function collectTeamsTranscript(
               signal,
             })
         : null,
+      maxFileBytes: args.maxFileBytes,
       onFetched: () => {
         requestsCompleted += 1;
         emit();

--- a/office-addin/src/teams/utils/collectTeamsTranscript.ts
+++ b/office-addin/src/teams/utils/collectTeamsTranscript.ts
@@ -18,6 +18,10 @@ import {
 } from "./teamsChatPager";
 import { groupSelectionsByConversation } from "./teamsChatSelection";
 import { conversationKey } from "./teamsConversationRef";
+import {
+  collectTeamsImageAssets,
+  planTeamsImageFetches,
+} from "./teamsTranscriptAssets";
 import { runWithConcurrency } from "../../utils/graph/graphClient";
 
 import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
@@ -60,6 +64,8 @@ export interface CollectTeamsTranscriptResult {
   skippedCount: number;
   chatsTotal: number;
   chatsCompleted: number;
+  /** Image files fetched from the messages, to upload beside the transcript. */
+  assetFiles: File[];
 }
 
 export interface CollectTeamsTranscriptArgs {
@@ -100,7 +106,9 @@ export async function collectTeamsTranscript(
       ? wholeChatRequests
       : group.messages.filter((entry) => entry.message === null).length,
   );
-  const requestsTotal = groupRequests.reduce((sum, count) => sum + count, 0);
+  // Grows once when the image phase starts: how many images a selection holds
+  // is unknowable before its messages are fetched.
+  let requestsTotal = groupRequests.reduce((sum, count) => sum + count, 0);
 
   let requestsCompleted = 0;
   let chatsCompleted = 0;
@@ -278,10 +286,36 @@ export async function collectTeamsTranscript(
   emit();
   await runWithConcurrency(tasks, TEAMS_CHAT_CONCURRENCY);
 
-  const present = sections.filter(
+  let present = sections.filter(
     (section): section is TeamsTranscriptSection =>
       section !== null && section.messages.length > 0,
   );
+
+  let assetFiles: File[] = [];
+  if (!signal?.aborted && planTeamsImageFetches(present) > 0) {
+    requestsTotal += planTeamsImageFetches(present);
+    emit();
+    const assets = await collectTeamsImageAssets({
+      sections: present,
+      fetchImage: (section, url) =>
+        section.kind === "chat"
+          ? fetcher.getHostedContent(section.chat.chatId, url, { signal })
+          : (channelFetcher?.getHostedContent(
+              section.channel.teamId,
+              section.channel.channelId,
+              url,
+              { signal },
+            ) ?? Promise.resolve(null)),
+      onFetched: () => {
+        requestsCompleted += 1;
+        emit();
+      },
+      signal,
+    });
+    present = assets.sections;
+    assetFiles = assets.files;
+  }
+
   return {
     sections: present,
     state: overallState(outcomes, present.length),
@@ -292,6 +326,7 @@ export async function collectTeamsTranscript(
     skippedCount,
     chatsTotal: groups.length,
     chatsCompleted,
+    assetFiles,
   };
 }
 

--- a/office-addin/src/teams/utils/collectTeamsTranscript.ts
+++ b/office-addin/src/teams/utils/collectTeamsTranscript.ts
@@ -19,8 +19,8 @@ import {
 import { groupSelectionsByConversation } from "./teamsChatSelection";
 import { conversationKey } from "./teamsConversationRef";
 import {
-  collectTeamsImageAssets,
-  planTeamsImageFetches,
+  collectTeamsMessageAssets,
+  planTeamsAssetFetches,
 } from "./teamsTranscriptAssets";
 import { runWithConcurrency } from "../../utils/graph/graphClient";
 
@@ -31,7 +31,11 @@ import type {
   ParsedTeamsMessage,
   TeamsSelfIdentity,
 } from "./parsedTeamsChat";
-import type { TeamsChannelFetcher, TeamsChatFetcher } from "./teamsChatFetcher";
+import type {
+  TeamsChannelFetcher,
+  TeamsChatFetcher,
+  TeamsFileFetcher,
+} from "./teamsChatFetcher";
 import type { GraphChatMessage, TeamsFetchState } from "./teamsChatGraph";
 import type {
   TeamsChatSelection,
@@ -75,6 +79,8 @@ export interface CollectTeamsTranscriptArgs {
   knownChats?: ReadonlyMap<string, ParsedTeamsChat>;
   /** Present only where the channel scopes were granted. */
   channelFetcher?: TeamsChannelFetcher | null;
+  /** Present only where `Files.Read.All` was granted. */
+  fileFetcher?: TeamsFileFetcher | null;
   /** Channel metadata from the browse cache, keyed by `teamId/channelId`. */
   knownChannels?: ReadonlyMap<string, ParsedTeamsChannel>;
   self?: TeamsSelfIdentity;
@@ -89,6 +95,7 @@ export async function collectTeamsTranscript(
   const {
     fetcher,
     channelFetcher,
+    fileFetcher,
     selections,
     knownChats,
     knownChannels,
@@ -292,10 +299,13 @@ export async function collectTeamsTranscript(
   );
 
   let assetFiles: File[] = [];
-  if (!signal?.aborted && planTeamsImageFetches(present) > 0) {
-    requestsTotal += planTeamsImageFetches(present);
+  const plannedAssets = signal?.aborted
+    ? 0
+    : planTeamsAssetFetches(present, fileFetcher != null);
+  if (plannedAssets > 0) {
+    requestsTotal += plannedAssets;
     emit();
-    const assets = await collectTeamsImageAssets({
+    const assets = await collectTeamsMessageAssets({
       sections: present,
       fetchImage: (section, url) =>
         section.kind === "chat"
@@ -306,6 +316,12 @@ export async function collectTeamsTranscript(
               url,
               { signal },
             ) ?? Promise.resolve(null)),
+      downloadFile: fileFetcher
+        ? (ref, maxBytes) =>
+            fileFetcher.downloadSharedFile(ref.contentUrl, maxBytes, {
+              signal,
+            })
+        : null,
       onFetched: () => {
         requestsCompleted += 1;
         emit();

--- a/office-addin/src/teams/utils/parsedTeamsChat.ts
+++ b/office-addin/src/teams/utils/parsedTeamsChat.ts
@@ -8,6 +8,7 @@ import { CHAT_MEMBER_EXPAND_CAP } from "./teamsChatGraph";
 import { buildTeamsMessageDeepLink } from "./teamsDeepLink";
 import {
   referencedAttachmentIds,
+  teamsBodyImageUrls,
   teamsMessageBodyToText,
 } from "./teamsMessageText";
 
@@ -35,6 +36,15 @@ export interface ParsedTeamsChat {
   previewText: string;
 }
 
+/** A file shared with a message, living in OneDrive/SharePoint. */
+export interface TeamsSharedFileRef {
+  /** `chatMessageAttachment` id — joins the ref to its inline body marker. */
+  attachmentId: string;
+  name: string;
+  /** Web URL of the file; bytes resolve only through the `/shares` endpoint. */
+  contentUrl: string;
+}
+
 export interface ParsedTeamsMessage {
   chatId: string;
   messageId: string;
@@ -47,6 +57,13 @@ export interface ParsedTeamsMessage {
   /** Root message of a channel reply; null for roots and for chat messages. */
   replyToId: string | null;
   deepLink: string;
+  /** Files shared as OneDrive/SharePoint references, in attachment order. */
+  sharedFiles: TeamsSharedFileRef[];
+  /**
+   * Body images in `[image]` occurrence order; null entries are images the
+   * message-reading token cannot fetch.
+   */
+  imageUrls: (string | null)[];
 }
 
 const UNKNOWN_SENDER = "Unknown";
@@ -132,7 +149,23 @@ export function parseTeamsMessage(
     markers,
     replyToId: message.replyToId ?? null,
     deepLink: message.webUrl ?? buildTeamsMessageDeepLink(chatId, message.id),
+    sharedFiles: sharedFileRefs(message),
+    imageUrls: teamsBodyImageUrls(message.body),
   };
+}
+
+function sharedFileRefs(message: GraphChatMessage): TeamsSharedFileRef[] {
+  const refs: TeamsSharedFileRef[] = [];
+  for (const attachment of message.attachments ?? []) {
+    if (attachment.contentType !== "reference") continue;
+    if (!attachment.id || !attachment.contentUrl || !attachment.name) continue;
+    refs.push({
+      attachmentId: attachment.id,
+      name: attachment.name,
+      contentUrl: attachment.contentUrl,
+    });
+  }
+  return refs;
 }
 
 /** Newest first, matching the order Graph returns chat messages in. */

--- a/office-addin/src/teams/utils/teamsChatFetcher.ts
+++ b/office-addin/src/teams/utils/teamsChatFetcher.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  channelGateKey,
+  fetchTeamsHostedContent,
   getChannelReply,
   getChatMessage,
   getTeamsChat,
@@ -32,6 +34,7 @@ import type {
   ListTeamsChatsResult,
   SearchChatMessagesResult,
   TeamsGraphCallOptions,
+  TeamsHostedContent,
 } from "./teamsChatGraph";
 import type {
   ChatPagingProgress,
@@ -68,6 +71,12 @@ export interface TeamsChatFetcher {
     messageId: string,
     options?: TeamsGraphCallOptions,
   ): Promise<GraphChatMessage | null>;
+  /** Bytes of a pasted image, by the URL its message body carries. */
+  getHostedContent(
+    chatId: string,
+    url: string,
+    options?: TeamsGraphCallOptions,
+  ): Promise<TeamsHostedContent | null>;
 }
 
 export function createGraphTeamsChatFetcher(
@@ -88,6 +97,8 @@ export function createGraphTeamsChatFetcher(
       pageChatMessagesBackwards({ ...args, tokenSource: tokenSource() }),
     getMessage: (chatId, messageId, options = {}) =>
       getChatMessage(chatId, messageId, tokenSource(), options),
+    getHostedContent: (chatId, url, options = {}) =>
+      fetchTeamsHostedContent(url, chatId, tokenSource(), options),
   };
 }
 
@@ -132,6 +143,13 @@ export interface TeamsChannelFetcher {
       onProgress?: (progress: ChatPagingProgress) => void;
     } & TeamsGraphCallOptions,
   ): Promise<PageChatMessagesResult>;
+  /** Bytes of a pasted image, by the URL its message body carries. */
+  getHostedContent(
+    teamId: string,
+    channelId: string,
+    url: string,
+    options?: TeamsGraphCallOptions,
+  ): Promise<TeamsHostedContent | null>;
 }
 
 export function createGraphTeamsChannelFetcher(
@@ -157,5 +175,12 @@ export function createGraphTeamsChannelFetcher(
       ),
     pageChannelBackwards: (args) =>
       pageChannelMessagesBackwards({ ...args, tokenSource: tokenSource() }),
+    getHostedContent: (teamId, channelId, url, options = {}) =>
+      fetchTeamsHostedContent(
+        url,
+        channelGateKey(teamId, channelId),
+        tokenSource(),
+        options,
+      ),
   };
 }

--- a/office-addin/src/teams/utils/teamsChatFetcher.ts
+++ b/office-addin/src/teams/utils/teamsChatFetcher.ts
@@ -22,6 +22,7 @@ import {
   pageChannelMessagesBackwards,
   pageChatMessagesBackwards,
 } from "./teamsChatPager";
+import { downloadTeamsSharedFile } from "./teamsSharedFilesGraph";
 import { makeGraphTokenSource } from "../../utils/graph/graphClient";
 
 import type {
@@ -40,6 +41,7 @@ import type {
   ChatPagingProgress,
   PageChatMessagesResult,
 } from "./teamsChatPager";
+import type { TeamsSharedFileDownload } from "./teamsSharedFilesGraph";
 import type { AcquireGraphToken } from "../../utils/graph/graphClient";
 
 export interface TeamsChatFetcher {
@@ -182,5 +184,28 @@ export function createGraphTeamsChannelFetcher(
         tokenSource(),
         options,
       ),
+  };
+}
+
+/**
+ * Shared files are a third consent decision: `Files.Read.All` is broad and
+ * admin-gated, so a tenant can have working chats and channels while file
+ * bytes stay out of reach. Callers treat a null file fetcher as "markers only".
+ */
+export interface TeamsFileFetcher {
+  downloadSharedFile(
+    contentUrl: string,
+    maxBytes: number,
+    options?: TeamsGraphCallOptions,
+  ): Promise<TeamsSharedFileDownload>;
+}
+
+export function createGraphTeamsFileFetcher(
+  acquireToken: AcquireGraphToken,
+): TeamsFileFetcher {
+  const tokenSource = () => makeGraphTokenSource(acquireToken);
+  return {
+    downloadSharedFile: (contentUrl, maxBytes, options = {}) =>
+      downloadTeamsSharedFile(contentUrl, maxBytes, tokenSource(), options),
   };
 }

--- a/office-addin/src/teams/utils/teamsChatGraph.ts
+++ b/office-addin/src/teams/utils/teamsChatGraph.ts
@@ -152,18 +152,21 @@ interface GraphInit {
 }
 
 /**
- * One Graph JSON round-trip under a per-request timeout, optionally behind the
- * per-chat gate, honouring a single `Retry-After` on 429. Returns the status
- * instead of throwing so callers can degrade to `partial`; aborts propagate.
+ * One Graph round-trip under a per-request timeout, optionally behind the
+ * per-chat gate, honouring a single `Retry-After` on 429. Aborts propagate;
+ * everything else resolves through `read` so callers can degrade to `partial`.
  */
-async function requestGraphJson<T>(args: {
+async function requestGraph<T>(args: {
   url: string;
   tokenSource: GraphTokenSource;
   gateKey?: string | null;
+  accept: string;
   init?: GraphInit;
   options: TeamsGraphCallOptions;
-}): Promise<GraphJsonResult<T>> {
-  const { url, tokenSource, gateKey, init, options } = args;
+  read: (response: Response) => Promise<T>;
+  fallback: T;
+}): Promise<T> {
+  const { url, tokenSource, gateKey, accept, init, options, read } = args;
   const parentSignal = options.signal;
   const transport = options.transport ?? globalThis.fetch.bind(globalThis);
 
@@ -172,7 +175,7 @@ async function requestGraphJson<T>(args: {
   // against the chat, traded for not re-queueing behind unrelated pages.
   const send = (signal: AbortSignal) => {
     const call = () =>
-      graphFetch(url, tokenSource, "application/json", signal, transport, init);
+      graphFetch(url, tokenSource, accept, signal, transport, init);
     return gateKey ? runGatedByChat(gateKey, signal, call) : call();
   };
 
@@ -190,11 +193,7 @@ async function requestGraphJson<T>(args: {
             response = await send(signal);
           }
         }
-        if (!response.ok) {
-          return { ok: false, status: response.status, payload: null };
-        }
-        const payload = (await response.json()) as T;
-        return { ok: true, status: response.status, payload };
+        return read(response);
       },
     );
   } catch (error) {
@@ -202,8 +201,63 @@ async function requestGraphJson<T>(args: {
       throw parentSignal.reason ?? error;
     }
     console.warn("[teamsChatGraph] request failed:", url, error);
-    return { ok: false, status: 0, payload: null };
+    return args.fallback;
   }
+}
+
+async function requestGraphJson<T>(args: {
+  url: string;
+  tokenSource: GraphTokenSource;
+  gateKey?: string | null;
+  init?: GraphInit;
+  options: TeamsGraphCallOptions;
+}): Promise<GraphJsonResult<T>> {
+  return requestGraph<GraphJsonResult<T>>({
+    ...args,
+    accept: "application/json",
+    fallback: { ok: false, status: 0, payload: null },
+    read: async (response) => {
+      if (!response.ok) {
+        return { ok: false, status: response.status, payload: null };
+      }
+      const payload = (await response.json()) as T;
+      return { ok: true, status: response.status, payload };
+    },
+  });
+}
+
+export interface TeamsHostedContent {
+  bytes: ArrayBuffer;
+  contentType: string;
+}
+
+/**
+ * Bytes of a hosted content — a pasted image — by the absolute URL the message
+ * body carries. Reads the same conversation as the message fetches, so it
+ * shares their gate.
+ */
+export async function fetchTeamsHostedContent(
+  url: string,
+  gateKey: string,
+  tokenSource: GraphTokenSource,
+  options: TeamsGraphCallOptions = {},
+): Promise<TeamsHostedContent | null> {
+  return requestGraph<TeamsHostedContent | null>({
+    url,
+    tokenSource,
+    gateKey,
+    accept: "*/*",
+    options,
+    fallback: null,
+    read: async (response) => {
+      if (!response.ok) return null;
+      return {
+        bytes: await response.arrayBuffer(),
+        contentType:
+          response.headers.get("Content-Type") ?? "application/octet-stream",
+      };
+    },
+  });
 }
 
 export interface ListTeamsChatsResult {

--- a/office-addin/src/teams/utils/teamsChatGraph.ts
+++ b/office-addin/src/teams/utils/teamsChatGraph.ts
@@ -63,6 +63,11 @@ export interface GraphChatMessageBody {
 export interface GraphChatMessageAttachment {
   id?: string;
   contentType?: string;
+  /**
+   * SharePoint/OneDrive web URL for `reference` attachments — the bytes are
+   * reachable only through the `/shares` endpoint, never directly.
+   */
+  contentUrl?: string | null;
   name?: string | null;
 }
 

--- a/office-addin/src/teams/utils/teamsChatGraph.ts
+++ b/office-addin/src/teams/utils/teamsChatGraph.ts
@@ -205,7 +205,7 @@ async function requestGraph<T>(args: {
   }
 }
 
-async function requestGraphJson<T>(args: {
+export async function requestGraphJson<T>(args: {
   url: string;
   tokenSource: GraphTokenSource;
   gateKey?: string | null;

--- a/office-addin/src/teams/utils/teamsMessageText.ts
+++ b/office-addin/src/teams/utils/teamsMessageText.ts
@@ -36,6 +36,27 @@ export function teamsMessageBodyToText(
   return normalizeText(htmlToPlainText(doc.body.innerHTML));
 }
 
+/**
+ * `img` sources in body order — the same order their `[image]` markers take in
+ * the rendered text. Only Graph hosted-content URLs are fetchable with the
+ * message-reading token; anything else (external stickers, data URIs) stays
+ * null so occurrence indexes still line up.
+ */
+export function teamsBodyImageUrls(
+  body: GraphChatMessageBody | null | undefined,
+): (string | null)[] {
+  const content = body?.content ?? "";
+  if (body?.contentType !== "html" || content.length === 0) return [];
+  const doc = new DOMParser().parseFromString(content, "text/html");
+  return Array.from(doc.body.querySelectorAll("img")).map((element) => {
+    const src = element.getAttribute("src") ?? "";
+    return HOSTED_CONTENT_URL.test(src) ? src : null;
+  });
+}
+
+const HOSTED_CONTENT_URL =
+  /^https:\/\/graph\.microsoft\.com\/(?:v1\.0|beta)\/.+\/hostedContents\/[^/]+\/\$value$/;
+
 /** Attachment ids referenced by an `<attachment>` element in the body. */
 export function referencedAttachmentIds(
   body: GraphChatMessageBody | null | undefined,

--- a/office-addin/src/teams/utils/teamsSharedFilesGraph.ts
+++ b/office-addin/src/teams/utils/teamsSharedFilesGraph.ts
@@ -1,0 +1,97 @@
+/**
+ * Downloads the OneDrive/SharePoint files shared into Teams messages. A
+ * message carries only the file's web URL; the bytes resolve through the
+ * `/shares` endpoint — encode the URL as a share token, read the driveItem for
+ * its size and pre-authenticated download URL, then fetch that URL plain.
+ *
+ * Two-step on purpose: the driveItem's `size` lets an oversized file be
+ * refused before a byte of it is downloaded.
+ */
+
+import { requestGraphJson } from "./teamsChatGraph";
+import { GRAPH_BASE } from "../../utils/graph/graphClient";
+import { runWithGraphTimeout } from "../../utils/graph/graphRequestTimeout";
+
+import type { TeamsGraphCallOptions } from "./teamsChatGraph";
+import type { GraphTokenSource } from "../../utils/graph/graphClient";
+
+/** Files can dwarf messages; give the plain download more room than a page. */
+const FILE_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+export interface TeamsSharedFileContent {
+  bytes: ArrayBuffer;
+  contentType: string;
+}
+
+export type TeamsSharedFileDownload =
+  | { state: "ok"; content: TeamsSharedFileContent }
+  /** Known too big from metadata — nothing was downloaded. */
+  | { state: "too-large" }
+  | { state: "error" };
+
+/** `u!` + base64url of the web URL, per the `/shares` addressing contract. */
+export function shareTokenForUrl(url: string): string {
+  const bytes = new TextEncoder().encode(url);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `u!${btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_")}`;
+}
+
+interface ShareDriveItem {
+  name?: string;
+  size?: number;
+  file?: { mimeType?: string | null } | null;
+  "@microsoft.graph.downloadUrl"?: string;
+}
+
+export async function downloadTeamsSharedFile(
+  contentUrl: string,
+  maxBytes: number,
+  tokenSource: GraphTokenSource,
+  options: TeamsGraphCallOptions = {},
+): Promise<TeamsSharedFileDownload> {
+  const item = await requestGraphJson<ShareDriveItem>({
+    url: `${GRAPH_BASE}/shares/${shareTokenForUrl(contentUrl)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+    tokenSource,
+    options,
+  });
+  if (!item.ok || !item.payload) return { state: "error" };
+  // A shared folder has no file facet and nothing attachable.
+  if (!item.payload.file) return { state: "error" };
+  if ((item.payload.size ?? 0) > maxBytes) return { state: "too-large" };
+  const downloadUrl = item.payload["@microsoft.graph.downloadUrl"];
+  if (!downloadUrl) return { state: "error" };
+
+  // The download URL is pre-authenticated: no Authorization header, and none
+  // would survive the redirect to SharePoint anyway.
+  const transport = options.transport ?? globalThis.fetch.bind(globalThis);
+  try {
+    return await runWithGraphTimeout(
+      FILE_DOWNLOAD_TIMEOUT_MS,
+      `Shared file download timed out after ${FILE_DOWNLOAD_TIMEOUT_MS}ms`,
+      options.signal,
+      async (signal) => {
+        const response = await transport(downloadUrl, { signal });
+        if (!response.ok) return { state: "error" as const };
+        const bytes = await response.arrayBuffer();
+        if (bytes.byteLength > maxBytes) return { state: "too-large" as const };
+        return {
+          state: "ok" as const,
+          content: {
+            bytes,
+            contentType:
+              response.headers.get("Content-Type") ??
+              item.payload?.file?.mimeType ??
+              "application/octet-stream",
+          },
+        };
+      },
+    );
+  } catch (error) {
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? error;
+    }
+    console.warn("[teamsSharedFilesGraph] download failed:", contentUrl, error);
+    return { state: "error" };
+  }
+}

--- a/office-addin/src/teams/utils/teamsSharedFilesGraph.ts
+++ b/office-addin/src/teams/utils/teamsSharedFilesGraph.ts
@@ -50,8 +50,10 @@ export async function downloadTeamsSharedFile(
   tokenSource: GraphTokenSource,
   options: TeamsGraphCallOptions = {},
 ): Promise<TeamsSharedFileDownload> {
+  // No $select: naming properties suppresses the @microsoft.graph.downloadUrl
+  // annotation (wire-observed), and it is the whole point of this request.
   const item = await requestGraphJson<ShareDriveItem>({
-    url: `${GRAPH_BASE}/shares/${shareTokenForUrl(contentUrl)}/driveItem?$select=name,size,file,@microsoft.graph.downloadUrl`,
+    url: `${GRAPH_BASE}/shares/${shareTokenForUrl(contentUrl)}/driveItem`,
     tokenSource,
     options,
   });

--- a/office-addin/src/teams/utils/teamsTranscriptAssets.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptAssets.ts
@@ -1,0 +1,162 @@
+/**
+ * Turns the images pasted into selected Teams messages into upload files and
+ * stamps each message's `[image]` marker with the uploaded name, which is how
+ * the model joins file ↔ message: the backend keys parsed uploads by filename
+ * and the marker sits at the exact message position.
+ *
+ * Everything degrades to the bare marker: a failed fetch, an oversized image
+ * or the cap leaves `[image]` exactly as it reads today.
+ */
+
+import { runWithConcurrency } from "../../utils/graph/graphClient";
+
+import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
+import type { ParsedTeamsMessage } from "./parsedTeamsChat";
+import type { TeamsHostedContent } from "./teamsChatGraph";
+
+/** Vision input is expensive; a transcript is an excerpt, not an album. */
+export const MAX_TRANSCRIPT_IMAGES = 10;
+/** Pasted screenshots are small; anything bigger is not worth the tokens. */
+export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+/** Same-conversation fetches serialize on the gate anyway. */
+const IMAGE_FETCH_CONCURRENCY = 3;
+
+export type FetchTeamsImage = (
+  section: TeamsTranscriptSection,
+  url: string,
+) => Promise<TeamsHostedContent | null>;
+
+export interface TeamsImageAssetsResult {
+  /** The input sections with fetched images stamped into their markers. */
+  sections: TeamsTranscriptSection[];
+  files: File[];
+}
+
+/** Fetches the plan will attempt — the progress denominator. */
+export function planTeamsImageFetches(
+  sections: readonly TeamsTranscriptSection[],
+): number {
+  return imageFetchPlan(sections).length;
+}
+
+export async function collectTeamsImageAssets(args: {
+  sections: readonly TeamsTranscriptSection[];
+  fetchImage: FetchTeamsImage;
+  /** Called exactly once per planned fetch, success or not. */
+  onFetched?: () => void;
+  signal?: AbortSignal;
+}): Promise<TeamsImageAssetsResult> {
+  const plan = imageFetchPlan(args.sections);
+  const uploadedByUrl = new Map<string, string>();
+  const filesByHash = new Map<string, File>();
+
+  const tasks = plan.map((planned) => async () => {
+    try {
+      if (args.signal?.aborted) return;
+      const content = await args.fetchImage(planned.section, planned.url);
+      if (!content) return;
+      const size = content.bytes.byteLength;
+      if (size === 0 || size > MAX_IMAGE_BYTES) return;
+      const hash = fnv1a64Hex(content.bytes);
+      let file = filesByHash.get(hash);
+      if (!file) {
+        file = new File(
+          [content.bytes],
+          `teams-img-${hash}.${imageExtension(content.contentType)}`,
+          { type: content.contentType },
+        );
+        filesByHash.set(hash, file);
+      }
+      uploadedByUrl.set(planned.url, file.name);
+    } catch {
+      // One image failing must not sink the transcript.
+    } finally {
+      args.onFetched?.();
+    }
+  });
+  await runWithConcurrency(tasks, IMAGE_FETCH_CONCURRENCY);
+
+  return {
+    sections: args.sections.map((section) => ({
+      ...section,
+      messages: section.messages.map((message) =>
+        stampMessageImages(message, uploadedByUrl),
+      ),
+    })),
+    files: [...filesByHash.values()],
+  };
+}
+
+/**
+ * Replaces the n-th `[image]` marker with its uploaded name. The names array
+ * is aligned to marker occurrences, exactly as `imageUrls` is.
+ */
+export function stampImageMarkers(
+  text: string,
+  names: readonly (string | null)[],
+): string {
+  let index = 0;
+  return text.replaceAll("[image]", (marker) => {
+    const name = names[index] ?? null;
+    index += 1;
+    return name ? `[image: attached as ${name}]` : marker;
+  });
+}
+
+interface PlannedImage {
+  url: string;
+  section: TeamsTranscriptSection;
+}
+
+function imageFetchPlan(
+  sections: readonly TeamsTranscriptSection[],
+): PlannedImage[] {
+  const seen = new Set<string>();
+  const plan: PlannedImage[] = [];
+  for (const section of sections) {
+    for (const message of section.messages) {
+      for (const url of message.imageUrls) {
+        if (!url || seen.has(url)) continue;
+        seen.add(url);
+        if (plan.length < MAX_TRANSCRIPT_IMAGES) plan.push({ url, section });
+      }
+    }
+  }
+  return plan;
+}
+
+function stampMessageImages(
+  message: ParsedTeamsMessage,
+  uploadedByUrl: ReadonlyMap<string, string>,
+): ParsedTeamsMessage {
+  if (!message.imageUrls.some((url) => url && uploadedByUrl.has(url))) {
+    return message;
+  }
+  const names = message.imageUrls.map((url) =>
+    url ? (uploadedByUrl.get(url) ?? null) : null,
+  );
+  return { ...message, text: stampImageMarkers(message.text, names) };
+}
+
+/**
+ * Dedupe key and filename stem. Not cryptographic on purpose: it only has to
+ * tell ≤{@link MAX_TRANSCRIPT_IMAGES} images apart, and unlike `crypto.subtle`
+ * it exists in every runtime the add-in and its tests run in.
+ */
+function fnv1a64Hex(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of view) {
+    hash ^= BigInt(byte);
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+function imageExtension(contentType: string): string {
+  const subtype =
+    contentType.split(";")[0]?.split("/")[1]?.trim().toLowerCase() ?? "";
+  if (subtype === "jpeg") return "jpg";
+  if (subtype === "svg+xml") return "svg";
+  return /^[a-z0-9]+$/.test(subtype) ? subtype : "png";
+}

--- a/office-addin/src/teams/utils/teamsTranscriptAssets.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptAssets.ts
@@ -1,86 +1,155 @@
 /**
- * Turns the images pasted into selected Teams messages into upload files and
- * stamps each message's `[image]` marker with the uploaded name, which is how
- * the model joins file ↔ message: the backend keys parsed uploads by filename
- * and the marker sits at the exact message position.
+ * Turns what selected Teams messages carry — pasted images, shared files —
+ * into upload files, and stamps each message's marker with the uploaded name.
+ * That name is how the model joins file ↔ message: the backend keys parsed
+ * uploads by filename and the marker sits at the exact message position.
  *
- * Everything degrades to the bare marker: a failed fetch, an oversized image
- * or the cap leaves `[image]` exactly as it reads today.
+ * Everything degrades to the bare marker: a failed fetch, a missing file
+ * grant or the caps leave `[image]` / `[attachment: …]` exactly as they read
+ * today. The one exception speaks up — a file refused for size is stamped
+ * "too large to attach", because silence there would read as an oversight.
  */
 
 import { runWithConcurrency } from "../../utils/graph/graphClient";
 
 import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
-import type { ParsedTeamsMessage } from "./parsedTeamsChat";
+import type { ParsedTeamsMessage, TeamsSharedFileRef } from "./parsedTeamsChat";
 import type { TeamsHostedContent } from "./teamsChatGraph";
+import type { TeamsSharedFileDownload } from "./teamsSharedFilesGraph";
 
 /** Vision input is expensive; a transcript is an excerpt, not an album. */
 export const MAX_TRANSCRIPT_IMAGES = 10;
 /** Pasted screenshots are small; anything bigger is not worth the tokens. */
 export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+export const MAX_TRANSCRIPT_FILES = 10;
+export const MAX_SHARED_FILE_BYTES = 10 * 1024 * 1024;
+/** Ceiling across all shared files, so ten maximal ones can't stack up. */
+export const MAX_TOTAL_FILE_BYTES = 25 * 1024 * 1024;
 /** Same-conversation fetches serialize on the gate anyway. */
-const IMAGE_FETCH_CONCURRENCY = 3;
+const ASSET_FETCH_CONCURRENCY = 3;
 
 export type FetchTeamsImage = (
   section: TeamsTranscriptSection,
   url: string,
 ) => Promise<TeamsHostedContent | null>;
 
-export interface TeamsImageAssetsResult {
-  /** The input sections with fetched images stamped into their markers. */
+export type DownloadTeamsFile = (
+  ref: TeamsSharedFileRef,
+  maxBytes: number,
+) => Promise<TeamsSharedFileDownload>;
+
+export interface TeamsAssetsResult {
+  /** The input sections with fetched assets stamped into their markers. */
   sections: TeamsTranscriptSection[];
   files: File[];
 }
 
 /** Fetches the plan will attempt — the progress denominator. */
-export function planTeamsImageFetches(
+export function planTeamsAssetFetches(
   sections: readonly TeamsTranscriptSection[],
+  canFetchFiles: boolean,
 ): number {
-  return imageFetchPlan(sections).length;
+  return (
+    imageFetchPlan(sections).length +
+    (canFetchFiles ? fileFetchPlan(sections).length : 0)
+  );
 }
 
-export async function collectTeamsImageAssets(args: {
+export async function collectTeamsMessageAssets(args: {
   sections: readonly TeamsTranscriptSection[];
   fetchImage: FetchTeamsImage;
+  /** Null when `Files.Read.All` was not granted — file markers stay bare. */
+  downloadFile: DownloadTeamsFile | null;
   /** Called exactly once per planned fetch, success or not. */
   onFetched?: () => void;
   signal?: AbortSignal;
-}): Promise<TeamsImageAssetsResult> {
-  const plan = imageFetchPlan(args.sections);
-  const uploadedByUrl = new Map<string, string>();
+}): Promise<TeamsAssetsResult> {
+  const uploadedImageByUrl = new Map<string, string>();
+  const uploadedFileByUrl = new Map<string, string>();
+  const tooLargeFileUrls = new Set<string>();
   const filesByHash = new Map<string, File>();
+  let fileBudgetUsed = 0;
 
-  const tasks = plan.map((planned) => async () => {
-    try {
-      if (args.signal?.aborted) return;
-      const content = await args.fetchImage(planned.section, planned.url);
-      if (!content) return;
-      const size = content.bytes.byteLength;
-      if (size === 0 || size > MAX_IMAGE_BYTES) return;
-      const hash = fnv1a64Hex(content.bytes);
-      let file = filesByHash.get(hash);
-      if (!file) {
-        file = new File(
-          [content.bytes],
-          `teams-img-${hash}.${imageExtension(content.contentType)}`,
-          { type: content.contentType },
-        );
-        filesByHash.set(hash, file);
+  const imageTasks = imageFetchPlan(args.sections).map(
+    (planned) => async () => {
+      try {
+        if (args.signal?.aborted) return;
+        const content = await args.fetchImage(planned.section, planned.url);
+        if (!content) return;
+        const size = content.bytes.byteLength;
+        if (size === 0 || size > MAX_IMAGE_BYTES) return;
+        const hash = fnv1a64Hex(content.bytes);
+        let file = filesByHash.get(hash);
+        if (!file) {
+          file = new File(
+            [content.bytes],
+            `teams-img-${hash}.${imageExtension(content.contentType)}`,
+            { type: content.contentType },
+          );
+          filesByHash.set(hash, file);
+        }
+        uploadedImageByUrl.set(planned.url, file.name);
+      } catch {
+        // One asset failing must not sink the transcript.
+      } finally {
+        args.onFetched?.();
       }
-      uploadedByUrl.set(planned.url, file.name);
-    } catch {
-      // One image failing must not sink the transcript.
-    } finally {
-      args.onFetched?.();
-    }
-  });
-  await runWithConcurrency(tasks, IMAGE_FETCH_CONCURRENCY);
+    },
+  );
+
+  const downloadFile = args.downloadFile;
+  const fileTasks = downloadFile
+    ? fileFetchPlan(args.sections).map((ref) => async () => {
+        try {
+          if (args.signal?.aborted) return;
+          const remaining = MAX_TOTAL_FILE_BYTES - fileBudgetUsed;
+          if (remaining <= 0) {
+            tooLargeFileUrls.add(ref.contentUrl);
+            return;
+          }
+          const result = await downloadFile(
+            ref,
+            Math.min(MAX_SHARED_FILE_BYTES, remaining),
+          );
+          if (result.state === "too-large") {
+            tooLargeFileUrls.add(ref.contentUrl);
+            return;
+          }
+          if (result.state !== "ok") return;
+          fileBudgetUsed += result.content.bytes.byteLength;
+          const hash = fnv1a64Hex(result.content.bytes);
+          let file = filesByHash.get(hash);
+          if (!file) {
+            file = new File(
+              [result.content.bytes],
+              `teams-file-${hash.slice(0, 8)}-${fileNameSlug(ref.name)}`,
+              { type: result.content.contentType },
+            );
+            filesByHash.set(hash, file);
+          }
+          uploadedFileByUrl.set(ref.contentUrl, file.name);
+        } catch {
+          // One asset failing must not sink the transcript.
+        } finally {
+          args.onFetched?.();
+        }
+      })
+    : [];
+
+  await runWithConcurrency(
+    [...imageTasks, ...fileTasks],
+    ASSET_FETCH_CONCURRENCY,
+  );
 
   return {
     sections: args.sections.map((section) => ({
       ...section,
       messages: section.messages.map((message) =>
-        stampMessageImages(message, uploadedByUrl),
+        stampMessageFiles(
+          stampMessageImages(message, uploadedImageByUrl),
+          uploadedFileByUrl,
+          tooLargeFileUrls,
+        ),
       ),
     })),
     files: [...filesByHash.values()],
@@ -125,6 +194,23 @@ function imageFetchPlan(
   return plan;
 }
 
+function fileFetchPlan(
+  sections: readonly TeamsTranscriptSection[],
+): TeamsSharedFileRef[] {
+  const seen = new Set<string>();
+  const plan: TeamsSharedFileRef[] = [];
+  for (const section of sections) {
+    for (const message of section.messages) {
+      for (const ref of message.sharedFiles) {
+        if (seen.has(ref.contentUrl)) continue;
+        seen.add(ref.contentUrl);
+        if (plan.length < MAX_TRANSCRIPT_FILES) plan.push(ref);
+      }
+    }
+  }
+  return plan;
+}
+
 function stampMessageImages(
   message: ParsedTeamsMessage,
   uploadedByUrl: ReadonlyMap<string, string>,
@@ -139,9 +225,46 @@ function stampMessageImages(
 }
 
 /**
+ * Rewrites a file's `[attachment: name]` marker — inline in the body when the
+ * message referenced it there, in the appended markers otherwise.
+ */
+function stampMessageFiles(
+  message: ParsedTeamsMessage,
+  uploadedByUrl: ReadonlyMap<string, string>,
+  tooLargeUrls: ReadonlySet<string>,
+): ParsedTeamsMessage {
+  const stampFor = (ref: TeamsSharedFileRef): string | null => {
+    const uploaded = uploadedByUrl.get(ref.contentUrl);
+    if (uploaded) return `[attachment: ${ref.name} — attached as ${uploaded}]`;
+    if (tooLargeUrls.has(ref.contentUrl)) {
+      return `[attachment: ${ref.name} — too large to attach]`;
+    }
+    return null;
+  };
+  if (!message.sharedFiles.some((ref) => stampFor(ref) !== null)) {
+    return message;
+  }
+  let text = message.text;
+  const markers = [...message.markers];
+  for (const ref of message.sharedFiles) {
+    const stamped = stampFor(ref);
+    if (!stamped) continue;
+    const plain = `[attachment: ${ref.name}]`;
+    if (text.includes(plain)) {
+      text = text.replace(plain, stamped);
+      continue;
+    }
+    const index = markers.indexOf(plain);
+    if (index >= 0) markers[index] = stamped;
+    else markers.push(stamped);
+  }
+  return { ...message, text, markers };
+}
+
+/**
  * Dedupe key and filename stem. Not cryptographic on purpose: it only has to
- * tell ≤{@link MAX_TRANSCRIPT_IMAGES} images apart, and unlike `crypto.subtle`
- * it exists in every runtime the add-in and its tests run in.
+ * tell a handful of assets apart, and unlike `crypto.subtle` it exists in
+ * every runtime the add-in and its tests run in.
  */
 function fnv1a64Hex(bytes: ArrayBuffer): string {
   const view = new Uint8Array(bytes);
@@ -159,4 +282,18 @@ function imageExtension(contentType: string): string {
   if (subtype === "jpeg") return "jpg";
   if (subtype === "svg+xml") return "svg";
   return /^[a-z0-9]+$/.test(subtype) ? subtype : "png";
+}
+
+const MAX_FILE_SLUG_LENGTH = 48;
+
+/** Keeps the extension — the backend picks its parser from it. */
+function fileNameSlug(name: string): string {
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const extension = dot > 0 ? name.slice(dot + 1) : "";
+  const clean = (value: string) =>
+    value.replace(/[\\/:*?"<>|\s]+/g, "_").replace(/^_+|_+$/g, "");
+  const cleanStem = clean(stem).slice(0, MAX_FILE_SLUG_LENGTH) || "file";
+  const cleanExtension = clean(extension);
+  return cleanExtension ? `${cleanStem}.${cleanExtension}` : cleanStem;
 }

--- a/office-addin/src/teams/utils/teamsTranscriptAssets.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptAssets.ts
@@ -22,6 +22,10 @@ export const MAX_TRANSCRIPT_IMAGES = 10;
 /** Pasted screenshots are small; anything bigger is not worth the tokens. */
 export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
 export const MAX_TRANSCRIPT_FILES = 10;
+/**
+ * Fallback per-file cap for when the deployment's configured upload limit is
+ * not available — normally the backend's own `max_upload_size_kb` governs.
+ */
 export const MAX_SHARED_FILE_BYTES = 10 * 1024 * 1024;
 /** Ceiling across all shared files, so ten maximal ones can't stack up. */
 export const MAX_TOTAL_FILE_BYTES = 25 * 1024 * 1024;
@@ -60,6 +64,8 @@ export async function collectTeamsMessageAssets(args: {
   fetchImage: FetchTeamsImage;
   /** Null when `Files.Read.All` was not granted — file markers stay bare. */
   downloadFile: DownloadTeamsFile | null;
+  /** The deployment's upload limit; what the backend would refuse anyway. */
+  maxFileBytes?: number;
   /** Called exactly once per planned fetch, success or not. */
   onFetched?: () => void;
   signal?: AbortSignal;
@@ -68,6 +74,9 @@ export async function collectTeamsMessageAssets(args: {
   const uploadedFileByUrl = new Map<string, string>();
   const tooLargeFileUrls = new Set<string>();
   const filesByHash = new Map<string, File>();
+  const maxFileBytes = args.maxFileBytes ?? MAX_SHARED_FILE_BYTES;
+  // The total budget must never undercut a single file the deployment allows.
+  const totalFileBudget = Math.max(MAX_TOTAL_FILE_BYTES, maxFileBytes);
   let fileBudgetUsed = 0;
 
   const imageTasks = imageFetchPlan(args.sections).map(
@@ -102,14 +111,14 @@ export async function collectTeamsMessageAssets(args: {
     ? fileFetchPlan(args.sections).map((ref) => async () => {
         try {
           if (args.signal?.aborted) return;
-          const remaining = MAX_TOTAL_FILE_BYTES - fileBudgetUsed;
+          const remaining = totalFileBudget - fileBudgetUsed;
           if (remaining <= 0) {
             tooLargeFileUrls.add(ref.contentUrl);
             return;
           }
           const result = await downloadFile(
             ref,
-            Math.min(MAX_SHARED_FILE_BYTES, remaining),
+            Math.min(maxFileBytes, remaining),
           );
           if (result.state === "too-large") {
             tooLargeFileUrls.add(ref.contentUrl);


### PR DESCRIPTION
Fetches what selected Teams messages carry and uploads it beside the transcript, each marker stamped with the uploaded filename so the model joins file ↔ message by name. Pasted images come through `hostedContents` with the scopes we already hold; OneDrive/SharePoint files resolve through `/shares` behind a new `Files.Read.All` grant with the same partial-consent fallback as channels — no grant, markers stay bare. Caps: 10 images ≤4 MB, 10 files ≤10 MB (25 MB total), oversized files disclosed as "too large to attach".

Stacked on #939.

ERMAIN-564