### PR TITLE
Index the Teams transcript's identifiers and strip them before the model

### DIFF
--- a/backend/erato/src/services/file_processor/mod.rs
+++ b/backend/erato/src/services/file_processor/mod.rs
@@ -1288,6 +1288,56 @@ fn strip_empty_markdown_table_rows(text: &str) -> String {
     output.join("\n")
 }
 
+/// Names the machine-readable index the Teams add-in appends to a transcript.
+const TRANSCRIPT_INDEX_MARKER: &str = "erato:teams-transcript";
+
+/// Removes that index from the extracted text.
+///
+/// It carries message ids, deep links and the file-to-message join: rendering
+/// data that costs tokens and tells a model nothing. It travels inside the
+/// transcript so the two share one lifetime, and this is where the two part
+/// ways — every consumer of a file's text reaches it through `parse_file`.
+///
+/// The span is bounded by the comment delimiters when they survived extraction
+/// and by the line otherwise, because a markdown renderer may have escaped them
+/// (`\<!--`) or dropped them; anything left on that line is payload either way.
+fn strip_transcript_index(content: &str) -> String {
+    if !content.contains(TRANSCRIPT_INDEX_MARKER) {
+        return content.to_string();
+    }
+
+    let mut kept = String::with_capacity(content.len());
+    let mut rest = content;
+    while let Some(found) = rest.find(TRANSCRIPT_INDEX_MARKER) {
+        let line_start = rest[..found].rfind('\n').map_or(0, |index| index + 1);
+        let mut start = rest[line_start..found]
+            .rfind("<!--")
+            .map_or(line_start, |index| line_start + index);
+        // A markdown renderer escapes the delimiters rather than emitting them.
+        if rest[..start].ends_with('\\') {
+            start -= 1;
+        }
+        let line_end = rest[found..]
+            .find('\n')
+            .map_or(rest.len(), |index| found + index);
+        let end = ["-->", "--\\>"]
+            .iter()
+            .filter_map(|terminator| {
+                rest[found..]
+                    .find(terminator)
+                    .map(|index| found + index + terminator.len())
+            })
+            .min()
+            .unwrap_or(line_end);
+        kept.push_str(&rest[..start]);
+        rest = &rest[end..];
+    }
+    kept.push_str(rest);
+    // The index is the last thing in the file, so removing it leaves the blank
+    // line that separated it from the prose.
+    kept.trim_end().to_string()
+}
+
 fn append_email_plain_text_if_missing(content: &mut String, plain_text: Option<String>) {
     let Some(plain_text) = plain_text else {
         return;
@@ -1830,6 +1880,8 @@ impl FileProcessor for XbergProcessor {
                         "Email final cleanup stats"
                     );
                 }
+
+                content = strip_transcript_index(&content);
 
                 let total_elapsed = total_timer.finish();
                 tracing::debug!(
@@ -3014,5 +3066,97 @@ Content-Type: text/html; charset=utf-8
             !extracted.contains("R0lGODlhAQABA"),
             "pasted base64 blob leaked:\n{extracted}"
         );
+    }
+
+    /// The prose half of a Teams transcript, as the add-in writes it.
+    const TRANSCRIPT_PROSE: &str = "# Teams chat: Product sync\n\
+        Participants: Ada Lovelace, Grace Hopper\n\
+        Exported: 10 August 2026 14:03 (UTC)\n\
+        Included: all 2 messages, 3 March 2026.\n\
+        \n\
+        ## 3 March 2026\n\
+        \n\
+        [1] Ada Lovelace (09:14):\n\
+        Can we move the sync to Thursday?\n\
+        \n\
+        [2] Grace Hopper (09:16):\n\
+        Thursday works.\n";
+
+    /// The index block, carrying exactly what the prose refuses to show.
+    const TRANSCRIPT_INDEX_BLOCK: &str = "<!-- erato:teams-transcript v1 \
+        {\"version\":1,\"exportedAt\":\"2026-08-10T14:03:00.000Z\",\"timeZone\":\"UTC\",\
+        \"sections\":[{\"kind\":\"chat\",\"ref\":{\"kind\":\"chat\",\
+        \"chatId\":\"19:abc123@thread.v2\"},\"title\":\"Product sync\"}],\
+        \"messages\":[{\"ordinal\":1,\"section\":0,\"ref\":{\"conversation\":{\"kind\":\"chat\",\
+        \"chatId\":\"19:abc123@thread.v2\"},\"messageId\":\"1754983230123\",\
+        \"parentMessageId\":null},\"sender\":\"Ada Lovelace\",\
+        \"deepLink\":\"https://teams.microsoft.com/l/message/19%3Aabc123%40thread.v2/1754983230123\",\
+        \"text\":\"Can we move the sync to Thursday?\",\"assets\":[]}]} -->";
+
+    #[tokio::test]
+    async fn test_xberg_strips_teams_transcript_index_block() {
+        // Non-negotiable: the index exists for the UI, and a single path that lets it through
+        // silently spends the prose's whole token diet on rendering data.
+        let transcript = format!("{TRANSCRIPT_PROSE}\n{TRANSCRIPT_INDEX_BLOCK}\n");
+        let processor = XbergProcessor;
+        let extracted = processor
+            .parse_file(transcript.into_bytes(), Some("text/plain"))
+            .await
+            .expect("transcript should extract");
+
+        assert!(
+            !extracted.contains("erato:teams-transcript"),
+            "index marker survived extraction:\n{extracted}"
+        );
+        assert!(
+            !extracted.contains("1754983230123"),
+            "message id survived extraction:\n{extracted}"
+        );
+        assert!(
+            !extracted.contains("19:abc123@thread.v2"),
+            "chat id survived extraction:\n{extracted}"
+        );
+        assert!(
+            !extracted.contains("teams.microsoft.com"),
+            "deep link survived extraction:\n{extracted}"
+        );
+        assert!(
+            extracted.contains("[1] Ada Lovelace (09:14):")
+                && extracted.contains("Thursday works."),
+            "conversation lost with the index:\n{extracted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_xberg_leaves_transcript_prose_unchanged_by_the_index() {
+        // The block must be invisible to the model in the strong sense: a transcript with one
+        // extracts to what the same transcript without one does.
+        let processor = XbergProcessor;
+        let with_index = processor
+            .parse_file(
+                format!("{TRANSCRIPT_PROSE}\n{TRANSCRIPT_INDEX_BLOCK}\n").into_bytes(),
+                Some("text/plain"),
+            )
+            .await
+            .expect("transcript with index should extract");
+        let without_index = processor
+            .parse_file(TRANSCRIPT_PROSE.as_bytes().to_vec(), Some("text/plain"))
+            .await
+            .expect("transcript without index should extract");
+
+        assert_eq!(with_index.trim(), without_index.trim());
+    }
+
+    #[test]
+    fn strip_transcript_index_handles_escaped_delimiters_and_leaves_other_text() {
+        let escaped = "prose\n\n\\<!-- erato:teams-transcript v1 {\"version\":1} --\\>\n";
+        assert_eq!(strip_transcript_index(escaped), "prose");
+
+        // A comment that never opened: the line it sits on is still all payload.
+        let bare = "prose\n\nerato:teams-transcript v1 {\"version\":1}\n";
+        assert_eq!(strip_transcript_index(bare), "prose");
+
+        let untouched = "prose with <!-- an ordinary comment --> in it\n";
+        assert_eq!(strip_transcript_index(untouched), untouched);
     }
 }

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
 import {
+  buildTeamsTranscriptDocument,
   buildTeamsTranscriptFile,
   buildTeamsTranscriptMarkdown,
 } from "../buildTeamsTranscriptFile";
 import { buildTeamsMessageDeepLink } from "../teamsDeepLink";
