### PR TITLE
fix(office-addin): upload the Teams transcript as text/plain

### DIFF
--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -548,7 +548,7 @@ describe("TeamsChatPickerDialog", () => {
     expect(uploads[0]).toHaveLength(1);
     const file = uploads[0][0];
     expect(file.name).toBe("teams-Product_sync.md");
-    expect(file.type).toBe("text/markdown");
+    expect(file.type).toBe("text/plain");
 
     const text = await file.text();
     expect(text).toContain("# Teams chat: Product sync");

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -91,8 +91,17 @@ describe("buildTeamsTranscriptFile", () => {
       timeZone: "UTC",
     });
     expect(file?.name).toBe("teams-Product_sync.md");
-    expect(file?.type).toBe("text/markdown");
     await expect(file?.text()).resolves.toContain("# Teams chat: Product sync");
+  });
+
+  it("keeps the .md name but uploads as plain text", () => {
+    const file = buildTeamsTranscriptFile({
+      sections: [section()],
+      exportedAt,
+      timeZone: "UTC",
+    });
+    expect(file?.name.endsWith(".md")).toBe(true);
+    expect(file?.type).toBe("text/plain");
   });
 
   it("names a multi-chat export by its chat count", () => {

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -59,8 +59,12 @@ export function buildTeamsTranscriptFile(
 ): File | null {
   const markdown = buildTeamsTranscriptMarkdown(input);
   if (markdown === null) return null;
+  // The `.md` name and the plain-text MIME serve different readers: the extension
+  // gets the UI to render the transcript richly, while `text/plain` picks the
+  // extractor that hands the model the bytes verbatim instead of reserialising
+  // them through a markdown parser.
   return new File([markdown], buildTeamsTranscriptFilename(input.sections), {
-    type: "text/markdown",
+    type: "text/plain",
   });
 }
 


### PR DESCRIPTION
The Teams transcript now uploads as `text/plain` so the backend's verbatim extractor handles it instead of the markdown round-trip. The `.md` filename stays for the rich preview.

https://linear.app/erato-labs/issue/ERMAIN-577