### PR TITLE
Bump oauth2-proxy to v7.15.2-erato.4

### DIFF
--- a/frontend/local-auth/docker-compose.entra-id.yml
+++ b/frontend/local-auth/docker-compose.entra-id.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   oauth2-proxy:
     # https://github.com/oauth2-proxy/oauth2-proxy/releases
-    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.3
+    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.4
     network_mode: host
     volumes:
       - ./oauth2-proxy-entra-id.cfg:/etc/oauth2-proxy/oauth2-proxy.cfg

--- a/frontend/local-auth/docker-compose.keycloak.yml
+++ b/frontend/local-auth/docker-compose.keycloak.yml
@@ -29,7 +29,7 @@ services:
       start_period: 15s
 
   oauth2-proxy:
-    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.3
+    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.4
     network_mode: host
     volumes:
       - ./oauth2-proxy-keycloak.cfg:/etc/oauth2-proxy/oauth2-proxy.cfg

--- a/frontend/local-auth/docker-compose.yml
+++ b/frontend/local-auth/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   oauth2-proxy:
     # https://github.com/oauth2-proxy/oauth2-proxy/releases
-    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.3
+    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.4
     network_mode: host
     volumes:
       - ./oauth2-proxy.cfg:/etc/oauth2-proxy/oauth2-proxy.cfg

--- a/infrastructure/charts/erato/README.md
+++ b/infrastructure/charts/erato/README.md
@@ -437,7 +437,7 @@ chart.
 | oauth2Proxy.image.pullPolicy | string | `"IfNotPresent"` | OAuth2 Proxy image pull policy |
 | oauth2Proxy.image.pullSecrets | list | `[]` | OAuth2 Proxy image pull secrets |
 | oauth2Proxy.image.repository | string | `"registry.eratolabs.com/erato/oauth2-proxy"` | OAuth2 Proxy image repository |
-| oauth2Proxy.image.tag | string | `"v7.15.2-erato.3"` | OAuth2 Proxy image tag |
+| oauth2Proxy.image.tag | string | `"v7.15.2-erato.4"` | OAuth2 Proxy image tag |
 | oauth2Proxy.metrics.enabled | bool | `false` | Enable oauth2-proxy metrics exposure resources. |
 | oauth2Proxy.metrics.port | int | `44180` | oauth2-proxy metrics listener port. Must match oauth2-proxy config (e.g. metrics_address). |
 | oauth2Proxy.metrics.service.addPrometheusAnnotations | bool | `true` | Add standard `prometheus.io/*` scrape annotations to the metrics Service. |

--- a/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
+++ b/infrastructure/charts/erato/tests/oauth2-proxy-deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
           value: oauth2-proxy
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.3
+          value: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.4
 
   - it: should not render when oauth2Proxy is disabled
     set:

--- a/infrastructure/charts/erato/values.yaml
+++ b/infrastructure/charts/erato/values.yaml
@@ -69,7 +69,7 @@ oauth2Proxy:
     # -- OAuth2 Proxy image repository
     repository: registry.eratolabs.com/erato/oauth2-proxy
     # -- OAuth2 Proxy image tag
-    tag: v7.15.2-erato.3
+    tag: v7.15.2-erato.4
     # -- OAuth2 Proxy image pull policy
     pullPolicy: IfNotPresent
     # -- OAuth2 Proxy image pull secrets

--- a/office-addin/local-auth/docker-compose.yml
+++ b/office-addin/local-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   oauth2-proxy:
-    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.3
+    image: registry.eratolabs.com/erato/oauth2-proxy:v7.15.2-erato.4
     network_mode: host
     volumes:
       - ./oauth2-proxy-entra-id.cfg:/etc/oauth2-proxy/oauth2-proxy.cfg

--- a/office-addin/local-auth/oauth2-proxy-entra-id.template.cfg
+++ b/office-addin/local-auth/oauth2-proxy-entra-id.template.cfg
@@ -39,5 +39,7 @@ set_xauthrequest = true
 pass_authorization_header = true
 pass_access_token = true
 skip_jwt_bearer_tokens = true
+# Required due to Office returning expired ID tokens; Still requires current access token
+insecure_oidc_allow_expired_id_token_on_external_redemption = true
 session_store_type = "redis"
 redis_connection_url = "redis://localhost:6379"


### PR DESCRIPTION
## Summary

- bump tracked oauth2-proxy image pins from `v7.15.2-erato.3` to `v7.15.2-erato.4`
- update the Helm image assertion and generated chart documentation
- enable `insecure_oidc_allow_expired_id_token_on_external_redemption` in the Office Entra local-auth template

## Why

Office/NAA can keep returning an expired ID token while the accompanying access token is still current. The oauth2-proxy fork now has an opt-in compatibility setting for this external-redemption case. This rollout keeps normal access-token validation in place while allowing the Office add-in to establish its oauth2-proxy session.

Related Linear issue: [ERMAIN-600](https://linear.app/erato-labs/issue/ERMAIN-600/roll-out-oauth2-proxy-v7152-erato4-for-expired-office-id-token)

Follow-up to ERMAIN-459.

## Validation

- `pnpm exec prettier . --check`
- `./scripts/check-i18n-extract.sh`
- `pnpm run i18n:compile`
- `pnpm run lint`
- `pnpm run lint:strict`
- `pnpm run typecheck`
- `pnpm exec vitest run` — 120 files, 1,015 passed, 11 skipped
- `just deps`
- `just validate_schema`
- `just lint`
- `just unittest` — 21 suites, 170 tests passed
- `just docs_check`
- `git diff --check`