### PR TITLE
Preview attached Teams chats as a conversation

### DIFF
--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -263,6 +263,39 @@ describe("GroupedFileAttachmentsPreview", () => {
     expect(screen.queryByRole("button", { name: /remove/i })).toBeNull();
   });
 
+  it("renders a thread message without checkboxes when it cannot be toggled", async () => {
+    await renderWithI18n(
+      <GroupedFileAttachmentsPreview
+        groups={[
+          {
+            id: "group-conversation",
+            label: "Project Alpha",
+            items: [
+              {
+                kind: "threadMessageGroup",
+                id: "message-1",
+                label: "Anna Schmidt",
+                sublabel: "5 August 2026, 14:22",
+                defaultCollapsed: false,
+                attachments: [
+                  {
+                    id: "file-1",
+                    file: { id: "file-1", filename: "invoice.pdf", size: 2048 },
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        onRemoveFile={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Anna Schmidt")).toBeVisible();
+    expect(screen.getByText("invoice")).toBeVisible();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
   it("forwards file removal through item ids", async () => {
     const onRemoveFile = vi.fn();
 

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -99,8 +99,13 @@ export type FileAttachmentGroupItem =
       /** Secondary line, typically date + subject. */
       sublabel?: string;
       /** Whether the whole message is included. Drives the header checkbox. */
-      selected: boolean;
-      onToggle: () => void;
+      selected?: boolean;
+      /**
+       * Omit where inclusion is fixed: the card and its attachment rows then
+       * render read-only. A checkbox that cannot change anything reads as
+       * broken.
+       */
+      onToggle?: () => void;
       /** Initially collapsed when true. Default: true. */
       defaultCollapsed?: boolean;
       attachments: ThreadMessageAttachmentItem[];
@@ -109,8 +114,9 @@ export type FileAttachmentGroupItem =
 export interface ThreadMessageAttachmentItem {
   id: string;
   file: FileResource;
-  selected: boolean;
-  onToggle: () => void;
+  selected?: boolean;
+  /** Omit to render the attachment read-only, without a checkbox. */
+  onToggle?: () => void;
   validation?: { ok: boolean; reason?: string };
 }
 
@@ -165,8 +171,8 @@ function getFileId(item: ItemWithFile): string {
 
 interface SelectableAttachmentRowProps {
   file: FileResource;
-  selected: boolean;
-  onToggle: () => void;
+  selected?: boolean;
+  onToggle?: () => void;
   disabled: boolean;
   showFileType: boolean;
   showSize: boolean;
@@ -174,9 +180,12 @@ interface SelectableAttachmentRowProps {
   validation?: { ok: boolean; reason?: string };
 }
 
+const SELECTABLE_ROW_CLASS =
+  "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border border-[var(--theme-border)] bg-[var(--theme-bg-secondary)] p-2";
+
 const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   file,
-  selected,
+  selected = true,
   onToggle,
   disabled,
   showFileType,
@@ -186,13 +195,36 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
 }) => {
   const filename = getFileName(file);
   const invalid = validation?.ok === false;
-  return (
-    <label
-      className={clsx(
-        "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border border-[var(--theme-border)] bg-[var(--theme-bg-secondary)] p-2",
-        !selected && "opacity-50",
+  const body = (
+    <div className="min-w-0 flex-1">
+      <FilePreviewBase
+        file={file}
+        onRemove={() => onToggle?.()}
+        disabled={disabled}
+        showRemoveButton={false}
+        showSize={showSize}
+        showFileType={showFileType}
+        filenameTruncateLength={filenameTruncateLength}
+        filenameClassName="max-w-full"
+        chromeless
+      />
+      {invalid && validation.reason && (
+        <p className="mt-0.5 text-xs text-[var(--theme-error-fg)]">
+          {validation.reason}
+        </p>
       )}
-    >
+    </div>
+  );
+  const className = clsx(SELECTABLE_ROW_CLASS, !selected && "opacity-50");
+
+  // Without a toggle there is nothing to label, so the row is a plain
+  // container rather than a `label` pointing at a control that isn't there.
+  if (!onToggle) {
+    return <div className={className}>{body}</div>;
+  }
+
+  return (
+    <label className={className}>
       <input
         type="checkbox"
         checked={selected}
@@ -201,24 +233,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
         className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
         aria-label={`${t`Include`} ${filename}`}
       />
-      <div className="min-w-0 flex-1">
-        <FilePreviewBase
-          file={file}
-          onRemove={() => onToggle()}
-          disabled={disabled}
-          showRemoveButton={false}
-          showSize={showSize}
-          showFileType={showFileType}
-          filenameTruncateLength={filenameTruncateLength}
-          filenameClassName="max-w-full"
-          chromeless
-        />
-        {invalid && validation.reason && (
-          <p className="mt-0.5 text-xs text-[var(--theme-error-fg)]">
-            {validation.reason}
-          </p>
-        )}
-      </div>
+      {body}
     </label>
   );
 };
@@ -226,8 +241,8 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
 interface ThreadMessageGroupSectionProps {
   label: string;
   sublabel?: string;
-  selected: boolean;
-  onToggle: () => void;
+  selected?: boolean;
+  onToggle?: () => void;
   attachments: ThreadMessageAttachmentItem[];
   defaultCollapsed?: boolean;
   disabled: boolean;
@@ -264,7 +279,7 @@ const ThreadMessageHeaderText: React.FC<{
 const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
   label,
   sublabel,
-  selected,
+  selected = true,
   onToggle,
   attachments,
   defaultCollapsed = true,
@@ -307,15 +322,17 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
         ) : (
           <span className="size-4 shrink-0" aria-hidden="true" />
         )}
-        <input
-          type="checkbox"
-          checked={selected}
-          onChange={onToggle}
-          disabled={disabled}
-          className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
-          aria-label={`${t`Include message`} ${label}`}
-          onClick={(event) => event.stopPropagation()}
-        />
+        {onToggle && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={onToggle}
+            disabled={disabled}
+            className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
+            aria-label={`${t`Include message`} ${label}`}
+            onClick={(event) => event.stopPropagation()}
+          />
+        )}
         {hasAttachments ? (
           <button
             type="button"

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -327,6 +327,7 @@ export type {
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 export { FileTypeUtil, type FileType } from "@/utils/fileTypes";
 export type { LocalFilePreviewItem } from "@/components/ui/FileUpload/FilePreviewBase";
+export { FileAttachmentsPreview } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 export type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 export type {
   FileAttachmentGroup,

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -500,7 +500,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-zYvgFz93HaKWKXugLNVA+ZkveAn9IzrpSijI7MzXIC9+EKtFtEAVrsf300m/0jmy8yZyigxQWMvasgdwlOa30A==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-C8aScySda7KlXmVWTXx7uNTdA1HdCp3tzs690FRtUzHvTvBk3MDWsmhuPZi73jo/pfHgzTv8KWYKLqTcFNY82g==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -1307,6 +1307,9 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -2221,6 +2224,10 @@ packages:
     resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -2661,11 +2668,29 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -2987,6 +3012,10 @@ packages:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
+  katex@0.18.1:
+    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3107,6 +3136,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -3167,6 +3199,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -3417,6 +3452,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -3652,8 +3690,14 @@ packages:
   regl@2.1.1:
     resolution: {integrity: sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -4069,11 +4113,17 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -4118,6 +4168,9 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4220,6 +4273,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -4766,6 +4822,7 @@ snapshots:
       fuse.js: 7.4.2
       iconoir-react: 7.11.0(react@19.2.7)
       immer: 10.2.0
+      katex: 0.18.1
       lettersanitizer: 1.0.7
       lodash: 4.18.1
       mermaid: 11.16.1
@@ -4783,7 +4840,9 @@ snapshots:
       react-syntax-highlighter: 16.1.1(react@19.2.7)
       react-use: 17.6.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-window: 1.8.11(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rehype-katex: 7.0.1
       remark-gfm: 4.0.1
+      remark-math: 6.0.0
       simple-icons: 16.23.0
       sse.js: 2.8.0
       use-debounce: 10.1.1(react@19.2.7)
@@ -5563,6 +5622,8 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 25.9.3
+
+  '@types/katex@0.16.8': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -6521,6 +6582,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@6.0.1: {}
+
   entities@7.0.1: {}
 
   entities@8.0.0: {}
@@ -7102,6 +7165,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -7125,6 +7225,13 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -7445,6 +7552,10 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
+  katex@0.18.1:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -7604,6 +7715,18 @@ snapshots:
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7786,6 +7909,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -8121,6 +8254,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -8386,6 +8523,16 @@ snapshots:
 
   regl@2.1.1: {}
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.47
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -8393,6 +8540,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -8907,6 +9063,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -8914,6 +9075,11 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -8983,6 +9149,11 @@ snapshots:
 
   uuid@14.0.0: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -9051,6 +9222,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1410,6 +1410,36 @@ msgid "officeAddin.teams.picker.wholeChatBound"
 msgstr "Ganze Chats fügen die letzten {messageLimit} Nachrichten hinzu."
 
 #. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.allMessages"
+msgstr "{count, plural, one {Alle # Nachricht} other {Alle # Nachrichten}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.lastMessages"
+msgstr "{count, plural, one {Letzte # Nachricht — ältere Nachrichten nicht enthalten} other {Letzte # Nachrichten — ältere Nachrichten nicht enthalten}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.messageCount"
+msgstr "{count, plural, one {# Nachricht} other {# Nachrichten}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.selectedMessages"
+msgstr "{count, plural, one {# ausgewählte Nachricht} other {# ausgewählte Nachrichten}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.skipped"
+msgstr "{skipped, plural, one {# konnte nicht geladen werden} other {# konnten nicht geladen werden}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.transcriptLabel"
+msgstr "Teams-Unterhaltung"
+
+#. js-lingui-explicit-id
 #: src/teams/providers/TeamsAuthProvider.tsx
 msgid "officeAddin.teams.signedIn.title"
 msgstr "Angemeldet. Versuche erneut, den Chat hinzuzufügen."

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1415,6 +1415,11 @@ msgid "officeAddin.teams.preview.allMessages"
 msgstr "{count, plural, one {Alle # Nachricht} other {Alle # Nachrichten}}"
 
 #. js-lingui-explicit-id
+#: src/teams/components/TeamsAttachmentsPreview.tsx
+msgid "officeAddin.teams.preview.conversationRegion"
+msgstr "Vorschau der Teams-Unterhaltung"
+
+#. js-lingui-explicit-id
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.lastMessages"
 msgstr "{count, plural, one {Letzte # Nachricht — ältere Nachrichten nicht enthalten} other {Letzte # Nachrichten — ältere Nachrichten nicht enthalten}}"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1415,6 +1415,11 @@ msgid "officeAddin.teams.preview.allMessages"
 msgstr "{count, plural, one {All # message} other {All # messages}}"
 
 #. js-lingui-explicit-id
+#: src/teams/components/TeamsAttachmentsPreview.tsx
+msgid "officeAddin.teams.preview.conversationRegion"
+msgstr "Teams conversation preview"
+
+#. js-lingui-explicit-id
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.lastMessages"
 msgstr "{count, plural, one {Last # message — older messages not included} other {Last # messages — older messages not included}}"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1410,6 +1410,36 @@ msgid "officeAddin.teams.picker.wholeChatBound"
 msgstr "Whole chats add the last {messageLimit} messages."
 
 #. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.allMessages"
+msgstr "{count, plural, one {All # message} other {All # messages}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.lastMessages"
+msgstr "{count, plural, one {Last # message — older messages not included} other {Last # messages — older messages not included}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.messageCount"
+msgstr "{count, plural, one {# message} other {# messages}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.selectedMessages"
+msgstr "{count, plural, one {# selected message} other {# selected messages}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.skipped"
+msgstr "{skipped, plural, one {# could not be loaded} other {# could not be loaded}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.transcriptLabel"
+msgstr "Teams conversation"
+
+#. js-lingui-explicit-id
 #: src/teams/providers/TeamsAuthProvider.tsx
 msgid "officeAddin.teams.signedIn.title"
 msgstr "Signed in. Try adding the chat again."

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1415,6 +1415,11 @@ msgid "officeAddin.teams.preview.allMessages"
 msgstr "{count, plural, one {Todos los # mensaje} other {Todos los # mensajes}}"
 
 #. js-lingui-explicit-id
+#: src/teams/components/TeamsAttachmentsPreview.tsx
+msgid "officeAddin.teams.preview.conversationRegion"
+msgstr "Vista previa de la conversación de Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.lastMessages"
 msgstr "{count, plural, one {Último # mensaje — los mensajes anteriores no se incluyen} other {Últimos # mensajes — los mensajes anteriores no se incluyen}}"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1410,6 +1410,36 @@ msgid "officeAddin.teams.picker.wholeChatBound"
 msgstr "Los chats completos añaden los últimos {messageLimit} mensajes."
 
 #. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.allMessages"
+msgstr "{count, plural, one {Todos los # mensaje} other {Todos los # mensajes}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.lastMessages"
+msgstr "{count, plural, one {Último # mensaje — los mensajes anteriores no se incluyen} other {Últimos # mensajes — los mensajes anteriores no se incluyen}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.messageCount"
+msgstr "{count, plural, one {# mensaje} other {# mensajes}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.selectedMessages"
+msgstr "{count, plural, one {# mensaje seleccionado} other {# mensajes seleccionados}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.skipped"
+msgstr "{skipped, plural, one {# no se pudo cargar} other {# no se pudieron cargar}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.transcriptLabel"
+msgstr "Conversación de Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/providers/TeamsAuthProvider.tsx
 msgid "officeAddin.teams.signedIn.title"
 msgstr "Sesión iniciada. Vuelve a intentar añadir el chat."

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1415,6 +1415,11 @@ msgid "officeAddin.teams.preview.allMessages"
 msgstr "{count, plural, one {Tous les # message} other {Tous les # messages}}"
 
 #. js-lingui-explicit-id
+#: src/teams/components/TeamsAttachmentsPreview.tsx
+msgid "officeAddin.teams.preview.conversationRegion"
+msgstr "Aperçu de la conversation Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.lastMessages"
 msgstr "{count, plural, one {# dernier message — les messages plus anciens ne sont pas inclus} other {# derniers messages — les messages plus anciens ne sont pas inclus}}"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1410,6 +1410,36 @@ msgid "officeAddin.teams.picker.wholeChatBound"
 msgstr "Les conversations entières ajoutent les {messageLimit} derniers messages."
 
 #. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.allMessages"
+msgstr "{count, plural, one {Tous les # message} other {Tous les # messages}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.lastMessages"
+msgstr "{count, plural, one {# dernier message — les messages plus anciens ne sont pas inclus} other {# derniers messages — les messages plus anciens ne sont pas inclus}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.messageCount"
+msgstr "{count, plural, one {# message} other {# messages}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.selectedMessages"
+msgstr "{count, plural, one {# message sélectionné} other {# messages sélectionnés}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.skipped"
+msgstr "{skipped, plural, one {# n'a pas pu être chargé} other {# n'ont pas pu être chargés}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.transcriptLabel"
+msgstr "Conversation Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/providers/TeamsAuthProvider.tsx
 msgid "officeAddin.teams.signedIn.title"
 msgstr "Connecté. Essayez à nouveau d'ajouter la conversation."

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1410,6 +1410,36 @@ msgid "officeAddin.teams.picker.wholeChatBound"
 msgstr "Całe czaty dodają ostatnie {messageLimit} wiadomości."
 
 #. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.allMessages"
+msgstr "{count, plural, one {Wszystkie # wiadomość} few {Wszystkie # wiadomości} many {Wszystkie # wiadomości} other {Wszystkie # wiadomości}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.lastMessages"
+msgstr "{count, plural, one {Ostatnia # wiadomość — starsze wiadomości nie są uwzględnione} few {Ostatnie # wiadomości — starsze wiadomości nie są uwzględnione} many {Ostatnich # wiadomości — starsze wiadomości nie są uwzględnione} other {Ostatnich # wiadomości — starsze wiadomości nie są uwzględnione}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.messageCount"
+msgstr "{count, plural, one {# wiadomość} few {# wiadomości} many {# wiadomości} other {# wiadomości}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.selectedMessages"
+msgstr "{count, plural, one {# wybrana wiadomość} few {# wybrane wiadomości} many {# wybranych wiadomości} other {# wybranych wiadomości}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.skipped"
+msgstr "{skipped, plural, one {# nie mogła zostać wczytana} few {# nie mogły zostać wczytane} many {# nie mogło zostać wczytanych} other {# nie mogło zostać wczytanych}}"
+
+#. js-lingui-explicit-id
+#: src/teams/utils/teamsAttachmentGroups.ts
+msgid "officeAddin.teams.preview.transcriptLabel"
+msgstr "Konwersacja w usłudze Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/providers/TeamsAuthProvider.tsx
 msgid "officeAddin.teams.signedIn.title"
 msgstr "Zalogowano. Spróbuj ponownie dodać czat."

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1415,6 +1415,11 @@ msgid "officeAddin.teams.preview.allMessages"
 msgstr "{count, plural, one {Wszystkie # wiadomość} few {Wszystkie # wiadomości} many {Wszystkie # wiadomości} other {Wszystkie # wiadomości}}"
 
 #. js-lingui-explicit-id
+#: src/teams/components/TeamsAttachmentsPreview.tsx
+msgid "officeAddin.teams.preview.conversationRegion"
+msgstr "Podgląd konwersacji w usłudze Teams"
+
+#. js-lingui-explicit-id
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.lastMessages"
 msgstr "{count, plural, one {Ostatnia # wiadomość — starsze wiadomości nie są uwzględnione} few {Ostatnie # wiadomości — starsze wiadomości nie są uwzględnione} many {Ostatnich # wiadomości — starsze wiadomości nie są uwzględnione} other {Ostatnich # wiadomości — starsze wiadomości nie są uwzględnione}}"

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -333,11 +333,14 @@ describe("Teams personal tab composition", () => {
     );
   });
 
-  it("installs only the add-menu contribution, so no Outlook affordances appear", async () => {
+  it("installs only the Teams contributions, so no Outlook affordances appear", async () => {
     renderTab();
     await screen.findByTestId("teams-message-list");
 
-    expect(Object.keys(componentRegistry)).toEqual(["ChatAddMenuExtraContent"]);
+    expect(Object.keys(componentRegistry)).toEqual([
+      "ChatAddMenuExtraContent",
+      "ChatAttachmentsPreview",
+    ]);
   });
 
   it("selects chats under the Teams storage key, never the neutral one", async () => {

--- a/office-addin/src/teams/__tests__/installTeamsComponentRegistrations.test.ts
+++ b/office-addin/src/teams/__tests__/installTeamsComponentRegistrations.test.ts
@@ -1,13 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { registry, addMenu } = vi.hoisted(() => {
+const { registry, addMenu, attachmentsPreview } = vi.hoisted(() => {
   const registry: Record<string, unknown> = {};
-  return { registry, addMenu: () => null };
+  return {
+    registry,
+    addMenu: () => null,
+    attachmentsPreview: () => null,
+  };
 });
 
 vi.mock("@erato/frontend/library", () => ({ componentRegistry: registry }));
 vi.mock("../components/TeamsChatAddMenuExtraContent", () => ({
   TeamsChatAddMenuExtraContent: addMenu,
+}));
+vi.mock("../components/TeamsAttachmentsPreview", () => ({
+  TeamsAttachmentsPreview: attachmentsPreview,
 }));
 
 import { installTeamsComponentRegistrations } from "../installTeamsComponentRegistrations";
@@ -17,9 +24,12 @@ describe("installTeamsComponentRegistrations", () => {
     for (const key of Object.keys(registry)) delete registry[key];
   });
 
-  it("contributes the add-menu row and no Outlook renderers", () => {
+  it("contributes the add-menu row and the attachments preview, and no Outlook renderers", () => {
     installTeamsComponentRegistrations();
 
-    expect(registry).toEqual({ ChatAddMenuExtraContent: addMenu });
+    expect(registry).toEqual({
+      ChatAddMenuExtraContent: addMenu,
+      ChatAttachmentsPreview: attachmentsPreview,
+    });
   });
 });

--- a/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
+++ b/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
@@ -2,6 +2,7 @@ import {
   FileAttachmentsPreview,
   GroupedFileAttachmentsPreview,
 } from "@erato/frontend/library";
+import { t } from "@lingui/core/macro";
 import { useMemo } from "react";
 
 import { useTeamsChatPicker } from "../providers/TeamsChatPickerProvider";
@@ -36,14 +37,28 @@ export function TeamsAttachmentsPreview(props: FileAttachmentsPreviewProps) {
 
   return (
     <>
-      <GroupedFileAttachmentsPreview
-        groups={preview.groups}
-        onRemoveFile={props.onRemoveFile}
-        disabled={props.disabled}
-        showFileTypes={props.showFileTypes}
-        showFileSizes={props.showFileSizes}
-        defaultVisibleItems={10}
-      />
+      <div
+        className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus:ring-2 focus:ring-theme-focus"
+        role="region"
+        // A bounded scroll area needs a focus target before a keyboard user can
+        // arrow or page through it.
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        aria-label={t({
+          id: "officeAddin.teams.preview.conversationRegion",
+          message: "Teams conversation preview",
+        })}
+      >
+        <GroupedFileAttachmentsPreview
+          groups={preview.groups}
+          onRemoveFile={props.onRemoveFile}
+          disabled={props.disabled}
+          showFileTypes={props.showFileTypes}
+          showFileSizes={props.showFileSizes}
+          defaultVisibleItems={10}
+          stickyGroupHeaders={true}
+        />
+      </div>
       <FileAttachmentsPreview {...props} attachedFiles={rest} />
     </>
   );

--- a/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
+++ b/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
@@ -1,0 +1,50 @@
+import {
+  FileAttachmentsPreview,
+  GroupedFileAttachmentsPreview,
+} from "@erato/frontend/library";
+import { useMemo } from "react";
+
+import { useTeamsChatPicker } from "../providers/TeamsChatPickerProvider";
+import { buildTeamsAttachmentGroups } from "../utils/teamsAttachmentGroups";
+
+import type { FileAttachmentsPreviewProps } from "@erato/frontend/library";
+
+/**
+ * The composer's attachment region in the Teams tab: an attached transcript is
+ * shown as the conversation it came from, with its images and shared files
+ * sitting under the messages they arrived with.
+ *
+ * Anything the picker did not produce — a file added by another route, or a
+ * transcript whose sections this session no longer holds — keeps the ordinary
+ * flat chips underneath.
+ */
+export function TeamsAttachmentsPreview(props: FileAttachmentsPreviewProps) {
+  const { attachedTranscript } = useTeamsChatPicker();
+  const { attachedFiles } = props;
+  const preview = useMemo(
+    () => buildTeamsAttachmentGroups(attachedTranscript, attachedFiles),
+    [attachedTranscript, attachedFiles],
+  );
+
+  if (!preview) {
+    return <FileAttachmentsPreview {...props} />;
+  }
+
+  const rest = attachedFiles.filter(
+    (file) => !preview.claimedFileIds.has(file.id),
+  );
+
+  return (
+    <>
+      <GroupedFileAttachmentsPreview
+        groups={preview.groups}
+        onRemoveFile={props.onRemoveFile}
+        disabled={props.disabled}
+        showFileTypes={props.showFileTypes}
+        showFileSizes={props.showFileSizes}
+        defaultVisibleItems={10}
+      />
+      <FileAttachmentsPreview {...props} attachedFiles={rest} />
+    </>
+  );
+}

--- a/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
@@ -1,0 +1,124 @@
+import { i18n } from "@lingui/core";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TeamsAttachmentsPreview } from "../TeamsAttachmentsPreview";
+
+import type { TeamsAttachedTranscript } from "../../utils/teamsAttachmentGroups";
+import type {
+  FileAttachmentGroup,
+  FileAttachmentsPreviewProps,
+  FileUploadItem,
+  GroupedFileAttachmentsPreviewProps,
+} from "@erato/frontend/library";
+
+const state = vi.hoisted(() => ({
+  attachedTranscript: null as TeamsAttachedTranscript | null,
+}));
+
+vi.mock("@erato/frontend/library", () => ({
+  FileAttachmentsPreview: ({ attachedFiles }: FileAttachmentsPreviewProps) => (
+    <div data-testid="flat-preview">
+      {attachedFiles.map((file) => file.filename).join(",")}
+    </div>
+  ),
+  GroupedFileAttachmentsPreview: ({
+    groups,
+  }: GroupedFileAttachmentsPreviewProps) => (
+    <div data-testid="grouped-preview">
+      {groups.map((group: FileAttachmentGroup) => (
+        <div key={group.id} data-testid="group">
+          {group.label}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+vi.mock("../../providers/TeamsChatPickerProvider", () => ({
+  useTeamsChatPicker: () => ({ attachedTranscript: state.attachedTranscript }),
+}));
+
+function upload(filename: string, id = filename): FileUploadItem {
+  return { id, filename } as FileUploadItem;
+}
+
+const transcript = upload("teams-Product_sync.md", "upload-transcript");
+const image = upload("teams-img-abc.png", "upload-image");
+const unrelated = upload("holiday.pdf", "upload-holiday");
+
+const attached: TeamsAttachedTranscript = {
+  fileName: transcript.filename,
+  sections: [
+    {
+      kind: "chat",
+      chat: {
+        chatId: "19:chat",
+        title: "Product sync",
+        participants: [],
+        selfDisplayName: null,
+        participantsTruncated: false,
+        chatType: "group",
+        lastActivityAt: null,
+        previewText: "",
+      },
+      messages: [
+        {
+          chatId: "19:chat",
+          messageId: "m1",
+          senderName: "Ada Lovelace",
+          createdAt: "2026-03-01T08:00:00Z",
+          editedAt: null,
+          subject: null,
+          text: "Screenshot [image: attached as teams-img-abc.png]",
+          markers: [],
+          sharedFiles: [],
+          imageUrls: [],
+          replyToId: null,
+          deepLink: "https://teams.microsoft.com/l/message/19:chat/m1",
+        },
+      ],
+      selection: "messages",
+    },
+  ],
+};
+
+function renderPreview(
+  attachedFiles: FileUploadItem[],
+  overrides: Partial<FileAttachmentsPreviewProps> = {},
+) {
+  return render(
+    <TeamsAttachmentsPreview
+      attachedFiles={attachedFiles}
+      maxFiles={50}
+      onRemoveFile={() => {}}
+      onRemoveAllFiles={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+describe("TeamsAttachmentsPreview", () => {
+  beforeEach(() => {
+    i18n.activate("en");
+    state.attachedTranscript = null;
+  });
+  afterEach(cleanup);
+
+  it("renders the composer's flat chips when no transcript is attached", () => {
+    renderPreview([unrelated]);
+
+    expect(screen.queryByTestId("grouped-preview")).toBeNull();
+    expect(screen.getByTestId("flat-preview")).toHaveTextContent("holiday.pdf");
+  });
+
+  it("renders the conversation and leaves unrelated uploads as chips", () => {
+    state.attachedTranscript = attached;
+    renderPreview([transcript, image, unrelated]);
+
+    expect(screen.getByTestId("group")).toHaveTextContent("Product sync");
+    expect(screen.getByTestId("flat-preview")).toHaveTextContent("holiday.pdf");
+    expect(screen.getByTestId("flat-preview")).not.toHaveTextContent(
+      "teams-img-abc.png",
+    );
+  });
+});

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -425,6 +425,17 @@ function Opener() {
   );
 }
 
+/** Surfaces what the composer's preview reads back off the context. */
+function AttachedProbe() {
+  const { attachedTranscript } = useTeamsChatPicker();
+  if (!attachedTranscript) return null;
+  return (
+    <div data-testid="attached-transcript">
+      {attachedTranscript.fileName}:{attachedTranscript.sections.length}
+    </div>
+  );
+}
+
 function renderPicker() {
   // StrictMode on purpose: the app runs under it, and its double-mount is what
   // exposed the alive-ref arming bug the plain renderer never would.
@@ -432,6 +443,7 @@ function renderPicker() {
     <StrictMode>
       <TeamsChatPickerProvider>
         <Opener />
+        <AttachedProbe />
       </TeamsChatPickerProvider>
     </StrictMode>,
   );
@@ -557,6 +569,20 @@ describe("TeamsChatPickerDialog", () => {
     expect(text).toContain("Works for me.");
     // Dialog closes on a clean attach.
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("keeps the delivered transcript's sections for the composer preview", async () => {
+    renderPicker();
+    fireEvent.click(selectChat());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Attach" }));
+    });
+    await waitFor(() => expect(uploads).toHaveLength(1));
+
+    expect(screen.getByTestId("attached-transcript")).toHaveTextContent(
+      "teams-Product_sync.md:1",
+    );
   });
 
   it("records the window that was actually fetched in the transcript", async () => {

--- a/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
@@ -5,6 +5,7 @@ import { buildTeamsTranscriptFile } from "../utils/buildTeamsTranscriptFile";
 import { collectTeamsTranscript } from "../utils/collectTeamsTranscript";
 import { TEAMS_GRAPH_TRANSCRIPT_TIMEOUT_MS } from "../utils/teamsGraphTimeouts";
 
+import type { TeamsTranscriptSection } from "../utils/buildTeamsTranscriptFile";
 import type { TeamsTranscriptProgress } from "../utils/collectTeamsTranscript";
 import type { ParsedTeamsChannel } from "../utils/parsedTeamsChannel";
 import type {
@@ -24,6 +25,12 @@ export interface TeamsTranscriptBuildOutcome {
   file: File | null;
   /** Images fetched from the messages, uploaded beside the transcript. */
   assets: File[];
+  /**
+   * The conversations behind `file`, in the order it renders them. Carried out
+   * of the build so the composer can preview the transcript as a conversation
+   * instead of as one opaque markdown chip.
+   */
+  sections: TeamsTranscriptSection[];
   state: TeamsFetchState;
   messageCount: number;
   skippedCount: number;
@@ -49,6 +56,7 @@ export interface UseTeamsTranscriptBuildResult {
 const ABORTED_OUTCOME: TeamsTranscriptBuildOutcome = {
   file: null,
   assets: [],
+  sections: [],
   state: "error",
   messageCount: 0,
   skippedCount: 0,
@@ -134,6 +142,7 @@ export function useTeamsTranscriptBuild(
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
           assets: collected.assetFiles,
+          sections: collected.sections,
           state: collected.state,
           messageCount: collected.messageCount,
           skippedCount: collected.skippedCount,

--- a/office-addin/src/teams/installTeamsComponentRegistrations.ts
+++ b/office-addin/src/teams/installTeamsComponentRegistrations.ts
@@ -1,8 +1,10 @@
 import { componentRegistry } from "@erato/frontend/library";
 
+import { TeamsAttachmentsPreview } from "./components/TeamsAttachmentsPreview";
 import { TeamsChatAddMenuExtraContent } from "./components/TeamsChatAddMenuExtraContent";
 
 /** Install Teams-only registry contributions before the first chat render. */
 export function installTeamsComponentRegistrations() {
   componentRegistry.ChatAddMenuExtraContent = TeamsChatAddMenuExtraContent;
+  componentRegistry.ChatAttachmentsPreview = TeamsAttachmentsPreview;
 }

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -31,12 +31,14 @@ import {
 import type { UseTeamsChannelListResult } from "../hooks/useTeamsChannelList";
 import type { UseTeamsChatListResult } from "../hooks/useTeamsChatList";
 import type { TeamsTranscriptBuildOutcome } from "../hooks/useTeamsTranscriptBuild";
+import type { TeamsTranscriptSection } from "../utils/buildTeamsTranscriptFile";
 import type { TeamsTranscriptProgress } from "../utils/collectTeamsTranscript";
 import type { ParsedTeamsChannel } from "../utils/parsedTeamsChannel";
 import type {
   ParsedTeamsChat,
   TeamsSelfIdentity,
 } from "../utils/parsedTeamsChat";
+import type { TeamsAttachedTranscript } from "../utils/teamsAttachmentGroups";
 import type {
   TeamsChannelFetcher,
   TeamsChatFetcher,
@@ -89,6 +91,13 @@ export interface TeamsChatPickerContextValue {
   progress: TeamsTranscriptProgress | null;
   partialOutcome: TeamsTranscriptBuildOutcome | null;
   attachError: TeamsAttachFailure | null;
+
+  /**
+   * The transcript this session last handed to the composer, or null when it
+   * never did. Survives closing the dialog — the composer previews it for as
+   * long as the upload stays attached.
+   */
+  attachedTranscript: TeamsAttachedTranscript | null;
 }
 
 const EMPTY_CHAT_LIST: UseTeamsChatListResult = {
@@ -138,6 +147,7 @@ const CLOSED_PICKER: TeamsChatPickerContextValue = {
   progress: null,
   partialOutcome: null,
   attachError: null,
+  attachedTranscript: null,
 };
 
 const TeamsChatPickerContext =
@@ -178,9 +188,16 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const [partialOutcome, setPartialOutcome] =
     useState<TeamsTranscriptBuildOutcome | null>(null);
 
+  const [attachedTranscript, setAttachedTranscript] =
+    useState<TeamsAttachedTranscript | null>(null);
+
   const handoffRef = useRef<((files: File[]) => Promise<void>) | null>(null);
   const cancelledRef = useRef(false);
-  const lastBuildRef = useRef<{ key: string; files: File[] } | null>(null);
+  const lastBuildRef = useRef<{
+    key: string;
+    files: File[];
+    sections: TeamsTranscriptSection[];
+  } | null>(null);
 
   // The object id is the reliable match; the login hint can differ from a
   // member's primary SMTP address, which would leave the viewer in their own
@@ -268,10 +285,14 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
    * walking Graph again, which is tens of seconds.
    */
   const deliver = useCallback(
-    async (files: File[], retryKey?: string): Promise<boolean> => {
+    async (
+      files: File[],
+      sections: TeamsTranscriptSection[],
+      retryKey?: string,
+    ): Promise<boolean> => {
       const handoff = handoffRef.current;
       const fail = () => {
-        if (retryKey) lastBuildRef.current = { key: retryKey, files };
+        if (retryKey) lastBuildRef.current = { key: retryKey, files, sections };
         setAttachError("upload-failed");
         return false;
       };
@@ -290,6 +311,12 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       if (useFileUploadStore.getState().error) {
         return fail();
       }
+      // The transcript leads, its assets follow — the order every caller
+      // hands over, and the order the preview joins back together.
+      const [transcript] = files;
+      if (transcript) {
+        setAttachedTranscript({ fileName: transcript.name, sections });
+      }
       close();
       return true;
     },
@@ -306,7 +333,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     const key = teamsSelectionDedupeKey(selections, messageLimit);
     const built = lastBuildRef.current;
     if (built?.key === key) {
-      await deliver(built.files, key);
+      await deliver(built.files, built.sections, key);
       return;
     }
 
@@ -328,7 +355,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       setPartialOutcome(outcome);
       return;
     }
-    await deliver([outcome.file, ...outcome.assets], key);
+    await deliver([outcome.file, ...outcome.assets], outcome.sections, key);
   }, [
     build,
     chatList.chatsById,
@@ -346,7 +373,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     setPartialOutcome(null);
     // Put the offer back if the composer never took it — the partial
     // transcript is the only copy of a walk that already ran.
-    if (!(await deliver([outcome.file, ...outcome.assets]))) {
+    if (!(await deliver([outcome.file, ...outcome.assets], outcome.sections))) {
       setPartialOutcome(outcome);
     }
   }, [deliver, partialOutcome]);
@@ -378,10 +405,12 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       progress,
       partialOutcome,
       attachError,
+      attachedTranscript,
     }),
     [
       attach,
       attachError,
+      attachedTranscript,
       attachPartial,
       cancelBuild,
       channelFetcher,

--- a/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
@@ -1,0 +1,305 @@
+import { i18n } from "@lingui/core";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
+import { buildTeamsAttachmentGroups } from "../teamsAttachmentGroups";
+import { buildTeamsMessageDeepLink } from "../teamsDeepLink";
+
+import type { TeamsTranscriptSection } from "../buildTeamsTranscriptFile";
+import type { ParsedTeamsChannel } from "../parsedTeamsChannel";
+import type { ParsedTeamsChat, ParsedTeamsMessage } from "../parsedTeamsChat";
+import type {
+  FileAttachmentGroup,
+  FileAttachmentGroupItem,
+  FileUploadItem,
+} from "@erato/frontend/library";
+
+const chat: ParsedTeamsChat = {
+  chatId: MOCK_CHAT_ID,
+  title: "Product sync",
+  participants: ["Ada Lovelace"],
+  selfDisplayName: null,
+  participantsTruncated: false,
+  chatType: "group",
+  lastActivityAt: "2026-08-10T09:15:00Z",
+  previewText: "",
+};
+
+const channel: ParsedTeamsChannel = {
+  ref: { kind: "channel", teamId: "team-1", channelId: "chan-1" },
+  teamId: "team-1",
+  channelId: "chan-1",
+  name: "Releases",
+  teamName: "Contoso",
+  membershipType: "standard",
+  isThreaded: true,
+};
+
+function message(
+  overrides: Partial<ParsedTeamsMessage> = {},
+): ParsedTeamsMessage {
+  const messageId = overrides.messageId ?? "1741000000000";
+  return {
+    chatId: MOCK_CHAT_ID,
+    messageId,
+    senderName: "Ada Lovelace",
+    createdAt: "2026-03-03T09:14:00Z",
+    editedAt: null,
+    subject: null,
+    text: "Can we move the sync to Thursday?",
+    markers: [],
+    sharedFiles: [],
+    imageUrls: [],
+    replyToId: null,
+    deepLink: buildTeamsMessageDeepLink(MOCK_CHAT_ID, messageId),
+    ...overrides,
+  };
+}
+
+function upload(filename: string, id = filename): FileUploadItem {
+  return { id, filename } as FileUploadItem;
+}
+
+const TRANSCRIPT = upload("teams-Product_sync.md", "upload-transcript");
+
+function chatSection(
+  overrides: Partial<Extract<TeamsTranscriptSection, { kind: "chat" }>> = {},
+): TeamsTranscriptSection {
+  return {
+    kind: "chat",
+    chat,
+    messages: [message()],
+    selection: "whole-chat",
+    limit: 200,
+    ...overrides,
+  };
+}
+
+function itemKinds(group: FileAttachmentGroup): string[] {
+  return group.items.map((item) => item.kind);
+}
+
+function transcriptRow(group: FileAttachmentGroup) {
+  const [first] = group.items;
+  if (first.kind !== "attachment") {
+    throw new Error(`expected a transcript row, got ${first.kind}`);
+  }
+  return first;
+}
+
+type ThreadRow = Extract<
+  FileAttachmentGroupItem,
+  { kind: "threadMessageGroup" }
+>;
+
+function threadRows(group: FileAttachmentGroup): ThreadRow[] {
+  return group.items.filter(
+    (item): item is ThreadRow => item.kind === "threadMessageGroup",
+  );
+}
+
+describe("buildTeamsAttachmentGroups", () => {
+  beforeEach(() => {
+    i18n.activate("en");
+  });
+
+  it("falls back to flat chips when the sections are unavailable", () => {
+    expect(buildTeamsAttachmentGroups(null, [TRANSCRIPT])).toBeNull();
+    expect(
+      buildTeamsAttachmentGroups(
+        { fileName: TRANSCRIPT.filename, sections: [] },
+        [TRANSCRIPT],
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to flat chips when the transcript is no longer attached", () => {
+    expect(
+      buildTeamsAttachmentGroups(
+        { fileName: TRANSCRIPT.filename, sections: [chatSection()] },
+        [upload("holiday.pdf")],
+      ),
+    ).toBeNull();
+  });
+
+  it("summarises a whole conversation instead of listing its messages", () => {
+    const messages = [
+      message({ messageId: "m1", createdAt: "2026-03-01T08:00:00Z" }),
+      message({ messageId: "m2", createdAt: "2026-03-03T09:14:00Z" }),
+    ];
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({ messages, selection: "whole-chat", truncated: true }),
+        ],
+      },
+      [TRANSCRIPT],
+    );
+
+    expect(preview).not.toBeNull();
+    const [group] = preview!.groups;
+    expect(group.label).toBe("Product sync");
+    expect(group.metaLabel).toContain("2 messages");
+    expect(group.collapsible).toBe(true);
+    expect(group.defaultCollapsed).toBe(true);
+    expect(itemKinds(group)).toEqual(["attachment"]);
+    const row = transcriptRow(group);
+    expect(row.file).toMatchObject({
+      id: TRANSCRIPT.id,
+      displayName: "Last 2 messages — older messages not included",
+    });
+  });
+
+  it("renders one card per hand-picked message, oldest first", () => {
+    const messages = [
+      message({
+        messageId: "m2",
+        senderName: "Grace Hopper",
+        createdAt: "2026-03-03T09:14:00Z",
+      }),
+      message({
+        messageId: "m1",
+        senderName: "Ada Lovelace",
+        createdAt: "2026-03-01T08:00:00Z",
+      }),
+    ];
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({ messages, selection: "messages", limit: undefined }),
+        ],
+      },
+      [TRANSCRIPT],
+    );
+
+    const [group] = preview!.groups;
+    expect(group.defaultCollapsed).toBe(false);
+    expect(transcriptRow(group).file).toMatchObject({
+      displayName: "2 selected messages",
+    });
+    expect(threadRows(group).map((row) => row.label)).toEqual([
+      "Ada Lovelace",
+      "Grace Hopper",
+    ]);
+    // Nothing here can be taken back out of an uploaded transcript, so the
+    // cards carry no inclusion toggle.
+    expect(threadRows(group).every((row) => row.onToggle === undefined)).toBe(
+      true,
+    );
+  });
+
+  it("keeps one group per conversation across chats and channels", () => {
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({ selection: "messages" }),
+          {
+            kind: "channel",
+            channel,
+            messages: [message({ messageId: "c1" })],
+            selection: "whole-chat",
+            limit: 200,
+          },
+        ],
+      },
+      [TRANSCRIPT],
+    );
+
+    expect(preview!.groups).toHaveLength(2);
+    expect(preview!.groups.map((group) => group.label)).toEqual([
+      "Product sync",
+      "Releases · Contoso",
+    ]);
+    // Both cards stand for slices of the same upload.
+    for (const group of preview!.groups) {
+      expect(transcriptRow(group).file).toMatchObject({ id: TRANSCRIPT.id });
+    }
+    expect([...preview!.claimedFileIds]).toEqual([TRANSCRIPT.id]);
+  });
+
+  it("nests a message's uploads under it, joined by the stamped filename", () => {
+    const image = upload("teams-img-abc.png", "upload-image");
+    const shared = upload("teams-file-abc-report.pdf", "upload-report");
+    const unrelated = upload("holiday.pdf", "upload-holiday");
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({
+            selection: "messages",
+            messages: [
+              message({
+                messageId: "m1",
+                createdAt: "2026-03-01T08:00:00Z",
+                text: "Here it is [image: attached as teams-img-abc.png]",
+                markers: [
+                  "[attachment: report.pdf — attached as teams-file-abc-report.pdf]",
+                ],
+              }),
+              message({ messageId: "m2", createdAt: "2026-03-02T08:00:00Z" }),
+            ],
+          }),
+        ],
+      },
+      [TRANSCRIPT, image, shared, unrelated],
+    );
+
+    const rows = threadRows(preview!.groups[0]);
+    expect(rows[0].attachments.map((item) => item.file)).toEqual([
+      image,
+      shared,
+    ]);
+    expect(rows[1].attachments).toEqual([]);
+    // The unrelated upload stays a flat chip, the joined ones do not.
+    expect([...preview!.claimedFileIds].sort()).toEqual([
+      image.id,
+      shared.id,
+      TRANSCRIPT.id,
+    ]);
+  });
+
+  it("lists a whole conversation's uploads beside its summary row", () => {
+    const image = upload("teams-img-abc.png", "upload-image");
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({
+            messages: [
+              message({
+                text: "Screenshot [image: attached as teams-img-abc.png]",
+              }),
+              // The same asset in a second message must not double up.
+              message({
+                messageId: "m2",
+                text: "Again [image: attached as teams-img-abc.png]",
+              }),
+            ],
+          }),
+        ],
+      },
+      [TRANSCRIPT, image],
+    );
+
+    const [group] = preview!.groups;
+    expect(itemKinds(group)).toEqual(["attachment", "attachment"]);
+    expect(group.items[1]).toMatchObject({ id: image.id, file: image });
+  });
+
+  it("reports how many messages could not be loaded", () => {
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [chatSection({ selection: "messages", skippedCount: 2 })],
+      },
+      [TRANSCRIPT],
+    );
+
+    expect(transcriptRow(preview!.groups[0]).file).toMatchObject({
+      displayName: "1 selected message · 2 could not be loaded",
+    });
+  });
+});

--- a/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
@@ -190,6 +190,43 @@ describe("buildTeamsAttachmentGroups", () => {
     );
   });
 
+  it("shows an excerpt so two messages from one sender are distinguishable", () => {
+    const messages = [
+      message({ messageId: "m1", text: "Can we move the sync to Thursday?" }),
+      message({ messageId: "m2", text: "Actually Friday works better." }),
+    ];
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [chatSection({ messages, selection: "messages" })],
+      },
+      [TRANSCRIPT],
+    );
+
+    const rows = threadRows(preview!.groups[0]);
+    expect(rows[0].sublabel).toContain("Can we move the sync to Thursday?");
+    expect(rows[1].sublabel).toContain("Actually Friday works better.");
+  });
+
+  it("truncates a long excerpt and flattens its whitespace", () => {
+    const messages = [
+      message({ messageId: "m1", text: `A${"b".repeat(200)}` }),
+      message({ messageId: "m2", text: "line one\n\n  line two" }),
+    ];
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [chatSection({ messages, selection: "messages" })],
+      },
+      [TRANSCRIPT],
+    );
+
+    const rows = threadRows(preview!.groups[0]);
+    expect(rows[0].sublabel).toContain(`A${"b".repeat(99)}…`);
+    expect(rows[0].sublabel).not.toContain("b".repeat(101));
+    expect(rows[1].sublabel).toContain("line one line two");
+  });
+
   it("keeps one group per conversation across chats and channels", () => {
     const preview = buildTeamsAttachmentGroups(
       {

--- a/office-addin/src/teams/utils/teamsAttachmentGroups.ts
+++ b/office-addin/src/teams/utils/teamsAttachmentGroups.ts
@@ -191,11 +191,31 @@ function includedSummary(section: TeamsTranscriptSection): string {
   return parts.join(" · ");
 }
 
+/** Enough of a message to tell two from the same sender apart, no more. */
+const EXCERPT_LENGTH = 100;
+
 function messageSublabel(message: ParsedTeamsMessage): string {
   const when = message.createdAt ? toDate(message.createdAt) : null;
-  return [when ? when.toLocaleString() : "", message.subject ?? ""]
+  return [
+    when ? when.toLocaleString() : "",
+    message.subject ?? "",
+    excerpt(message.text),
+  ]
     .filter((part) => part.length > 0)
     .join(" · ");
+}
+
+/**
+ * A card carrying only sender and timestamp is unreviewable: chat messages
+ * rarely have a subject, so two messages from one person minutes apart read
+ * identically — and reviewing the picked messages is the whole point of
+ * showing them individually.
+ */
+function excerpt(text: string): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length > EXCERPT_LENGTH
+    ? `${flat.slice(0, EXCERPT_LENGTH).trimEnd()}…`
+    : flat;
 }
 
 /**

--- a/office-addin/src/teams/utils/teamsAttachmentGroups.ts
+++ b/office-addin/src/teams/utils/teamsAttachmentGroups.ts
@@ -1,0 +1,256 @@
+/**
+ * Turns an attached Teams transcript back into the conversations it was built
+ * from, as composer preview groups: one card per conversation, with the
+ * transcript demoted to a single summary row inside it.
+ *
+ * One group per section, never one merged stream — a selection can span chats
+ * and channels that share no timeline. A whole conversation stays a summary:
+ * the default window is a few hundred messages, and that many cards in a task
+ * pane is unusable. Hand-picked messages get a card each, because verifying
+ * them one by one is exactly why the user picked them.
+ *
+ * Pure, and null whenever the structure is not fully available — a
+ * half-rendered conversation is worse than the flat chips it replaces.
+ */
+
+import { plural, t } from "@lingui/core/macro";
+
+import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
+import type { ParsedTeamsMessage } from "./parsedTeamsChat";
+import type {
+  FileAttachmentGroup,
+  FileAttachmentGroupItem,
+  FileUploadItem,
+} from "@erato/frontend/library";
+
+/**
+ * What the composer needs to recognise a transcript it is already holding: the
+ * uploaded filename — the same key the message markers name their assets by —
+ * and the conversations behind it.
+ */
+export interface TeamsAttachedTranscript {
+  fileName: string;
+  sections: TeamsTranscriptSection[];
+}
+
+export interface TeamsAttachmentPreviewGroups {
+  groups: FileAttachmentGroup[];
+  /** Uploads the groups account for; the rest stay ordinary flat chips. */
+  claimedFileIds: Set<string>;
+}
+
+export function buildTeamsAttachmentGroups(
+  attached: TeamsAttachedTranscript | null,
+  attachedFiles: readonly FileUploadItem[],
+): TeamsAttachmentPreviewGroups | null {
+  if (!attached || attached.sections.length === 0) return null;
+
+  const uploadsByName = new Map<string, FileUploadItem>();
+  for (const file of attachedFiles) {
+    if (!uploadsByName.has(file.filename)) {
+      uploadsByName.set(file.filename, file);
+    }
+  }
+  const transcript = uploadsByName.get(attached.fileName);
+  if (!transcript) return null;
+
+  const claimedFileIds = new Set<string>([transcript.id]);
+  /** Null once an upload has been placed, so it never gets a second row. */
+  const claim = (name: string): FileUploadItem | null => {
+    const file = uploadsByName.get(name);
+    if (!file || claimedFileIds.has(file.id)) return null;
+    claimedFileIds.add(file.id);
+    return file;
+  };
+
+  const groups = attached.sections.map((section): FileAttachmentGroup => {
+    const key = sectionKey(section);
+    const items: FileAttachmentGroupItem[] = [
+      {
+        kind: "attachment",
+        id: `${key}:transcript`,
+        // One transcript covers every section, so it is named by what this
+        // section contributes to it rather than by its filename. Removing the
+        // row removes the file, which drops the whole preview back to chips.
+        file: {
+          id: transcript.id,
+          filename: transcript.filename,
+          displayName: includedSummary(section),
+        },
+        labelOverride: t({
+          id: "officeAddin.teams.preview.transcriptLabel",
+          message: "Teams conversation",
+        }),
+      },
+    ];
+
+    if (section.selection === "messages") {
+      for (const message of oldestFirst(section.messages)) {
+        items.push({
+          kind: "threadMessageGroup",
+          id: `${key}:${message.messageId}`,
+          label: message.senderName,
+          sublabel: messageSublabel(message),
+          defaultCollapsed: false,
+          attachments: messageAssetFiles(message, claim).map((file) => ({
+            id: file.id,
+            file,
+          })),
+        });
+      }
+    } else {
+      // The summary row stands for the messages; the files that rode along
+      // with them still get a row each, so nothing is attached invisibly.
+      for (const message of section.messages) {
+        for (const file of messageAssetFiles(message, claim)) {
+          items.push({ kind: "attachment", id: file.id, file });
+        }
+      }
+    }
+
+    return {
+      id: `teams:${key}`,
+      label: sectionTitle(section),
+      metaLabel: sectionMeta(section),
+      items,
+      collapsible: true,
+      defaultCollapsed: section.selection !== "messages",
+    };
+  });
+
+  return { groups, claimedFileIds };
+}
+
+function sectionKey(section: TeamsTranscriptSection): string {
+  return section.kind === "chat"
+    ? `chat:${section.chat.chatId}`
+    : `channel:${section.channel.teamId}/${section.channel.channelId}`;
+}
+
+function sectionTitle(section: TeamsTranscriptSection): string {
+  if (section.kind === "chat") return section.chat.title;
+  const { name, teamName } = section.channel;
+  return teamName ? `${name} · ${teamName}` : name;
+}
+
+/** The header line: how much of the conversation this card stands for. */
+function sectionMeta(section: TeamsTranscriptSection): string {
+  const count = section.messages.length;
+  const countLabel = t({
+    id: "officeAddin.teams.preview.messageCount",
+    message: plural(count, { one: "# message", other: "# messages" }),
+  });
+  return [countLabel, dateRange(section.messages)]
+    .filter((part) => part.length > 0)
+    .join(" · ");
+}
+
+/**
+ * Mirrors the transcript's own "Included:" line, minus the date range the
+ * group header already carries.
+ */
+function includedSummary(section: TeamsTranscriptSection): string {
+  const count = section.messages.length;
+  const parts = [
+    section.selection === "messages"
+      ? t({
+          id: "officeAddin.teams.preview.selectedMessages",
+          message: plural(count, {
+            one: "# selected message",
+            other: "# selected messages",
+          }),
+        })
+      : section.truncated
+        ? t({
+            id: "officeAddin.teams.preview.lastMessages",
+            message: plural(count, {
+              one: "Last # message — older messages not included",
+              other: "Last # messages — older messages not included",
+            }),
+          })
+        : t({
+            id: "officeAddin.teams.preview.allMessages",
+            message: plural(count, {
+              one: "All # message",
+              other: "All # messages",
+            }),
+          }),
+  ];
+  const skipped = section.skippedCount ?? 0;
+  if (skipped > 0) {
+    parts.push(
+      t({
+        id: "officeAddin.teams.preview.skipped",
+        message: plural(skipped, {
+          one: "# could not be loaded",
+          other: "# could not be loaded",
+        }),
+      }),
+    );
+  }
+  return parts.join(" · ");
+}
+
+function messageSublabel(message: ParsedTeamsMessage): string {
+  const when = message.createdAt ? toDate(message.createdAt) : null;
+  return [when ? when.toLocaleString() : "", message.subject ?? ""]
+    .filter((part) => part.length > 0)
+    .join(" · ");
+}
+
+/**
+ * The uploads a message carries, joined by the filename the asset collector
+ * stamped into its markers — the same key the backend keys parsed uploads by.
+ */
+function messageAssetFiles(
+  message: ParsedTeamsMessage,
+  claim: (name: string) => FileUploadItem | null,
+): FileUploadItem[] {
+  const stamp = /attached as ([^\]]+)\]/g;
+  const files: FileUploadItem[] = [];
+  for (const source of [message.text, ...message.markers]) {
+    for (const match of source.matchAll(stamp)) {
+      const file = claim(match[1].trim());
+      if (file) files.push(file);
+    }
+  }
+  return files;
+}
+
+/** Reads as a conversation; Graph hands chat messages back newest first. */
+function oldestFirst(
+  messages: readonly ParsedTeamsMessage[],
+): ParsedTeamsMessage[] {
+  return [...messages].sort((a, b) => createdAtMs(a) - createdAtMs(b));
+}
+
+function dateRange(messages: readonly ParsedTeamsMessage[]): string {
+  const days = messages
+    .map((message) => createdAtMs(message))
+    .filter((ms) => ms > 0)
+    .sort((a, b) => a - b);
+  const oldest = days.at(0);
+  const newest = days.at(-1);
+  if (oldest === undefined || newest === undefined) return "";
+  const from = formatDay(oldest);
+  const to = formatDay(newest);
+  return from === to ? from : `${from} – ${to}`;
+}
+
+function formatDay(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function createdAtMs(message: ParsedTeamsMessage): number {
+  const date = message.createdAt ? toDate(message.createdAt) : null;
+  return date ? date.getTime() : 0;
+}
+
+function toDate(iso: string): Date | null {
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}


### PR DESCRIPTION
Renders an attached Teams transcript as one card per picked chat or channel — per-message rows for hand-picked messages, a summary row for a whole conversation — with its uploaded images and files joined to their message by filename. Falls back to the composer's flat chips whenever the sections aren't available.

https://linear.app/erato-labs/issue/ERMAIN-581