### PR TITLE
Pin Teams message windows to creation time, pace chat reads, gate add-menu rows on the file limit

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInputAddControls.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddControls.tsx
@@ -112,6 +112,7 @@ export function ChatInputAddControls({
                   onSelectFiles={onSelectFiles}
                   onClose={close}
                   disabled={disabled}
+                  uploadDisabled={uploadDisabled}
                   isProcessing={isProcessing}
                 />
               )

--- a/frontend/src/components/ui/Chat/__tests__/ChatInputAddControls.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/ChatInputAddControls.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { componentRegistry } from "@/config/componentRegistry";
+
+import { ChatInputAddControls } from "../ChatInputAddControls";
+
+import type { ChatAddMenuExtraContentProps } from "@/config/componentRegistry";
+
+vi.mock("@/hooks/files/useChatFileSources", () => ({
+  useChatFileSources: () => ({
+    isProcessing: false,
+    fileSourceItems: [],
+    onSelectFiles: vi.fn(),
+    dropzoneRootProps: (props: object = {}) => props,
+    dropzoneInputProps: (props: object = {}) => props,
+    cloudPickerProps: null,
+  }),
+}));
+
+const seenExtraContentProps: ChatAddMenuExtraContentProps[] = [];
+function ProbeExtraContent(props: ChatAddMenuExtraContentProps) {
+  seenExtraContentProps.push(props);
+  return <div data-testid="probe-extra-content" />;
+}
+
+function renderControls(props: Partial<{ uploadDisabled: boolean }> = {}) {
+  return render(
+    <ChatInputAddControls
+      canUpload
+      upload={{ message: "" }}
+      facets={[]}
+      selectedFacetIds={[]}
+      onToggleFacet={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe("ChatInputAddControls", () => {
+  const previousExtraContent = componentRegistry.ChatAddMenuExtraContent;
+
+  afterEach(() => {
+    componentRegistry.ChatAddMenuExtraContent = previousExtraContent;
+    seenExtraContentProps.length = 0;
+  });
+
+  // Host rows add files through onSelectFiles, so they must see the
+  // attachment-limit state — overflow past the limit is silently discarded
+  // by the composer merge, not rejected.
+  it("forwards the upload-limit state to host extra content", () => {
+    componentRegistry.ChatAddMenuExtraContent = ProbeExtraContent;
+
+    renderControls({ uploadDisabled: true });
+    fireEvent.click(screen.getByTestId("chat-input-add-menu-trigger"));
+
+    expect(screen.getByTestId("probe-extra-content")).toBeInTheDocument();
+    const props = seenExtraContentProps.at(-1);
+    expect(props?.uploadDisabled).toBe(true);
+    expect(props?.disabled).toBe(false);
+  });
+
+  it("leaves host extra content enabled below the limit", () => {
+    componentRegistry.ChatAddMenuExtraContent = ProbeExtraContent;
+
+    renderControls();
+    fireEvent.click(screen.getByTestId("chat-input-add-menu-trigger"));
+
+    const props = seenExtraContentProps.at(-1);
+    expect(props?.uploadDisabled).toBe(false);
+    expect(props?.disabled).toBe(false);
+  });
+});

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -65,6 +65,12 @@ export interface ChatAddMenuExtraContentProps {
   onClose: () => void;
   /** Whether the composer is disabled. */
   disabled?: boolean;
+  /**
+   * The composer cannot take more files (e.g. the attachment limit is
+   * reached). Rows that add files must disable on this — overflow past the
+   * limit is silently discarded, not rejected.
+   */
+  uploadDisabled?: boolean;
   /** Whether an upload/link is currently in flight. */
   isProcessing?: boolean;
 }

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -99,6 +99,7 @@ export { EditIcon } from "@/components/ui/icons/index";
 export { EditPencil } from "@/components/ui/icons/index";
 export { ErrorIcon } from "@/components/ui/icons/index";
 export { FileTextIcon } from "@/components/ui/icons/index";
+export { FilterSortIcon } from "@/components/ui/icons/index";
 export { FolderIcon } from "@/components/ui/icons/index";
 export { GridXmark } from "@/components/ui/icons/index";
 export { GridXmarkIcon } from "@/components/ui/icons/index";

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-rCGyZ1oK2hDTNe9M3VtQohSb2H5d7MLvdG5VTTvNQ1fFjCi4wH6aPIBmF/LZtZ2rVglguECpegZbV4/UaYa9gQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-KbQY0l26MtyGFohK+MOxvs7ArtvJNGjmn+CBbVp1LP2Fc1y+z2kQpzkf/X0iV6NbrC4rtqy1z0icWEwFfK1NbQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
+++ b/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
@@ -64,8 +64,11 @@ export function AddinChatAddMenuExtraContent({
   const isSuggestionEligible =
     host === "Outlook" && currentChatId === null && messageOrder.length === 0;
 
-  const isBusy =
-    disabled || uploadDisabled || isProcessing || isUploadingEmailContent;
+  const isBusy = disabled || isProcessing || isUploadingEmailContent;
+  // Restores only clear a dismissal and ride a separate send-time upload
+  // outside the composer's file slots, so the attachment limit gates only
+  // genuine uploads.
+  const isUploadBlocked = uploadDisabled && !isSuggestionEligible;
   const canUploadEmailContent = !!onSelectFiles;
   const selectableAttachments = useMemo(
     () => attachments.filter((attachment) => !attachment.isInline),
@@ -190,7 +193,12 @@ export function AddinChatAddMenuExtraContent({
               tabIndex={-1}
               data-add-menu-item=""
               onClick={handleSelectEmailBody}
-              disabled={isBusy || !canUploadEmailContent || isAlreadyAdded}
+              disabled={
+                isBusy ||
+                isUploadBlocked ||
+                !canUploadEmailContent ||
+                isAlreadyAdded
+              }
               title={emailBodyFile.name}
               data-testid="addin-add-menu-email-thread"
               className={rowClassName}
@@ -249,6 +257,7 @@ export function AddinChatAddMenuExtraContent({
             onClick={() => handleSelectAttachment(attachment.id)}
             disabled={
               isBusy ||
+              isUploadBlocked ||
               !canUploadEmailContent ||
               isCloudAttachment ||
               isAlreadyAdded

--- a/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
+++ b/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
@@ -42,6 +42,7 @@ export function AddinChatAddMenuExtraContent({
   onSelectFiles,
   onClose,
   disabled = false,
+  uploadDisabled = false,
   isProcessing = false,
 }: ChatAddMenuExtraContentProps) {
   const { host } = useOffice();
@@ -63,7 +64,8 @@ export function AddinChatAddMenuExtraContent({
   const isSuggestionEligible =
     host === "Outlook" && currentChatId === null && messageOrder.length === 0;
 
-  const isBusy = disabled || isProcessing || isUploadingEmailContent;
+  const isBusy =
+    disabled || uploadDisabled || isProcessing || isUploadingEmailContent;
   const canUploadEmailContent = !!onSelectFiles;
   const selectableAttachments = useMemo(
     () => attachments.filter((attachment) => !attachment.isInline),

--- a/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
+++ b/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
@@ -23,6 +23,7 @@ export function TeamsChatAddMenuExtraContent({
   onSelectFiles,
   onClose,
   disabled = false,
+  uploadDisabled = false,
   isProcessing = false,
 }: ChatAddMenuExtraContentProps) {
   const { unavailableReason } = useTeamsChatFetcher();
@@ -37,7 +38,11 @@ export function TeamsChatAddMenuExtraContent({
 
   const supportsMarkdown = getSupportedFileTypes(capabilities).includes("text");
   const isDisabled =
-    disabled || isProcessing || !onSelectFiles || !supportsMarkdown;
+    disabled ||
+    uploadDisabled ||
+    isProcessing ||
+    !onSelectFiles ||
+    !supportsMarkdown;
 
   return (
     <>

--- a/office-addin/src/teams/components/__tests__/TeamsChatAddMenuExtraContent.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsChatAddMenuExtraContent.test.tsx
@@ -72,7 +72,7 @@ describe("TeamsChatAddMenuExtraContent", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("disables the row while the composer is busy or has no upload path", () => {
+  it("disables the row while the composer is busy, full, or has no upload path", () => {
     const { rerender } = render(
       <TeamsChatAddMenuExtraContent onClose={() => {}} />,
     );
@@ -92,6 +92,17 @@ describe("TeamsChatAddMenuExtraContent", () => {
         onSelectFiles={onSelectFiles}
         onClose={() => {}}
         disabled
+      />,
+    );
+    expect(screen.getByRole("menuitem")).toBeDisabled();
+
+    // At the attachment limit a picked conversation would be silently
+    // truncated by the composer merge, so the row must not open the picker.
+    rerender(
+      <TeamsChatAddMenuExtraContent
+        onSelectFiles={onSelectFiles}
+        onClose={() => {}}
+        uploadDisabled
       />,
     );
     expect(screen.getByRole("menuitem")).toBeDisabled();

--- a/office-addin/src/teams/utils/__tests__/teamsChatGraph.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsChatGraph.test.ts
@@ -8,14 +8,30 @@ import {
 import { makeGraphTokenSource } from "../../../utils/graph/graphClient";
 import {
   getChatMessage,
+  getTeamsChat,
   listChatMessagesPage,
   listTeamsChatsPage,
   searchChatMessages,
   splitSearchSummaryHighlights,
 } from "../teamsChatGraph";
-import { resetTeamsChatRateGates } from "../teamsChatRateGate";
+import {
+  resetTeamsChatRateGates,
+  runAtChatMetadataRate,
+} from "../teamsChatRateGate";
 
 import type { GraphTransport } from "../../../utils/graph/graphClient";
+import type * as teamsChatRateGateModule from "../teamsChatRateGate";
+
+// Pass-through spy on the metadata pacer: the wiring (`metadataRate: true` on
+// exactly the List/Get chat calls) is otherwise invisible to tests, because a
+// freshly reset gate never sleeps on its first call.
+vi.mock("../teamsChatRateGate", async (importOriginal) => {
+  const actual = await importOriginal<typeof teamsChatRateGateModule>();
+  return {
+    ...actual,
+    runAtChatMetadataRate: vi.fn(actual.runAtChatMetadataRate),
+  };
+});
 
 const tokenSource = () => makeGraphTokenSource(async () => "token");
 
@@ -29,10 +45,29 @@ function transportReturning(
 
 beforeEach(() => {
   resetTeamsChatRateGates();
+  vi.mocked(runAtChatMetadataRate).mockClear();
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("chat metadata rate wiring", () => {
+  it("paces List chats and Get chat, but not message pages", async () => {
+    const transport = transportReturning(() => jsonResponse({ value: [] }));
+
+    await listTeamsChatsPage(tokenSource(), { transport });
+    expect(runAtChatMetadataRate).toHaveBeenCalledTimes(1);
+
+    // Reset between calls so real-timer gate waits don't slow the test.
+    resetTeamsChatRateGates();
+    await getTeamsChat(MOCK_CHAT_ID, tokenSource(), { transport });
+    expect(runAtChatMetadataRate).toHaveBeenCalledTimes(2);
+
+    resetTeamsChatRateGates();
+    await listChatMessagesPage(MOCK_CHAT_ID, tokenSource(), { transport });
+    expect(runAtChatMetadataRate).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("listTeamsChatsPage", () => {

--- a/office-addin/src/teams/utils/__tests__/teamsChatGraph.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsChatGraph.test.ts
@@ -65,7 +65,10 @@ describe("listTeamsChatsPage", () => {
 });
 
 describe("listChatMessagesPage", () => {
-  it("requests the documented maximum page size and surfaces the nextLink", async () => {
+  // The $orderby pins the window to creation time: Graph's default is
+  // lastModifiedDateTime, which moves on edits and reactions and would pull
+  // ancient messages into the newest-N window.
+  it("requests the maximum page size ordered by creation time and surfaces the nextLink", async () => {
     const transport = transportReturning(() =>
       jsonResponse({
         value: [mockGraphChatMessage()],
@@ -77,7 +80,7 @@ describe("listChatMessagesPage", () => {
     });
 
     expect(transport.mock.calls[0][0]).toBe(
-      "https://graph.microsoft.com/v1.0/chats/19%3Aabc123%40thread.v2/messages?$top=50",
+      "https://graph.microsoft.com/v1.0/chats/19%3Aabc123%40thread.v2/messages?$top=50&$orderby=createdDateTime%20desc",
     );
     expect(page.messages).toHaveLength(1);
     expect(page.nextLink).toBe("https://graph.microsoft.com/v1.0/next");

--- a/office-addin/src/teams/utils/__tests__/teamsChatRateGate.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsChatRateGate.test.ts
@@ -79,6 +79,34 @@ describe("runAtChatMetadataRate", () => {
     }
   });
 
+  it("admits the next start while a slow call is still in flight", async () => {
+    vi.useFakeTimers();
+    const startedAt: number[] = [];
+    let finishFirst: () => void = () => undefined;
+
+    const first = runAtChatMetadataRate(undefined, () => {
+      startedAt.push(Date.now());
+      return new Promise<void>((resolve) => {
+        finishFirst = resolve;
+      });
+    });
+    const second = runAtChatMetadataRate(undefined, async () => {
+      startedAt.push(Date.now());
+    });
+
+    // The second start must not wait for the first request to COMPLETE —
+    // Graph's ceiling counts starts, and completion-chaining would serialize
+    // the whole metadata family at one request per round-trip.
+    await vi.advanceTimersByTimeAsync(MIN_CHAT_METADATA_START_INTERVAL_MS);
+    expect(startedAt).toHaveLength(2);
+
+    finishFirst();
+    await Promise.all([first, second]);
+    expect(startedAt[1] - startedAt[0]).toBeGreaterThanOrEqual(
+      MIN_CHAT_METADATA_START_INTERVAL_MS,
+    );
+  });
+
   it("keeps pacing when a call rejects", async () => {
     vi.useFakeTimers();
     const startedAt: number[] = [];

--- a/office-addin/src/teams/utils/__tests__/teamsChatRateGate.test.ts
+++ b/office-addin/src/teams/utils/__tests__/teamsChatRateGate.test.ts
@@ -1,13 +1,19 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   MAX_CONCURRENT_CHAT_READS,
+  MIN_CHAT_METADATA_START_INTERVAL_MS,
   resetTeamsChatRateGates,
+  runAtChatMetadataRate,
   runWithChatReadSlot,
 } from "../teamsChatRateGate";
 
 beforeEach(() => {
   resetTeamsChatRateGates();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("runWithChatReadSlot", () => {
@@ -47,5 +53,50 @@ describe("runWithChatReadSlot", () => {
     await expect(
       runWithChatReadSlot(() => Promise.resolve("free")),
     ).resolves.toBe("free");
+  });
+});
+
+describe("runAtChatMetadataRate", () => {
+  // Graph's List/Get chat ceiling counts request STARTS per second, so the
+  // assertion is on start timestamps — a concurrency peak proves nothing.
+  it("spaces request starts by the metadata interval", async () => {
+    vi.useFakeTimers();
+    const startedAt: number[] = [];
+
+    const runs = Array.from({ length: 4 }, () =>
+      runAtChatMetadataRate(undefined, async () => {
+        startedAt.push(Date.now());
+      }),
+    );
+    await vi.runAllTimersAsync();
+    await Promise.all(runs);
+
+    expect(startedAt).toHaveLength(4);
+    for (let i = 1; i < startedAt.length; i += 1) {
+      expect(startedAt[i] - startedAt[i - 1]).toBeGreaterThanOrEqual(
+        MIN_CHAT_METADATA_START_INTERVAL_MS,
+      );
+    }
+  });
+
+  it("keeps pacing when a call rejects", async () => {
+    vi.useFakeTimers();
+    const startedAt: number[] = [];
+
+    const failed = runAtChatMetadataRate(undefined, () => {
+      startedAt.push(Date.now());
+      return Promise.reject(new Error("throttled"));
+    }).catch(() => "handled");
+    const next = runAtChatMetadataRate(undefined, async () => {
+      startedAt.push(Date.now());
+      return "ok";
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(failed).resolves.toBe("handled");
+    await expect(next).resolves.toBe("ok");
+    expect(startedAt[1] - startedAt[0]).toBeGreaterThanOrEqual(
+      MIN_CHAT_METADATA_START_INTERVAL_MS,
+    );
   });
 });

--- a/office-addin/src/teams/utils/teamsChatGraph.ts
+++ b/office-addin/src/teams/utils/teamsChatGraph.ts
@@ -12,7 +12,7 @@
  *     hydration alike, so the gate cannot live in any one of them.
  */
 
-import { runGatedByChat } from "./teamsChatRateGate";
+import { runAtChatMetadataRate, runGatedByChat } from "./teamsChatRateGate";
 import { channelRef, chatRef } from "./teamsConversationRef";
 import {
   GRAPH_BASE,
@@ -162,23 +162,32 @@ async function requestGraph<T>(args: {
   url: string;
   tokenSource: GraphTokenSource;
   gateKey?: string | null;
+  /** Pace the request start under the 5 rps List/Get chat per-user ceiling. */
+  metadataRate?: boolean;
   accept: string;
   init?: GraphInit;
   options: TeamsGraphCallOptions;
   read: (response: Response) => Promise<T>;
   fallback: T;
 }): Promise<T> {
-  const { url, tokenSource, gateKey, accept, init, options, read } = args;
+  const { url, tokenSource, gateKey, metadataRate, accept, init, options } =
+    args;
+  const { read } = args;
   const parentSignal = options.signal;
   const transport = options.transport ?? globalThis.fetch.bind(globalThis);
 
   // The gate wraps `graphFetch`, so its 401 force-refresh replay rides inside
   // one slot rather than waiting out another interval — a rare extra request
   // against the chat, traded for not re-queueing behind unrelated pages.
+  // The metadata pacer sits innermost for the same reason: it must space the
+  // actual request starts, not admissions into an outer queue.
   const send = (signal: AbortSignal) => {
     const call = () =>
       graphFetch(url, tokenSource, accept, signal, transport, init);
-    return gateKey ? runGatedByChat(gateKey, signal, call) : call();
+    const paced = metadataRate
+      ? () => runAtChatMetadataRate(signal, call)
+      : call;
+    return gateKey ? runGatedByChat(gateKey, signal, paced) : paced();
   };
 
   try {
@@ -211,6 +220,7 @@ export async function requestGraphJson<T>(args: {
   url: string;
   tokenSource: GraphTokenSource;
   gateKey?: string | null;
+  metadataRate?: boolean;
   init?: GraphInit;
   options: TeamsGraphCallOptions;
 }): Promise<GraphJsonResult<T>> {
@@ -283,7 +293,7 @@ export async function listTeamsChatsPage(
   const result = await requestGraphJson<{
     value?: GraphChat[];
     "@odata.nextLink"?: string;
-  }>({ url, tokenSource, options });
+  }>({ url, tokenSource, metadataRate: true, options });
   if (!result.ok || !result.payload) {
     return { chats: [], nextLink: null, state: "error" };
   }
@@ -305,6 +315,7 @@ export async function getTeamsChat(
     url,
     tokenSource,
     gateKey: chatId,
+    metadataRate: true,
     options,
   });
   return result.ok ? (result.payload ?? null) : null;
@@ -320,6 +331,10 @@ export interface ListChatMessagesPageResult {
 /**
  * One page of a chat's messages, newest first. Chat messages sort descending
  * only, so following `@odata.nextLink` *is* paging backwards through history.
+ *
+ * The `$orderby` is load-bearing: Graph's default is `lastModifiedDateTime`,
+ * which moves on edits AND reactions, so without it a thumbs-up on an
+ * ancient message pulls that message into the newest-N window.
  */
 export async function listChatMessagesPage(
   chatId: string,
@@ -328,7 +343,7 @@ export async function listChatMessagesPage(
 ): Promise<ListChatMessagesPageResult> {
   const url =
     options.nextLink ??
-    `${GRAPH_BASE}/chats/${encodeURIComponent(chatId)}/messages?$top=${CHAT_MESSAGE_PAGE_SIZE}`;
+    `${GRAPH_BASE}/chats/${encodeURIComponent(chatId)}/messages?$top=${CHAT_MESSAGE_PAGE_SIZE}&$orderby=createdDateTime%20desc`;
   const result = await requestGraphJson<{
     value?: GraphChatMessage[];
     "@odata.nextLink"?: string;

--- a/office-addin/src/teams/utils/teamsChatGraph.ts
+++ b/office-addin/src/teams/utils/teamsChatGraph.ts
@@ -457,6 +457,11 @@ export async function listTeamChannels(
  * a series of openers with every answer missing. Expanding costs nothing extra
  * against the per-channel ceiling; fetching replies per post would cost one
  * gated request each.
+ *
+ * Unlike the chat endpoint this one supports no `$orderby`, and its fixed
+ * order is by the reply chain's last activity — so a reply or reaction on an
+ * old thread pulls the whole thread into the newest-N window. Unfixable
+ * server-side; the renderer re-sorts openers chronologically.
  */
 export async function listChannelMessagesPage(
   teamId: string,

--- a/office-addin/src/teams/utils/teamsChatRateGate.ts
+++ b/office-addin/src/teams/utils/teamsChatRateGate.ts
@@ -21,7 +21,12 @@ export const MIN_CHAT_REQUEST_INTERVAL_MS = 1100;
 export const MIN_CHAT_METADATA_START_INTERVAL_MS = 220;
 
 interface ChatGate {
-  /** Resolves once the currently queued request has started. */
+  /**
+   * Resolves when the next entrant may proceed: at request START for the
+   * metadata gate (starts are what Graph's 5 rps ceiling counts, so requests
+   * may overlap), at COMPLETION for the per-chat gate (deliberate — 1 rps
+   * plus headroom for in-flight overlap).
+   */
   tail: Promise<void>;
   lastStartedAt: number;
 }
@@ -75,6 +80,7 @@ export async function runWithChatReadSlot<T>(
 async function runPaced<T>(
   gate: ChatGate,
   intervalMs: number,
+  releaseOnStart: boolean,
   signal: AbortSignal | undefined,
   run: () => Promise<T>,
 ): Promise<T> {
@@ -91,8 +97,11 @@ async function runPaced<T>(
       await sleep(waitMs, signal);
     }
     gate.lastStartedAt = Date.now();
+    if (releaseOnStart) release();
     return await run();
   } finally {
+    // Resolving twice is a no-op, so for a start-released gate this is only
+    // the abort path: an entrant that dies queued must still free the tail.
     release();
   }
 }
@@ -104,7 +113,7 @@ export async function runGatedByChat<T>(
 ): Promise<T> {
   const gate = gates.get(chatId) ?? freshGate();
   gates.set(chatId, gate);
-  return runPaced(gate, MIN_CHAT_REQUEST_INTERVAL_MS, signal, run);
+  return runPaced(gate, MIN_CHAT_REQUEST_INTERVAL_MS, false, signal, run);
 }
 
 /** Paces the start of a List chats / Get chat call under the per-user ceiling. */
@@ -115,6 +124,7 @@ export async function runAtChatMetadataRate<T>(
   return runPaced(
     metadataGate,
     MIN_CHAT_METADATA_START_INTERVAL_MS,
+    true,
     signal,
     run,
   );

--- a/office-addin/src/teams/utils/teamsChatRateGate.ts
+++ b/office-addin/src/teams/utils/teamsChatRateGate.ts
@@ -13,17 +13,32 @@ import { sleep } from "../../utils/graph/graphClient";
 /** 1 rps plus headroom for clock skew and in-flight request overlap. */
 export const MIN_CHAT_REQUEST_INTERVAL_MS = 1100;
 
+/**
+ * Graph's List chats / Get chat ceiling is 5 request STARTS per second per
+ * user. A concurrency cap alone cannot honour that — fast responses hand
+ * slots on faster than 5/s — so starts are paced instead: 200ms plus headroom.
+ */
+export const MIN_CHAT_METADATA_START_INTERVAL_MS = 220;
+
 interface ChatGate {
   /** Resolves once the currently queued request has started. */
   tail: Promise<void>;
   lastStartedAt: number;
 }
 
+function freshGate(): ChatGate {
+  return { tail: Promise.resolve(), lastStartedAt: Number.NEGATIVE_INFINITY };
+}
+
 const gates = new Map<string, ChatGate>();
+
+/** All chats share one metadata gate — the 5 rps ceiling is per user. */
+let metadataGate = freshGate();
 
 /** Test seam — production code never resets the module-level gates. */
 export function resetTeamsChatRateGates(): void {
   gates.clear();
+  metadataGate = freshGate();
   inFlightSlots = 0;
   waitingForSlot.length = 0;
 }
@@ -57,17 +72,12 @@ export async function runWithChatReadSlot<T>(
   }
 }
 
-export async function runGatedByChat<T>(
-  chatId: string,
+async function runPaced<T>(
+  gate: ChatGate,
+  intervalMs: number,
   signal: AbortSignal | undefined,
   run: () => Promise<T>,
 ): Promise<T> {
-  const gate = gates.get(chatId) ?? {
-    tail: Promise.resolve(),
-    lastStartedAt: Number.NEGATIVE_INFINITY,
-  };
-  gates.set(chatId, gate);
-
   const previous = gate.tail;
   let release: () => void = () => undefined;
   gate.tail = new Promise<void>((resolve) => {
@@ -76,8 +86,7 @@ export async function runGatedByChat<T>(
 
   try {
     await previous;
-    const waitMs =
-      gate.lastStartedAt + MIN_CHAT_REQUEST_INTERVAL_MS - Date.now();
+    const waitMs = gate.lastStartedAt + intervalMs - Date.now();
     if (Number.isFinite(waitMs) && waitMs > 0) {
       await sleep(waitMs, signal);
     }
@@ -86,4 +95,27 @@ export async function runGatedByChat<T>(
   } finally {
     release();
   }
+}
+
+export async function runGatedByChat<T>(
+  chatId: string,
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  const gate = gates.get(chatId) ?? freshGate();
+  gates.set(chatId, gate);
+  return runPaced(gate, MIN_CHAT_REQUEST_INTERVAL_MS, signal, run);
+}
+
+/** Paces the start of a List chats / Get chat call under the per-user ceiling. */
+export async function runAtChatMetadataRate<T>(
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  return runPaced(
+    metadataGate,
+    MIN_CHAT_METADATA_START_INTERVAL_MS,
+    signal,
+    run,
+  );
 }


### PR DESCRIPTION
Fixes the three verified defects from the post-ERMAIN-593 review sweep ([ERMAIN-609](https://linear.app/erato-labs/issue/ERMAIN-609)). None is a regression from the recent Teams work — all predate it.

## 1. "Last N messages" could select edited (or reacted-to) old messages

`listChatMessagesPage` sent no `$orderby`, and Graph's documented default for `/chats/{id}/messages` is `lastModifiedDateTime desc` — which moves on edits **and reactions**. A thumbs-up on an ancient message pulled it into the newest-N window and displaced a genuinely recent message. The initial request now pins `$orderby=createdDateTime desc` (documented as supported alongside `$top`); `@odata.nextLink` is still followed verbatim. Channel messages can't be fixed the same way (that endpoint supports no `$orderby`).

## 2. Host "+"-menu rows ignored the attachment limit

`ChatInput` computes `uploadDisabled` and the built-in file-source rows honour it, but the host contribution slot only received `disabled` — so the Teams chats row and the Outlook email-thread/attachment rows stayed active at capacity, and the overflow was then silently dropped by the composer's `slice(0, maxFiles)` merge. `ChatAddMenuExtraContentProps` now carries `uploadDisabled`, and both host contributions disable their rows on it.

## 3. The cross-chat gate bounded concurrency, not the 5 rps start rate

Graph's List chats / Get chat ceiling is 5 request **starts** per second per user. `runWithChatReadSlot` capped in-flight reads at 4 but handed freed slots straight to the next waiter, so fast responses could start far more than 5/s — and `listTeamsChatsPage` wasn't covered at all. A shared start-rate pacer (220 ms between starts) now sits in the Graph wire layer, innermost so it spaces actual request starts, applied to both `listTeamsChatsPage` and `getTeamsChat`. The per-chat 1.1 s gate, Retry-After handling and the concurrency slot are unchanged.

Also regenerates `component-registry.generated.ts` for the `FilterSortIcon` drift left by #970, and updates the office-addin lockfile's library-tarball hash.