### PR TITLE
Teach and resolve Teams transcript message citations

### DIFF
--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.test.tsx
@@ -168,6 +168,18 @@ describe("TeamsTranscriptPreview", () => {
     );
   });
 
+  it("reveals the message a citation's #msg anchor names", async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+    respondWith(transcript());
+    const { container } = await renderPreview(
+      <TeamsTranscriptPreview {...FILE} url={`${FILE.url}#msg=1`} />,
+    );
+
+    await screen.findByText("Product sync");
+    expect(container.querySelector('[data-ordinal="1"]')).toHaveClass("ring-2");
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the markdown when the file carries no block", async () => {
     // The dead end this replaces was "Preview is not available"; plain text
     // beats it even for a file that was never a transcript.

--- a/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
@@ -40,6 +40,20 @@ type LoadState =
   /** Readable, but carrying no block this build understands. */
   | { kind: "markdown"; text: string };
 
+const MESSAGE_ANCHOR = "#msg=";
+
+/**
+ * Citations deep-link into a transcript as "…teams-chat.md#msg=7" (see the
+ * erato-file:// handling in MessageContent). The fragment never reaches the
+ * server — fetch strips it — so it only has to be read out here.
+ */
+const parseMessageAnchor = (url: string): number | null => {
+  const anchorAt = url.lastIndexOf(MESSAGE_ANCHOR);
+  if (anchorAt === -1) return null;
+  const ordinal = Number(url.slice(anchorAt + MESSAGE_ANCHOR.length));
+  return Number.isInteger(ordinal) && ordinal > 0 ? ordinal : null;
+};
+
 /**
  * A stored Teams transcript, opened as the conversation it was taken from.
  *
@@ -154,6 +168,7 @@ export const TeamsTranscriptPreview: React.FC<TeamsTranscriptPreviewProps> = ({
   return (
     <TeamsConversationView
       index={state.index}
+      focusOrdinal={parseMessageAnchor(url)}
       resolveAsset={resolveAsset}
       // `resolveAsset` only ever returns a member of this list, so matching on
       // identity narrows back to the upload without asserting a type.

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -495,6 +495,37 @@ describe("MessageContent", () => {
     );
   });
 
+  it("passes Teams message anchors through to the preview callback for erato-file links", () => {
+    const onFileLinkPreview = vi.fn();
+    const file = makeFile({
+      filename: "teams-Product_sync.md",
+      download_url: "https://files.example.com/teams-Product_sync.md",
+      preview_url: "https://files.example.com/preview/teams-Product_sync.md",
+      file_capability: FileTypeUtil.createMockFileCapability(
+        "teams-Product_sync.md",
+      ),
+    });
+
+    renderWithTheme(
+      <MessageContent
+        content={textContent("[3](erato-file://file_123#msg=3)")}
+        filesById={{ [file.id]: file }}
+        onFileLinkPreview={onFileLinkPreview}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("3"));
+
+    expect(onFileLinkPreview).toHaveBeenCalledTimes(1);
+    expect(onFileLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "file_123",
+        preview_url:
+          "https://files.example.com/preview/teams-Product_sync.md#msg=3",
+      }),
+    );
+  });
+
   it("resolves preview-only erato-file links without requiring a download url", () => {
     const onFileLinkPreview = vi.fn();
     const file = makeFile({

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -427,6 +427,17 @@ const MARKDOWN_IMAGE_STYLE = {
 } as const;
 const UNRESOLVED_IMAGE_ANCHOR = "#unresolved-link";
 
+/** A deep-link anchor, accepted as either "?page=4" or the "#page=4" form. */
+const getAnchorParam = (urlObj: URL, name: string): string | null => {
+  const query = urlObj.searchParams.get(name);
+  if (query) {
+    return query;
+  }
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  const hashMatch = urlObj.hash.match(new RegExp(`^#${name}=(\\d+)$`));
+  return hashMatch ? hashMatch[1] : null;
+};
+
 const getEratoFileIdFromUrl = (url: string): string | null => {
   // eslint-disable-next-line lingui/no-unlocalized-strings
   if (!url.startsWith("erato-file://")) {
@@ -536,23 +547,27 @@ export const MessageContent = memo(function MessageContent({
           return null;
         }
 
-        let pageParam = urlObj.searchParams.get("page");
-        if (!pageParam && urlObj.hash) {
-          const hashMatch = urlObj.hash.match(/^#page=(\d+)$/);
-          if (hashMatch) {
-            pageParam = hashMatch[1];
-          }
-        }
+        // Which anchor the file's viewer honours: PDFs jump to a page, Teams
+        // transcripts to the message ordinal a citation names.
+        const filename = file.filename.toLowerCase();
+        const anchorName = filename.endsWith(".pdf")
+          ? "page"
+          : filename.endsWith(".md")
+            ? "msg"
+            : null;
+        const anchorValue = anchorName
+          ? getAnchorParam(urlObj, anchorName)
+          : null;
 
         const resolvedHref =
-          pageParam && previewUrl
-            ? `${previewUrl}#page=${pageParam}`
+          anchorValue && previewUrl
+            ? `${previewUrl}#${anchorName}=${anchorValue}`
             : (previewUrl ?? "#");
 
         return {
           resolvedHref,
           previewFile:
-            pageParam && file.filename.toLowerCase().endsWith(".pdf")
+            anchorValue && previewUrl
               ? {
                   ...file,
                   preview_url: resolvedHref,

--- a/frontend/src/components/ui/Teams/TeamsConversationView.test.tsx
+++ b/frontend/src/components/ui/Teams/TeamsConversationView.test.tsx
@@ -313,6 +313,33 @@ describe("TeamsConversationView", () => {
     );
   });
 
+  it("reveals and highlights the cited message", async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+    const { container } = await renderView(
+      <TeamsConversationView
+        index={index([message(1), message(2), message(3)])}
+        focusOrdinal={2}
+      />,
+    );
+
+    const cited = container.querySelector('[data-ordinal="2"]');
+    expect(cited).toHaveClass("ring-2");
+    expect(container.querySelector('[data-ordinal="1"]')).not.toHaveClass(
+      "ring-2",
+    );
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+    scrollIntoView.mockRestore();
+  });
+
+  it("scrolls nowhere when no message is cited", async () => {
+    const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+    await renderView(<TeamsConversationView index={index([message(1)])} />);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    scrollIntoView.mockRestore();
+  });
+
   it("drops the heading when the host already names the conversation", async () => {
     await renderView(
       <TeamsConversationView index={index([message(1)])} showTitle={false} />,

--- a/frontend/src/components/ui/Teams/TeamsConversationView.tsx
+++ b/frontend/src/components/ui/Teams/TeamsConversationView.tsx
@@ -1,5 +1,6 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
+import { useCallback } from "react";
 
 import {
   componentRegistry,
@@ -55,6 +56,11 @@ export interface TeamsConversationViewProps {
    * chip is not clickable — a message still says what rode along with it.
    */
   resolveAsset?: (asset: TeamsTranscriptIndexAsset) => FileResource | null;
+  /**
+   * Ordinal of a cited message: scrolled into view on mount and kept
+   * highlighted, so a citation lands on the message it names.
+   */
+  focusOrdinal?: number | null;
   className?: string;
 }
 
@@ -88,6 +94,7 @@ export const DefaultTeamsConversationView: React.FC<
   onOpenInTeams,
   onFilePreview,
   resolveAsset,
+  focusOrdinal,
   className,
 }) => {
   const positions =
@@ -111,6 +118,7 @@ export const DefaultTeamsConversationView: React.FC<
             onOpenInTeams={onOpenInTeams}
             onFilePreview={onFilePreview}
             resolveAsset={resolveAsset}
+            focusOrdinal={focusOrdinal ?? null}
           />
         );
       })}
@@ -123,6 +131,7 @@ const ConversationSection: React.FC<
     section: TeamsTranscriptIndexSection;
     messages: TeamsTranscriptIndexMessage[];
     showTitle: boolean;
+    focusOrdinal: number | null;
   }
 > = ({
   section,
@@ -131,6 +140,7 @@ const ConversationSection: React.FC<
   onOpenInTeams,
   onFilePreview,
   resolveAsset,
+  focusOrdinal,
 }) => {
   const title = section.teamName
     ? `${section.title} · ${section.teamName}`
@@ -205,6 +215,7 @@ const ConversationSection: React.FC<
                     key={message.ordinal}
                     message={message}
                     isViewer={run.isViewer}
+                    isFocused={message.ordinal === focusOrdinal}
                     onOpenInTeams={onOpenInTeams}
                     onFilePreview={onFilePreview}
                     resolveAsset={resolveAsset}
@@ -223,18 +234,34 @@ const MessageBlock: React.FC<
   ConversationCallbacks & {
     message: TeamsTranscriptIndexMessage;
     isViewer: boolean;
+    isFocused: boolean;
   }
-> = ({ message, isViewer, onOpenInTeams, onFilePreview, resolveAsset }) => {
+> = ({
+  message,
+  isViewer,
+  isFocused,
+  onOpenInTeams,
+  onFilePreview,
+  resolveAsset,
+}) => {
   const body = bodyWithoutAssetMarkers(message);
   const createdAt = toDate(message.createdAt);
+  // A callback ref rather than an effect: it fires exactly once, when the
+  // cited message's node exists, which is the only moment the jump can happen.
+  const revealOnMount = useCallback((node: HTMLDivElement | null) => {
+    node?.scrollIntoView({ block: "center" });
+  }, []);
 
   return (
     <div
+      ref={isFocused ? revealOnMount : undefined}
+      data-ordinal={message.ordinal}
       className={clsx(
         "rounded-[var(--theme-radius-message)] border px-2 py-1.5",
         isViewer
           ? "border-theme-border-strong bg-theme-bg-accent"
           : "border-theme-border bg-theme-bg-secondary",
+        isFocused && "ring-2 ring-theme-focus",
       )}
     >
       <div className="flex items-start gap-2">

--- a/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
+++ b/office-addin/src/teams/utils/__tests__/buildTeamsTranscriptFile.test.ts
@@ -190,6 +190,27 @@ describe("buildTeamsTranscriptMarkdown", () => {
     expectNoIdentifiers(markdown, ["1754983230123"]);
   });
 
+  it("teaches the citation link form once, whatever the section count", () => {
+    const markdown = render([
+      section(),
+      section({
+        selection: "messages",
+        chat: { ...chat, chatId: "19:other@thread.v2", title: "Other" },
+        messages: [message({ messageId: "c" })],
+      }),
+    ]);
+    const prose = proseOf(markdown);
+    expect(
+      prose.match(
+        /link its ordinal as \[n\]\(erato-file:\/\/<file_id>#msg=n\)/g,
+      ),
+    ).toHaveLength(1);
+    // The lesson closes the prose, after every conversation it applies to.
+    expect(prose.indexOf("To cite a message above")).toBeGreaterThan(
+      prose.indexOf("# Teams chat: Other"),
+    );
+  });
+
   it("numbers messages contiguously from 1 across every section", () => {
     const markdown = render([
       section({

--- a/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
+++ b/office-addin/src/teams/utils/buildTeamsTranscriptFile.ts
@@ -7,7 +7,8 @@
  * message text. Message ids and Teams permalinks stay out — they exist for
  * rendering and back-linking — so each message is cited by the ordinal in its
  * heading, and the identifiers ride in the trailing index block that the
- * backend strips before the file reaches a model.
+ * backend strips before the file reaches a model. A closing line teaches the
+ * link form that turns an ordinal into a citation the renderer can resolve.
  *
  * Formatting is fixed English/ISO rather than locale-dependent: the transcript
  * is read by the model, and a deterministic rendering is what makes it
@@ -65,6 +66,15 @@ export interface TeamsTranscriptInput {
 }
 
 const MAX_FILENAME_SLUG_LENGTH = 80;
+
+/**
+ * Teaches the model the citation form the renderer resolves into a jump back
+ * to the message. The file id it names is deliberately absent here — the
+ * backend prints it as `erato_file_id` in the header it wraps every attached
+ * file with, so the model joins the two at read time.
+ */
+const CITATION_LINE =
+  "To cite a message above, link its ordinal as [n](erato-file://<file_id>#msg=n), where <file_id> is this file's erato_file_id.";
 
 /** Null when nothing renderable survived — an empty file is never uploaded. */
 export function buildTeamsTranscriptFile(
@@ -143,7 +153,7 @@ export function buildTeamsTranscriptDocument(
     messages,
   };
   return {
-    markdown: `${rendered.join("\n\n")}\n\n${serializeTeamsTranscriptIndex(index)}\n`,
+    markdown: `${rendered.join("\n\n")}\n\n${CITATION_LINE}\n\n${serializeTeamsTranscriptIndex(index)}\n`,
     index,
   };
 }


### PR DESCRIPTION
Implements ERMAIN-582: the model can cite a Teams transcript message and the reader can jump to it.

- The transcript serializer closes its prose with one teaching line: cite message *n* as `[n](erato-file://<file_id>#msg=n)`, joining `<file_id>` from the `erato_file_id` header the backend wraps every attached file with. No identifiers return to the payload — the ERMAIN-584 diet stands.
- `MessageContent` generalizes the existing PDF `#page=` anchor handling: `#msg=N` is honored for `.md` files and rides the `preview_url` into the file-preview modal.
- `TeamsTranscriptPreview` reads the `#msg=` anchor off its URL (fetch ignores fragments, as in `PdfPreview`) and passes a new `focusOrdinal` to `TeamsConversationView`, which scrolls the cited message into view on mount and keeps it highlighted.
- The citation click lands in our preview; the external jump stays the per-message "Open in Teams" button. The constructed chat deep link behind it was verified live in the Teams client