### PR TITLE
Add a chat-input seam for grouped attachment previews

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -13,6 +13,7 @@ import { messages as enMessages } from "@/locales/en/messages.json";
 import { ChatInput } from "./ChatInput";
 import { useToastStore } from "../Toast/toastStore";
 
+import type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { ChatContextValue } from "@/providers/ChatProvider";
 import type { I18n, Messages } from "@lingui/core";
@@ -206,6 +207,7 @@ describe("ChatInput", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     componentRegistry.ChatInputAttachmentPreview = null;
+    componentRegistry.ChatAttachmentsPreview = null;
     componentRegistry.ChatTopLeftAccessory = null;
     vi.stubGlobal("localStorage", {
       getItem: vi.fn(() => null),
@@ -853,6 +855,85 @@ describe("ChatInput", () => {
     expect(screen.getByTestId("attachments-preview")).toHaveTextContent("1");
     expect(
       container.querySelector('[data-testid="inline-attachment-preview"]'),
+    ).toBeNull();
+  });
+
+  it("renders a registered attachments preview override instead of the flat preview", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const removeFile = vi.fn();
+    const attachedFiles = [
+      {
+        id: "file-1",
+        filename: "report.pdf",
+        download_url: "/files/report.pdf",
+        preview_url: undefined,
+        file_contents_unavailable_missing_permissions: false,
+        file_capability: {
+          extensions: ["pdf"],
+          id: "pdf",
+          mime_types: ["application/pdf"],
+          operations: ["extract_text"],
+        },
+      },
+    ] as unknown as FileUploadItem[];
+
+    mockUseChatInputHandlers.mockReturnValue({
+      attachedFiles,
+      fileError: null,
+      setFileError: vi.fn(),
+      handleFilesUploaded: vi.fn(),
+      handleRemoveFile: removeFile,
+      handleRemoveAllFiles: vi.fn(),
+      setAttachedFiles: vi.fn(),
+      createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+    });
+
+    const MockGroupedPreview = ({
+      attachedFiles: files,
+      onRemoveFile,
+    }: FileAttachmentsPreviewProps) => (
+      <div data-testid="grouped-attachments-preview">
+        <span>{files.length}</span>
+        <button
+          type="button"
+          onClick={() => onRemoveFile(files[0].id)}
+          data-testid="grouped-remove-file"
+        >
+          remove
+        </button>
+      </div>
+    );
+    MockGroupedPreview.displayName = "MockGroupedPreview";
+    componentRegistry.ChatAttachmentsPreview = MockGroupedPreview;
+
+    const onSendMessage = vi.fn();
+    const { i18n } = await import("@lingui/core");
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={onSendMessage} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId("attachments-preview")).toBeNull();
+    expect(screen.getByTestId("grouped-attachments-preview")).toHaveTextContent(
+      "1",
+    );
+
+    fireEvent.click(screen.getByTestId("grouped-remove-file"));
+    expect(removeFile).toHaveBeenCalledWith("file-1");
+
+    // The override replaces the region above the shell, so it must not land
+    // inside the shell the way ChatInputAttachmentPreview does.
+    const shell = container.querySelector('[data-ui="chat-input-shell"]');
+    expect(
+      shell?.querySelector('[data-testid="grouped-attachments-preview"]'),
     ).toBeNull();
   });
 

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -13,7 +13,10 @@ import {
 import { FileAttachmentsPreview } from "@/components/ui/FileUpload";
 import { FileUploadWithTokenCheck } from "@/components/ui/FileUpload/FileUploadWithTokenCheck";
 import { ConfirmationDialog } from "@/components/ui/Modal/ConfirmationDialog";
-import { componentRegistry } from "@/config/componentRegistry";
+import {
+  componentRegistry,
+  resolveComponentOverride,
+} from "@/config/componentRegistry";
 import { useAudioDictationRecorder } from "@/hooks/audio/useAudioDictationRecorder";
 import { useAudioTranscriptionRecorder } from "@/hooks/audio/useAudioTranscriptionRecorder";
 import { useTokenManagement, useActiveModelSelection } from "@/hooks/chat";
@@ -1984,6 +1987,10 @@ export const ChatInput = ({
   const ChatInputAttachmentPreview =
     componentRegistry.ChatInputAttachmentPreview;
   const hasAttachmentPreviewOverride = ChatInputAttachmentPreview !== null;
+  const AttachmentsPreview = resolveComponentOverride(
+    componentRegistry.ChatAttachmentsPreview,
+    FileAttachmentsPreview,
+  );
   const hasTopLeftAccessoryOverride =
     componentRegistry.ChatTopLeftAccessory !== null;
 
@@ -2099,7 +2106,7 @@ export const ChatInput = ({
         )}
 
         {!hasAttachmentPreviewOverride && (
-          <FileAttachmentsPreview
+          <AttachmentsPreview
             attachedFiles={attachedFiles}
             maxFiles={maxFiles}
             onRemoveFile={handleRemoveFileById}

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -28,6 +28,7 @@ import type { ChatHistoryListProps } from "@/components/ui/Chat/ChatHistoryList"
 import type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
 import type { ChatTopLeftAccessoryProps } from "@/components/ui/Chat/ChatTopLeftAccessory";
 import type { StarterPromptsRendererProps } from "@/components/ui/Chat/StarterPromptsSection";
+import type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 import type { FileSourceSelectorProps } from "@/components/ui/FileUpload/FileSourceSelector";
 import type { GroupedFileAttachmentsPreviewProps } from "@/components/ui/FileUpload/GroupedFileAttachmentsPreview";
 import type { WelcomeScreenProps } from "@/components/ui/WelcomeScreen";
@@ -102,6 +103,18 @@ export interface ComponentRegistry {
    * Used to render custom attachment chips/thumbnails inside the chat input shell.
    */
   ChatInputAttachmentPreview: ComponentType<ChatInputAttachmentPreviewProps> | null;
+
+  /**
+   * Override for the attachments region the composer renders above the chat
+   * input shell. It receives exactly the props the default flat preview gets,
+   * so a replacement can render its own layout (e.g. grouped cards) and still
+   * handle removal and preview.
+   *
+   * When null, the default `FileAttachmentsPreview` renders. Ignored while
+   * `ChatInputAttachmentPreview` is set — that override moves the preview
+   * inside the shell instead of replacing this region.
+   */
+  ChatAttachmentsPreview: ComponentType<FileAttachmentsPreviewProps> | null;
 
   /**
    * Override for the grouped attachments preview.
@@ -229,6 +242,7 @@ const emptyComponentRegistry = (): ComponentRegistry => ({
   ChatFileSourceSelector: null,
   ChatAddMenuExtraContent: null,
   ChatInputAttachmentPreview: null,
+  ChatAttachmentsPreview: null,
   ChatGroupedAttachmentsPreview: null,
   ChatHistoryList: null,
   ChatWelcomeScreen: null,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -327,6 +327,7 @@ export type {
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 export { FileTypeUtil, type FileType } from "@/utils/fileTypes";
 export type { LocalFilePreviewItem } from "@/components/ui/FileUpload/FilePreviewBase";
+export type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 export type {
   FileAttachmentGroup,
   FileAttachmentGroupItem,

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -32,6 +32,7 @@ export type { CollapseProps } from "@/components/ui/Controls/Collapse";
 export { DropdownMenu } from "@/components/ui/Controls/DropdownMenu";
 export type { DropdownMenuItem } from "@/components/ui/Controls/DropdownMenu";
 export type { DropdownMenuProps } from "@/components/ui/Controls/DropdownMenu";
+export { Tooltip } from "@/components/ui/Controls/Tooltip";
 export { Alert } from "@/components/ui/Feedback/Alert";
 export type { AlertType } from "@/components/ui/Feedback/Alert";
 export { Avatar } from "@/components/ui/Feedback/Avatar";
@@ -41,6 +42,8 @@ export type { CopyErrorButtonProps } from "@/components/ui/Feedback/CopyErrorBut
 export { LoadingIndicator } from "@/components/ui/Feedback/LoadingIndicator";
 export type { LoadingState } from "@/components/ui/Feedback/LoadingIndicator";
 export { SpinnerIcon } from "@/components/ui/Feedback/SpinnerIcon";
+export { FileAttachmentsPreview } from "@/components/ui/FileUpload/FileAttachmentsPreview";
+export type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 export { FilePreviewBase } from "@/components/ui/FileUpload/FilePreviewBase";
 export { formatFileSize } from "@/components/ui/FileUpload/FilePreviewBase";
 export { getFileName } from "@/components/ui/FileUpload/FilePreviewBase";


### PR DESCRIPTION
Adds a `componentRegistry.ChatAttachmentsPreview` seam so a route can replace the composer's attachments region; defaults to null and keeps rendering today's flat `FileAttachmentsPreview`. Pure enabler — nothing registers it yet.

https://linear.app/erato-labs/issue/ERMAIN-580