### PR TITLE
Name the viewer in Teams chat transcripts

### DIFF
--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -220,6 +220,7 @@ const PRODUCT_SYNC: ParsedTeamsChat = {
   chatId: MOCK_CHAT_ID,
   title: "Product sync",
   participants: ["Ada Lovelace", "Grace Hopper"],
+  selfDisplayName: null,
   participantsTruncated: false,
   chatType: "group",
   lastActivityAt: "2026-08-10T09:15:00Z",

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -15,6 +15,7 @@ const chat: ParsedTeamsChat = {
   chatId: MOCK_CHAT_ID,
   title: "Product sync",
   participants: ["Ada Lovelace", "Grace Hopper"],
+  selfDisplayName: null,
   participantsTruncated: false,
   chatType: "group",
   lastActivityAt: "2026-08-10T09:15:00Z",
@@ -239,6 +240,26 @@ describe("buildTeamsTranscriptMarkdown", () => {
     );
   });
 
+  it("names the viewer beside the participants of a 1:1", () => {
+    const markdown = render([
+      section({
+        chat: {
+          ...chat,
+          chatType: "oneOnOne",
+          title: "Ada Lovelace",
+          participants: ["Ada Lovelace"],
+          selfDisplayName: "Grace Hopper",
+        },
+      }),
+    ]);
+    expect(markdown).toContain("Participants: Ada Lovelace");
+    expect(markdown).toContain("Viewer: Grace Hopper (the signed-in user).");
+  });
+
+  it("omits the viewer legend when the roster never matched the signed-in user", () => {
+    expect(render([section()])).not.toContain("Viewer:");
+  });
+
   it("repeats a full section per chat", () => {
     const markdown = render([
       section(),
@@ -362,6 +383,10 @@ describe("channel sections", () => {
   it("titles the section with the channel and its team", () => {
     const markdown = render([channelSection([message()])]);
     expect(markdown).toContain("# Teams channel: Test Channel 1 · Contoso");
+  });
+
+  it("names no viewer, a channel having no member roster to match against", () => {
+    expect(render([channelSection([message()])])).not.toContain("Viewer:");
   });
 
   it("links a picked channel message by Graph's own url", () => {

--- a/office-addin/src/teams/utils/__tests__/filterTeamsChats.test.ts
+++ b/office-addin/src/teams/utils/__tests__/filterTeamsChats.test.ts
@@ -9,6 +9,7 @@ function chat(overrides: Partial<ParsedTeamsChat>): ParsedTeamsChat {
     chatId: "c1",
     title: "Untitled",
     participants: [],
+    selfDisplayName: null,
     participantsTruncated: false,
     chatType: "group",
     previewText: null,

--- a/office-addin/src/teams/utils/__tests__/parsedTeamsChat.test.ts
+++ b/office-addin/src/teams/utils/__tests__/parsedTeamsChat.test.ts
@@ -83,6 +83,24 @@ describe("parseTeamsChat", () => {
     );
   });
 
+  it("keeps the signed-in user's own roster name", () => {
+    const chat = mockGraphChat({
+      chatType: "oneOnOne",
+      members: [
+        { id: "m0", displayName: "Grace Hopper", userId: "me-1" },
+        { id: "m1", displayName: "Ada Lovelace", userId: "u1" },
+      ],
+    });
+    const parsed = parseTeamsChat(chat, me);
+    expect(parsed?.selfDisplayName).toBe("Grace Hopper");
+    expect(parsed?.participants).toEqual(["Ada Lovelace"]);
+  });
+
+  it("leaves the self name null when no member matches", () => {
+    expect(parseTeamsChat(mockGraphChat(), me)?.selfDisplayName).toBeNull();
+    expect(parseTeamsChat(mockGraphChat())?.selfDisplayName).toBeNull();
+  });
+
   it("returns null for a chat with no id", () => {
     expect(parseTeamsChat(mockGraphChat({ id: undefined }))).toBeNull();
   });

--- a/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
@@ -17,6 +17,7 @@ const chat: ParsedTeamsChat = {
   chatId: MOCK_CHAT_ID,
   title: "Product sync",
   participants: [],
+  selfDisplayName: null,
   participantsTruncated: false,
   chatType: "group",
   lastActivityAt: null,

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -121,6 +121,15 @@ function renderSection(
         `Participants: ${participants}${section.chat.participantsTruncated ? " (and possibly others)" : ""}`,
       );
     }
+    // Without this the model cannot tell "you" from "them" in a 1:1. The name
+    // comes from the member roster, so a channel — which has none — says
+    // nothing rather than guessing, as does a chat whose roster never matched
+    // the signed-in user.
+    if (section.chat.selfDisplayName) {
+      lines.push(
+        `Viewer: ${section.chat.selfDisplayName} (the signed-in user).`,
+      );
+    }
   }
   lines.push(
     `Exported: ${formatDateTime(input.exportedAt ?? new Date(), timeZone)}`,

--- a/office-addin/src/teams/utils/collectTeamsTranscript.ts
+++ b/office-addin/src/teams/utils/collectTeamsTranscript.ts
@@ -465,6 +465,7 @@ async function resolveChat(
       chatId,
       title: fallbackTitle,
       participants: [],
+      selfDisplayName: null,
       participantsTruncated: false,
       chatType: "unknown",
       lastActivityAt: null,

--- a/office-addin/src/teams/utils/parsedTeamsChat.ts
+++ b/office-addin/src/teams/utils/parsedTeamsChat.ts
@@ -29,6 +29,12 @@ export interface ParsedTeamsChat {
   title: string;
   /** Member display names, excluding the signed-in user. */
   participants: string[];
+  /**
+   * The signed-in user's own name as the roster spells it — the same Graph
+   * field messages are attributed with, so it matches `senderName` exactly.
+   * Null when no member could be matched against `self`.
+   */
+  selfDisplayName: string | null;
   /** True when `$expand=members` may have truncated the roster. */
   participantsTruncated: boolean;
   chatType: string;
@@ -79,7 +85,7 @@ export function chatDisplayTitle(
   const topic = chat.topic?.trim();
   if (topic) return topic;
 
-  const names = otherMemberNames(chat.members ?? [], self);
+  const names = splitMemberNames(chat.members ?? [], self).others;
   if (names.length === 0) return UNTITLED_CHAT;
   if (chat.chatType === "oneOnOne") return names[0];
 
@@ -114,10 +120,12 @@ export function parseTeamsChat(
 ): ParsedTeamsChat | null {
   if (!chat.id) return null;
   const members = chat.members ?? [];
+  const names = splitMemberNames(members, self);
   return {
     chatId: chat.id,
     title: chatDisplayTitle(chat, self),
-    participants: otherMemberNames(members, self),
+    participants: names.others,
+    selfDisplayName: names.self,
     participantsTruncated: members.length >= CHAT_MEMBER_EXPAND_CAP,
     chatType: chat.chatType ?? "unknown",
     lastActivityAt:
@@ -203,17 +211,22 @@ function unreferencedAttachmentMarkers(message: GraphChatMessage): string[] {
   return markers;
 }
 
-function otherMemberNames(
+/** The roster is the only place the signed-in user's display name appears. */
+function splitMemberNames(
   members: GraphChatMember[],
   self?: TeamsSelfIdentity,
-): string[] {
-  const names: string[] = [];
+): { others: string[]; self: string | null } {
+  const others: string[] = [];
+  let own: string | null = null;
   for (const member of members) {
-    if (isSelf(member, self)) continue;
     const name = member.displayName?.trim();
-    if (name) names.push(name);
+    if (isSelf(member, self)) {
+      if (name) own = name;
+      continue;
+    }
+    if (name) others.push(name);
   }
-  return names;
+  return { others, self: own };
 }
 
 function isSelf(member: GraphChatMember, self?: TeamsSelfIdentity): boolean {


### PR DESCRIPTION
Chat sections now carry a one-line viewer legend so the model can tell the signed-in user apart from the other speakers. Omitted for channels and whenever the roster does not identify the viewer.

https://linear.app/erato-labs/issue/ERMAIN-579