+import { parseTeamsTranscriptIndex } from "../teamsTranscriptIndex";
 
 import type { TeamsTranscriptSection } from "../buildTeamsTranscriptFile";
 import type { ParsedTeamsChannel } from "../parsedTeamsChannel";
@@ -88,13 +90,18 @@ const render = (sections: TeamsTranscriptSection[]) =>
 const ordinalsOf = (markdown: string): number[] =>
   [...markdown.matchAll(/^\[(\d+)\] /gm)].map((match) => Number(match[1]));
 
+/** The transcript minus its index block — what the backend leaves for the model. */
+const proseOf = (markdown: string): string =>
+  markdown.slice(0, markdown.lastIndexOf("<!--"));
+
 /** What the model reads carries no way to address a message but its ordinal. */
 function expectNoIdentifiers(markdown: string, messageIds: string[]): void {
-  expect(markdown).not.toContain("teams.microsoft.com");
-  expect(markdown).not.toContain(MOCK_CHAT_ID);
-  expect(markdown).not.toContain(encodeURIComponent(MOCK_CHAT_ID));
+  const prose = proseOf(markdown);
+  expect(prose).not.toContain("teams.microsoft.com");
+  expect(prose).not.toContain(MOCK_CHAT_ID);
+  expect(prose).not.toContain(encodeURIComponent(MOCK_CHAT_ID));
   for (const messageId of messageIds) {
-    expect(markdown).not.toContain(messageId);
+    expect(prose).not.toContain(messageId);
   }
 }
 
