### PR TITLE
Render the Teams composer preview from the transcript's index block

### DIFF
--- a/backend/erato/src/services/file_processor/mod.rs
+++ b/backend/erato/src/services/file_processor/mod.rs
@@ -1291,6 +1291,15 @@ fn strip_empty_markdown_table_rows(text: &str) -> String {
 /// Names the machine-readable index the Teams add-in appends to a transcript.
 const TRANSCRIPT_INDEX_MARKER: &str = "erato:teams-transcript";
 
+/// Whether text beginning at the marker opens a real index block, i.e. the
+/// marker is followed by the serializer's `v<n>` version token.
+fn starts_index_block(from_marker: &str) -> bool {
+    let mut after = from_marker[TRANSCRIPT_INDEX_MARKER.len()..]
+        .trim_start()
+        .chars();
+    after.next() == Some('v') && after.next().is_some_and(|char| char.is_ascii_digit())
+}
+
 /// Removes that index from the extracted text.
 ///
 /// It carries message ids, deep links and the file-to-message join: rendering
@@ -1298,9 +1307,14 @@ const TRANSCRIPT_INDEX_MARKER: &str = "erato:teams-transcript";
 /// transcript so the two share one lifetime, and this is where the two part
 /// ways — every consumer of a file's text reaches it through `parse_file`.
 ///
-/// The span is bounded by the comment delimiters when they survived extraction
-/// and by the line otherwise, because a markdown renderer may have escaped them
-/// (`\<!--`) or dropped them; anything left on that line is payload either way.
+/// The span never leaves the line the marker sits on. The serializer writes the
+/// block as one line and JSON-escapes its payload, so a legitimate block cannot
+/// span two — while a message that merely names the marker would otherwise
+/// swallow every line up to the real block's terminator at the end of the file.
+///
+/// Within that line the span is bounded by the comment delimiters when they
+/// survived extraction and by the line otherwise, because a markdown renderer
+/// may have escaped them (`\<!--`) or dropped them.
 fn strip_transcript_index(content: &str) -> String {
     if !content.contains(TRANSCRIPT_INDEX_MARKER) {
         return content.to_string();
@@ -1309,6 +1323,18 @@ fn strip_transcript_index(content: &str) -> String {
     let mut kept = String::with_capacity(content.len());
     let mut rest = content;
     while let Some(found) = rest.find(TRANSCRIPT_INDEX_MARKER) {
+        let line_end = rest[found..]
+            .find('\n')
+            .map_or(rest.len(), |index| found + index);
+
+        // Prose that names the marker keeps its line; only the serializer's own
+        // `<marker> v<n>` head identifies a block worth removing.
+        if !starts_index_block(&rest[found..line_end]) {
+            kept.push_str(&rest[..line_end]);
+            rest = &rest[line_end..];
+            continue;
+        }
+
         let line_start = rest[..found].rfind('\n').map_or(0, |index| index + 1);
         let mut start = rest[line_start..found]
             .rfind("<!--")
@@ -1317,13 +1343,10 @@ fn strip_transcript_index(content: &str) -> String {
         if rest[..start].ends_with('\\') {
             start -= 1;
         }
-        let line_end = rest[found..]
-            .find('\n')
-            .map_or(rest.len(), |index| found + index);
         let end = ["-->", "--\\>"]
             .iter()
             .filter_map(|terminator| {
-                rest[found..]
+                rest[found..line_end]
                     .find(terminator)
                     .map(|index| found + index + terminator.len())
             })
@@ -3158,5 +3181,40 @@ Content-Type: text/html; charset=utf-8
 
         let untouched = "prose with <!-- an ordinary comment --> in it\n";
         assert_eq!(strip_transcript_index(untouched), untouched);
+    }
+
+    #[test]
+    fn strip_transcript_index_keeps_prose_that_only_names_the_marker() {
+        // A message discussing the format, followed by a real block. The block's
+        // terminator must not reach backwards and swallow the conversation.
+        let content = concat!(
+            "[1] Ada Lovelace (09:14):\n",
+            "We should name the block erato:teams-transcript I think.\n",
+            "\n",
+            "[2] Grace Hopper (09:16):\n",
+            "Sounds good, ship it.\n",
+            "\n",
+            "<!-- erato:teams-transcript v1 {\"version\":1} -->\n",
+        );
+
+        let stripped = strip_transcript_index(content);
+
+        assert!(stripped.contains("We should name the block"));
+        assert!(stripped.contains("Sounds good, ship it."));
+        assert!(!stripped.contains("{\"version\":1}"));
+        assert_eq!(stripped.matches("[2] Grace Hopper").count(), 1);
+    }
+
+    #[test]
+    fn strip_transcript_index_never_crosses_a_line() {
+        // Marker without a terminator on its own line: only that line goes, even
+        // though a later line closes a comment.
+        let content = "keep me\nerato:teams-transcript v1 {\"version\":1}\nalso keep -->\ntail\n";
+        let stripped = strip_transcript_index(content);
+
+        assert!(stripped.contains("keep me"));
+        assert!(stripped.contains("also keep"));
+        assert!(stripped.contains("tail"));
+        assert!(!stripped.contains("{\"version\":1}"));
     }
 }

--- a/frontend/src/utils/emailClipboard.test.ts
+++ b/frontend/src/utils/emailClipboard.test.ts
@@ -68,7 +68,7 @@ describe("htmlToPlainText", () => {
       htmlToPlainText(
         "<table><tr><td>Price</td><td>40</td></tr><tr><td>Tax</td><td>5</td></tr></table>",
       ),
-    ).toBe("Price | 40\n\nTax | 5");
+    ).toBe("Price | 40\nTax | 5");
   });
 
   it("separates header cells and cells holding block content", () => {
@@ -76,7 +76,33 @@ describe("htmlToPlainText", () => {
       htmlToPlainText(
         "<table>\n  <tr>\n    <th>Item</th>\n    <th>Qty</th>\n  </tr>\n  <tr>\n    <td><p>Bolt</p></td>\n    <td>7</td>\n  </tr>\n</table>",
       ),
-    ).toBe("Item | Qty\n\nBolt | 7");
+    ).toBe("Item | Qty\nBolt | 7");
+  });
+
+  it("keeps a row whose first cell is empty on its own line", () => {
+    // The ordinary shape of a pasted cross-tab. The empty cell must hold its
+    // column rather than letting the next one weld onto the row above.
+    expect(
+      htmlToPlainText(
+        "<table><tr><th>Name</th><th>Qty</th></tr><tr><td></td><td>7</td></tr><tr><td>Nut</td><td>9</td></tr></table>",
+      ),
+    ).toBe("Name | Qty\n| 7\nNut | 9");
+  });
+
+  it("does not weld prose onto a following table cell", () => {
+    expect(
+      htmlToPlainText(
+        "<p>Summary</p><table><tr><td></td><td>X</td></tr></table>",
+      ),
+    ).toBe("Summary\n| X");
+  });
+
+  it("keeps adjacent tables apart", () => {
+    expect(
+      htmlToPlainText(
+        "<table><tr><td>a</td><td>b</td></tr></table><table><tr><td></td><td>c</td></tr></table>",
+      ),
+    ).toBe("a | b\n| c");
   });
 
   it("keeps indentation and blank lines inside a code fence", () => {

--- a/frontend/src/utils/emailClipboard.ts
+++ b/frontend/src/utils/emailClipboard.ts
@@ -31,10 +31,10 @@ const BLOCK_TAGS = new Set([
   "P",
   "PRE",
   "SECTION",
-  "TABLE",
-  "TR",
   "UL",
 ]);
+
+const ROW_TAGS = new Set(["TABLE", "TR"]);
 
 /**
  * Marks the boundary between two cells of a row while the tree is walked. A
@@ -46,6 +46,19 @@ const BLOCK_TAGS = new Set([
  */
 const CELL_BREAK = "\u0000";
 const CELL_BREAK_RUN = new RegExp(`[ \\t\\n]*${CELL_BREAK}[ \\t\\n]*`, "g");
+
+/**
+ * Marks a row or table boundary. A plain newline cannot stand in: the cell-break
+ * run absorbs the whitespace around it, so a row whose first cell is empty — the
+ * ordinary shape of a pasted cross-tab — would let the following cell reach back
+ * across the boundary and weld itself onto the previous row. Resolved to a
+ * newline only after the cell breaks are, so absorption can never cross it.
+ */
+const ROW_BREAK = "\u0001";
+const ROW_BREAK_RUN = new RegExp(
+  `[ \\t\\n${ROW_BREAK}]*${ROW_BREAK}[ \\t\\n${ROW_BREAK}]*`,
+  "g",
+);
 
 /**
  * Converts an HTML fragment to readable plain text. Unlike bare
@@ -72,6 +85,12 @@ export function htmlToPlainText(html: string): string {
       parts.push("\n");
       return;
     }
+    if (ROW_TAGS.has(tag)) {
+      parts.push(ROW_BREAK);
+      node.childNodes.forEach(visit);
+      parts.push(ROW_BREAK);
+      return;
+    }
     if (tag === "TD" || tag === "TH") {
       if (isCell((node as Element).previousElementSibling)) {
         parts.push(CELL_BREAK);
@@ -89,7 +108,11 @@ export function htmlToPlainText(html: string): string {
     }
   };
   doc.body.childNodes.forEach(visit);
-  const text = parts.join("").replace(CELL_BREAK_RUN, " | ");
+  // Cell breaks first: they may absorb whitespace, but never a row boundary.
+  const text = parts
+    .join("")
+    .replace(CELL_BREAK_RUN, " | ")
+    .replace(ROW_BREAK_RUN, "\n");
   return mapOutsideCodeFences(text, (segment) =>
     segment.replace(/[ \t]*\n[ \t]*/g, "\n").replace(/\n{3,}/g, "\n\n"),
   ).trim();

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -500,7 +500,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-iKVR4BxVJIlteD8Gg2S64twXNKtsadZ+TxZhZLqy/kUzQz8UxkWcrD1wlbMbVSz5TSOcdw9ws49qlITIBpxgTA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-Q6yDyXueNQjf1WMACTgrw6b9hGv3w3duY0Fql1wuVrDBN+MnWCYxad1aZvgSTs1E/l3hJm0gBeWWO4ZcbLSPyA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1435,6 +1435,7 @@ msgid "officeAddin.teams.preview.selectedMessages"
 msgstr "{count, plural, one {# ausgewählte Nachricht} other {# ausgewählte Nachrichten}}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: section.skippedCount
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.skipped"
 msgstr "{skipped, plural, one {# konnte nicht geladen werden} other {# konnten nicht geladen werden}}"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1435,6 +1435,7 @@ msgid "officeAddin.teams.preview.selectedMessages"
 msgstr "{count, plural, one {# selected message} other {# selected messages}}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: section.skippedCount
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.skipped"
 msgstr "{skipped, plural, one {# could not be loaded} other {# could not be loaded}}"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1435,6 +1435,7 @@ msgid "officeAddin.teams.preview.selectedMessages"
 msgstr "{count, plural, one {# mensaje seleccionado} other {# mensajes seleccionados}}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: section.skippedCount
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.skipped"
 msgstr "{skipped, plural, one {# no se pudo cargar} other {# no se pudieron cargar}}"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1435,6 +1435,7 @@ msgid "officeAddin.teams.preview.selectedMessages"
 msgstr "{count, plural, one {# message sélectionné} other {# messages sélectionnés}}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: section.skippedCount
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.skipped"
 msgstr "{skipped, plural, one {# n'a pas pu être chargé} other {# n'ont pas pu être chargés}}"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1435,6 +1435,7 @@ msgid "officeAddin.teams.preview.selectedMessages"
 msgstr "{count, plural, one {# wybrana wiadomość} few {# wybrane wiadomości} many {# wybranych wiadomości} other {# wybranych wiadomości}}"
 
 #. js-lingui-explicit-id
+#. placeholder {0}: section.skippedCount
 #: src/teams/utils/teamsAttachmentGroups.ts
 msgid "officeAddin.teams.preview.skipped"
 msgstr "{skipped, plural, one {# nie mogła zostać wczytana} few {# nie mogły zostać wczytane} many {# nie mogło zostać wczytanych} other {# nie mogło zostać wczytanych}}"

--- a/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
+++ b/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
@@ -5,6 +5,7 @@ import {
 import { t } from "@lingui/core/macro";
 import { useMemo } from "react";
 
+import { useTeamsTranscriptIndex } from "../hooks/useTeamsTranscriptIndex";
 import { useTeamsChatPicker } from "../providers/TeamsChatPickerProvider";
 import { buildTeamsAttachmentGroups } from "../utils/teamsAttachmentGroups";
 
@@ -15,19 +16,33 @@ import type { FileAttachmentsPreviewProps } from "@erato/frontend/library";
  * shown as the conversation it came from, with its images and shared files
  * sitting under the messages they arrived with.
  *
+ * The conversation is read out of the transcript file itself, which is the one
+ * description of it that outlives this session.
+ *
  * Anything the picker did not produce — a file added by another route, or a
- * transcript whose sections this session no longer holds — keeps the ordinary
- * flat chips underneath.
+ * transcript whose index block cannot be read — keeps the ordinary flat chips
+ * underneath.
  */
 export function TeamsAttachmentsPreview(props: FileAttachmentsPreviewProps) {
   const { attachedTranscript } = useTeamsChatPicker();
+  const { index, isReading } = useTeamsTranscriptIndex(attachedTranscript);
   const { attachedFiles } = props;
   const preview = useMemo(
-    () => buildTeamsAttachmentGroups(attachedTranscript, attachedFiles),
-    [attachedTranscript, attachedFiles],
+    () =>
+      buildTeamsAttachmentGroups(
+        attachedTranscript && index
+          ? { fileName: attachedTranscript.name, index }
+          : null,
+        attachedFiles,
+      ),
+    [attachedTranscript, index, attachedFiles],
   );
 
   if (!preview) {
+    // Reading an in-memory file settles within a frame or two. Leaving the
+    // region empty for that long beats mounting the flat chips and pulling them
+    // straight back out from under the user the moment the block parses.
+    if (isReading) return null;
     return <FileAttachmentsPreview {...props} />;
   }
 

--- a/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
@@ -2,9 +2,11 @@ import { i18n } from "@lingui/core";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildTeamsTranscriptFile } from "../../utils/buildTeamsTranscriptFile";
 import { TeamsAttachmentsPreview } from "../TeamsAttachmentsPreview";
 
-import type { TeamsAttachedTranscript } from "../../utils/teamsAttachmentGroups";
+import type { TeamsTranscriptSection } from "../../utils/buildTeamsTranscriptFile";
+import type { ParsedTeamsMessage } from "../../utils/parsedTeamsChat";
 import type {
   FileAttachmentGroup,
   FileAttachmentsPreviewProps,
@@ -13,7 +15,7 @@ import type {
 } from "@erato/frontend/library";
 
 const state = vi.hoisted(() => ({
-  attachedTranscript: null as TeamsAttachedTranscript | null,
+  attachedTranscript: null as File | null,
 }));
 
 vi.mock("@erato/frontend/library", () => ({
@@ -29,6 +31,9 @@ vi.mock("@erato/frontend/library", () => ({
       {groups.map((group: FileAttachmentGroup) => (
         <div key={group.id} data-testid="group">
           {group.label}
+          <span data-testid="group-items">
+            {group.items.map((item) => item.kind).join(",")}
+          </span>
         </div>
       ))}
     </div>
@@ -46,41 +51,57 @@ const transcript = upload("teams-Product_sync.md", "upload-transcript");
 const image = upload("teams-img-abc.png", "upload-image");
 const unrelated = upload("holiday.pdf", "upload-holiday");
 
-const attached: TeamsAttachedTranscript = {
-  fileName: transcript.filename,
-  sections: [
-    {
-      kind: "chat",
-      chat: {
-        chatId: "19:chat",
-        title: "Product sync",
-        participants: [],
-        selfDisplayName: null,
-        participantsTruncated: false,
-        chatType: "group",
-        lastActivityAt: null,
-        previewText: "",
-      },
-      messages: [
-        {
+function message(
+  overrides: Partial<ParsedTeamsMessage> = {},
+): ParsedTeamsMessage {
+  const messageId = overrides.messageId ?? "m1";
+  return {
+    chatId: "19:chat",
+    messageId,
+    senderName: "Ada Lovelace",
+    createdAt: "2026-03-01T08:00:00Z",
+    editedAt: null,
+    subject: null,
+    text: "Screenshot [image: teams-img-abc.png]",
+    markers: [],
+    sharedFiles: [],
+    imageUrls: [],
+    replyToId: null,
+    deepLink: `https://teams.microsoft.com/l/message/19:chat/${messageId}`,
+    ...overrides,
+  };
+}
+
+/**
+ * A fresh file per call: the read of a transcript is cached by file identity,
+ * so a shared one would answer later tests without ever being read.
+ */
+function transcriptFile(
+  selection: TeamsTranscriptSection["selection"] = "messages",
+): File {
+  const file = buildTeamsTranscriptFile({
+    sections: [
+      {
+        kind: "chat",
+        chat: {
           chatId: "19:chat",
-          messageId: "m1",
-          senderName: "Ada Lovelace",
-          createdAt: "2026-03-01T08:00:00Z",
-          editedAt: null,
-          subject: null,
-          text: "Screenshot [image: teams-img-abc.png]",
-          markers: [],
-          sharedFiles: [],
-          imageUrls: [],
-          replyToId: null,
-          deepLink: "https://teams.microsoft.com/l/message/19:chat/m1",
+          title: "Product sync",
+          participants: [],
+          selfDisplayName: null,
+          participantsTruncated: false,
+          chatType: "group",
+          lastActivityAt: null,
+          previewText: "",
         },
-      ],
-      selection: "messages",
-    },
-  ],
-};
+        messages: [message()],
+        selection,
+      },
+    ],
+    timeZone: "UTC",
+  });
+  if (!file) throw new Error("expected a transcript");
+  return file;
+}
 
 function renderPreview(
   attachedFiles: FileUploadItem[],
@@ -111,14 +132,73 @@ describe("TeamsAttachmentsPreview", () => {
     expect(screen.getByTestId("flat-preview")).toHaveTextContent("holiday.pdf");
   });
 
-  it("renders the conversation and leaves unrelated uploads as chips", () => {
-    state.attachedTranscript = attached;
+  it("renders the conversation out of the transcript's own index block", async () => {
+    state.attachedTranscript = transcriptFile();
     renderPreview([transcript, image, unrelated]);
 
-    expect(screen.getByTestId("group")).toHaveTextContent("Product sync");
+    expect(await screen.findByTestId("group")).toHaveTextContent(
+      "Product sync",
+    );
     expect(screen.getByTestId("flat-preview")).toHaveTextContent("holiday.pdf");
     expect(screen.getByTestId("flat-preview")).not.toHaveTextContent(
       "teams-img-abc.png",
     );
+  });
+
+  it("waits for the block rather than flashing the flat chips first", async () => {
+    state.attachedTranscript = transcriptFile();
+    renderPreview([transcript, image, unrelated]);
+
+    expect(screen.queryByTestId("flat-preview")).toBeNull();
+    expect(screen.queryByTestId("grouped-preview")).toBeNull();
+    await screen.findByTestId("grouped-preview");
+  });
+
+  it("expands hand-picked messages into a row each", async () => {
+    state.attachedTranscript = transcriptFile("messages");
+    renderPreview([transcript, image]);
+
+    expect(await screen.findByTestId("group-items")).toHaveTextContent(
+      "attachment,threadMessageGroup",
+    );
+  });
+
+  it("collapses a whole conversation to its summary row", async () => {
+    state.attachedTranscript = transcriptFile("whole-chat");
+    renderPreview([transcript, image]);
+
+    // The transcript row, then the image that rode along with the messages it
+    // stands for — no per-message rows.
+    expect(await screen.findByTestId("group-items")).toHaveTextContent(
+      "attachment,attachment",
+    );
+  });
+
+  it("falls back to flat chips for a transcript with no index block", async () => {
+    state.attachedTranscript = new File(
+      ["# Teams chat: Product sync\n\nHello.\n"],
+      transcript.filename,
+      { type: "text/plain" },
+    );
+    renderPreview([transcript, image, unrelated]);
+
+    expect(await screen.findByTestId("flat-preview")).toHaveTextContent(
+      "teams-Product_sync.md,teams-img-abc.png,holiday.pdf",
+    );
+    expect(screen.queryByTestId("grouped-preview")).toBeNull();
+  });
+
+  it("falls back to flat chips when the index block is unreadable", async () => {
+    state.attachedTranscript = new File(
+      ['# Teams chat\n\n<!-- erato:teams-transcript v1 {"sections": -->\n'],
+      transcript.filename,
+      { type: "text/plain" },
+    );
+    renderPreview([transcript, image, unrelated]);
+
+    expect(await screen.findByTestId("flat-preview")).toHaveTextContent(
+      "teams-Product_sync.md,teams-img-abc.png,holiday.pdf",
+    );
+    expect(screen.queryByTestId("grouped-preview")).toBeNull();
   });
 });

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -433,11 +433,7 @@ function Opener() {
 function AttachedProbe() {
   const { attachedTranscript } = useTeamsChatPicker();
   if (!attachedTranscript) return null;
-  return (
-    <div data-testid="attached-transcript">
-      {attachedTranscript.fileName}:{attachedTranscript.sections.length}
-    </div>
-  );
+  return <div data-testid="attached-transcript">{attachedTranscript.name}</div>;
 }
 
 function renderPicker() {
@@ -575,7 +571,7 @@ describe("TeamsChatPickerDialog", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("keeps the delivered transcript's sections for the composer preview", async () => {
+  it("keeps the delivered transcript file for the composer preview", async () => {
     renderPicker();
     fireEvent.click(selectChat());
 
@@ -585,7 +581,7 @@ describe("TeamsChatPickerDialog", () => {
     await waitFor(() => expect(uploads).toHaveLength(1));
 
     expect(screen.getByTestId("attached-transcript")).toHaveTextContent(
-      "teams-Product_sync.md:1",
+      "teams-Product_sync.md",
     );
   });
 

--- a/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptBuild.ts
@@ -5,7 +5,6 @@ import { buildTeamsTranscriptFile } from "../utils/buildTeamsTranscriptFile";
 import { collectTeamsTranscript } from "../utils/collectTeamsTranscript";
 import { TEAMS_GRAPH_TRANSCRIPT_TIMEOUT_MS } from "../utils/teamsGraphTimeouts";
 
-import type { TeamsTranscriptSection } from "../utils/buildTeamsTranscriptFile";
 import type { TeamsTranscriptProgress } from "../utils/collectTeamsTranscript";
 import type { ParsedTeamsChannel } from "../utils/parsedTeamsChannel";
 import type {
@@ -25,12 +24,6 @@ export interface TeamsTranscriptBuildOutcome {
   file: File | null;
   /** Images fetched from the messages, uploaded beside the transcript. */
   assets: File[];
-  /**
-   * The conversations behind `file`, in the order it renders them. Carried out
-   * of the build so the composer can preview the transcript as a conversation
-   * instead of as one opaque markdown chip.
-   */
-  sections: TeamsTranscriptSection[];
   state: TeamsFetchState;
   messageCount: number;
   skippedCount: number;
@@ -56,7 +49,6 @@ export interface UseTeamsTranscriptBuildResult {
 const ABORTED_OUTCOME: TeamsTranscriptBuildOutcome = {
   file: null,
   assets: [],
-  sections: [],
   state: "error",
   messageCount: 0,
   skippedCount: 0,
@@ -142,7 +134,6 @@ export function useTeamsTranscriptBuild(
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           }),
           assets: collected.assetFiles,
-          sections: collected.sections,
           state: collected.state,
           messageCount: collected.messageCount,
           skippedCount: collected.skippedCount,

--- a/office-addin/src/teams/hooks/useTeamsTranscriptIndex.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptIndex.ts
@@ -1,0 +1,56 @@
+import { useEffect, useReducer } from "react";
+
+import { parseTeamsTranscriptIndex } from "../utils/teamsTranscriptIndex";
+
+import type { TeamsTranscriptIndex } from "../utils/teamsTranscriptIndex";
+
+/**
+ * Reads a transcript's index block back out of the file, so a caller renders
+ * what was uploaded instead of what it happens to remember building.
+ *
+ * Results are kept per `File` for as long as the file is referenced. Reading a
+ * blob is asynchronous, and the composer re-renders on every keystroke: without
+ * this, each render would start over from "not read yet" and the preview would
+ * fall back to plain chips between the render and the parse that follows it.
+ */
+const INDEX_BY_FILE = new WeakMap<File, TeamsTranscriptIndex | null>();
+
+export interface TeamsTranscriptIndexRead {
+  /** Null while reading, and for a file that carries no usable block. */
+  index: TeamsTranscriptIndex | null;
+  /** True until this file has been read — nothing is known about it yet. */
+  isReading: boolean;
+}
+
+const NOTHING_TO_READ: TeamsTranscriptIndexRead = {
+  index: null,
+  isReading: false,
+};
+
+export function useTeamsTranscriptIndex(
+  file: File | null,
+): TeamsTranscriptIndexRead {
+  const [, onRead] = useReducer((reads: number) => reads + 1, 0);
+
+  useEffect(() => {
+    if (!file || INDEX_BY_FILE.has(file)) return;
+    let alive = true;
+    const settle = (index: TeamsTranscriptIndex | null) => {
+      INDEX_BY_FILE.set(file, index);
+      if (alive) onRead();
+    };
+    void file.text().then(
+      (text) => settle(parseTeamsTranscriptIndex(text)),
+      // An unreadable file is indistinguishable from one without a block: the
+      // caller has nothing to render either way.
+      () => settle(null),
+    );
+    return () => {
+      alive = false;
+    };
+  }, [file]);
+
+  if (!file) return NOTHING_TO_READ;
+  if (!INDEX_BY_FILE.has(file)) return { index: null, isReading: true };
+  return { index: INDEX_BY_FILE.get(file) ?? null, isReading: false };
+}

--- a/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
+++ b/office-addin/src/teams/providers/TeamsChatPickerProvider.tsx
@@ -31,14 +31,12 @@ import {
 import type { UseTeamsChannelListResult } from "../hooks/useTeamsChannelList";
 import type { UseTeamsChatListResult } from "../hooks/useTeamsChatList";
 import type { TeamsTranscriptBuildOutcome } from "../hooks/useTeamsTranscriptBuild";
-import type { TeamsTranscriptSection } from "../utils/buildTeamsTranscriptFile";
 import type { TeamsTranscriptProgress } from "../utils/collectTeamsTranscript";
 import type { ParsedTeamsChannel } from "../utils/parsedTeamsChannel";
 import type {
   ParsedTeamsChat,
   TeamsSelfIdentity,
 } from "../utils/parsedTeamsChat";
-import type { TeamsAttachedTranscript } from "../utils/teamsAttachmentGroups";
 import type {
   TeamsChannelFetcher,
   TeamsChatFetcher,
@@ -93,11 +91,11 @@ export interface TeamsChatPickerContextValue {
   attachError: TeamsAttachFailure | null;
 
   /**
-   * The transcript this session last handed to the composer, or null when it
-   * never did. Survives closing the dialog — the composer previews it for as
-   * long as the upload stays attached.
+   * The transcript file this session last handed to the composer, or null when
+   * it never did. Survives closing the dialog — the composer reads the
+   * conversation back out of it for as long as the upload stays attached.
    */
-  attachedTranscript: TeamsAttachedTranscript | null;
+  attachedTranscript: File | null;
 }
 
 const EMPTY_CHAT_LIST: UseTeamsChatListResult = {
@@ -188,16 +186,13 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
   const [partialOutcome, setPartialOutcome] =
     useState<TeamsTranscriptBuildOutcome | null>(null);
 
-  const [attachedTranscript, setAttachedTranscript] =
-    useState<TeamsAttachedTranscript | null>(null);
+  const [attachedTranscript, setAttachedTranscript] = useState<File | null>(
+    null,
+  );
 
   const handoffRef = useRef<((files: File[]) => Promise<void>) | null>(null);
   const cancelledRef = useRef(false);
-  const lastBuildRef = useRef<{
-    key: string;
-    files: File[];
-    sections: TeamsTranscriptSection[];
-  } | null>(null);
+  const lastBuildRef = useRef<{ key: string; files: File[] } | null>(null);
 
   // The object id is the reliable match; the login hint can differ from a
   // member's primary SMTP address, which would leave the viewer in their own
@@ -285,14 +280,10 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
    * walking Graph again, which is tens of seconds.
    */
   const deliver = useCallback(
-    async (
-      files: File[],
-      sections: TeamsTranscriptSection[],
-      retryKey?: string,
-    ): Promise<boolean> => {
+    async (files: File[], retryKey?: string): Promise<boolean> => {
       const handoff = handoffRef.current;
       const fail = () => {
-        if (retryKey) lastBuildRef.current = { key: retryKey, files, sections };
+        if (retryKey) lastBuildRef.current = { key: retryKey, files };
         setAttachError("upload-failed");
         return false;
       };
@@ -311,12 +302,10 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       if (useFileUploadStore.getState().error) {
         return fail();
       }
-      // The transcript leads, its assets follow — the order every caller
-      // hands over, and the order the preview joins back together.
+      // The transcript leads, its assets follow — the order every caller hands
+      // over, and what makes the first file the one the preview reads from.
       const [transcript] = files;
-      if (transcript) {
-        setAttachedTranscript({ fileName: transcript.name, sections });
-      }
+      if (transcript) setAttachedTranscript(transcript);
       close();
       return true;
     },
@@ -333,7 +322,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     const key = teamsSelectionDedupeKey(selections, messageLimit);
     const built = lastBuildRef.current;
     if (built?.key === key) {
-      await deliver(built.files, built.sections, key);
+      await deliver(built.files, key);
       return;
     }
 
@@ -355,7 +344,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
       setPartialOutcome(outcome);
       return;
     }
-    await deliver([outcome.file, ...outcome.assets], outcome.sections, key);
+    await deliver([outcome.file, ...outcome.assets], key);
   }, [
     build,
     chatList.chatsById,
@@ -373,7 +362,7 @@ export function TeamsChatPickerProvider({ children }: { children: ReactNode }) {
     setPartialOutcome(null);
     // Put the offer back if the composer never took it — the partial
     // transcript is the only copy of a walk that already ran.
-    if (!(await deliver([outcome.file, ...outcome.assets], outcome.sections))) {
+    if (!(await deliver([outcome.file, ...outcome.assets]))) {
       setPartialOutcome(outcome);
     }
   }, [deliver, partialOutcome]);

--- a/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
@@ -2,12 +2,18 @@ import { i18n } from "@lingui/core";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";
+import { buildTeamsTranscriptDocument } from "../buildTeamsTranscriptFile";
 import { buildTeamsAttachmentGroups } from "../teamsAttachmentGroups";
 import { buildTeamsMessageDeepLink } from "../teamsDeepLink";
+import {
+  TEAMS_TRANSCRIPT_INDEX_VERSION,
+  parseTeamsTranscriptIndex,
+} from "../teamsTranscriptIndex";
 
 import type { TeamsTranscriptSection } from "../buildTeamsTranscriptFile";
 import type { ParsedTeamsChannel } from "../parsedTeamsChannel";
 import type { ParsedTeamsChat, ParsedTeamsMessage } from "../parsedTeamsChat";
+import type { TeamsAttachedTranscript } from "../teamsAttachmentGroups";
 import type {
   FileAttachmentGroup,
   FileAttachmentGroupItem,
@@ -75,6 +81,18 @@ function chatSection(
   };
 }
 
+/**
+ * The preview's real input: the index block as it survives a round trip
+ * through the transcript the composer holds.
+ */
+function attach(sections: TeamsTranscriptSection[]): TeamsAttachedTranscript {
+  const document = buildTeamsTranscriptDocument({ sections, timeZone: "UTC" });
+  if (!document) throw new Error("expected a transcript");
+  const index = parseTeamsTranscriptIndex(document.markdown);
+  if (!index) throw new Error("expected an index block");
+  return { fileName: TRANSCRIPT.filename, index };
+}
+
 function itemKinds(group: FileAttachmentGroup): string[] {
   return group.items.map((item) => item.kind);
 }
@@ -103,11 +121,20 @@ describe("buildTeamsAttachmentGroups", () => {
     i18n.activate("en");
   });
 
-  it("falls back to flat chips when the sections are unavailable", () => {
+  it("falls back to flat chips when the index is unavailable", () => {
     expect(buildTeamsAttachmentGroups(null, [TRANSCRIPT])).toBeNull();
     expect(
       buildTeamsAttachmentGroups(
-        { fileName: TRANSCRIPT.filename, sections: [] },
+        {
+          fileName: TRANSCRIPT.filename,
+          index: {
+            version: TEAMS_TRANSCRIPT_INDEX_VERSION,
+            exportedAt: "2026-03-03T10:00:00Z",
+            timeZone: "UTC",
+            sections: [],
+            messages: [],
+          },
+        },
         [TRANSCRIPT],
       ),
     ).toBeNull();
@@ -115,25 +142,21 @@ describe("buildTeamsAttachmentGroups", () => {
 
   it("falls back to flat chips when the transcript is no longer attached", () => {
     expect(
-      buildTeamsAttachmentGroups(
-        { fileName: TRANSCRIPT.filename, sections: [chatSection()] },
-        [upload("holiday.pdf")],
-      ),
+      buildTeamsAttachmentGroups(attach([chatSection()]), [
+        upload("holiday.pdf"),
+      ]),
     ).toBeNull();
   });
 
   it("summarises a whole conversation instead of listing its messages", () => {
     const messages = [
-      message({ messageId: "m1", createdAt: "2026-03-01T08:00:00Z" }),
       message({ messageId: "m2", createdAt: "2026-03-03T09:14:00Z" }),
+      message({ messageId: "m1", createdAt: "2026-03-01T08:00:00Z" }),
     ];
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({ messages, selection: "whole-chat", truncated: true }),
-        ],
-      },
+      attach([
+        chatSection({ messages, selection: "whole-chat", truncated: true }),
+      ]),
       [TRANSCRIPT],
     );
 
@@ -151,7 +174,8 @@ describe("buildTeamsAttachmentGroups", () => {
     });
   });
 
-  it("renders one card per hand-picked message, oldest first", () => {
+  it("renders one card per hand-picked message, in transcript order", () => {
+    // Newest first, as Graph hands chat messages back.
     const messages = [
       message({
         messageId: "m2",
@@ -165,12 +189,9 @@ describe("buildTeamsAttachmentGroups", () => {
       }),
     ];
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({ messages, selection: "messages", limit: undefined }),
-        ],
-      },
+      attach([
+        chatSection({ messages, selection: "messages", limit: undefined }),
+      ]),
       [TRANSCRIPT],
     );
 
@@ -192,14 +213,19 @@ describe("buildTeamsAttachmentGroups", () => {
 
   it("shows an excerpt so two messages from one sender are distinguishable", () => {
     const messages = [
-      message({ messageId: "m1", text: "Can we move the sync to Thursday?" }),
-      message({ messageId: "m2", text: "Actually Friday works better." }),
+      message({
+        messageId: "m2",
+        createdAt: "2026-03-03T09:14:00Z",
+        text: "Actually Friday works better.",
+      }),
+      message({
+        messageId: "m1",
+        createdAt: "2026-03-01T08:00:00Z",
+        text: "Can we move the sync to Thursday?",
+      }),
     ];
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [chatSection({ messages, selection: "messages" })],
-      },
+      attach([chatSection({ messages, selection: "messages" })]),
       [TRANSCRIPT],
     );
 
@@ -210,14 +236,19 @@ describe("buildTeamsAttachmentGroups", () => {
 
   it("truncates a long excerpt and flattens its whitespace", () => {
     const messages = [
-      message({ messageId: "m1", text: `A${"b".repeat(200)}` }),
-      message({ messageId: "m2", text: "line one\n\n  line two" }),
+      message({
+        messageId: "m2",
+        createdAt: "2026-03-03T09:14:00Z",
+        text: "line one\n\n  line two",
+      }),
+      message({
+        messageId: "m1",
+        createdAt: "2026-03-01T08:00:00Z",
+        text: `A${"b".repeat(200)}`,
+      }),
     ];
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [chatSection({ messages, selection: "messages" })],
-      },
+      attach([chatSection({ messages, selection: "messages" })]),
       [TRANSCRIPT],
     );
 
@@ -229,19 +260,16 @@ describe("buildTeamsAttachmentGroups", () => {
 
   it("keeps one group per conversation across chats and channels", () => {
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({ selection: "messages" }),
-          {
-            kind: "channel",
-            channel,
-            messages: [message({ messageId: "c1" })],
-            selection: "whole-chat",
-            limit: 200,
-          },
-        ],
-      },
+      attach([
+        chatSection({ selection: "messages" }),
+        {
+          kind: "channel",
+          channel,
+          messages: [message({ messageId: "c1" })],
+          selection: "whole-chat",
+          limit: 200,
+        },
+      ]),
       [TRANSCRIPT],
     );
 
@@ -262,23 +290,20 @@ describe("buildTeamsAttachmentGroups", () => {
     const shared = upload("teams-file-abc-report.pdf", "upload-report");
     const unrelated = upload("holiday.pdf", "upload-holiday");
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({
-            selection: "messages",
-            messages: [
-              message({
-                messageId: "m1",
-                createdAt: "2026-03-01T08:00:00Z",
-                text: "Here it is [image: teams-img-abc.png]",
-                markers: ["[attachment: teams-file-abc-report.pdf]"],
-              }),
-              message({ messageId: "m2", createdAt: "2026-03-02T08:00:00Z" }),
-            ],
-          }),
-        ],
-      },
+      attach([
+        chatSection({
+          selection: "messages",
+          messages: [
+            message({ messageId: "m2", createdAt: "2026-03-02T08:00:00Z" }),
+            message({
+              messageId: "m1",
+              createdAt: "2026-03-01T08:00:00Z",
+              text: "Here it is [image: teams-img-abc.png]",
+              markers: ["[attachment: teams-file-abc-report.pdf]"],
+            }),
+          ],
+        }),
+      ]),
       [TRANSCRIPT, image, shared, unrelated],
     );
 
@@ -299,16 +324,13 @@ describe("buildTeamsAttachmentGroups", () => {
   it("ignores a bare marker that happens to name one of the user's own files", () => {
     const own = upload("report.pdf", "upload-own");
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({
-            selection: "messages",
-            // Never fetched, so the marker still carries the Teams-side name.
-            messages: [message({ markers: ["[attachment: report.pdf]"] })],
-          }),
-        ],
-      },
+      attach([
+        chatSection({
+          selection: "messages",
+          // Never fetched, so the marker still carries the Teams-side name.
+          messages: [message({ markers: ["[attachment: report.pdf]"] })],
+        }),
+      ]),
       [TRANSCRIPT, own],
     );
 
@@ -319,23 +341,20 @@ describe("buildTeamsAttachmentGroups", () => {
   it("lists a whole conversation's uploads beside its summary row", () => {
     const image = upload("teams-img-abc.png", "upload-image");
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [
-          chatSection({
-            messages: [
-              message({
-                text: "Screenshot [image: teams-img-abc.png]",
-              }),
-              // The same asset in a second message must not double up.
-              message({
-                messageId: "m2",
-                text: "Again [image: teams-img-abc.png]",
-              }),
-            ],
-          }),
-        ],
-      },
+      attach([
+        chatSection({
+          messages: [
+            message({
+              text: "Screenshot [image: teams-img-abc.png]",
+            }),
+            // The same asset in a second message must not double up.
+            message({
+              messageId: "m2",
+              text: "Again [image: teams-img-abc.png]",
+            }),
+          ],
+        }),
+      ]),
       [TRANSCRIPT, image],
     );
 
@@ -346,10 +365,7 @@ describe("buildTeamsAttachmentGroups", () => {
 
   it("reports how many messages could not be loaded", () => {
     const preview = buildTeamsAttachmentGroups(
-      {
-        fileName: TRANSCRIPT.filename,
-        sections: [chatSection({ selection: "messages", skippedCount: 2 })],
-      },
+      attach([chatSection({ selection: "messages", skippedCount: 2 })]),
       [TRANSCRIPT],
     );
 

--- a/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsAttachmentGroups.test.ts
@@ -261,13 +261,38 @@ describe("buildTeamsAttachmentGroups", () => {
   it("keeps one group per conversation across chats and channels", () => {
     const preview = buildTeamsAttachmentGroups(
       attach([
-        chatSection({ selection: "messages" }),
+        chatSection({
+          selection: "messages",
+          // Newest first, as Graph hands chat messages back; rendered oldest first.
+          messages: [
+            message({
+              messageId: "k2",
+              senderName: "Grace Hopper",
+              createdAt: "2026-03-03T09:05:00Z",
+            }),
+            message({
+              messageId: "k1",
+              senderName: "Ada Lovelace",
+              createdAt: "2026-03-03T09:00:00Z",
+            }),
+          ],
+        }),
         {
           kind: "channel",
           channel,
-          messages: [message({ messageId: "c1" })],
-          selection: "whole-chat",
-          limit: 200,
+          messages: [
+            message({
+              messageId: "c1",
+              senderName: "Tom Weber",
+              createdAt: "2026-03-04T10:00:00Z",
+            }),
+            message({
+              messageId: "c2",
+              senderName: "Anna Roth",
+              createdAt: "2026-03-04T10:20:00Z",
+            }),
+          ],
+          selection: "messages",
         },
       ]),
       [TRANSCRIPT],
@@ -278,6 +303,19 @@ describe("buildTeamsAttachmentGroups", () => {
       "Product sync",
       "Releases · Contoso",
     ]);
+    // The index is one flat array tagged by section, so a wrong partition
+    // silently merges every conversation into every card. Assert membership,
+    // not just the group count.
+    expect(threadRows(preview!.groups[0]).map((row) => row.label)).toEqual([
+      "Ada Lovelace",
+      "Grace Hopper",
+    ]);
+    expect(threadRows(preview!.groups[1]).map((row) => row.label)).toEqual([
+      "Tom Weber",
+      "Anna Roth",
+    ]);
+    expect(preview!.groups[0].metaLabel).toContain("2 messages");
+    expect(preview!.groups[1].metaLabel).toContain("2 messages");
     // Both cards stand for slices of the same upload.
     for (const group of preview!.groups) {
       expect(transcriptRow(group).file).toMatchObject({ id: TRANSCRIPT.id });

--- a/office-addin/src/teams/utils/__tests__/teamsMessageText.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsMessageText.test.ts
@@ -68,7 +68,17 @@ describe("teamsMessageBodyToText", () => {
           "<table><tr><th>Item</th><th>Price</th></tr><tr><td>Bolt</td><td>40</td></tr></table>",
         ),
       ),
-    ).toBe("Item | Price\n\nBolt | 40");
+    ).toBe("Item | Price\nBolt | 40");
+  });
+
+  it("keeps a row whose first cell is empty on its own line", () => {
+    expect(
+      teamsMessageBodyToText(
+        html(
+          "<table><tr><th>Item</th><th>Qty</th></tr><tr><td></td><td>7</td></tr></table>",
+        ),
+      ),
+    ).toBe("Item | Qty\n| 7");
   });
 
   it("backticks inline code", () => {

--- a/office-addin/src/teams/utils/teamsAttachmentGroups.ts
+++ b/office-addin/src/teams/utils/teamsAttachmentGroups.ts
@@ -3,6 +3,10 @@
  * from, as composer preview groups: one card per conversation, with the
  * transcript demoted to a single summary row inside it.
  *
+ * Everything it renders comes out of the transcript's own index block, so the
+ * preview describes the file that was actually uploaded rather than state kept
+ * beside it — the same source every later reader of a transcript has.
+ *
  * One group per section, never one merged stream — a selection can span chats
  * and channels that share no timeline. A whole conversation stays a summary:
  * the default window is a few hundred messages, and that many cards in a task
@@ -15,10 +19,14 @@
 
 import { plural, t } from "@lingui/core/macro";
 
-import { uploadedAssetNames } from "./teamsTranscriptAssets";
+import { conversationKey } from "./teamsConversationRef";
 
-import type { TeamsTranscriptSection } from "./buildTeamsTranscriptFile";
-import type { ParsedTeamsMessage } from "./parsedTeamsChat";
+import type {
+  TeamsTranscriptIndex,
+  TeamsTranscriptIndexMessage,
+  TeamsTranscriptIndexSection,
+  TeamsTranscriptIndexWindow,
+} from "./teamsTranscriptIndex";
 import type {
   FileAttachmentGroup,
   FileAttachmentGroupItem,
@@ -28,11 +36,11 @@ import type {
 /**
  * What the composer needs to recognise a transcript it is already holding: the
  * uploaded filename — the same key the message markers name their assets by —
- * and the conversations behind it.
+ * and the index read back out of the file.
  */
 export interface TeamsAttachedTranscript {
   fileName: string;
-  sections: TeamsTranscriptSection[];
+  index: TeamsTranscriptIndex;
 }
 
 export interface TeamsAttachmentPreviewGroups {
@@ -45,7 +53,7 @@ export function buildTeamsAttachmentGroups(
   attached: TeamsAttachedTranscript | null,
   attachedFiles: readonly FileUploadItem[],
 ): TeamsAttachmentPreviewGroups | null {
-  if (!attached || attached.sections.length === 0) return null;
+  if (!attached || attached.index.sections.length === 0) return null;
 
   const uploadsByName = new Map<string, FileUploadItem>();
   for (const file of attachedFiles) {
@@ -65,84 +73,100 @@ export function buildTeamsAttachmentGroups(
     return file;
   };
 
-  const groups = attached.sections.map((section): FileAttachmentGroup => {
-    const key = sectionKey(section);
-    const items: FileAttachmentGroupItem[] = [
-      {
-        kind: "attachment",
-        id: `${key}:transcript`,
-        // One transcript covers every section, so it is named by what this
-        // section contributes to it rather than by its filename. Removing the
-        // row removes the file, which drops the whole preview back to chips.
-        file: {
-          id: transcript.id,
-          filename: transcript.filename,
-          displayName: includedSummary(section),
-        },
-        labelOverride: t({
-          id: "officeAddin.teams.preview.transcriptLabel",
-          message: "Teams conversation",
-        }),
-      },
-    ];
+  const bySection = messagesBySection(attached.index.messages);
 
-    if (section.selection === "messages") {
-      for (const message of oldestFirst(section.messages)) {
-        items.push({
-          kind: "threadMessageGroup",
-          id: `${key}:${message.messageId}`,
-          label: message.senderName,
-          sublabel: messageSublabel(message),
-          defaultCollapsed: false,
-          attachments: messageAssetFiles(message, claim).map((file) => ({
-            id: file.id,
-            file,
-          })),
-        });
-      }
-    } else {
-      // The summary row stands for the messages; the files that rode along
-      // with them still get a row each, so nothing is attached invisibly.
-      for (const message of section.messages) {
-        for (const file of messageAssetFiles(message, claim)) {
-          items.push({ kind: "attachment", id: file.id, file });
+  const groups = attached.index.sections.map(
+    (section, position): FileAttachmentGroup => {
+      const key = conversationKey(section.ref);
+      // Index order, not a re-sort: the rows then read in the order the
+      // transcript itself does, which for a channel is thread by thread rather
+      // than one interleaved timeline.
+      const messages = bySection.get(position) ?? [];
+      const items: FileAttachmentGroupItem[] = [
+        {
+          kind: "attachment",
+          id: `${key}:transcript`,
+          // One transcript covers every section, so it is named by what this
+          // section contributes to it rather than by its filename. Removing the
+          // row removes the file, which drops the whole preview back to chips.
+          file: {
+            id: transcript.id,
+            filename: transcript.filename,
+            displayName: includedSummary(section, messages.length),
+          },
+          labelOverride: t({
+            id: "officeAddin.teams.preview.transcriptLabel",
+            message: "Teams conversation",
+          }),
+        },
+      ];
+
+      if (section.selection === "messages") {
+        for (const message of messages) {
+          items.push({
+            kind: "threadMessageGroup",
+            id: `${key}:${message.ref.messageId}`,
+            label: message.sender,
+            sublabel: messageSublabel(message),
+            defaultCollapsed: false,
+            attachments: claimAssets(message, claim).map((file) => ({
+              id: file.id,
+              file,
+            })),
+          });
+        }
+      } else {
+        // The summary row stands for the messages; the files that rode along
+        // with them still get a row each, so nothing is attached invisibly.
+        for (const message of messages) {
+          for (const file of claimAssets(message, claim)) {
+            items.push({ kind: "attachment", id: file.id, file });
+          }
         }
       }
-    }
 
-    return {
-      id: `teams:${key}`,
-      label: sectionTitle(section),
-      metaLabel: sectionMeta(section),
-      items,
-      collapsible: true,
-      defaultCollapsed: section.selection !== "messages",
-    };
-  });
+      return {
+        id: `teams:${key}`,
+        label: sectionTitle(section),
+        metaLabel: sectionMeta(section, messages.length),
+        items,
+        collapsible: true,
+        defaultCollapsed: section.selection !== "messages",
+      };
+    },
+  );
 
   return { groups, claimedFileIds };
 }
 
-function sectionKey(section: TeamsTranscriptSection): string {
-  return section.kind === "chat"
-    ? `chat:${section.chat.chatId}`
-    : `channel:${section.channel.teamId}/${section.channel.channelId}`;
+function messagesBySection(
+  messages: readonly TeamsTranscriptIndexMessage[],
+): Map<number, TeamsTranscriptIndexMessage[]> {
+  const bySection = new Map<number, TeamsTranscriptIndexMessage[]>();
+  for (const message of messages) {
+    const collected = bySection.get(message.section);
+    if (collected) collected.push(message);
+    else bySection.set(message.section, [message]);
+  }
+  return bySection;
 }
 
-function sectionTitle(section: TeamsTranscriptSection): string {
-  if (section.kind === "chat") return section.chat.title;
-  const { name, teamName } = section.channel;
-  return teamName ? `${name} · ${teamName}` : name;
+function sectionTitle(section: TeamsTranscriptIndexSection): string {
+  return section.teamName
+    ? `${section.title} · ${section.teamName}`
+    : section.title;
 }
 
 /** The header line: how much of the conversation this card stands for. */
-function sectionMeta(section: TeamsTranscriptSection): string {
-  const count = section.messages.length;
+function sectionMeta(
+  section: TeamsTranscriptIndexSection,
+  count: number,
+): string {
   const countLabel = t({
     id: "officeAddin.teams.preview.messageCount",
     message: plural(count, { one: "# message", other: "# messages" }),
   });
-  return [countLabel, dateRange(section.messages)]
+  return [countLabel, dateRange(section.window)]
     .filter((part) => part.length > 0)
     .join(" · ");
 }
@@ -151,8 +175,10 @@ function sectionMeta(section: TeamsTranscriptSection): string {
  * Mirrors the transcript's own "Included:" line, minus the date range the
  * group header already carries.
  */
-function includedSummary(section: TeamsTranscriptSection): string {
-  const count = section.messages.length;
+function includedSummary(
+  section: TeamsTranscriptIndexSection,
+  count: number,
+): string {
   const parts = [
     section.selection === "messages"
       ? t({
@@ -178,12 +204,11 @@ function includedSummary(section: TeamsTranscriptSection): string {
             }),
           }),
   ];
-  const skipped = section.skippedCount ?? 0;
-  if (skipped > 0) {
+  if (section.skippedCount > 0) {
     parts.push(
       t({
         id: "officeAddin.teams.preview.skipped",
-        message: plural(skipped, {
+        message: plural(section.skippedCount, {
           one: "# could not be loaded",
           other: "# could not be loaded",
         }),
@@ -196,8 +221,8 @@ function includedSummary(section: TeamsTranscriptSection): string {
 /** Enough of a message to tell two from the same sender apart, no more. */
 const EXCERPT_LENGTH = 100;
 
-function messageSublabel(message: ParsedTeamsMessage): string {
-  const when = message.createdAt ? toDate(message.createdAt) : null;
+function messageSublabel(message: TeamsTranscriptIndexMessage): string {
+  const when = toDate(message.createdAt);
   return [
     when ? when.toLocaleString() : "",
     message.subject ?? "",
@@ -224,52 +249,38 @@ function excerpt(text: string): string {
  * The uploads a message carries, joined by the filename the asset collector
  * stamped into its markers — the same key the backend keys parsed uploads by.
  */
-function messageAssetFiles(
-  message: ParsedTeamsMessage,
+function claimAssets(
+  message: TeamsTranscriptIndexMessage,
   claim: (name: string) => FileUploadItem | null,
 ): FileUploadItem[] {
   const files: FileUploadItem[] = [];
-  for (const name of uploadedAssetNames([message.text, ...message.markers])) {
+  for (const name of message.assets) {
     const file = claim(name);
     if (file) files.push(file);
   }
   return files;
 }
 
-/** Reads as a conversation; Graph hands chat messages back newest first. */
-function oldestFirst(
-  messages: readonly ParsedTeamsMessage[],
-): ParsedTeamsMessage[] {
-  return [...messages].sort((a, b) => createdAtMs(a) - createdAtMs(b));
-}
-
-function dateRange(messages: readonly ParsedTeamsMessage[]): string {
-  const days = messages
-    .map((message) => createdAtMs(message))
-    .filter((ms) => ms > 0)
-    .sort((a, b) => a - b);
-  const oldest = days.at(0);
-  const newest = days.at(-1);
-  if (oldest === undefined || newest === undefined) return "";
-  const from = formatDay(oldest);
-  const to = formatDay(newest);
+function dateRange(window: TeamsTranscriptIndexWindow): string {
+  const from = formatDay(window.from);
+  const to = formatDay(window.to);
+  if (from === null || to === null) return "";
   return from === to ? from : `${from} – ${to}`;
 }
 
-function formatDay(ms: number): string {
-  return new Date(ms).toLocaleDateString(undefined, {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
+function formatDay(iso: string | null): string | null {
+  const date = toDate(iso);
+  return date
+    ? date.toLocaleDateString(undefined, {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+    : null;
 }
 
-function createdAtMs(message: ParsedTeamsMessage): number {
-  const date = message.createdAt ? toDate(message.createdAt) : null;
-  return date ? date.getTime() : 0;
-}
-
-function toDate(iso: string): Date | null {
+function toDate(iso: string | null): Date | null {
+  if (!iso) return null;
   const parsed = new Date(iso);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }


### PR DESCRIPTION
The composer preview now parses the structured block out of the transcript file it is holding instead of reading sections the picker kept in memory, so the block's format is exercised end to end before send. A file with no block, or an unreadable one, still falls back to the ordinary flat chips.

https://linear.app/erato-labs/issue/ERMAIN-593