### PR TITLE
Cite Teams transcript messages by ordinal

### DIFF
--- a/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
@@ -69,7 +69,7 @@ const attached: TeamsAttachedTranscript = {
           createdAt: "2026-03-01T08:00:00Z",
           editedAt: null,
           subject: null,
-          text: "Screenshot [image: attached as teams-img-abc.png]",
+          text: "Screenshot [image: teams-img-abc.png]",
           markers: [],
           sharedFiles: [],
           imageUrls: [],

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -1264,7 +1264,7 @@ describe("TeamsChatPickerDialog", () => {
     expect(transcript.name).toBe("teams-Product_sync.md");
     expect(image.name).toMatch(/^teams-img-[0-9a-f]{16}\.png$/);
     await expect(transcript.text()).resolves.toContain(
-      `[image: attached as ${image.name}]`,
+      `[image: ${image.name}]`,
     );
   });
 

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -85,6 +85,19 @@ const exportedAt = new Date("2026-08-10T14:03:00Z");
 const render = (sections: TeamsTranscriptSection[]) =>
   buildTeamsTranscriptMarkdown({ sections, exportedAt, timeZone: "UTC" }) ?? "";
 
+const ordinalsOf = (markdown: string): number[] =>
+  [...markdown.matchAll(/^\[(\d+)\] /gm)].map((match) => Number(match[1]));
+
+/** What the model reads carries no way to address a message but its ordinal. */
+function expectNoIdentifiers(markdown: string, messageIds: string[]): void {
+  expect(markdown).not.toContain("teams.microsoft.com");
+  expect(markdown).not.toContain(MOCK_CHAT_ID);
+  expect(markdown).not.toContain(encodeURIComponent(MOCK_CHAT_ID));
+  for (const messageId of messageIds) {
+    expect(markdown).not.toContain(messageId);
+  }
+}
+
 describe("buildTeamsTranscriptFile", () => {
   it("builds a slugged markdown file", async () => {
     const file = buildTeamsTranscriptFile({
@@ -144,32 +157,57 @@ describe("buildTeamsTranscriptMarkdown", () => {
     );
   });
 
-  it("emits the chat-invariant link base once for a whole-chat ingest", () => {
+  it("cites messages by ordinal in a whole-chat ingest, never by id or link", () => {
     const markdown = render([
       section({
-        messages: [message({ messageId: "a" }), message({ messageId: "b" })],
+        messages: [
+          message({ messageId: "1754983230123" }),
+          message({ messageId: "1754983321123" }),
+        ],
       }),
     ]);
-    expect(markdown).toContain(
-      "Message links: https://teams.microsoft.com/l/message/19%3Aabc123%40thread.v2/{id}" +
-        "?context=%7B%22contextType%22%3A%22chat%22%7D",
-    );
-    expect(markdown).toContain("· id a");
-    expect(markdown).toContain("· id b");
-    // The encoded chat id repeated per message is the transcript's biggest
-    // avoidable token cost.
-    expect(markdown.match(/19%3Aabc123%40thread\.v2/g)).toHaveLength(1);
+    expect(markdown).toContain("[1] Ada Lovelace (09:14):");
+    expect(markdown).toContain("[2] Ada Lovelace (09:14):");
+    expectNoIdentifiers(markdown, ["1754983230123", "1754983321123"]);
   });
 
-  it("emits a full deep link per explicitly selected message", () => {
+  it("cites hand-picked messages by ordinal, never by deep link", () => {
     const markdown = render([
       section({
         selection: "messages",
-        messages: [message({ messageId: "z" })],
+        messages: [message({ messageId: "1754983230123" })],
       }),
     ]);
-    expect(markdown).toContain(buildTeamsMessageDeepLink(MOCK_CHAT_ID, "z"));
+    expect(markdown).toContain("[1] Ada Lovelace (09:14):");
     expect(markdown).toContain("Included: 1 selected message.");
+    expectNoIdentifiers(markdown, ["1754983230123"]);
+  });
+
+  it("numbers messages contiguously from 1 across every section", () => {
+    const markdown = render([
+      section({
+        messages: [message({ messageId: "b" }), message({ messageId: "a" })],
+      }),
+      section({
+        selection: "messages",
+        chat: { ...chat, chatId: "19:other@thread.v2", title: "Other" },
+        messages: [message({ messageId: "c" })],
+      }),
+    ]);
+    expect(ordinalsOf(markdown)).toEqual([1, 2, 3]);
+  });
+
+  it("assigns the same ordinals when the same input is rendered again", () => {
+    const sections = () => [
+      section({
+        messages: [
+          message({ messageId: "b", createdAt: "2026-03-04T10:00:00Z" }),
+          message({ messageId: "a", createdAt: "2026-03-03T09:14:00Z" }),
+        ],
+      }),
+    ];
+    expect(render(sections())).toBe(render(sections()));
+    expect(ordinalsOf(render(sections()))).toEqual([1, 2]);
   });
 
   it("groups messages under day headings, oldest first", () => {
@@ -199,7 +237,7 @@ describe("buildTeamsTranscriptMarkdown", () => {
     const markdown = render([
       section({ messages: [message({ editedAt: "2026-03-03T09:20:00Z" })] }),
     ]);
-    expect(markdown).toContain("**Ada Lovelace** — 09:14 (edited) ·");
+    expect(markdown).toContain("[1] Ada Lovelace (09:14, edited):");
   });
 
   it("carries a chat message's subject in its heading", () => {
@@ -207,7 +245,7 @@ describe("buildTeamsTranscriptMarkdown", () => {
       section({ messages: [message({ subject: "Thursday sync" })] }),
     ]);
     expect(markdown).toContain(
-      "**Ada Lovelace** — 09:14 · Subject: Thursday sync · id 1741000000000",
+      "[1] Ada Lovelace (09:14, Subject: Thursday sync):",
     );
   });
 
@@ -353,7 +391,7 @@ describe("channel sections", () => {
     );
     expect(markdown).not.toContain("## 10 August 2026");
     // The reply's own day is disclosed inline instead.
-    expect(markdown).toContain("**Ada Lovelace** — 10 August 2026, 10:30");
+    expect(markdown).toContain("[2] Ada Lovelace (10 August 2026, 10:30):");
   });
 
   it("anchors a reply whose root is absent at its own timestamp", () => {
@@ -389,24 +427,24 @@ describe("channel sections", () => {
     expect(render([channelSection([message()])])).not.toContain("Viewer:");
   });
 
-  it("links a picked channel message by Graph's own url", () => {
-    const webUrl =
-      "https://teams.microsoft.com/l/message/19%3Achan%40thread.tacv2/1741000000000" +
-      "?tenantId=t1&groupId=g1&parentMessageId=1741000000000";
+  it("cites a picked channel message by ordinal, dropping Graph's own url", () => {
     const markdown = render([
       channelSection(
         [
           message({
             chatId: "team-1/chan-1",
-            deepLink: webUrl,
+            messageId: "1741000000000",
+            deepLink:
+              "https://teams.microsoft.com/l/message/19%3Achan%40thread.tacv2/1741000000000" +
+              "?tenantId=t1&groupId=g1&parentMessageId=1741000000000",
           }),
         ],
         { selection: "messages", limit: undefined },
       ),
     ]);
-    expect(markdown).toContain(`· ${webUrl}`);
-    // The team/channel pair is not a chat id, so nothing may address it as one.
-    expect(markdown).not.toContain("team-1%2Fchan-1");
+    expect(markdown).toContain("[1] Ada Lovelace (09:14):");
+    expectNoIdentifiers(markdown, ["1741000000000"]);
+    expect(markdown).not.toContain("team-1");
   });
 
   it("carries a channel post's subject and leaves its subjectless replies bare", () => {
@@ -427,17 +465,18 @@ describe("channel sections", () => {
       ]),
     ]);
     expect(markdown).toContain(
-      "**Ada Lovelace** — 09:00 · Subject: Release checklist · id root-a",
+      "[1] Ada Lovelace (09:00, Subject: Release checklist):",
     );
-    expect(markdown).toContain("**Ada Lovelace** — 09:05 · id reply-a1");
+    expect(markdown).toContain("[2] Ada Lovelace (09:05):");
     expect(markdown.match(/Subject:/g)).toHaveLength(1);
   });
 
-  it("says the ids are not links when the whole channel is ingested", () => {
-    const markdown = render([channelSection([message({ messageId: "a" })])]);
-    expect(markdown).toContain(
-      "Message links: not reconstructible for a whole channel — each message shows its Teams message id instead.",
-    );
-    expect(markdown).toContain("· id a");
+  it("shows no id and no link when the whole channel is ingested", () => {
+    const markdown = render([
+      channelSection([message({ messageId: "1741000000000" })]),
+    ]);
+    expect(markdown).toContain("[1] Ada Lovelace (09:14):");
+    expect(markdown).not.toContain("Message links");
+    expectNoIdentifiers(markdown, ["1741000000000"]);
   });
 });

--- a/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
+++ b/office-addin/src/teams/utils/__tests__/collectTeamsTranscript.test.ts
@@ -342,9 +342,7 @@ describe("collectTeamsTranscript", () => {
     expect(result.assetFiles).toHaveLength(1);
     const name = result.assetFiles[0].name;
     expect(name).toMatch(/^teams-img-[0-9a-f]{16}\.png$/);
-    expect(result.sections[0].messages[0].text).toContain(
-      `[image: attached as ${name}]`,
-    );
+    expect(result.sections[0].messages[0].text).toContain(`[image: ${name}]`);
     // The denominator grows by the image fetch once its count is known.
     expect(Math.max(...totals)).toBe(Math.min(...totals) + 1);
   });
@@ -404,7 +402,7 @@ describe("collectTeamsTranscript", () => {
     const name = result.assetFiles[0].name;
     expect(name).toMatch(/^teams-file-[0-9a-f]{8}-Q3_Plan\.docx$/);
     expect(result.sections[0].messages[0].markers).toEqual([
-      `[attachment: Q3 Plan.docx — attached as ${name}]`,
+      `[attachment: ${name}]`,
     ]);
   });
 

--- a/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
@@ -271,10 +271,8 @@ describe("buildTeamsAttachmentGroups", () => {
               message({
                 messageId: "m1",
                 createdAt: "2026-03-01T08:00:00Z",
-                text: "Here it is [image: attached as teams-img-abc.png]",
-                markers: [
-                  "[attachment: report.pdf — attached as teams-file-abc-report.pdf]",
-                ],
+                text: "Here it is [image: teams-img-abc.png]",
+                markers: ["[attachment: teams-file-abc-report.pdf]"],
               }),
               message({ messageId: "m2", createdAt: "2026-03-02T08:00:00Z" }),
             ],
@@ -298,6 +296,26 @@ describe("buildTeamsAttachmentGroups", () => {
     ]);
   });
 
+  it("ignores a bare marker that happens to name one of the user's own files", () => {
+    const own = upload("report.pdf", "upload-own");
+    const preview = buildTeamsAttachmentGroups(
+      {
+        fileName: TRANSCRIPT.filename,
+        sections: [
+          chatSection({
+            selection: "messages",
+            // Never fetched, so the marker still carries the Teams-side name.
+            messages: [message({ markers: ["[attachment: report.pdf]"] })],
+          }),
+        ],
+      },
+      [TRANSCRIPT, own],
+    );
+
+    expect(threadRows(preview!.groups[0])[0].attachments).toEqual([]);
+    expect([...preview!.claimedFileIds]).toEqual([TRANSCRIPT.id]);
+  });
+
   it("lists a whole conversation's uploads beside its summary row", () => {
     const image = upload("teams-img-abc.png", "upload-image");
     const preview = buildTeamsAttachmentGroups(
@@ -307,12 +325,12 @@ describe("buildTeamsAttachmentGroups", () => {
           chatSection({
             messages: [
               message({
-                text: "Screenshot [image: attached as teams-img-abc.png]",
+                text: "Screenshot [image: teams-img-abc.png]",
               }),
               // The same asset in a second message must not double up.
               message({
                 messageId: "m2",
-                text: "Again [image: attached as teams-img-abc.png]",
+                text: "Again [image: teams-img-abc.png]",
               }),
             ],
           }),

--- a/office-addin/src/teams/utils/__tests__/teamsDeepLink.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsDeepLink.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
-import {
-  buildTeamsMessageDeepLink,
-  teamsMessageDeepLinkBase,
-  teamsMessageDeepLinkSuffix,
-} from "../teamsDeepLink";
+import { buildTeamsMessageDeepLink } from "../teamsDeepLink";
 
 describe("buildTeamsMessageDeepLink", () => {
   it("builds the byte-exact permalink for a thread chat id", () => {
@@ -25,11 +21,5 @@ describe("buildTeamsMessageDeepLink", () => {
     expect(buildTeamsMessageDeepLink("19:x@thread.v2", "a/b")).toContain(
       "/a%2Fb?",
     );
-  });
-
-  it("splits into a chat-invariant base plus the shared context suffix", () => {
-    expect(
-      `${teamsMessageDeepLinkBase(MOCK_CHAT_ID)}/9${teamsMessageDeepLinkSuffix()}`,
-    ).toBe(buildTeamsMessageDeepLink(MOCK_CHAT_ID, "9"));
   });
 });

--- a/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsTranscriptAssets.test.ts
@@ -57,7 +57,7 @@ describe("stampImageMarkers", () => {
   it("replaces markers by occurrence index and leaves unfetched ones", () => {
     expect(
       stampImageMarkers("a [image] b [image] c", [null, "teams-img-1.png"]),
-    ).toBe("a [image] b [image: attached as teams-img-1.png] c");
+    ).toBe("a [image] b [image: teams-img-1.png] c");
   });
 
   it("returns the text unchanged with nothing to stamp", () => {
@@ -111,7 +111,7 @@ describe("collectTeamsMessageAssets", () => {
     const name = result.files[0].name;
     expect(name).toMatch(/^teams-img-[0-9a-f]{16}\.jpg$/);
     for (const stamped of result.sections[0].messages) {
-      expect(stamped.text).toBe(`[image: attached as ${name}]`);
+      expect(stamped.text).toBe(`[image: ${name}]`);
     }
   });
 
@@ -202,11 +202,13 @@ describe("shared files", () => {
     expect(result.files).toHaveLength(1);
     const name = result.files[0].name;
     expect(name).toMatch(/^teams-file-[0-9a-f]{8}-Q3_Plan\.docx$/);
+    // The uploaded name replaces the Teams-side one: it ends with the same
+    // filename, and the backend joins the parsed upload by it.
     expect(result.sections[0].messages[0].text).toBe(
-      `see [attachment: Q3 Plan.docx — attached as ${name}]`,
+      `see [attachment: ${name}]`,
     );
     expect(result.sections[0].messages[1].markers).toEqual([
-      `[attachment: notes.pdf — attached as ${name}]`,
+      `[attachment: ${name}]`,
     ]);
   });
 

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -1,7 +1,12 @@
 /**
  * Turns fetched Teams messages into the single markdown `File` handed to the
- * composer's `onSelectFiles`. Pure and synchronous, so the File shown in the
- * preview is byte-identical to the one uploaded.
+ * composer's `onSelectFiles`. Pure and synchronous, so one call produces both
+ * what is previewed and what is uploaded.
+ *
+ * Only what the model reads goes in: who said what, when, and the message
+ * text. Message ids and Teams permalinks stay out — they exist for rendering
+ * and back-linking, and everything that needs them reads the parsed sections
+ * instead — so each message is cited by the ordinal in its heading.
  *
  * Formatting is fixed English/ISO rather than locale-dependent: the transcript
  * is read by the model, and a deterministic rendering is what makes it
@@ -9,10 +14,6 @@
  */
 
 import { isRestrictedChannel } from "./parsedTeamsChannel";
-import {
-  teamsMessageDeepLinkBase,
-  teamsMessageDeepLinkSuffix,
-} from "./teamsDeepLink";
 
 import type { ParsedTeamsChannel } from "./parsedTeamsChannel";
 import type { ParsedTeamsChat, ParsedTeamsMessage } from "./parsedTeamsChat";
@@ -91,9 +92,12 @@ export function buildTeamsTranscriptMarkdown(
   input: TeamsTranscriptInput,
 ): string | null {
   const timeZone = input.timeZone ?? "UTC";
+  // Ordinals run across the whole transcript, not per section: a selection can
+  // span several conversations, and a citation has to name exactly one message.
+  const ordinals = { next: 1 };
   const rendered = input.sections
     .filter((section) => section.messages.length > 0)
-    .map((section) => renderSection(section, input, timeZone));
+    .map((section) => renderSection(section, input, timeZone, ordinals));
   if (rendered.length === 0) return null;
   return `${rendered.join("\n\n")}\n`;
 }
@@ -102,6 +106,7 @@ function renderSection(
   section: TeamsTranscriptSection,
   input: TeamsTranscriptInput,
   timeZone: string,
+  ordinals: { next: number },
 ): string {
   const lines: string[] = [];
   if (section.kind === "channel") {
@@ -135,25 +140,15 @@ function renderSection(
     `Exported: ${formatDateTime(input.exportedAt ?? new Date(), timeZone)}`,
   );
   lines.push(includedLine(section, timeZone));
-  // A whole conversation repeats the link on every message, so a chat emits the
-  // invariant prefix once and bare ids after it. A channel permalink carries
-  // groupId, tenantId and parentMessageId, none of which factor out that way —
-  // so a whole channel keeps the ids and says they are not links.
-  const idOnly = section.selection === "whole-chat";
-  if (idOnly) {
-    lines.push(
-      section.kind === "chat"
-        ? `Message links: ${teamsMessageDeepLinkBase(section.chat.chatId)}/{id}${teamsMessageDeepLinkSuffix()} — substitute the id shown on each message.`
-        : "Message links: not reconstructible for a whole channel — each message shows its Teams message id instead.",
-    );
-  }
 
   let currentDay: string | null = null;
   const pushMessage = (
     message: ParsedTeamsMessage,
     dateLabel: string | null,
   ) => {
-    lines.push("", renderMessageHeading(message, idOnly, timeZone, dateLabel));
+    const ordinal = ordinals.next;
+    ordinals.next += 1;
+    lines.push("", renderMessageHeading(message, ordinal, timeZone, dateLabel));
     if (message.text.length > 0) lines.push(message.text);
     for (const marker of message.markers) lines.push(marker);
   };
@@ -232,24 +227,27 @@ function byCreatedAsc(a: ParsedTeamsMessage, b: ParsedTeamsMessage): number {
   return createdAtMs(a) - createdAtMs(b);
 }
 
+/**
+ * `[7] Ada Lovelace (09:14, edited):` — the ordinal is the message's whole
+ * address, so everything else in the parentheses is what a reader of the
+ * conversation would ask for. Only the time is always there: the day comes
+ * from the heading above, except for a channel reply that landed on a later
+ * day than its thread.
+ */
 function renderMessageHeading(
   message: ParsedTeamsMessage,
-  idOnly: boolean,
+  ordinal: number,
   timeZone: string,
   dateLabel: string | null,
 ): string {
   const time = formatTime(message.createdAt, timeZone);
-  const edited = message.editedAt ? " (edited)" : "";
-  // The parsed link, never a rebuilt one: a channel message is addressed by
-  // Graph's own `webUrl`, and building one from `chatId` would encode the
-  // team/channel pair as if it were a chat id.
-  const link = idOnly ? `id ${message.messageId}` : message.deepLink;
-  const when = dateLabel ? `${dateLabel}, ${time}` : time;
+  const meta = [dateLabel ? `${dateLabel}, ${time}` : time];
+  if (message.editedAt) meta.push("edited");
   // Most chat messages carry no subject at all, so the label is emitted only
   // when there is one — an empty field on every heading would cost more tokens
   // than the subjects it exists to carry.
-  const subject = message.subject ? ` · Subject: ${message.subject}` : "";
-  return `**${message.senderName}** — ${when}${edited}${subject} · ${link}`;
+  if (message.subject) meta.push(`Subject: ${message.subject}`);
+  return `[${ordinal}] ${message.senderName} (${meta.join(", ")}):`;
 }
 
 function includedLine(

--- a/office-addin/src/teams/utils/teamsAttachmentGroups.ts
+++ b/office-addin/src/teams/utils/teamsAttachmentGroups.ts
@@ -15,6 +15,8 @@
 
 import { plural, t } from "@lingui/core/macro";
 
+import { uploadedAssetNames } from "./teamsTranscriptAssets";
+
 import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
 import type { ParsedTeamsMessage } from "./parsedTeamsChat";
 import type {
@@ -226,13 +228,10 @@ function messageAssetFiles(
   message: ParsedTeamsMessage,
   claim: (name: string) => FileUploadItem | null,
 ): FileUploadItem[] {
-  const stamp = /attached as ([^\]]+)\]/g;
   const files: FileUploadItem[] = [];
-  for (const source of [message.text, ...message.markers]) {
-    for (const match of source.matchAll(stamp)) {
-      const file = claim(match[1].trim());
-      if (file) files.push(file);
-    }
+  for (const name of uploadedAssetNames([message.text, ...message.markers])) {
+    const file = claim(name);
+    if (file) files.push(file);
   }
   return files;
 }

--- a/office-addin/src/teams/utils/teamsDeepLink.ts
+++ b/office-addin/src/teams/utils/teamsDeepLink.ts
@@ -12,17 +12,7 @@ export function buildTeamsMessageDeepLink(
   chatId: string,
   messageId: string,
 ): string {
-  return `${teamsMessageDeepLinkBase(chatId)}/${encodeURIComponent(messageId)}${TEAMS_CHAT_CONTEXT_QUERY}`;
-}
-
-/**
- * The chat-invariant prefix. A transcript emits this once and then only the
- * bare message ids: the encoded chat id repeated per line is pure token cost.
- */
-export function teamsMessageDeepLinkBase(chatId: string): string {
-  return `${TEAMS_MESSAGE_DEEP_LINK_ROOT}/${encodeURIComponent(chatId)}`;
-}
-
-export function teamsMessageDeepLinkSuffix(): string {
-  return TEAMS_CHAT_CONTEXT_QUERY;
+  const chat = encodeURIComponent(chatId);
+  const message = encodeURIComponent(messageId);
+  return `${TEAMS_MESSAGE_DEEP_LINK_ROOT}/${chat}/${message}${TEAMS_CHAT_CONTEXT_QUERY}`;
 }

--- a/office-addin/src/teams/utils/teamsTranscriptAssets.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptAssets.ts
@@ -1,8 +1,10 @@
 /**
  * Turns what selected Teams messages carry — pasted images, shared files —
- * into upload files, and stamps each message's marker with the uploaded name.
+ * into upload files, and rewrites each message's marker to the uploaded name.
  * That name is how the model joins file ↔ message: the backend keys parsed
- * uploads by filename and the marker sits at the exact message position.
+ * uploads by filename and the marker sits at the exact message position. It
+ * replaces the original name rather than joining it, because a marker naming
+ * the file twice costs tokens for a name the uploaded one already ends with.
  *
  * Everything degrades to the bare marker: a failed fetch, a missing file
  * grant or the caps leave `[image]` / `[attachment: …]` exactly as they read
@@ -31,6 +33,18 @@ export const MAX_SHARED_FILE_BYTES = 10 * 1024 * 1024;
 export const MAX_TOTAL_FILE_BYTES = 25 * 1024 * 1024;
 /** Same-conversation fetches serialize on the gate anyway. */
 const ASSET_FETCH_CONCURRENCY = 3;
+
+const IMAGE_UPLOAD_PREFIX = "teams-img-";
+const FILE_UPLOAD_PREFIX = "teams-file-";
+/**
+ * A marker naming an upload minted here. Anchored on those prefixes so the
+ * bare marker of a file that was never fetched — which still carries its
+ * Teams-side name — is not read as an upload.
+ */
+const UPLOADED_ASSET_MARKER = new RegExp(
+  `\\[(?:image|attachment): ((?:${IMAGE_UPLOAD_PREFIX}|${FILE_UPLOAD_PREFIX})[^\\]]+)\\]`,
+  "g",
+);
 
 export type FetchTeamsImage = (
   section: TeamsTranscriptSection,
@@ -92,7 +106,7 @@ export async function collectTeamsMessageAssets(args: {
         if (!file) {
           file = new File(
             [content.bytes],
-            `teams-img-${hash}.${imageExtension(content.contentType)}`,
+            `${IMAGE_UPLOAD_PREFIX}${hash}.${imageExtension(content.contentType)}`,
             { type: content.contentType },
           );
           filesByHash.set(hash, file);
@@ -131,7 +145,7 @@ export async function collectTeamsMessageAssets(args: {
           if (!file) {
             file = new File(
               [result.content.bytes],
-              `teams-file-${hash.slice(0, 8)}-${fileNameSlug(ref.name)}`,
+              `${FILE_UPLOAD_PREFIX}${hash.slice(0, 8)}-${fileNameSlug(ref.name)}`,
               { type: result.content.contentType },
             );
             filesByHash.set(hash, file);
@@ -177,8 +191,22 @@ export function stampImageMarkers(
   return text.replaceAll("[image]", (marker) => {
     const name = names[index] ?? null;
     index += 1;
-    return name ? `[image: attached as ${name}]` : marker;
+    return name ? `[image: ${name}]` : marker;
   });
+}
+
+/**
+ * The uploads a message names, in marker order — how anything downstream of
+ * the transcript joins a file back to the message it rode in on.
+ */
+export function uploadedAssetNames(sources: readonly string[]): string[] {
+  const names: string[] = [];
+  for (const source of sources) {
+    for (const match of source.matchAll(UPLOADED_ASSET_MARKER)) {
+      names.push(match[1]);
+    }
+  }
+  return names;
 }
 
 interface PlannedImage {
@@ -244,7 +272,7 @@ function stampMessageFiles(
 ): ParsedTeamsMessage {
   const stampFor = (ref: TeamsSharedFileRef): string | null => {
     const uploaded = uploadedByUrl.get(ref.contentUrl);
-    if (uploaded) return `[attachment: ${ref.name} — attached as ${uploaded}]`;
+    if (uploaded) return `[attachment: ${uploaded}]`;
     if (tooLargeUrls.has(ref.contentUrl)) {
       return `[attachment: ${ref.name} — too large to attach]`;
     }


### PR DESCRIPTION
Message ids, deep links and the "Message links:" template are gone from the transcript, each message is now headed `[3] Sarah Neumann (09:14):`, and an uploaded attachment is named once instead of twice. Measured with o200k_base: a 200-message whole chat drops 5,964 → 4,282 tokens (-28%) and a 25-message hand-picked selection 2,467 → 592 (-76%).

https://linear.app/erato-labs/issue/ERMAIN-584