### PR TITLE
fix: keep table cells and fenced code intact in html-to-text

### DIFF
--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -289,6 +289,7 @@ export {
   htmlToPlainText,
   transformEmailFencesForCopy,
 } from "@/utils/emailClipboard";
+export { mapOutsideCodeFences } from "@/utils/codeFences";
 export { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 export {
   extractTextFromContent,

--- a/frontend/src/utils/codeFences.ts
+++ b/frontend/src/utils/codeFences.ts
@@ -1,0 +1,29 @@
+/**
+ * A fenced block: an opening run of at least three backticks or tildes at the
+ * start of a line, through the next line that holds nothing but the same run.
+ * An unterminated opener matches nothing and stays ordinary text.
+ */
+const CODE_FENCE_BLOCK =
+  /^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm;
+
+/**
+ * Applies `transform` to everything outside fenced code blocks and passes the
+ * fences through unchanged.
+ *
+ * Inside a fence, whitespace is content: indentation and blank lines carry the
+ * meaning of Python, YAML or a diff. The collapsing that prose needs — trimming
+ * line-leading whitespace, folding blank runs — silently breaks such a block
+ * while the fence around it still makes the result look intact.
+ */
+export function mapOutsideCodeFences(
+  text: string,
+  transform: (segment: string) => string,
+): string {
+  let result = "";
+  let index = 0;
+  for (const match of text.matchAll(CODE_FENCE_BLOCK)) {
+    result += transform(text.slice(index, match.index)) + match[0];
+    index = match.index + match[0].length;
+  }
+  return result + transform(text.slice(index));
+}

--- a/frontend/src/utils/emailClipboard.test.ts
+++ b/frontend/src/utils/emailClipboard.test.ts
@@ -62,6 +62,28 @@ describe("htmlToPlainText", () => {
   it("collapses excess blank lines from pretty-printed markup", () => {
     expect(htmlToPlainText("<p>A</p>\n\n  <p>B</p>")).toBe("A\n\nB");
   });
+
+  it("separates table cells", () => {
+    expect(
+      htmlToPlainText(
+        "<table><tr><td>Price</td><td>40</td></tr><tr><td>Tax</td><td>5</td></tr></table>",
+      ),
+    ).toBe("Price | 40\n\nTax | 5");
+  });
+
+  it("separates header cells and cells holding block content", () => {
+    expect(
+      htmlToPlainText(
+        "<table>\n  <tr>\n    <th>Item</th>\n    <th>Qty</th>\n  </tr>\n  <tr>\n    <td><p>Bolt</p></td>\n    <td>7</td>\n  </tr>\n</table>",
+      ),
+    ).toBe("Item | Qty\n\nBolt | 7");
+  });
+
+  it("keeps indentation and blank lines inside a code fence", () => {
+    const code =
+      "```\ndef f(x):\n    if x:\n\n        return 1\n    return 0\n```";
+    expect(htmlToPlainText(`<div>${code}</div>`)).toBe(code);
+  });
 });
 
 describe("transformEmailFencesForCopy", () => {

--- a/frontend/src/utils/emailClipboard.ts
+++ b/frontend/src/utils/emailClipboard.ts
@@ -1,3 +1,4 @@
+import { mapOutsideCodeFences } from "./codeFences";
 import { sanitizeHtmlPreview } from "./sanitizeHtmlPreview";
 
 const SKIPPED_TAGS = new Set(["SCRIPT", "STYLE", "TEMPLATE"]);
@@ -36,10 +37,21 @@ const BLOCK_TAGS = new Set([
 ]);
 
 /**
+ * Marks the boundary between two cells of a row while the tree is walked. A
+ * literal " | " cannot be pushed there: markup around the boundary — layout
+ * whitespace, a block element inside the cell — still contributes newlines that
+ * would tear the row apart again, so the separator is resolved only once the
+ * whole text is assembled. The parser turns any NUL in the source into U+FFFD,
+ * so the marker cannot collide with document text.
+ */
+const CELL_BREAK = "\u0000";
+const CELL_BREAK_RUN = new RegExp(`[ \\t\\n]*${CELL_BREAK}[ \\t\\n]*`, "g");
+
+/**
  * Converts an HTML fragment to readable plain text. Unlike bare
  * `textContent` (which fuses `<p>Hi</p><p>Bye</p>` into "HiBye"), this emits
- * newlines at `<br>` and block-element boundaries and skips style/script
- * content.
+ * newlines at `<br>` and block-element boundaries, separates table cells and
+ * skips style/script content.
  */
 export function htmlToPlainText(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
@@ -60,6 +72,13 @@ export function htmlToPlainText(html: string): string {
       parts.push("\n");
       return;
     }
+    if (tag === "TD" || tag === "TH") {
+      if (isCell((node as Element).previousElementSibling)) {
+        parts.push(CELL_BREAK);
+      }
+      node.childNodes.forEach(visit);
+      return;
+    }
     const isBlock = BLOCK_TAGS.has(tag);
     if (isBlock) {
       parts.push("\n");
@@ -70,11 +89,14 @@ export function htmlToPlainText(html: string): string {
     }
   };
   doc.body.childNodes.forEach(visit);
-  return parts
-    .join("")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  const text = parts.join("").replace(CELL_BREAK_RUN, " | ");
+  return mapOutsideCodeFences(text, (segment) =>
+    segment.replace(/[ \t]*\n[ \t]*/g, "\n").replace(/\n{3,}/g, "\n\n"),
+  ).trim();
+}
+
+function isCell(element: Element | null): boolean {
+  return element?.tagName === "TD" || element?.tagName === "TH";
 }
 
 const EMAIL_FENCE_RE =

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -500,7 +500,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-C8aScySda7KlXmVWTXx7uNTdA1HdCp3tzs690FRtUzHvTvBk3MDWsmhuPZi73jo/pfHgzTv8KWYKLqTcFNY82g==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-iKVR4BxVJIlteD8Gg2S64twXNKtsadZ+TxZhZLqy/kUzQz8UxkWcrD1wlbMbVSz5TSOcdw9ws49qlITIBpxgTA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -140,6 +140,10 @@ vi.mock("@erato/frontend/library", () => ({
   FILE_PREVIEW_STYLES: { progress: { container: "", bar: "" } },
   useFileUploadStore: { getState: () => hooks.uploadStore },
   useFeatureConfig: () => ({ upload: { maxSizeBytes: 10 * 1024 * 1024 } }),
+  mapOutsideCodeFences: (
+    text: string,
+    transform: (segment: string) => string,
+  ) => transform(text),
   // Tag-stripping stand-in; the real block handling has its own unit tests.
   htmlToPlainText: (html: string) => {
     let text = html;

--- a/office-addin/src/teams/utils/__tests__/teamsMessageText.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsMessageText.test.ts
@@ -39,6 +39,38 @@ describe("teamsMessageBodyToText", () => {
     ).toBe("see\n\n```\nnpm run test\n```");
   });
 
+  it("keeps indentation and blank lines inside a fenced code block", () => {
+    const code = "def f(x):\n    if x:\n\n        return 1\n    return 0";
+    expect(teamsMessageBodyToText(html(`<codeblock>${code}</codeblock>`))).toBe(
+      `\`\`\`\n${code}\n\`\`\``,
+    );
+  });
+
+  it("keeps the indentation of a code block's first line", () => {
+    expect(
+      teamsMessageBodyToText(
+        html("<pre>\n    steps:\n      - run: build\n</pre>"),
+      ),
+    ).toBe("```\n    steps:\n      - run: build\n```");
+  });
+
+  it("keeps a blank-line run inside a fence in a text body", () => {
+    const code = "```\nheader = 1\n\n\nfooter = 2\n```";
+    expect(teamsMessageBodyToText({ contentType: "text", content: code })).toBe(
+      code,
+    );
+  });
+
+  it("keeps table cells apart", () => {
+    expect(
+      teamsMessageBodyToText(
+        html(
+          "<table><tr><th>Item</th><th>Price</th></tr><tr><td>Bolt</td><td>40</td></tr></table>",
+        ),
+      ),
+    ).toBe("Item | Price\n\nBolt | 40");
+  });
+
   it("backticks inline code", () => {
     expect(teamsMessageBodyToText(html("<p>run <code>ls</code> now</p>"))).toBe(
       "run `ls` now",

--- a/office-addin/src/teams/utils/teamsMessageText.ts
+++ b/office-addin/src/teams/utils/teamsMessageText.ts
@@ -10,7 +10,7 @@
  * and blank-line collapsing. The result is a string that never becomes DOM.
  */
 
-import { htmlToPlainText } from "@erato/frontend/library";
+import { htmlToPlainText, mapOutsideCodeFences } from "@erato/frontend/library";
 
 import type {
   GraphChatMessageAttachment,
@@ -109,7 +109,12 @@ function rewriteTeamsElements(
     element.replaceWith(pre);
   }
   for (const element of Array.from(root.querySelectorAll("pre"))) {
-    element.textContent = `\n\`\`\`\n${(element.textContent ?? "").trim()}\n\`\`\`\n`;
+    // Blank edges only: a trim would take the indentation of the first line
+    // with it whenever the whole block is indented.
+    const code = (element.textContent ?? "")
+      .replace(/^(?:[ \t]*\n)+/, "")
+      .replace(/\s+$/, "");
+    element.textContent = `\n\`\`\`\n${code}\n\`\`\`\n`;
   }
   replaceWithText(
     root,
@@ -173,9 +178,7 @@ function unwrapSafeLink(href: string): string {
 }
 
 function normalizeText(text: string): string {
-  return text
-    .replace(/\r\n?/g, "\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  return mapOutsideCodeFences(text.replace(/\r\n?/g, "\n"), (segment) =>
+    segment.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n"),
+  ).trim();
 }


### PR DESCRIPTION
htmlToPlainText fused adjacent table cells ("<td>Price</td><td>40</td>" reached the model as "Price40") and its whitespace normalisation stripped indentation and blank lines inside code fences, so pasted Python or YAML arrived semantically broken while the fence made it look fine. Cells now get a " | " separator and fenced regions are exempt from normalisation, in the shared converter so every caller benefits.

https://linear.app/erato-labs/issue/ERMAIN-587