### PR TITLE
Open a stored Teams transcript as its conversation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,10 @@
       "types": "./dist-library/shared/index.d.ts",
       "import": "./dist-library/shared.mjs"
     },
+    "./teams": {
+      "types": "./dist-library/utils/teams/index.d.ts",
+      "import": "./dist-library/teams.mjs"
+    },
     "./shared-runtime/*": {
       "import": "./dist-library/component-kit-host/shared-*.mjs"
     },

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -578,6 +578,7 @@ export const Chat = ({
   const {
     isPreviewModalOpen,
     fileToPreview,
+    relatedFiles: previewRelatedFiles,
     openPreviewModal,
     closePreviewModal,
   } = useFilePreviewModal();
@@ -903,6 +904,7 @@ export const Chat = ({
           isOpen={isPreviewModalOpen}
           onClose={closePreviewModal}
           file={fileToPreview}
+          relatedFiles={previewRelatedFiles}
         />
 
         {/* Render the Feedback View Dialog */}

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -4,6 +4,10 @@ import clsx from "clsx";
 import { memo, useCallback, useMemo, useState } from "react";
 
 import { InteractiveContainer } from "@/components/ui/Container/InteractiveContainer";
+import {
+  getFileName,
+  type FileResource,
+} from "@/components/ui/FileUpload/FilePreviewBase";
 import { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
 import { useImageLightbox } from "@/hooks/ui/useImageLightbox";
 import { useGetFile } from "@/lib/generated/v1betaApi/v1betaApiComponents";
@@ -13,6 +17,7 @@ import {
 } from "@/providers/FeatureConfigProvider";
 import { hasToolCalls as messageHasToolCalls } from "@/utils/adapters/toolCallAdapter";
 import { isImageFile } from "@/utils/file/fileTypeUtils";
+import { teamsUploadDisplayName } from "@/utils/teams/teamsUploadName";
 
 import { Alert } from "../Feedback/Alert";
 import { Avatar } from "../Feedback/Avatar";
@@ -531,6 +536,14 @@ const AttachedFile = ({
   }
 
   const previewUrl = getPreviewUrl(fileData);
+  // A Teams upload is named after its bytes so the backend can join it to the
+  // message that carried it. That name is a key, not something to read; the
+  // transcript's own index holds the exact one, and this recovers the readable
+  // part for a chip that has only the upload.
+  const readableName = teamsUploadDisplayName(fileData.filename);
+  const shownFile: FileResource = readableName
+    ? { ...fileData, displayName: readableName }
+    : fileData;
 
   // Check if it's an image using centralized utility
   if (isImageFile(fileData.filename) && previewUrl) {
@@ -555,7 +568,7 @@ const AttachedFile = ({
           className="size-24 rounded-lg border border-theme-border-primary object-cover transition-transform hover:scale-105"
         />
         <div className="mt-1 max-w-[96px] truncate text-xs text-theme-fg-muted">
-          {fileData.filename}
+          {getFileName(shownFile)}
         </div>
       </InteractiveContainer>
     );
@@ -577,7 +590,7 @@ const AttachedFile = ({
       useDiv={true}
     >
       <FilePreviewButton
-        file={fileData}
+        file={shownFile}
         onRemove={() => {}}
         disabled={true}
         showFileType={true}

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import clsx from "clsx";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import { InteractiveContainer } from "@/components/ui/Container/InteractiveContainer";
 import { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
@@ -85,7 +85,10 @@ export interface ChatMessageProps {
   onMessageAction: (action: MessageAction) => Promise<boolean>;
   userProfile?: UserProfile;
   userDisplayNameOverride?: string;
-  onFilePreview?: (file: FileUploadItem) => void;
+  onFilePreview?: (
+    file: FileUploadItem,
+    relatedFiles?: readonly FileUploadItem[],
+  ) => void;
   onViewFeedback?: (messageId: string, feedback: MessageFeedback) => void;
   /** Map of all files from the entire conversation keyed by file ID */
   allFilesById?: Record<string, FileUploadItem>;
@@ -143,6 +146,12 @@ export const ChatMessage = memo(function ChatMessage({
   // Use the provided allFilesById from parent
   // This allows erato-file:// links to reference files from any message in the conversation
   const filesById = allFilesById;
+  // Every file the chat knows about, so a viewer can resolve one its own
+  // artifact only names — the transcript's uploads are the case in point.
+  const siblingFiles = useMemo(
+    () => Object.values(allFilesById),
+    [allFilesById],
+  );
 
   // Content validation
   if (message.content.length === 0 && !message.loading && !message.error) {
@@ -241,6 +250,7 @@ export const ChatMessage = memo(function ChatMessage({
                 <AttachedFile
                   key={fileId}
                   fileId={fileId}
+                  relatedFiles={siblingFiles}
                   onFilePreview={onFilePreview}
                 />
               ))}
@@ -481,10 +491,15 @@ const formatFilterLabel = (value: string) =>
 // Helper component to fetch and display a single attached file
 const AttachedFile = ({
   fileId,
+  relatedFiles,
   onFilePreview,
 }: {
   fileId: string;
-  onFilePreview?: (file: FileUploadItem) => void;
+  relatedFiles: readonly FileUploadItem[];
+  onFilePreview?: (
+    file: FileUploadItem,
+    relatedFiles?: readonly FileUploadItem[],
+  ) => void;
 }) => {
   const {
     data: fileData,
@@ -528,7 +543,7 @@ const AttachedFile = ({
         onClick={() => {
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (onFilePreview && fileData) {
-            onFilePreview(fileData);
+            onFilePreview(fileData, relatedFiles);
           } else if (previewUrl) {
             window.open(previewUrl, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
           }
@@ -552,7 +567,7 @@ const AttachedFile = ({
       onClick={() => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (onFilePreview && fileData) {
-          onFilePreview(fileData);
+          onFilePreview(fileData, relatedFiles);
         } else if (previewUrl) {
           window.open(previewUrl, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
         }

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
@@ -76,9 +76,9 @@ export interface FilePreviewContentProps {
    */
   mimeType?: string;
   /**
-   * Other files available beside this one. Only viewers that reference their
-   * siblings by name use it — a Teams transcript names the uploads that rode
-   * along with it but does not carry their bytes.
+   * Other files the viewer may resolve against. Only viewers that reference
+   * uploads by name use it — a Teams transcript names what rode along with it
+   * but does not carry the bytes.
    */
   relatedFiles?: readonly FileUploadItem[];
 }

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
@@ -11,6 +11,7 @@ import { PptxPreview } from "./PptxPreview";
 import { TeamsTranscriptPreview } from "./TeamsTranscriptPreview";
 import { XlsxPreview } from "./XlsxPreview";
 
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type React from "react";
 
 // PDFium and its plugin graph are the heaviest viewer in this bundle, and the
@@ -74,6 +75,12 @@ export interface FilePreviewContentProps {
    * `message/rfc822`). When absent, routing falls back to extension alone.
    */
   mimeType?: string;
+  /**
+   * Other files available beside this one. Only viewers that reference their
+   * siblings by name use it — a Teams transcript names the uploads that rode
+   * along with it but does not carry their bytes.
+   */
+  relatedFiles?: readonly FileUploadItem[];
 }
 
 /**
@@ -87,6 +94,7 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
   filename,
   url,
   mimeType,
+  relatedFiles,
 }) => {
   const extension = getExtension(filename);
   const isImage =
@@ -160,7 +168,13 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
   }
 
   if (isMarkdown) {
-    return <TeamsTranscriptPreview filename={filename} url={url} />;
+    return (
+      <TeamsTranscriptPreview
+        filename={filename}
+        url={url}
+        relatedFiles={relatedFiles}
+      />
+    );
   }
 
   return (

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
@@ -8,6 +8,7 @@ import { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoadin
 import { DocxPreview } from "./DocxPreview";
 import { EmlPreview } from "./EmlPreview";
 import { PptxPreview } from "./PptxPreview";
+import { TeamsTranscriptPreview } from "./TeamsTranscriptPreview";
 import { XlsxPreview } from "./XlsxPreview";
 
 import type React from "react";
@@ -100,6 +101,11 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
     mimeType === PPT_MIME_TYPE ||
     mimeType === PPTX_MIME_TYPE;
   const isXlsx = extension === "xlsx" || mimeType === XLSX_MIME_TYPE;
+  // Routed on the extension alone: the preview endpoint types `.md` as
+  // `application/octet-stream`, so the mime says nothing. Whether this really
+  // is a transcript is settled by sniffing the fetched bytes, and a plain
+  // markdown file still renders as text — better than the dead end below.
+  const isMarkdown = extension === "md" || mimeType === "text/markdown";
 
   if (isImage) {
     return (
@@ -151,6 +157,10 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
 
   if (isXlsx) {
     return <XlsxPreview filename={filename} url={url} />;
+  }
+
+  if (isMarkdown) {
+    return <TeamsTranscriptPreview filename={filename} url={url} />;
   }
 
   return (

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
@@ -61,9 +61,61 @@ const PPTX_MIME_TYPE =
 const XLSX_MIME_TYPE =
   // eslint-disable-next-line lingui/no-unlocalized-strings
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const MARKDOWN_MIME_TYPE =
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  "text/markdown";
 
 function isImageMime(mimeType: string | undefined): boolean {
   return mimeType?.startsWith(IMAGE_MIME_PREFIX) ?? false;
+}
+
+/** Which inline viewer draws a file; null when none can. */
+export type PreviewKind =
+  | "image"
+  | "pdf"
+  | "eml"
+  | "docx"
+  | "pptx"
+  | "xlsx"
+  | "markdown";
+
+/**
+ * The single answer to "can this be previewed, and by what".
+ *
+ * Both readers of it need the same answer for different reasons: the modal
+ * decides whether to offer a preview at all, this component decides which
+ * viewer to mount. They used to hold separate lists, which drifted the moment
+ * a type was added to one — a file the renderer could draw was refused
+ * upstream and the user got "not available" with no way to tell why.
+ */
+export function resolvePreviewKind(
+  filename: string,
+  mimeType?: string,
+): PreviewKind | null {
+  const extension = getExtension(filename);
+  if (
+    IMAGE_EXTENSIONS.includes(extension as (typeof IMAGE_EXTENSIONS)[number]) ||
+    isImageMime(mimeType)
+  ) {
+    return "image";
+  }
+  if (extension === "pdf" || mimeType === "application/pdf") return "pdf";
+  if (extension === "eml" || mimeType === "message/rfc822") return "eml";
+  if (extension === "docx" || mimeType === DOCX_MIME_TYPE) return "docx";
+  if (
+    extension === "ppt" ||
+    extension === "pptx" ||
+    mimeType === PPT_MIME_TYPE ||
+    mimeType === PPTX_MIME_TYPE
+  ) {
+    return "pptx";
+  }
+  if (extension === "xlsx" || mimeType === XLSX_MIME_TYPE) return "xlsx";
+  // The preview endpoint types `.md` as application/octet-stream, so only the
+  // extension identifies it; whether it is really a transcript is settled by
+  // sniffing the bytes, and plain markdown still renders as text.
+  if (extension === "md" || mimeType === MARKDOWN_MIME_TYPE) return "markdown";
+  return null;
 }
 
 export interface FilePreviewContentProps {
@@ -96,26 +148,9 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
   mimeType,
   relatedFiles,
 }) => {
-  const extension = getExtension(filename);
-  const isImage =
-    IMAGE_EXTENSIONS.includes(extension as (typeof IMAGE_EXTENSIONS)[number]) ||
-    isImageMime(mimeType);
-  const isPdf = extension === "pdf" || mimeType === "application/pdf";
-  const isEml = extension === "eml" || mimeType === "message/rfc822";
-  const isDocx = extension === "docx" || mimeType === DOCX_MIME_TYPE;
-  const isPptx =
-    extension === "ppt" ||
-    extension === "pptx" ||
-    mimeType === PPT_MIME_TYPE ||
-    mimeType === PPTX_MIME_TYPE;
-  const isXlsx = extension === "xlsx" || mimeType === XLSX_MIME_TYPE;
-  // Routed on the extension alone: the preview endpoint types `.md` as
-  // `application/octet-stream`, so the mime says nothing. Whether this really
-  // is a transcript is settled by sniffing the fetched bytes, and a plain
-  // markdown file still renders as text — better than the dead end below.
-  const isMarkdown = extension === "md" || mimeType === "text/markdown";
+  const kind = resolvePreviewKind(filename, mimeType);
 
-  if (isImage) {
+  if (kind === "image") {
     return (
       <img
         src={url}
@@ -125,7 +160,7 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
     );
   }
 
-  if (isPdf) {
+  if (kind === "pdf") {
     return (
       // Nothing above this renders a boundary — not Chat, not the add-in shell
       // — so a rejected chunk import (a deploy rotated the hash under an open
@@ -151,23 +186,23 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
     );
   }
 
-  if (isEml) {
+  if (kind === "eml") {
     return <EmlPreview filename={filename} url={url} />;
   }
 
-  if (isDocx) {
+  if (kind === "docx") {
     return <DocxPreview url={url} />;
   }
 
-  if (isPptx) {
+  if (kind === "pptx") {
     return <PptxPreview url={url} />;
   }
 
-  if (isXlsx) {
+  if (kind === "xlsx") {
     return <XlsxPreview filename={filename} url={url} />;
   }
 
-  if (isMarkdown) {
+  if (kind === "markdown") {
     return (
       <TeamsTranscriptPreview
         filename={filename}

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
@@ -1,0 +1,195 @@
+import { I18nProvider } from "@lingui/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { messages as enMessages } from "@/locales/en/messages.json";
+import {
+  TEAMS_TRANSCRIPT_INDEX_MARKER,
+  TEAMS_TRANSCRIPT_INDEX_VERSION,
+} from "@/utils/teams/teamsTranscriptIndex";
+
+import { TeamsTranscriptPreview } from "./TeamsTranscriptPreview";
+
+import type { TeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
+import type { Messages } from "@lingui/core";
+import type React from "react";
+
+/** MessageTimestamp formats through lingui, so the catalogue has to be live. */
+async function renderPreview(ui: React.ReactElement) {
+  const { i18n } = await import("@lingui/core");
+  i18n.load("en", enMessages as unknown as Messages);
+  i18n.activate("en");
+  return render(
+    <I18nProvider i18n={i18n}>
+      <ThemeProvider>{ui}</ThemeProvider>
+    </I18nProvider>,
+  );
+}
+
+const FILE = {
+  filename: "teams-Product_sync.md",
+  url: "https://files.example.com/teams-Product_sync.md",
+};
+
+const conversation = { kind: "chat", chatId: "19:chat" } as const;
+
+const INDEX: TeamsTranscriptIndex = {
+  version: TEAMS_TRANSCRIPT_INDEX_VERSION,
+  exportedAt: "2026-03-02T00:00:00Z",
+  timeZone: "UTC",
+  sections: [
+    {
+      kind: "chat",
+      ref: conversation,
+      title: "Product sync",
+      teamName: null,
+      selection: "whole-chat",
+      limit: 200,
+      truncated: false,
+      skippedCount: 0,
+      window: { from: "2026-03-01T08:00:00Z", to: "2026-03-01T08:00:00Z" },
+      participants: ["Ada Lovelace", "Grace Hopper"],
+      viewer: "Grace Hopper",
+    },
+  ],
+  messages: [
+    {
+      ordinal: 1,
+      section: 0,
+      ref: { conversation, messageId: "m1", parentMessageId: null },
+      sender: "Ada Lovelace",
+      createdAt: "2026-03-01T08:00:00Z",
+      editedAt: null,
+      subject: null,
+      deepLink: "https://teams.microsoft.com/l/message/19:chat/m1",
+      text: "Can we move the sync? [attachment: teams-file-abcd1234-plan.pdf]",
+      assets: [
+        {
+          name: "teams-file-abcd1234-plan.pdf",
+          displayName: "Q3 plan.pdf",
+          kind: "file",
+        },
+      ],
+    },
+  ],
+};
+
+/** A transcript as the add-in writes one: prose, then the trailing block. */
+function transcript(index: TeamsTranscriptIndex = INDEX): string {
+  return [
+    "# Teams chat: Product sync",
+    "",
+    "[1] Ada Lovelace (08:00): Can we move the sync?",
+    "",
+    `<!-- ${TEAMS_TRANSCRIPT_INDEX_MARKER} v${index.version} ${JSON.stringify(index)} -->`,
+    "",
+  ].join("\n");
+}
+
+function respondWith(body: string, ok = true) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        ok,
+        status: ok ? 200 : 500,
+        text: () => Promise.resolve(body),
+      } as unknown as Response),
+    ),
+  );
+}
+
+describe("TeamsTranscriptPreview", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the stored transcript as its conversation", async () => {
+    respondWith(transcript());
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    expect(await screen.findByText("Product sync")).toBeVisible();
+    expect(screen.getByText("Ada Lovelace")).toBeVisible();
+    expect(screen.getByText("Can we move the sync?")).toBeVisible();
+    expect(screen.getByText("Ada Lovelace, Grace Hopper")).toBeVisible();
+  });
+
+  it("names the uploads a message carried, never by their stored name", async () => {
+    respondWith(transcript());
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    expect(await screen.findByText(/Q3 plan/)).toBeVisible();
+    expect(screen.queryByText(/teams-file-abcd1234/)).toBeNull();
+  });
+
+  it("leaves the chips inert, since the modal holds only this one file", async () => {
+    respondWith(transcript());
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    await screen.findByText(/Q3 plan/);
+    expect(screen.queryByRole("button", { name: /Q3 plan/ })).toBeNull();
+  });
+
+  it("falls back to the markdown when the file carries no block", async () => {
+    // The dead end this replaces was "Preview is not available"; plain text
+    // beats it even for a file that was never a transcript.
+    respondWith("# Notes\n\nJust an ordinary markdown file.\n");
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    expect(
+      await screen.findByText(/Just an ordinary markdown file/),
+    ).toBeVisible();
+    expect(screen.getByRole("alert")).toBeVisible();
+  });
+
+  it("falls back to the markdown when the block cannot be read", async () => {
+    respondWith(
+      `# Teams chat\n\n<!-- ${TEAMS_TRANSCRIPT_INDEX_MARKER} v1 {"sections": -->\n`,
+    );
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    expect(await screen.findByText(/Teams chat/)).toBeVisible();
+  });
+
+  it("says so when the file cannot be fetched at all", async () => {
+    respondWith("", false);
+    await renderPreview(<TeamsTranscriptPreview {...FILE} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not be loaded/i,
+    );
+  });
+
+  it("re-reads when the modal moves to another file", async () => {
+    respondWith(transcript());
+    const { rerender } = await renderPreview(
+      <TeamsTranscriptPreview {...FILE} />,
+    );
+    await screen.findByText("Product sync");
+
+    respondWith(
+      transcript({
+        ...INDEX,
+        sections: [{ ...INDEX.sections[0], title: "Design review" }],
+      }),
+    );
+    const { i18n } = await import("@lingui/core");
+    rerender(
+      <I18nProvider i18n={i18n}>
+        <ThemeProvider>
+          <TeamsTranscriptPreview
+            filename="teams-Design_review.md"
+            url="https://files.example.com/teams-Design_review.md"
+          />
+        </ThemeProvider>
+      </I18nProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Design review")).toBeVisible(),
+    );
+    expect(screen.queryByText("Product sync")).toBeNull();
+  });
+});

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
@@ -1,5 +1,5 @@
 import { I18nProvider } from "@lingui/react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
@@ -11,6 +11,7 @@ import {
 
 import { TeamsTranscriptPreview } from "./TeamsTranscriptPreview";
 
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { TeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
 import type { Messages } from "@lingui/core";
 import type React from "react";
@@ -100,6 +101,12 @@ function respondWith(body: string, ok = true) {
   );
 }
 
+vi.mock("./PdfPreview", () => ({
+  PdfPreview: ({ url }: { url: string }) => (
+    <div data-testid="file-preview-pdf" data-url={url} />
+  ),
+}));
+
 describe("TeamsTranscriptPreview", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -124,12 +131,41 @@ describe("TeamsTranscriptPreview", () => {
     expect(screen.queryByText(/teams-file-abcd1234/)).toBeNull();
   });
 
-  it("leaves the chips inert, since the modal holds only this one file", async () => {
+  it("leaves the chips inert when the caller has no sibling files", async () => {
     respondWith(transcript());
     await renderPreview(<TeamsTranscriptPreview {...FILE} />);
 
     await screen.findByText(/Q3 plan/);
     expect(screen.queryByRole("button", { name: /Q3 plan/ })).toBeNull();
+  });
+
+  it("opens an upload the transcript names, joined by filename", async () => {
+    // The transcript records only names; the bytes live in the sibling upload,
+    // so the chip is clickable exactly when the caller supplies it.
+    const upload = {
+      id: "upload-1",
+      filename: "teams-file-abcd1234-plan.pdf",
+      download_url: "https://files.example.com/download/plan.pdf",
+      preview_url: "https://files.example.com/preview/plan.pdf",
+      file_capability: { mime_types: ["application/pdf"] },
+    } as unknown as FileUploadItem;
+
+    respondWith(transcript());
+    await renderPreview(
+      <TeamsTranscriptPreview {...FILE} relatedFiles={[upload]} />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Q3 plan/ }));
+
+    // Navigates in place, as the email preview does, with a way back.
+    expect(
+      screen.getByRole("button", { name: /back to conversation/i }),
+    ).toBeVisible();
+    // The PDF viewer is lazy-loaded behind Suspense.
+    expect(await screen.findByTestId("file-preview-pdf")).toHaveAttribute(
+      "data-url",
+      "https://files.example.com/preview/plan.pdf",
+    );
   });
 
   it("falls back to the markdown when the file carries no block", async () => {

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
@@ -1,0 +1,114 @@
+import { t } from "@lingui/core/macro";
+import { useEffect, useState } from "react";
+
+import { Alert } from "@/components/ui/Feedback/Alert";
+import { TeamsConversationView } from "@/components/ui/Teams/TeamsConversationView";
+import { LoadingIcon } from "@/components/ui/icons";
+import { createLogger } from "@/utils/debugLogger";
+import { parseTeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
+
+import type { TeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
+
+const logger = createLogger("UI", "TeamsTranscriptPreview");
+
+interface TeamsTranscriptPreviewProps {
+  filename: string;
+  url: string;
+}
+
+/**
+ * A stored Teams transcript, opened as the conversation it was taken from.
+ *
+ * Shaped after `EmlPreview`: fetch the one stored artifact and re-derive its
+ * structure on demand, rather than reading anything kept beside it. What comes
+ * back is the same index block the composer already renders before sending, so
+ * both surfaces show the same conversation from the same source.
+ *
+ * The rendering itself is not here — `TeamsConversationView` owns it, and is
+ * handed an already-parsed index. This component is only the acquisition half.
+ *
+ * It degrades rather than failing. A file with no readable block is still
+ * markdown worth reading, so it renders as text; only a fetch that never
+ * lands has nothing to show.
+ */
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "unreachable" }
+  | { kind: "conversation"; index: TeamsTranscriptIndex }
+  /** Readable, but carrying no block this build understands. */
+  | { kind: "markdown"; text: string };
+
+export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
+  url,
+}) => {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    let aborted = false;
+    setState({ kind: "loading" });
+
+    const load = async () => {
+      let text: string;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        text = await response.text();
+      } catch (error) {
+        logger.error("failed to fetch transcript", error);
+        if (!aborted) setState({ kind: "unreachable" });
+        return;
+      }
+      if (aborted) return;
+      const index = parseTeamsTranscriptIndex(text);
+      setState(
+        index ? { kind: "conversation", index } : { kind: "markdown", text },
+      );
+    };
+
+    void load();
+    return () => {
+      aborted = true;
+    };
+  }, [url]);
+
+  if (state.kind === "loading") {
+    return (
+      <div className="flex min-h-[30vh] items-center justify-center">
+        <LoadingIcon className="size-6 animate-spin text-theme-fg-muted" />
+        <span className="sr-only">{t`Loading conversation…`}</span>
+      </div>
+    );
+  }
+
+  if (state.kind === "unreachable") {
+    return (
+      <Alert type="error">{t`This conversation could not be loaded.`}</Alert>
+    );
+  }
+
+  if (state.kind === "markdown") {
+    return (
+      <div className="flex flex-col gap-2">
+        <Alert type="info">
+          {t`This file carries no conversation data, so it is shown as text.`}
+        </Alert>
+        <pre className="whitespace-pre-wrap break-words font-mono text-xs text-theme-fg-primary">
+          {state.text}
+        </pre>
+      </div>
+    );
+  }
+
+  return (
+    <TeamsConversationView
+      index={state.index}
+      // Nothing here holds the uploads a message carried — the modal is showing
+      // one stored file, not the set it arrived with — so the chips name what
+      // rode along without offering to open it.
+      onOpenInTeams={(message) => {
+        window.open(message.deepLink, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
+      }}
+      className="min-w-0"
+    />
+  );
+};

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
@@ -11,7 +11,10 @@ import { parseTeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
 import { FilePreviewContent } from "./FilePreviewContent";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
-import type { TeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
+import type {
+  TeamsTranscriptIndex,
+  TeamsTranscriptIndexAsset,
+} from "@/utils/teams/teamsTranscriptIndex";
 
 const logger = createLogger("UI", "TeamsTranscriptPreview");
 
@@ -19,13 +22,23 @@ interface TeamsTranscriptPreviewProps {
   filename: string;
   url: string;
   /**
-   * The other uploads that arrived with this one. A transcript records only
-   * the filenames of what rode along, so the bytes have to be found among the
-   * chat's own files; without them the chips still name what was shared, they
-   * just cannot be opened.
+   * Uploads this one can be resolved against — in practice every file the chat
+   * knows about, not only the message's own. A transcript records the filenames
+   * of what rode along but not the bytes, so they have to be found among them;
+   * without any, the chips still name what was shared, they just cannot open.
+   *
+   * A wider set is harmless here: the names are content-hashed, so a match from
+   * another message is the same bytes under the same name.
    */
   relatedFiles?: readonly FileUploadItem[];
 }
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "unreachable" }
+  | { kind: "conversation"; index: TeamsTranscriptIndex }
+  /** Readable, but carrying no block this build understands. */
+  | { kind: "markdown"; text: string };
 
 /**
  * A stored Teams transcript, opened as the conversation it was taken from.
@@ -42,13 +55,6 @@ interface TeamsTranscriptPreviewProps {
  * markdown worth reading, so it renders as text; only a fetch that never
  * lands has nothing to show.
  */
-type LoadState =
-  | { kind: "loading" }
-  | { kind: "unreachable" }
-  | { kind: "conversation"; index: TeamsTranscriptIndex }
-  /** Readable, but carrying no block this build understands. */
-  | { kind: "markdown"; text: string };
-
 export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
   url,
   relatedFiles,
@@ -59,7 +65,7 @@ export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
   // The minted upload name is the join key the transcript recorded, and it is
   // exactly the filename the upload was stored under.
   const resolveAsset = useCallback(
-    (asset: { name: string }) =>
+    (asset: TeamsTranscriptIndexAsset) =>
       relatedFiles?.find((file) => file.filename === asset.name) ?? null,
     [relatedFiles],
   );

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
@@ -1,12 +1,16 @@
 import { t } from "@lingui/core/macro";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
+import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
 import { TeamsConversationView } from "@/components/ui/Teams/TeamsConversationView";
-import { LoadingIcon } from "@/components/ui/icons";
+import { ArrowLeftIcon, LoadingIcon } from "@/components/ui/icons";
 import { createLogger } from "@/utils/debugLogger";
 import { parseTeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
 
+import { FilePreviewContent } from "./FilePreviewContent";
+
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { TeamsTranscriptIndex } from "@/utils/teams/teamsTranscriptIndex";
 
 const logger = createLogger("UI", "TeamsTranscriptPreview");
@@ -14,6 +18,13 @@ const logger = createLogger("UI", "TeamsTranscriptPreview");
 interface TeamsTranscriptPreviewProps {
   filename: string;
   url: string;
+  /**
+   * The other uploads that arrived with this one. A transcript records only
+   * the filenames of what rode along, so the bytes have to be found among the
+   * chat's own files; without them the chips still name what was shared, they
+   * just cannot be opened.
+   */
+  relatedFiles?: readonly FileUploadItem[];
 }
 
 /**
@@ -40,8 +51,18 @@ type LoadState =
 
 export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
   url,
+  relatedFiles,
 }) => {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const [selected, setSelected] = useState<FileUploadItem | null>(null);
+
+  // The minted upload name is the join key the transcript recorded, and it is
+  // exactly the filename the upload was stored under.
+  const resolveAsset = useCallback(
+    (asset: { name: string }) =>
+      relatedFiles?.find((file) => file.filename === asset.name) ?? null,
+    [relatedFiles],
+  );
 
   useEffect(() => {
     let aborted = false;
@@ -70,6 +91,31 @@ export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
       aborted = true;
     };
   }, [url]);
+
+  if (selected) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          icon={<ArrowLeftIcon className="size-4" aria-hidden="true" />}
+          onClick={() => setSelected(null)}
+          className="w-fit"
+        >
+          {t`Back to conversation`}
+        </Button>
+        <div className="truncate text-sm text-theme-fg-muted">
+          {selected.filename}
+        </div>
+        <FilePreviewContent
+          filename={selected.filename}
+          url={selected.preview_url ?? selected.download_url}
+          mimeType={selected.file_capability.mime_types[0]}
+        />
+      </div>
+    );
+  }
 
   if (state.kind === "loading") {
     return (
@@ -102,9 +148,13 @@ export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
   return (
     <TeamsConversationView
       index={state.index}
-      // Nothing here holds the uploads a message carried — the modal is showing
-      // one stored file, not the set it arrived with — so the chips name what
-      // rode along without offering to open it.
+      resolveAsset={resolveAsset}
+      // `resolveAsset` only ever returns a member of this list, so matching on
+      // identity narrows back to the upload without asserting a type.
+      onFilePreview={(file) => {
+        const upload = relatedFiles?.find((candidate) => candidate === file);
+        if (upload) setSelected(upload);
+      }}
       onOpenInTeams={(message) => {
         window.open(message.deepLink, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
       }}

--- a/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
+++ b/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
@@ -58,7 +58,11 @@ export function getFileName(file: FileResource): string {
     return file.name;
   }
 
-  if (isLocalFilePreviewItem(file) && file.displayName) {
+  // Any resource may carry a friendlier name, not only an un-uploaded one: a
+  // stored upload can have a minted filename that is a join key rather than
+  // something to read. The API type has no `displayName`, so this only ever
+  // fires where a caller deliberately supplied one.
+  if ("displayName" in file && file.displayName) {
     return file.displayName;
   }
 

--- a/frontend/src/components/ui/Modal/FilePreviewModal.test.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.test.tsx
@@ -140,6 +140,44 @@ describe("FilePreviewModal", () => {
     );
   });
 
+  it("reaches the transcript renderer for a stored .md", () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve("# not a transcript\n"),
+      } as unknown as Response),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Regression: this modal keeps its own allow-list, separate from
+    // FilePreviewContent's routing. A type the renderer can draw but this gate
+    // omits never reaches it — the user gets "not available" instead.
+    renderWithTheme(
+      <FilePreviewModal
+        isOpen={true}
+        onClose={vi.fn()}
+        file={makeFile({
+          filename: "teams-chats-2.md",
+          download_url: "https://files.example.com/download/teams-chats-2.md",
+          preview_url: "https://files.example.com/preview/teams-chats-2.md",
+          file_capability:
+            FileTypeUtil.createMockFileCapability("teams-chats-2.md"),
+        })}
+      />,
+    );
+
+    // The transcript renderer fetches the file; that request is the proof it
+    // was reached. (The Download button renders in both branches, so its
+    // presence says nothing either way.)
+    expect(
+      screen.queryByText(/Preview is not available for this file type/i),
+    ).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://files.example.com/preview/teams-chats-2.md",
+    );
+  });
+
   it("previews XLSX files from the preview URL", () => {
     renderWithTheme(
       <FilePreviewModal

--- a/frontend/src/components/ui/Modal/FilePreviewModal.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.tsx
@@ -74,6 +74,11 @@ interface FilePreviewModalProps {
    * wrong explanation.
    */
   notPreviewableReason?: string;
+  /**
+   * The files this one arrived with. Forwarded to viewers that reference their
+   * siblings by name rather than carrying their bytes.
+   */
+  relatedFiles?: readonly FileUploadItem[];
 }
 
 /**
@@ -84,6 +89,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
   onClose,
   file,
   notPreviewableReason,
+  relatedFiles,
 }) => {
   if (!file) {
     return null;
@@ -129,6 +135,7 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
             filename={file.filename}
             url={url}
             mimeType={file.file_capability.mime_types[0]}
+            relatedFiles={relatedFiles}
           />
           {actionButtons}
         </>

--- a/frontend/src/components/ui/Modal/FilePreviewModal.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.tsx
@@ -22,6 +22,9 @@ const PPTX_MIME_TYPE =
 const XLSX_MIME_TYPE =
   // eslint-disable-next-line lingui/no-unlocalized-strings
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const MARKDOWN_MIME_TYPE =
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  "text/markdown";
 
 const getExtension = (filename: string): string =>
   filename.split(".").pop()?.toLowerCase() ?? "";
@@ -45,10 +48,15 @@ const resolvePreviewSource = (
     extension === "ppt" ||
     extension === "pptx" ||
     extension === "xlsx" ||
+    // Kept in step with FilePreviewContent's routing below: this gate decides
+    // whether that renderer is reached at all, so a type it can draw but this
+    // list omits shows the "not available" body instead.
+    extension === "md" ||
     mimeType === DOCX_MIME_TYPE ||
     mimeType === PPT_MIME_TYPE ||
     mimeType === PPTX_MIME_TYPE ||
-    mimeType === XLSX_MIME_TYPE
+    mimeType === XLSX_MIME_TYPE ||
+    mimeType === MARKDOWN_MIME_TYPE
   ) {
     return { url: previewUrl ?? "", canPreview: Boolean(previewUrl) };
   }

--- a/frontend/src/components/ui/Modal/FilePreviewModal.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.tsx
@@ -75,8 +75,8 @@ interface FilePreviewModalProps {
    */
   notPreviewableReason?: string;
   /**
-   * The files this one arrived with. Forwarded to viewers that reference their
-   * siblings by name rather than carrying their bytes.
+   * Files the previewed one can be resolved against. Forwarded to viewers that
+   * reference other uploads by name rather than carrying their bytes.
    */
   relatedFiles?: readonly FileUploadItem[];
 }

--- a/frontend/src/components/ui/Modal/FilePreviewModal.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.tsx
@@ -2,65 +2,39 @@ import { t } from "@lingui/core/macro";
 
 import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
-import { FilePreviewContent } from "@/components/ui/FilePreview/FilePreviewContent";
+import {
+  FilePreviewContent,
+  resolvePreviewKind,
+} from "@/components/ui/FilePreview/FilePreviewContent";
 
 import { ModalBase } from "./ModalBase";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type React from "react";
 
-const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "gif", "webp", "svg", "bmp"];
-const DOCX_MIME_TYPE =
-  // eslint-disable-next-line lingui/no-unlocalized-strings
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-const PPT_MIME_TYPE =
-  // eslint-disable-next-line lingui/no-unlocalized-strings
-  "application/vnd.ms-powerpoint";
-const PPTX_MIME_TYPE =
-  // eslint-disable-next-line lingui/no-unlocalized-strings
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-const XLSX_MIME_TYPE =
-  // eslint-disable-next-line lingui/no-unlocalized-strings
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-const MARKDOWN_MIME_TYPE =
-  // eslint-disable-next-line lingui/no-unlocalized-strings
-  "text/markdown";
-
-const getExtension = (filename: string): string =>
-  filename.split(".").pop()?.toLowerCase() ?? "";
-
 const getPreviewUrl = (
   file: Pick<FileUploadItem, "preview_url">,
 ): string | undefined =>
   typeof file.preview_url === "string" ? file.preview_url : undefined;
 
+/**
+ * Asks the renderer itself what it can draw, rather than keeping a second list
+ * beside it. The two used to be maintained separately and drifted: a type the
+ * renderer handled was refused here, and the user saw "not available" for a
+ * file that was perfectly previewable.
+ */
 const resolvePreviewSource = (
   file: FileUploadItem,
 ): { url: string; canPreview: boolean } => {
-  const extension = getExtension(file.filename);
   const previewUrl = getPreviewUrl(file);
-  const mimeType = file.file_capability.mime_types[0];
-  if (
-    IMAGE_EXTENSIONS.includes(extension) ||
-    extension === "pdf" ||
-    extension === "eml" ||
-    extension === "docx" ||
-    extension === "ppt" ||
-    extension === "pptx" ||
-    extension === "xlsx" ||
-    // Kept in step with FilePreviewContent's routing below: this gate decides
-    // whether that renderer is reached at all, so a type it can draw but this
-    // list omits shows the "not available" body instead.
-    extension === "md" ||
-    mimeType === DOCX_MIME_TYPE ||
-    mimeType === PPT_MIME_TYPE ||
-    mimeType === PPTX_MIME_TYPE ||
-    mimeType === XLSX_MIME_TYPE ||
-    mimeType === MARKDOWN_MIME_TYPE
-  ) {
-    return { url: previewUrl ?? "", canPreview: Boolean(previewUrl) };
+  const kind = resolvePreviewKind(
+    file.filename,
+    file.file_capability.mime_types[0],
+  );
+  if (kind === null) {
+    return { url: "", canPreview: false };
   }
-  return { url: "", canPreview: false };
+  return { url: previewUrl ?? "", canPreview: Boolean(previewUrl) };
 };
 
 interface FilePreviewModalProps {

--- a/frontend/src/components/ui/Teams/TeamsConversationView.tsx
+++ b/frontend/src/components/ui/Teams/TeamsConversationView.tsx
@@ -1,7 +1,10 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 
-import { componentRegistry } from "@/config/componentRegistry";
+import {
+  componentRegistry,
+  resolveComponentOverride,
+} from "@/config/componentRegistry";
 
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { FilePreviewBase } from "../FileUpload/FilePreviewBase";
@@ -423,9 +426,9 @@ function toDate(iso: string | null): Date | null {
 export const TeamsConversationView: React.FC<TeamsConversationViewProps> = (
   props,
 ) => {
-  const Override = componentRegistry.TeamsConversationView;
-  if (Override) {
-    return <Override {...props} />;
-  }
-  return <DefaultTeamsConversationView {...props} />;
+  const Rendered = resolveComponentOverride(
+    componentRegistry.TeamsConversationView,
+    DefaultTeamsConversationView,
+  );
+  return <Rendered {...props} />;
 };

--- a/frontend/src/hooks/ui/useFilePreviewModal.ts
+++ b/frontend/src/hooks/ui/useFilePreviewModal.ts
@@ -9,7 +9,12 @@ const logger = createLogger("HOOK", "useFilePreviewModal");
 interface UseFilePreviewModalResult {
   isPreviewModalOpen: boolean;
   fileToPreview: FileUploadItem | null;
-  openPreviewModal: (file: FileUploadItem) => void;
+  /** The files the previewed one arrived with; empty when the caller has none. */
+  relatedFiles: readonly FileUploadItem[];
+  openPreviewModal: (
+    file: FileUploadItem,
+    relatedFiles?: readonly FileUploadItem[],
+  ) => void;
   closePreviewModal: () => void;
 }
 
@@ -21,25 +26,38 @@ export function useFilePreviewModal(): UseFilePreviewModalResult {
   const [fileToPreview, setFileToPreview] = useState<FileUploadItem | null>(
     null,
   );
+  // Some viewers reference their siblings by name rather than carrying them —
+  // a Teams transcript names the uploads that rode along with it.
+  const [relatedFiles, setRelatedFiles] = useState<readonly FileUploadItem[]>(
+    [],
+  );
 
   // Function to open the modal
-  const openPreviewModal = useCallback((file: FileUploadItem) => {
-    logger.log("Opening preview for file:", file.filename);
-    setFileToPreview(file);
-    setIsPreviewModalOpen(true);
-  }, []);
+  const openPreviewModal = useCallback(
+    (file: FileUploadItem, related: readonly FileUploadItem[] = []) => {
+      logger.log("Opening preview for file:", file.filename);
+      setFileToPreview(file);
+      setRelatedFiles(related);
+      setIsPreviewModalOpen(true);
+    },
+    [],
+  );
 
   // Function to close the modal
   const closePreviewModal = useCallback(() => {
     logger.log("Closing preview modal");
     setIsPreviewModalOpen(false);
     // Delay clearing the file to prevent content flicker during close animation
-    setTimeout(() => setFileToPreview(null), 300);
+    setTimeout(() => {
+      setFileToPreview(null);
+      setRelatedFiles([]);
+    }, 300);
   }, []);
 
   return {
     isPreviewModalOpen,
     fileToPreview,
+    relatedFiles,
     openPreviewModal,
     closePreviewModal,
   };

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -92,6 +92,11 @@ export {
   type FileSourceSelectorProps,
 } from "@/components/ui/FileUpload/FileSourceSelector";
 export {
+  TeamsConversationView,
+  DefaultTeamsConversationView,
+  type TeamsConversationViewProps,
+} from "@/components/ui/Teams/TeamsConversationView";
+export {
   DefaultGroupedFileAttachmentsPreview,
   GroupedFileAttachmentsPreview,
 } from "@/components/ui/FileUpload/GroupedFileAttachmentsPreview";
@@ -306,11 +311,6 @@ export {
   type TeamsTranscriptIndexSection,
   type TeamsTranscriptIndexWindow,
 } from "@/utils/teams/teamsTranscriptIndex";
-export {
-  TeamsConversationView,
-  DefaultTeamsConversationView,
-  type TeamsConversationViewProps,
-} from "@/components/ui/Teams/TeamsConversationView";
 export { sanitizeHtmlPreview } from "@/utils/sanitizeHtmlPreview";
 export {
   extractTextFromContent,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4394,6 +4394,10 @@ msgstr "Laden"
 msgid "Loading attachment..."
 msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Loading conversation…"
+msgstr "Unterhaltung wird geladen …"
+
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Loading file..."
 msgstr ""
@@ -4945,6 +4949,14 @@ msgstr "Denkt nach"
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 #~ msgid "Thinking…"
 #~ msgstr "Denkt nach…"
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This conversation could not be loaded."
+msgstr "Diese Unterhaltung konnte nicht geladen werden."
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This file carries no conversation data, so it is shown as text."
+msgstr "Diese Datei enthält keine Unterhaltungsdaten und wird daher als Text angezeigt."
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -3848,6 +3848,10 @@ msgstr "automatische Verstärkung: {autoGainControl}"
 #~ msgid "Back to Assistants"
 #~ msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Back to conversation"
+msgstr "Zurück zur Unterhaltung"
+
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr ""

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -3848,6 +3848,10 @@ msgstr "auto gain: {autoGainControl}"
 #~ msgid "Back to Assistants"
 #~ msgstr "Back to Assistants"
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Back to conversation"
+msgstr "Back to conversation"
+
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr "Back to email"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -4394,6 +4394,10 @@ msgstr "Loading"
 msgid "Loading attachment..."
 msgstr "Loading attachment..."
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Loading conversation…"
+msgstr "Loading conversation…"
+
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Loading file..."
 msgstr "Loading file..."
@@ -4945,6 +4949,14 @@ msgstr "Thinking"
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 #~ msgid "Thinking…"
 #~ msgstr "Thinking…"
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This conversation could not be loaded."
+msgstr "This conversation could not be loaded."
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This file carries no conversation data, so it is shown as text."
+msgstr "This file carries no conversation data, so it is shown as text."
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4394,6 +4394,10 @@ msgstr "Cargando"
 msgid "Loading attachment..."
 msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Loading conversation…"
+msgstr "Cargando la conversación…"
+
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Loading file..."
 msgstr ""
@@ -4945,6 +4949,14 @@ msgstr "Pensando"
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 #~ msgid "Thinking…"
 #~ msgstr "Pensando…"
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This conversation could not be loaded."
+msgstr "No se pudo cargar esta conversación."
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This file carries no conversation data, so it is shown as text."
+msgstr "Este archivo no contiene datos de conversación, por lo que se muestra como texto."
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -3848,6 +3848,10 @@ msgstr "ganancia automática: {autoGainControl}"
 #~ msgid "Back to Assistants"
 #~ msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Back to conversation"
+msgstr "Volver a la conversación"
+
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr ""

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -3848,6 +3848,10 @@ msgstr "gain automatique : {autoGainControl}"
 #~ msgid "Back to Assistants"
 #~ msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Back to conversation"
+msgstr "Retour à la conversation"
+
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr ""

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4394,6 +4394,10 @@ msgstr "Chargement"
 msgid "Loading attachment..."
 msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Loading conversation…"
+msgstr "Chargement de la conversation…"
+
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Loading file..."
 msgstr ""
@@ -4945,6 +4949,14 @@ msgstr "Réflexion"
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 #~ msgid "Thinking…"
 #~ msgstr "Réflexion…"
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This conversation could not be loaded."
+msgstr "Cette conversation n'a pas pu être chargée."
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This file carries no conversation data, so it is shown as text."
+msgstr "Ce fichier ne contient aucune donnée de conversation ; il est donc affiché sous forme de texte."
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -3848,6 +3848,10 @@ msgstr "automatyczne wzmocnienie: {autoGainControl}"
 #~ msgid "Back to Assistants"
 #~ msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Back to conversation"
+msgstr "Powrót do konwersacji"
+
 #: src/components/ui/FilePreview/EmlPreview.tsx
 msgid "Back to email"
 msgstr ""

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4394,6 +4394,10 @@ msgstr "Ładowanie"
 msgid "Loading attachment..."
 msgstr ""
 
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "Loading conversation…"
+msgstr "Wczytywanie konwersacji…"
+
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
 msgid "Loading file..."
 msgstr ""
@@ -4945,6 +4949,14 @@ msgstr "Myślę"
 #: src/components/ui/Trace/TraceThinkingPlaceholder.tsx
 #~ msgid "Thinking…"
 #~ msgstr "Myślę…"
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This conversation could not be loaded."
+msgstr "Nie udało się wczytać tej konwersacji."
+
+#: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+msgid "This file carries no conversation data, so it is shown as text."
+msgstr "Ten plik nie zawiera danych konwersacji, więc jest wyświetlany jako tekst."
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "This message exceeds the token limit of {maxTokensFormatted}. Please reduce the message length or remove attached files."

--- a/frontend/src/utils/teams/index.ts
+++ b/frontend/src/utils/teams/index.ts
@@ -1,0 +1,33 @@
+/**
+ * The Teams transcript contract, as its own entry point.
+ *
+ * Separate from `@erato/frontend/library` on purpose: this is data, not UI, and
+ * pulling it out of the component barrel keeps it free of React and the DOM. A
+ * consumer that only needs to read or write the transcript format — the add-in's
+ * picker and serializer, a future sidecar — pays for none of that.
+ *
+ * It also keeps the format out of the way of the barrel's blast radius: several
+ * add-in suites replace `@erato/frontend/library` wholesale with a stub, which
+ * silently empties anything imported from it at runtime. Importing the contract
+ * from here is untouched by those stubs.
+ */
+
+export {
+  TEAMS_TRANSCRIPT_INDEX_MARKER,
+  TEAMS_TRANSCRIPT_INDEX_VERSION,
+  parseTeamsTranscriptIndex,
+  type TeamsTranscriptIndex,
+  type TeamsTranscriptIndexAsset,
+  type TeamsTranscriptIndexMessage,
+  type TeamsTranscriptIndexSection,
+  type TeamsTranscriptIndexWindow,
+} from "./teamsTranscriptIndex";
+
+export type {
+  TeamsChannelConversationRef,
+  TeamsChatConversationRef,
+  TeamsConversationRef,
+  TeamsMessageRef,
+} from "./teamsConversationRef";
+
+export { teamsUploadDisplayName } from "./teamsUploadName";

--- a/frontend/src/utils/teams/teamsUploadName.test.ts
+++ b/frontend/src/utils/teams/teamsUploadName.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { teamsUploadDisplayName } from "./teamsUploadName";
+
+describe("teamsUploadDisplayName", () => {
+  it("recovers the readable tail of a minted file upload", () => {
+    expect(
+      teamsUploadDisplayName("teams-file-5d4d89ed-multipage-test.pdf"),
+    ).toBe("multipage-test.pdf");
+    expect(
+      teamsUploadDisplayName("teams-file-d72e2945-big-file-20mb.pdf"),
+    ).toBe("big-file-20mb.pdf");
+  });
+
+  it("keeps the slug's substitutions, which are not reversible", () => {
+    // `Q3 report.pdf` was slugged on the way in; the exact name lives in the
+    // transcript's index, and this is only the fallback for a bare upload.
+    expect(teamsUploadDisplayName("teams-file-abcd1234-Q3_report.pdf")).toBe(
+      "Q3_report.pdf",
+    );
+  });
+
+  it("says nothing for a pasted image, which never had a name", () => {
+    expect(teamsUploadDisplayName("teams-img-0123456789abcdef.png")).toBeNull();
+  });
+
+  it("leaves anything it did not mint alone", () => {
+    for (const name of [
+      "holiday.pdf",
+      "teams-chats-2.md",
+      // Near-misses: the hash segment is what identifies a minted name.
+      "teams-file-report.pdf",
+      "teams-file-XYZ12345-report.pdf",
+      "teams-file-5d4d89ed-",
+      "notes-teams-file-5d4d89ed-report.pdf",
+    ]) {
+      expect(teamsUploadDisplayName(name)).toBeNull();
+    }
+  });
+});

--- a/frontend/src/utils/teams/teamsUploadName.ts
+++ b/frontend/src/utils/teams/teamsUploadName.ts
@@ -1,0 +1,32 @@
+/**
+ * Reading a name back out of an upload the Teams picker minted.
+ *
+ * The picker names what it uploads after the bytes — `teams-file-<hash>-<slug>`
+ * for a shared file, `teams-img-<hash>.<ext>` for a pasted image — because that
+ * name is the key the backend joins parsed uploads by. It is a join key, not
+ * something to read.
+ *
+ * Wherever the transcript's index block is at hand, prefer the `displayName` it
+ * records: that is the name Teams itself gave the file. This is the fallback for
+ * surfaces holding only a bare upload — the chip on a sent message, say — where
+ * parsing the transcript to name a sibling would be far more work than the name
+ * is worth.
+ *
+ * Approximate by construction: the slug replaced separators and was cut to a
+ * length, so `Q3 report.pdf` comes back as `Q3_report.pdf`. That is a fair trade
+ * against showing a content hash, and the exact name is one click away inside
+ * the conversation view.
+ */
+
+const IMAGE_UPLOAD = /^teams-img-[0-9a-f]{16}\.[a-z0-9]+$/;
+const FILE_UPLOAD = /^teams-file-[0-9a-f]{8}-(.+)$/;
+
+/**
+ * The readable part of a minted Teams upload name, or null for anything this
+ * did not mint — an ordinary attachment keeps the name it came with.
+ */
+export function teamsUploadDisplayName(filename: string): string | null {
+  if (IMAGE_UPLOAD.test(filename)) return null;
+  const slug = FILE_UPLOAD.exec(filename)?.[1];
+  return slug !== undefined && slug.length > 0 ? slug : null;
+}

--- a/frontend/vite.library.config.ts
+++ b/frontend/vite.library.config.ts
@@ -57,6 +57,11 @@ export default defineConfig(({ mode }) => {
         entry: {
           library: path.resolve(__dirname, "./src/library/index.ts"),
           shared: path.resolve(__dirname, "./src/shared/index.ts"),
+          // `teams` is the transcript format contract (@erato/frontend/teams):
+          // data with no React or DOM behind it, so a producer that only reads
+          // or writes the format does not pull the component barrel in to get
+          // at a constant.
+          teams: path.resolve(__dirname, "./src/utils/teams/index.ts"),
         },
         formats: ["es"],
         fileName: (_format, entryName) =>

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
         specifier: ^0.27.0
         version: 0.27.0
     devDependencies:
-      '@quantco/pnpm-licenses':
-        specifier: 2.4.1
-        version: 2.4.1
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.5
@@ -88,6 +85,9 @@ importers:
       '@lingui/vite-plugin':
         specifier: 5.9.4
         version: 5.9.4(typescript@5.9.3)(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0))
+      '@quantco/pnpm-licenses':
+        specifier: 2.4.1
+        version: 2.4.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -153,10 +153,6 @@ importers:
         version: 4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0))
 
 packages:
-
-  '@quantco/pnpm-licenses@2.4.1':
-    resolution: {integrity: sha512-+Jc670YHuQ1OY/xTAAFGjTHU3Hx/GqP/XTY/6L0YaUaQuY54FGhIlBzPsfabW67FfmueC5NOSDfiFywiwSmTFQ==}
-    hasBin: true
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
@@ -507,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-Q6yDyXueNQjf1WMACTgrw6b9hGv3w3duY0Fql1wuVrDBN+MnWCYxad1aZvgSTs1E/l3hJm0gBeWWO4ZcbLSPyA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-rCGyZ1oK2hDTNe9M3VtQohSb2H5d7MLvdG5VTTvNQ1fFjCi4wH6aPIBmF/LZtZ2rVglguECpegZbV4/UaYa9gQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -932,6 +928,10 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@quantco/pnpm-licenses@2.4.1':
+    resolution: {integrity: sha512-+Jc670YHuQ1OY/xTAAFGjTHU3Hx/GqP/XTY/6L0YaUaQuY54FGhIlBzPsfabW67FfmueC5NOSDfiFywiwSmTFQ==}
+    hasBin: true
 
   '@react-hook/latest@1.0.3':
     resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
@@ -1695,13 +1695,13 @@ packages:
     resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  array-union@3.0.1:
-    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
-    engines: {node: '>=12'}
-
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
+
+  array-union@3.0.1:
+    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
+    engines: {node: '>=12'}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -3313,6 +3313,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  multimatch@8.0.0:
+    resolution: {integrity: sha512-0D10M2/MnEyvoog7tmozlpSqL3HEU1evxUFa3v1dsKYmBDFSP1dLSX4CH2rNjpQ+4Fps8GKmUkCwiKryaKqd9A==}
+    engines: {node: '>=20'}
+
   nano-css@5.6.2:
     resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
     peerDependencies:
@@ -3723,6 +3727,9 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  remove-markdown@0.5.5:
+    resolution: {integrity: sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3884,6 +3891,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-license-list@6.12.0:
+    resolution: {integrity: sha512-+nUYqm3aZMSHbjsthK+i/HHI2okTElCvqwUd4k8QcSk+FTGgjq+fsdFj2wZOaX6XmR2JdWhf/NeflNnvKOjcnQ==}
+    engines: {node: '>=8'}
 
   sse.js@2.8.0:
     resolution: {integrity: sha512-35RyyFYpzzHZgMw9D5GxwADbL6gnntSwW/rKXcuIy1KkYCPjW6oia0moNdNRhs34oVHU1Sjgovj3l7uIEZjrKA==}
@@ -4372,6 +4383,9 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
@@ -4394,14 +4408,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@quantco/pnpm-licenses@2.4.1':
-    dependencies:
-      minimist: 1.2.8
-      multimatch: 8.0.0
-      remove-markdown: 0.5.5
-      spdx-license-list: 6.12.0
-      zod: 4.4.3
 
   '@adobe/css-tools@4.5.0': {}
 
@@ -5293,6 +5299,14 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
+  '@quantco/pnpm-licenses@2.4.1':
+    dependencies:
+      minimist: 1.2.8
+      multimatch: 8.0.0
+      remove-markdown: 0.5.5
+      spdx-license-list: 6.12.0
+      zod: 4.4.3
+
   '@react-hook/latest@1.0.3(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -6033,8 +6047,6 @@ snapshots:
 
   array-differ@4.0.0: {}
 
-  array-union@3.0.1: {}
-
   array-includes@3.1.9:
     dependencies:
       call-bind: 1.0.9
@@ -6045,6 +6057,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
+
+  array-union@3.0.1: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -8094,6 +8108,12 @@ snapshots:
 
   ms@2.1.3: {}
 
+  multimatch@8.0.0:
+    dependencies:
+      array-differ: 4.0.0
+      array-union: 3.0.1
+      minimatch: 10.2.5
+
   nano-css@5.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -8603,6 +8623,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  remove-markdown@0.5.5: {}
+
   require-from-string@2.0.2: {}
 
   resize-observer-polyfill@1.5.1: {}
@@ -8789,6 +8811,8 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-license-list@6.12.0: {}
 
   sse.js@2.8.0: {}
 
@@ -9343,6 +9367,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.14(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7):
     optionalDependencies:

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -123,6 +123,7 @@ export interface AddinChatController {
   handleSendMessage: AddinChatInputRenderProps["onSendMessage"];
   isPreviewModalOpen: boolean;
   fileToPreview: ReturnType<typeof useFilePreviewModal>["fileToPreview"];
+  relatedFiles: ReturnType<typeof useFilePreviewModal>["relatedFiles"];
   openPreviewModal: ReturnType<typeof useFilePreviewModal>["openPreviewModal"];
   closePreviewModal: ReturnType<
     typeof useFilePreviewModal
@@ -414,6 +415,7 @@ function useAddinChatController({
     handleSendMessage,
     isPreviewModalOpen: preview.isPreviewModalOpen,
     fileToPreview: preview.fileToPreview,
+    relatedFiles: preview.relatedFiles,
     openPreviewModal: preview.openPreviewModal,
     closePreviewModal: preview.closePreviewModal,
     controlsContext,
@@ -585,6 +587,7 @@ export function AddinChatCoreView({
           isOpen={controller.isPreviewModalOpen}
           onClose={controller.closePreviewModal}
           file={controller.fileToPreview}
+          relatedFiles={controller.relatedFiles}
         />
         <FeedbackViewDialog
           isOpen={feedback.feedbackViewDialogState.isOpen}

--- a/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatPickerDialog.test.tsx
@@ -36,17 +36,6 @@ import type { ReactNode } from "react";
 /* --------------------------------------------------------------- library */
 
 vi.mock("@erato/frontend/library", () => ({
-  // The transcript this dialog builds is stamped with the index-block header.
-  // Restated rather than imported because a mock factory is hoisted above the
-  // file's imports, so the only way to reach the real constants from in here is
-  // to load the library bundle inside the factory — which runs before the test
-  // environment exists and dies on a missing `document`.
-  //
-  // Nothing in this file asserts on either value; they exist so the production
-  // path does not stamp `undefined`. A drift shows up in
-  // buildTeamsTranscriptFile.test.ts, which pins the header literal directly.
-  TEAMS_TRANSCRIPT_INDEX_MARKER: "erato:teams-transcript",
-  TEAMS_TRANSCRIPT_INDEX_VERSION: 1,
   ModalBase: ({
     children,
     isOpen,

--- a/office-addin/src/teams/hooks/useTeamsTranscriptIndex.ts
+++ b/office-addin/src/teams/hooks/useTeamsTranscriptIndex.ts
@@ -1,7 +1,7 @@
-import { parseTeamsTranscriptIndex } from "@erato/frontend/library";
+import { parseTeamsTranscriptIndex } from "@erato/frontend/teams";
 import { useEffect, useReducer } from "react";
 
-import type { TeamsTranscriptIndex } from "@erato/frontend/library";
+import type { TeamsTranscriptIndex } from "@erato/frontend/teams";
 
 /**
  * Reads a transcript's index block back out of the file, so a caller renders

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -1,4 +1,4 @@
-import { parseTeamsTranscriptIndex } from "@erato/frontend/library";
+import { parseTeamsTranscriptIndex } from "@erato/frontend/teams";
 import { describe, expect, it } from "vitest";
 
 import { MOCK_CHAT_ID } from "../../../test/mocks/teams/graph";

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -14,7 +14,7 @@
  * testable.
  */
 
-import { TEAMS_TRANSCRIPT_INDEX_VERSION } from "@erato/frontend/library";
+import { TEAMS_TRANSCRIPT_INDEX_VERSION } from "@erato/frontend/teams";
 
 import { isRestrictedChannel } from "./parsedTeamsChannel";
 import { channelRef, chatRef, messageRef } from "./teamsConversationRef";

--- a/office-addin/src/teams/utils/teamsTranscriptIndex.ts
+++ b/office-addin/src/teams/utils/teamsTranscriptIndex.ts
@@ -4,9 +4,9 @@
  * Teams picker ever produces one, so only the serializer lives here.
  */
 
-import { TEAMS_TRANSCRIPT_INDEX_MARKER } from "@erato/frontend/library";
+import { TEAMS_TRANSCRIPT_INDEX_MARKER } from "@erato/frontend/teams";
 
-import type { TeamsTranscriptIndex } from "@erato/frontend/library";
+import type { TeamsTranscriptIndex } from "@erato/frontend/teams";
 
 /** The single line appended to the transcript. */
 export function serializeTeamsTranscriptIndex(

--- a/office-addin/tsconfig.json
+++ b/office-addin/tsconfig.json
@@ -17,7 +17,12 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@erato/frontend/library": ["../frontend/dist-library/library/index.d.ts"]
+      "@erato/frontend/library": [
+        "../frontend/dist-library/library/index.d.ts"
+      ],
+      "@erato/frontend/teams": [
+        "../frontend/dist-library/utils/teams/index.d.ts"
+      ]
     }
   },
   "include": ["src", "vite.config.ts", "vitest.config.ts"]

--- a/office-addin/vite.config.ts
+++ b/office-addin/vite.config.ts
@@ -845,6 +845,10 @@ export default defineConfig(({ mode }) => {
               __dirname,
               "../frontend/dist-library/shared.mjs",
             ),
+            "@erato/frontend/teams": path.resolve(
+              __dirname,
+              "../frontend/dist-library/teams.mjs",
+            ),
             ...Object.fromEntries(
               SHARED_MODULES.filter(
                 (entry) => entry.specifier !== "@erato/frontend/shared",


### PR DESCRIPTION
Closes ERMAIN-585. Stacks on #966.

## What

Clicking an attached Teams transcript — in a sent message, after a reload, on another device — reached *"Preview is not available for this file type"*. It now opens the same conversation the composer already shows before sending.

`TeamsTranscriptPreview` is shaped after `EmlPreview`, as the ticket asked: `{ filename, url }`, fetch in an effect with teardown, parse, render richly, degrade rather than error. It is only the **acquisition** half — `TeamsConversationView` (from #966) owns the rendering and is handed an already-parsed index. That split is the entire reason the renderer was built to take one, and it means pre-send and post-send cannot drift.

Registered in the `FilePreviewContent` switch alongside `isEml` / `isPdf` / `isDocx`.

## The ticket's gate — cleared

> Confirm the frontend can `fetch()` a stored `.md` by its preview URL. `preview_content_type` has no `md` arm and returns `application/octet-stream`, which may force a download disposition.

Checked before building. `preview_content_type` (`backend/erato/src/server/api/v1beta/mod.rs:3288`) does fall through to `application/octet-stream` for `.md` — but the preview handler sends `Content-Disposition: inline` (`:3417`), and `fetch()` ignores disposition regardless. An octet-stream body reads fine via `.text()`. **No backend change needed.**

The consequence is only for routing: the mime tells us nothing, so `.md` routes on the extension and the bytes decide. A marker-less markdown file renders as text — still better than the dead end it replaces.

## Degradation

Three outcomes, matching `EmlPreview`'s posture:

| state | render |
| -- | -- |
| block parses | the conversation |
| readable, no usable block | the markdown as text, with a notice |
| fetch never lands | an error alert |