@@ -316,6 +323,186 @@ describe("buildTeamsTranscriptMarkdown", () => {
   });
 });
 
+describe("transcript index block", () => {
+  const build = (sections: TeamsTranscriptSection[]) => {
+    const document = buildTeamsTranscriptDocument({
+      sections,
+      exportedAt,
+      timeZone: "UTC",
+    });
+    if (!document) throw new Error("expected a transcript");
+    return document;
+  };
+
+  it("recovers the index it serialized", () => {
+    const { markdown, index } = build([
+      section({
+        messages: [
+          message({ messageId: "b", createdAt: "2026-03-04T10:00:00Z" }),
+          message({ messageId: "a", subject: "Thursday sync" }),
+        ],
+      }),
+      channelSection([message({ messageId: "c", chatId: "team-1/chan-1" })], {
+        selection: "messages",
+        limit: undefined,
+        skippedCount: 1,
+      }),
+    ]);
+    expect(parseTeamsTranscriptIndex(markdown)).toEqual(index);
+  });
+
+  it("sits at the end of the file, on one line", () => {
+    const { markdown } = build([section()]);
+    const block = markdown.slice(markdown.lastIndexOf("<!--")).trimEnd();
+    expect(block.startsWith("<!-- erato:teams-transcript v1 ")).toBe(true);
+    expect(block.endsWith("-->")).toBe(true);
+    expect(block).not.toContain("\n");
+  });
+
+  it("carries the identifiers the prose drops", () => {
+    const { index } = build([
+      section({
+        messages: [message({ messageId: "1754983230123" })],
+      }),
+    ]);
+    expect(index.sections[0].ref).toEqual({
+      kind: "chat",
+      chatId: MOCK_CHAT_ID,
+    });
+    expect(index.messages[0].ref).toEqual({
+      conversation: { kind: "chat", chatId: MOCK_CHAT_ID },
+      messageId: "1754983230123",
+      parentMessageId: null,
+    });
+    expect(index.messages[0].deepLink).toContain("teams.microsoft.com");
+  });
+
+  it("addresses a channel reply by team, channel and its root", () => {
+    const { index } = build([
+      channelSection([
+        message({ messageId: "root-a", createdAt: "2026-08-01T09:00:00Z" }),
+        message({
+          messageId: "reply-a1",
+          createdAt: "2026-08-01T09:05:00Z",
+          replyToId: "root-a",
+        }),
+      ]),
+    ]);
+    expect(index.messages[1].ref).toEqual({
+      conversation: { kind: "channel", teamId: "team-1", channelId: "chan-1" },
+      messageId: "reply-a1",
+      parentMessageId: "root-a",
+    });
+  });
+
+  it("numbers the index entries as the prose cites them", () => {
+    const { markdown, index } = build([
+      channelSection([
+        message({
+          messageId: "root-new",
+          createdAt: "2026-08-09T08:00:00Z",
+          text: "newer opener",
+        }),
+        message({
+          messageId: "root-old",
+          createdAt: "2026-08-01T09:00:00Z",
+          text: "older opener",
+        }),
+      ]),
+    ]);
+    // Threads are rendered oldest-opener-first, so the index must agree.
+    expect(index.messages.map((entry) => entry.ordinal)).toEqual([1, 2]);
+    expect(index.messages.map((entry) => entry.text)).toEqual([
+      "older opener",
+      "newer opener",
+    ]);
+    expect(ordinalsOf(proseOf(markdown))).toEqual([1, 2]);
+  });
+
+  it("names the uploads a message carries", () => {
+    const { index } = build([
+      section({
+        messages: [
+          message({
+            text: "see [image: teams-img-0123456789abcdef.png]",
+            markers: ["[attachment: teams-file-0123abcd-agenda.docx]"],
+          }),
+        ],
+      }),
+    ]);
+    expect(index.messages[0].assets).toEqual([
+      "teams-img-0123456789abcdef.png",
+      "teams-file-0123abcd-agenda.docx",
+    ]);
+    expect(index.messages[0].text).toContain("[attachment: teams-file-");
+  });
+
+  it("describes what each section contributed", () => {
+    const { index } = build([
+      section({
+        truncated: true,
+        messages: [
+          message({ messageId: "b", createdAt: "2026-08-10T08:00:00Z" }),
+          message({ messageId: "a", createdAt: "2026-03-03T09:14:00Z" }),
+        ],
+      }),
+      channelSection([message({ messageId: "c" })]),
+    ]);
+    expect(index.sections[0]).toMatchObject({
+      kind: "chat",
+      title: "Product sync",
+      selection: "whole-chat",
+      limit: 200,
+      truncated: true,
+      skippedCount: 0,
+      window: { from: "2026-03-03T09:14:00Z", to: "2026-08-10T08:00:00Z" },
+      participants: ["Ada Lovelace", "Grace Hopper"],
+      viewer: null,
+    });
+    expect(index.sections[1]).toMatchObject({
+      kind: "channel",
+      title: "Test Channel 1",
+      teamName: "Contoso",
+    });
+    expect(index.messages.map((entry) => entry.section)).toEqual([0, 0, 1]);
+  });
+
+  it("survives a message whose text would close the comment", () => {
+    const text = "cases: a --> b, c --- d, and <!-- not a block -->";
+    const { markdown, index } = build([
+      section({ messages: [message({ text })] }),
+    ]);
+    expect(parseTeamsTranscriptIndex(markdown)).toEqual(index);
+    expect(parseTeamsTranscriptIndex(markdown)?.messages[0].text).toBe(text);
+  });
+
+  it("reads no index out of a file that has none, and never throws", () => {
+    expect(
+      parseTeamsTranscriptIndex("# Teams chat: Product sync\n"),
+    ).toBeNull();
+    expect(parseTeamsTranscriptIndex("")).toBeNull();
+  });
+
+  it("refuses a malformed or unknown-version block", () => {
+    const { markdown } = build([section()]);
+    const payload = markdown.slice(markdown.lastIndexOf("<!--"));
+    expect(
+      parseTeamsTranscriptIndex("<!-- erato:teams-transcript v1 {oops -->"),
+    ).toBeNull();
+    expect(
+      parseTeamsTranscriptIndex('<!-- erato:teams-transcript v1 "text" -->'),
+    ).toBeNull();
+    expect(
+      parseTeamsTranscriptIndex(payload.replace('"version":1', '"version":2')),
+    ).toBeNull();
+    expect(
+      parseTeamsTranscriptIndex(
+        payload.replace('"ordinal":1', '"ordinal":"1"'),
+      ),
+    ).toBeNull();
+  });
+});
+
 describe("channel sections", () => {
   // Wire order: newest root first, each root followed by its replies
   // oldest-first — the flattened shape the channel pager returns.
@@ -444,7 +631,7 @@ describe("channel sections", () => {
     ]);
     expect(markdown).toContain("[1] Ada Lovelace (09:14):");
     expectNoIdentifiers(markdown, ["1741000000000"]);
-    expect(markdown).not.toContain("team-1");
+    expect(proseOf(markdown)).not.toContain("team-1");
   });
 
   it("carries a channel post's subject and leaves its subjectless replies bare", () => {

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -3,10 +3,11 @@
  * composer's `onSelectFiles`. Pure and synchronous, so one call produces both
  * what is previewed and what is uploaded.
  *
- * Only what the model reads goes in: who said what, when, and the message
- * text. Message ids and Teams permalinks stay out — they exist for rendering
- * and back-linking, and everything that needs them reads the parsed sections
- * instead — so each message is cited by the ordinal in its heading.
+ * Only what the model reads goes in the prose: who said what, when, and the
+ * message text. Message ids and Teams permalinks stay out — they exist for
+ * rendering and back-linking — so each message is cited by the ordinal in its
+ * heading, and the identifiers ride in the trailing index block that the
+ * backend strips before the file reaches a model.
  *
  * Formatting is fixed English/ISO rather than locale-dependent: the transcript
  * is read by the model, and a deterministic rendering is what makes it
@@ -14,9 +15,21 @@
  */
 
 import { isRestrictedChannel } from "./parsedTeamsChannel";
+import { channelRef, chatRef, messageRef } from "./teamsConversationRef";
+import { uploadedAssetNames } from "./teamsTranscriptAssets";
+import {
+  TEAMS_TRANSCRIPT_INDEX_VERSION,
+  serializeTeamsTranscriptIndex,
+} from "./teamsTranscriptIndex";
 
 import type { ParsedTeamsChannel } from "./parsedTeamsChannel";
 import type { ParsedTeamsChat, ParsedTeamsMessage } from "./parsedTeamsChat";
+import type { TeamsConversationRef } from "./teamsConversationRef";
+import type {
+  TeamsTranscriptIndex,
+  TeamsTranscriptIndexMessage,
+  TeamsTranscriptIndexSection,
+} from "./teamsTranscriptIndex";
 
 interface TeamsTranscriptSectionBase {
   /**
@@ -88,26 +101,68 @@ export function buildTeamsTranscriptFilename(
   return `teams-${slug}.md`;
 }
 
+export interface TeamsTranscriptDocument {
+  markdown: string;
+  index: TeamsTranscriptIndex;
+}
+
 export function buildTeamsTranscriptMarkdown(
   input: TeamsTranscriptInput,
 ): string | null {
+  return buildTeamsTranscriptDocument(input)?.markdown ?? null;
+}
+
+/**
+ * The prose and the index it ships with, built in one pass so the ordinals the
+ * prose cites and the ones the index records cannot disagree.
+ *
+ * The index goes last so the conversation leads the file — content first and
+ * the question at the end is what measures best — and a trailing block is also
+ * the one position that can be cut without disturbing the prose above it.
+ */
+export function buildTeamsTranscriptDocument(
+  input: TeamsTranscriptInput,
+): TeamsTranscriptDocument | null {
   const timeZone = input.timeZone ?? "UTC";
+  const exportedAt = input.exportedAt ?? new Date();
+  const sections = input.sections.filter(
+    (section) => section.messages.length > 0,
+  );
+  if (sections.length === 0) return null;
+
   // Ordinals run across the whole transcript, not per section: a selection can
   // span several conversations, and a citation has to name exactly one message.
-  const ordinals = { next: 1 };
-  const rendered = input.sections
-    .filter((section) => section.messages.length > 0)
-    .map((section) => renderSection(section, input, timeZone, ordinals));
-  if (rendered.length === 0) return null;
-  return `${rendered.join("\n\n")}\n`;
+  const messages: TeamsTranscriptIndexMessage[] = [];
+  const rendered = sections.map((section, position) =>
+    renderSection(section, { exportedAt, timeZone, position, messages }),
+  );
+  const index: TeamsTranscriptIndex = {
+    version: TEAMS_TRANSCRIPT_INDEX_VERSION,
+    exportedAt: exportedAt.toISOString(),
+    timeZone,
+    sections: sections.map(indexSection),
+    messages,
+  };
+  return {
+    markdown: `${rendered.join("\n\n")}\n\n${serializeTeamsTranscriptIndex(index)}\n`,
+    index,
+  };
+}
+
+interface RenderContext {
+  exportedAt: Date;
+  timeZone: string;
+  /** Position of the section being rendered, as the index records it. */
+  position: number;
+  /** Collected as the prose is written, so ordinals are assigned once. */
+  messages: TeamsTranscriptIndexMessage[];
 }
 
 function renderSection(
   section: TeamsTranscriptSection,
-  input: TeamsTranscriptInput,
-  timeZone: string,
-  ordinals: { next: number },
+  context: RenderContext,
 ): string {
+  const { timeZone } = context;
   const lines: string[] = [];
   if (section.kind === "channel") {
     lines.push(
@@ -136,9 +191,7 @@ function renderSection(
       );
     }
   }
-  lines.push(
-    `Exported: ${formatDateTime(input.exportedAt ?? new Date(), timeZone)}`,
-  );
+  lines.push(`Exported: ${formatDateTime(context.exportedAt, timeZone)}`);
   lines.push(includedLine(section, timeZone));
 
   let currentDay: string | null = null;
@@ -146,8 +199,8 @@ function renderSection(
     message: ParsedTeamsMessage,
     dateLabel: string | null,
   ) => {
-    const ordinal = ordinals.next;
-    ordinals.next += 1;
+    const ordinal = context.messages.length + 1;
+    context.messages.push(indexMessage(message, ordinal, section, context));
     lines.push("", renderMessageHeading(message, ordinal, timeZone, dateLabel));
     if (message.text.length > 0) lines.push(message.text);
     for (const marker of message.markers) lines.push(marker);
@@ -184,6 +237,62 @@ function renderSection(
     pushMessage(message, null);
   }
   return lines.join("\n");
+}
+
+function conversationRefOf(
+  section: TeamsTranscriptSection,
+): TeamsConversationRef {
+  return section.kind === "chat"
+    ? chatRef(section.chat.chatId)
+    : channelRef(section.channel.teamId, section.channel.channelId);
+}
+
+function indexSection(
+  section: TeamsTranscriptSection,
+): TeamsTranscriptIndexSection {
+  return {
+    kind: section.kind,
+    ref: conversationRefOf(section),
+    title: section.kind === "chat" ? section.chat.title : section.channel.name,
+    teamName: section.kind === "chat" ? null : section.channel.teamName,
+    selection: section.selection,
+    limit: section.limit ?? null,
+    truncated: section.truncated ?? false,
+    skippedCount: section.skippedCount ?? 0,
+    window: {
+      from: oldestCreatedAt(section.messages),
+      to: newestCreatedAt(section.messages),
+    },
+    participants: section.kind === "chat" ? section.chat.participants : [],
+    viewer: section.kind === "chat" ? section.chat.selfDisplayName : null,
+  };
+}
+
+function indexMessage(
+  message: ParsedTeamsMessage,
+  ordinal: number,
+  section: TeamsTranscriptSection,
+  context: RenderContext,
+): TeamsTranscriptIndexMessage {
+  const body = [message.text, ...message.markers].filter(
+    (part) => part.length > 0,
+  );
+  return {
+    ordinal,
+    section: context.position,
+    ref: messageRef(
+      conversationRefOf(section),
+      message.messageId,
+      message.replyToId,
+    ),
+    sender: message.senderName,
+    createdAt: message.createdAt,
+    editedAt: message.editedAt,
+    subject: message.subject,
+    deepLink: message.deepLink,
+    text: body.join("\n"),
+    assets: uploadedAssetNames(body),
+  };
 }
 
 /**

--- a/office-addin/src/teams/utils/teamsConversationRef.ts
+++ b/office-addin/src/teams/utils/teamsConversationRef.ts
@@ -19,6 +19,31 @@ export type TeamsConversationRef =
   | TeamsChatConversationRef
   | TeamsChannelConversationRef;
 
+/**
+ * A single message, addressable end to end. One shape, one place: the
+ * transcript index and anything that later resolves a message back to Graph
+ * have to name a message the same way, or the two hold different identities
+ * for the same thing.
+ *
+ * A channel reply is not addressable on its own — Graph only serves it under
+ * its root — so the root travels with the reference instead of being looked up
+ * again at resolve time.
+ */
+export interface TeamsMessageRef {
+  conversation: TeamsConversationRef;
+  messageId: string;
+  /** Root of a channel reply; null for roots and for chat messages. */
+  parentMessageId: string | null;
+}
+
+export function messageRef(
+  conversation: TeamsConversationRef,
+  messageId: string,
+  parentMessageId: string | null = null,
+): TeamsMessageRef {
+  return { conversation, messageId, parentMessageId };
+}
+
 /** Stable identity for grouping, dedupe keys and the per-conversation gate. */
 export function conversationKey(ref: TeamsConversationRef): string {
   return ref.kind === "chat"

--- a/office-addin/src/teams/utils/teamsTranscriptIndex.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptIndex.ts
@@ -1,0 +1,258 @@
+/**
+ * The machine-readable half of a Teams transcript: what the prose leaves out
+ * because the model has no use for it — ids, deep links, the file ↔ message
+ * join — carried in one trailing HTML comment.
+ *
+ * It rides inside the transcript rather than in a side channel so the two
+ * cannot drift apart: one artifact, one lifecycle, one privacy surface, and a
+ * snapshot that still says what it was a snapshot of. The backend strips the
+ * comment out of the extracted text, so nothing here reaches the model.
+ *
+ * An HTML comment rather than front matter: markdown renderers hide it, and it
+ * introduces no bare `---` for the backend's own file wrapper to collide with.
+ *
+ * It is a complete render source on purpose — a reader of the transcript never
+ * has to parse the prose to rebuild the conversation. The message text is
+ * therefore stored twice, which costs bytes in a file the model never reads.
+ */
+
+import type {
+  TeamsConversationRef,
+  TeamsMessageRef,
+} from "./teamsConversationRef";
+
+export const TEAMS_TRANSCRIPT_INDEX_MARKER = "erato:teams-transcript";
+export const TEAMS_TRANSCRIPT_INDEX_VERSION = 1;
+
+/** ISO bounds of what actually landed in a section. */
+export interface TeamsTranscriptIndexWindow {
+  from: string | null;
+  to: string | null;
+}
+
+export interface TeamsTranscriptIndexSection {
+  kind: "chat" | "channel";
+  ref: TeamsConversationRef;
+  /** Chat title, or the channel's own name — `teamName` renders beside it. */
+  title: string;
+  teamName: string | null;
+  selection: "whole-chat" | "messages";
+  /** Requested window of a whole-conversation ingest; null for a pick. */
+  limit: number | null;
+  truncated: boolean;
+  skippedCount: number;
+  window: TeamsTranscriptIndexWindow;
+  participants: string[];
+  /** The signed-in user, as the member roster spells them. */
+  viewer: string | null;
+}
+
+export interface TeamsTranscriptIndexMessage {
+  /** The `[n]` the prose cites this message by. */
+  ordinal: number;
+  /** Position in `sections`. */
+  section: number;
+  ref: TeamsMessageRef;
+  sender: string;
+  createdAt: string | null;
+  editedAt: string | null;
+  subject: string | null;
+  deepLink: string;
+  /** The body as the prose renders it, attachment markers included. */
+  text: string;
+  /** Filenames of the uploads this message carries, in marker order. */
+  assets: string[];
+}
+
+export interface TeamsTranscriptIndex {
+  version: number;
+  exportedAt: string;
+  /** IANA zone the prose rendered its dates in. */
+  timeZone: string;
+  sections: TeamsTranscriptIndexSection[];
+  messages: TeamsTranscriptIndexMessage[];
+}
+
+const INDEX_BLOCK = /<!--\s*erato:teams-transcript\s+v\d+\s+([\s\S]*?)-->/g;
+
+/** The single line appended to the transcript. */
+export function serializeTeamsTranscriptIndex(
+  index: TeamsTranscriptIndex,
+): string {
+  const payload = escapeCommentEnd(JSON.stringify(index));
+  return `<!-- ${TEAMS_TRANSCRIPT_INDEX_MARKER} v${index.version} ${payload} -->`;
+}
+
+/**
+ * Null for anything but an intact block of a version this build understands.
+ * A half-recovered index is worse than none: every reader of it would have to
+ * carry its own story for the parts that are missing.
+ */
+export function parseTeamsTranscriptIndex(
+  fileText: string,
+): TeamsTranscriptIndex | null {
+  const matches = [...fileText.matchAll(INDEX_BLOCK)];
+  const payload = matches.at(-1)?.[1];
+  if (payload === undefined) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload) as unknown;
+  } catch {
+    return null;
+  }
+  return toIndex(parsed);
+}
+
+/**
+ * `-->` inside the payload would end the comment early. Escaping the first `-`
+ * of every pair as a JSON escape keeps the parsed string byte-identical, so
+ * message text survives the round trip untouched.
+ */
+function escapeCommentEnd(json: string): string {
+  return json.replace(/-(?=-)/g, "\\u002d");
+}
+
+function toIndex(value: unknown): TeamsTranscriptIndex | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  if (record.version !== TEAMS_TRANSCRIPT_INDEX_VERSION) return null;
+  const exportedAt = asString(record.exportedAt);
+  const timeZone = asString(record.timeZone);
+  const sections = mapAll(record.sections, toSection);
+  const messages = mapAll(record.messages, toMessage);
+  if (exportedAt === null || timeZone === null) return null;
+  if (sections === null || messages === null) return null;
+  if (messages.some((message) => sections[message.section] === undefined)) {
+    return null;
+  }
+  return {
+    version: TEAMS_TRANSCRIPT_INDEX_VERSION,
+    exportedAt,
+    timeZone,
+    sections,
+    messages,
+  };
+}
+
+function toSection(value: unknown): TeamsTranscriptIndexSection | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const kind = record.kind;
+  const selection = record.selection;
+  if (kind !== "chat" && kind !== "channel") return null;
+  if (selection !== "whole-chat" && selection !== "messages") return null;
+  const ref = toConversationRef(record.ref);
+  const title = asString(record.title);
+  const truncated = asBoolean(record.truncated);
+  const skippedCount = asNumber(record.skippedCount);
+  const window = asRecord(record.window);
+  const participants = mapAll(record.participants, asString);
+  if (ref === null || title === null || window === null) return null;
+  if (truncated === null || skippedCount === null) return null;
+  if (participants === null) return null;
+  return {
+    kind,
+    ref,
+    title,
+    teamName: asString(record.teamName),
+    selection,
+    limit: asNumber(record.limit),
+    truncated,
+    skippedCount,
+    window: {
+      from: asString(window.from),
+      to: asString(window.to),
+    },
+    participants,
+    viewer: asString(record.viewer),
+  };
+}
+
+function toMessage(value: unknown): TeamsTranscriptIndexMessage | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const ordinal = asNumber(record.ordinal);
+  const section = asNumber(record.section);
+  const ref = toMessageRef(record.ref);
+  const sender = asString(record.sender);
+  const deepLink = asString(record.deepLink);
+  const text = asString(record.text);
+  const assets = mapAll(record.assets, asString);
+  if (ordinal === null || section === null || ref === null) return null;
+  if (sender === null || deepLink === null || text === null) return null;
+  if (assets === null) return null;
+  return {
+    ordinal,
+    section,
+    ref,
+    sender,
+    createdAt: asString(record.createdAt),
+    editedAt: asString(record.editedAt),
+    subject: asString(record.subject),
+    deepLink,
+    text,
+    assets,
+  };
+}
+
+function toConversationRef(value: unknown): TeamsConversationRef | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  if (record.kind === "chat") {
+    const chatId = asString(record.chatId);
+    return chatId === null ? null : { kind: "chat", chatId };
+  }
+  if (record.kind === "channel") {
+    const teamId = asString(record.teamId);
+    const channelId = asString(record.channelId);
+    if (teamId === null || channelId === null) return null;
+    return { kind: "channel", teamId, channelId };
+  }
+  return null;
+}
+
+function toMessageRef(value: unknown): TeamsMessageRef | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const conversation = toConversationRef(record.conversation);
+  const messageId = asString(record.messageId);
+  if (conversation === null || messageId === null) return null;
+  return {
+    conversation,
+    messageId,
+    parentMessageId: asString(record.parentMessageId),
+  };
+}
+
+/** All-or-nothing: one unreadable entry invalidates the block. */
+function mapAll<T>(
+  value: unknown,
+  read: (entry: unknown) => T | null,
+): T[] | null {
+  if (!Array.isArray(value)) return null;
+  const mapped: T[] = [];
+  for (const entry of value) {
+    const item = read(entry);
+    if (item === null) return null;
+    mapped.push(item);
+  }
+  return mapped;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}


### PR DESCRIPTION
The add-in appends the ids, deep links and asset joins the prose drops as one trailing `<!-- erato:teams-transcript v1 … -->` comment, with a permissive parser to read it back. The backend removes that comment in `parse_file`, so neither prompt composition nor token estimation ever sees it.

https://linear.app/erato-labs/issue/ERMAIN-586