### PR TITLE
feat(frontend): restore PDF text selection and copy (ERMAIN-570)

### DIFF
--- a/frontend/src/components/ui/FilePreview/PdfPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/PdfPreview.tsx
@@ -25,6 +25,11 @@ import {
   useScrollCapability,
 } from "@embedpdf/plugin-scroll/react";
 import {
+  SelectionLayer,
+  SelectionPluginPackage,
+  useSelectionCapability,
+} from "@embedpdf/plugin-selection/react";
+import {
   TilingLayer,
   TilingPluginPackage,
 } from "@embedpdf/plugin-tiling/react";
@@ -51,6 +56,7 @@ import {
   ZoomOutIcon,
 } from "@/components/ui/icons";
 
+import { copyTextToClipboard } from "./copySelectionText";
 import { getPdfEngine } from "./pdfEngine";
 
 import type React from "react";
@@ -58,6 +64,7 @@ import type React from "react";
 const MIN_ZOOM = 0.25;
 const MAX_ZOOM = 8;
 const PAGE_GAP = 12;
+const SELECTION_HIGHLIGHT = "rgba(59, 130, 246, 0.35)";
 
 const PDF_PLUGINS = [
   createPluginRegistration(DocumentManagerPluginPackage),
@@ -74,6 +81,9 @@ const PDF_PLUGINS = [
     extraRings: 0,
   }),
   createPluginRegistration(InteractionManagerPluginPackage),
+  createPluginRegistration(SelectionPluginPackage, {
+    marquee: { enabled: false },
+  }),
   createPluginRegistration(ZoomPluginPackage, {
     defaultZoomLevel: ZoomMode.FitWidth,
     minZoom: MIN_ZOOM,
@@ -188,6 +198,44 @@ const PdfToolbar: React.FC<{ documentId: string }> = ({ documentId }) => {
     </div>
   );
 };
+
+/**
+ * Copies the current PDF selection on Cmd/Ctrl+C.
+ *
+ * The selection plugin tracks the selection but binds no shortcut — its own
+ * `CopyToClipboard` only listens for a copy request that something else has to
+ * raise. Bound to the document rather than a container because the page layers
+ * are not focusable, so the keystroke never reaches them.
+ */
+const PdfCopyShortcut: React.FC<{ documentId: string }> = ({ documentId }) => {
+  const { provides: selection } = useSelectionCapability();
+
+  useEffect(() => {
+    if (!selection) {
+      return;
+    }
+
+    const scope = selection.forDocument(documentId);
+
+    const onCopy = (event: Event) => {
+      scope.getSelectedText().wait((lines) => {
+        const text = Array.isArray(lines) ? lines.join("\n") : String(lines);
+        if (!text) {
+          return;
+        }
+        event.preventDefault();
+        void copyTextToClipboard(text);
+      }, ignoreCopyFailure);
+    };
+
+    document.addEventListener("copy", onCopy);
+    return () => document.removeEventListener("copy", onCopy);
+  }, [documentId, selection]);
+
+  return null;
+};
+
+const ignoreCopyFailure = () => undefined;
 
 const PAGE_ANCHOR = "#page=";
 
@@ -308,10 +356,11 @@ const PdfDocument: React.FC<PdfPreviewProps> = ({ url }) => {
       {anchoredPage !== null && (
         <PdfPageAnchor documentId={activeDocumentId} page={anchoredPage} />
       )}
+      <PdfCopyShortcut documentId={activeDocumentId} />
       <PdfToolbar documentId={activeDocumentId} />
       <Viewport
         documentId={activeDocumentId}
-        className="min-h-0 flex-1 overflow-auto bg-[var(--pdf-preview-surface-bg)]"
+        className="min-h-0 flex-1 select-none overflow-auto bg-[var(--pdf-preview-surface-bg)]"
       >
         <Scroller
           documentId={activeDocumentId}
@@ -327,14 +376,28 @@ const PdfDocument: React.FC<PdfPreviewProps> = ({ url }) => {
                   boxShadow: "var(--pdf-preview-page-shadow)",
                 }}
               >
+                {/*
+                 * Both raster layers have to opt out of pointer events. The
+                 * page image is an <img>, so a drag across it starts a native
+                 * HTML5 image drag, and the pointercancel that follows kills
+                 * the selection mid-gesture — it freezes on the first glyph.
+                 * EmbedPDF v3 sets these upstream; v2 does not.
+                 */}
                 <RenderLayer
                   documentId={activeDocumentId}
                   pageIndex={pageIndex}
-                  style={{ position: "absolute" }}
+                  draggable={false}
+                  style={{ position: "absolute", pointerEvents: "none" }}
                 />
                 <TilingLayer
                   documentId={activeDocumentId}
                   pageIndex={pageIndex}
+                  style={{ pointerEvents: "none" }}
+                />
+                <SelectionLayer
+                  documentId={activeDocumentId}
+                  pageIndex={pageIndex}
+                  textStyle={{ background: SELECTION_HIGHLIGHT }}
                 />
               </PagePointerProvider>
             </Rotate>

--- a/frontend/src/components/ui/FilePreview/copySelectionText.test.ts
+++ b/frontend/src/components/ui/FilePreview/copySelectionText.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyTextToClipboard } from "./copySelectionText";
+
+const setClipboard = (writeText: () => Promise<void>) => {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("copyTextToClipboard", () => {
+  it("uses the Clipboard API when it is available", async () => {
+    const writeText = vi.fn(async () => undefined);
+    setClipboard(writeText);
+
+    await expect(copyTextToClipboard("selected text")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("selected text");
+  });
+
+  it("falls back to execCommand when the Clipboard API is withheld", async () => {
+    // Teams and Outlook on the web serve their frames with a
+    // Permissions-Policy that withholds clipboard-write, which is exactly
+    // where this viewer has to work.
+    setClipboard(() => Promise.reject(new Error("NotAllowedError")));
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      value: execCommand,
+      configurable: true,
+    });
+
+    await expect(copyTextToClipboard("selected text")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // The scratch textarea must not survive the copy.
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+
+  it("reports failure when neither route works", async () => {
+    setClipboard(() => Promise.reject(new Error("NotAllowedError")));
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn(() => false),
+      configurable: true,
+    });
+
+    await expect(copyTextToClipboard("selected text")).resolves.toBe(false);
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+  });
+
+  it("does nothing for an empty selection", async () => {
+    const writeText = vi.fn(async () => undefined);
+    setClipboard(writeText);
+
+    await expect(copyTextToClipboard("")).resolves.toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ui/FilePreview/copySelectionText.ts
+++ b/frontend/src/components/ui/FilePreview/copySelectionText.ts
@@ -1,0 +1,53 @@
+/**
+ * Puts `text` on the clipboard, preferring the async Clipboard API and falling
+ * back to a hidden textarea plus the deprecated `execCommand`.
+ *
+ * The fallback is the whole point: Teams and Outlook on the web serve their
+ * frames with a Permissions-Policy that withholds clipboard-write, so
+ * `navigator.clipboard.writeText` rejects there — which is exactly where the
+ * PDF viewer has to work, since a sandboxed frame is why it exists at all.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (!text) {
+    return false;
+  }
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return copyViaTextarea(text);
+  }
+}
+
+function copyViaTextarea(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Off-screen rather than hidden: execCommand ignores a selection inside an
+  // element that is not rendered.
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  textarea.style.top = "-9999px";
+  textarea.style.opacity = "0";
+
+  document.body.appendChild(textarea);
+  const previousSelection = document.getSelection()?.rangeCount
+    ? document.getSelection()?.getRangeAt(0)
+    : null;
+
+  try {
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+    if (previousSelection) {
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(previousSelection);
+    }
+  }
+}


### PR DESCRIPTION
Stacked on #941 (ERMAIN-566). Closes ERMAIN-570.

## Why

#941 replaced the spec-blocked `<iframe>` PDF viewer with PDFium-in-WebAssembly, because Teams hosts tabs in a sandboxed iframe where the native viewer is forbidden. The browser's viewer allowed select-and-copy; the replacement had **no text selection at all**.

## Root cause — traced, not guessed

```
pointerdown → beginSelection{modeId:"pointerMode"} → selectionChange{0→0}
→ dragstart{target:"IMG"} → pointercancel{target:"IMG"}   [stream dies]
```

`RenderLayer` in `@embedpdf/plugin-render@2.15.0` renders `jsx("img", { src, onLoad, ...props, style })` — the strings `draggable` and `pointerEvents` appear **nowhere in the file**. A drag across the page starts a native HTML5 image drag, `pointercancel` follows, and the selection freezes on its first glyph with `selecting` stuck true.

`@embedpdf/react@3.0.0-next.2` ships `draggable:false` + `pointerEvents:'none'` on exactly these elements — **this is upstream's own fix**, applied here on v2 via props the components already spread.

Ruled out by experiment, not assumption: interaction-mode gating (default mode is already `pointerMode`, and selection seeds it unconditionally), `GlobalPointerProvider` (byte-identical with it off), and `position: relative` (`PagePointerProvider` already sets it).

## What changed

1. `pointer-events: none` on **both** `RenderLayer` and `TilingLayer` — patching only one still yields a single character
2. `select-none` on the viewport — without it the browser paints its own DOM selection over the page furniture and the whole page takes a colour cast
3. `PdfCopyShortcut` binds Cmd/Ctrl+C → `selection.copyToClipboard()`. The plugin tracks the selection and ships a listener, but nothing ever raises the request
4. Translucent highlight — the plugin default is **opaque** and hides the glyphs
5. Re-registered `SelectionPluginPackage` (already in `package.json`; zero dependency churn)

## The clipboard risk, and why the fallback exists

**Teams and Outlook on the web withhold `clipboard-write` by Permissions-Policy**, and the plugin calls `navigator.clipboard.writeText` unconditionally — so copy would have failed silently in the exact two hosts this viewer was built for. `copySelectionText.ts` falls back to an off-screen textarea + `execCommand`.

Verified in headless Chromium against a real 10-page PDF, in both contexts:

| context | highlight rects | clipboard after Cmd+C |
|---|---|---|
| plain page | 2 | `"A comprehensive and content-heavy report th…"` |
| **`allow="clipboard-write 'none'"` + `sandbox`** | 2 | **same correct text** |

No native-selection leak in either. Unit tests cover all four branches of the copy helper (API path, policy-blocked fallback, both-fail, empty selection).

## Still worth a manual check

`execCommand` is documented as failing in Excel-on-web (office-js#2513), so **please confirm copy in a real Teams tab and Outlook task pane.** If it fails there, the fallback plan is in ERMAIN-570: switch the renderer to pdf.js, whose native DOM selection copies without touching the Clipboard API at all (and is 539 KB gzip against PDFium's 4.6 MB) — days of work rather than half a day, which is why it isn't the first move.

## Not chosen

- **EmbedPDF v3** — six days old, three prereleases in that span, README says "not yet recommended for production use", ground-up rewrite with no migration guide, and `plugin-interaction-manager`/`plugin-tiling`/`models` aren't published on 3.x. Its fix is three CSS properties applied here today. (2.x is MIT; 3.x is Apache-2.0.)
- **Own text layer over the page image** — 1–2 days to reimplement what the wiring gets for free.

## Cost

+8.7 KB gzip, no new dependencies. Frontend 1009 tests / 119 files pass; typecheck, lint `--max-warnings=0` and prettier clean.

## Residual upstream bugs (not fixed here)

Releasing the pointer outside the page leaves `selecting: true`; and a *numeric* `defaultZoomLevel` never lifts the zoom plugin's viewport gate so nothing renders at all — we use `ZoomMode.FitWidth` and are unaffected. Upstream has an open, zero-comment issue describing our exact symptom; worth reporting the `dragstart → pointercancel` trace with a note that v3 already fixed it.