### PR TITLE
Align chat add menu with the dropdown theme-token channel

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -1,6 +1,13 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
-import { Fragment, useId, useRef, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 
 import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 
@@ -83,10 +90,16 @@ export interface ChatInputAddMenuProps {
   className?: string;
 }
 
+// Same delayed close as DropdownMenu's item click, so a selection stays
+// visible for a beat before the menu dismisses.
+const CLOSE_ON_SELECT_DELAY_MS = 100;
+
 const sectionDivider = "my-1 h-px bg-theme-border";
 
+// Rows share DropdownMenu's item channel — geometry class, typography and
+// hover/focus colors — so customer themes retune every menu surface together.
 const rowClassName =
-  "flex w-full items-center gap-3 rounded-[var(--theme-radius-control)] px-3 py-2 text-left text-sm text-theme-fg-primary transition-colors hover:bg-theme-bg-hover";
+  "dropdown-item-geometry theme-transition flex w-full items-center gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown";
 
 // CSS selector for the menu's navigable rows; natively-disabled rows are
 // excluded from roving focus (aria-disabled tool rows stay reachable).
@@ -103,7 +116,7 @@ function SectionHeader({
   return (
     <div
       id={id}
-      className="px-3 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted"
+      className="px-[var(--theme-spacing-dropdown-padding-x)] pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted"
     >
       {children}
     </div>
@@ -129,6 +142,7 @@ export function ChatInputAddMenu({
 }: ChatInputAddMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const baseId = useId();
   // eslint-disable-next-line lingui/no-unlocalized-strings -- internal DOM id suffix
   const toolsHeaderId = `${baseId}-tools`;
@@ -147,6 +161,42 @@ export function ChatInputAddMenu({
     itemSelector: NAVIGABLE_ITEM_SELECTOR,
   });
 
+  const cancelPendingClose = useCallback(() => {
+    clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = undefined;
+  }, []);
+
+  const closeAfterSelect = useCallback(() => {
+    clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = undefined;
+      setIsOpen(false);
+    }, CLOSE_ON_SELECT_DELAY_MS);
+  }, []);
+
+  // Host content closes immediately: hosts open dialogs (or finish an async
+  // upload) on selection, and AnchoredPopover focus-returns to the trigger on
+  // close — delaying past the dialog's own focus grab would steal focus from
+  // an open aria-modal. Same convention as DropdownMenu's confirm dialogs.
+  const closeNow = useCallback(() => {
+    cancelPendingClose();
+    setIsOpen(false);
+  }, [cancelPendingClose]);
+
+  // A close scheduled by a selection must not survive a dismiss-and-reopen —
+  // without this, the stale timer closes the freshly reopened menu.
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        cancelPendingClose();
+      }
+      setIsOpen(open);
+    },
+    [cancelPendingClose],
+  );
+
+  useEffect(() => () => clearTimeout(closeTimerRef.current), []);
+
   const renderActionRow = (item: AddMenuActionItem, testId: string) => (
     <button
       key={item.id}
@@ -155,8 +205,13 @@ export function ChatInputAddMenu({
       tabIndex={-1}
       data-add-menu-item=""
       onClick={() => {
+        // A pending close means a selection already ran; the row stays
+        // mounted through the close delay, so swallow re-activations.
+        if (closeTimerRef.current !== undefined) {
+          return;
+        }
         item.onSelect();
-        setIsOpen(false);
+        closeAfterSelect();
       }}
       disabled={isBusy || item.disabled}
       data-testid={testId}
@@ -166,7 +221,10 @@ export function ChatInputAddMenu({
       )}
     >
       {item.icon && (
-        <span className="flex size-5 shrink-0 items-center justify-center text-theme-fg-secondary">
+        <span
+          className="flex size-5 shrink-0 items-center justify-center"
+          aria-hidden="true"
+        >
           {item.icon}
         </span>
       )}
@@ -222,9 +280,7 @@ export function ChatInputAddMenu({
     blocks.push({
       key: "extra-content",
       node: (
-        <div className="flex flex-col">
-          {extraContent({ close: () => setIsOpen(false) })}
-        </div>
+        <div className="flex flex-col">{extraContent({ close: closeNow })}</div>
       ),
     });
   }
@@ -271,14 +327,17 @@ export function ChatInputAddMenu({
                 )}
               >
                 {tool.icon && (
-                  <span className="flex size-5 shrink-0 items-center justify-center text-theme-fg-secondary">
+                  <span
+                    className="flex size-5 shrink-0 items-center justify-center"
+                    aria-hidden="true"
+                  >
                     {tool.icon}
                   </span>
                 )}
                 <span className="min-w-0 flex-1 truncate">{tool.label}</span>
                 <CheckIcon
                   className={clsx(
-                    "size-4 shrink-0 text-theme-fg-accent transition-opacity",
+                    "size-4 shrink-0 text-theme-fg-primary transition-opacity",
                     tool.checked ? "opacity-100" : "opacity-0",
                   )}
                 />
@@ -302,13 +361,19 @@ export function ChatInputAddMenu({
   return (
     <AnchoredPopover
       isOpen={isOpen}
-      onOpenChange={setIsOpen}
+      onOpenChange={handleOpenChange}
       panelRef={panelRef}
       ariaHasPopup="menu"
       role="menu"
       preferredOrientation={{ vertical: "top", horizontal: "left" }}
       initialFocusSelector={NAVIGABLE_ITEM_SELECTOR}
-      panelClassName="w-[min(20rem,calc(100vw-16px))] overflow-y-auto p-1"
+      panelStyle={{
+        maxWidth:
+          "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
+        minWidth: "var(--theme-layout-dropdown-min-width)",
+      }}
+      panelClassName="flex w-80 flex-col"
+      viewportPadding="var(--theme-layout-dropdown-viewport-margin)"
       dataUi="chat-input-add-menu"
       // `relative` is the only styling this needs beyond the shared Button:
       // it anchors the absolutely-positioned count badge. Size, radius, hover
@@ -345,7 +410,11 @@ export function ChatInputAddMenu({
         </Button>
       )}
     >
-      <div className="flex flex-col" data-ui="chat-input-add-menu-content">
+      <div
+        className="dropdown-panel-chrome-geometry flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+        role="none"
+        data-ui="chat-input-add-menu-content"
+      >
         {blocks.map((block, index) => (
           <Fragment key={block.key}>
             {index > 0 && <div className={sectionDivider} />}

--- a/frontend/src/components/ui/Chat/FacetSelector.tsx
+++ b/frontend/src/components/ui/Chat/FacetSelector.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/Controls/Button";
 
 import { DropdownMenu } from "../Controls/DropdownMenu";
-import { ResolvedIcon, ToolsIcon } from "../icons";
+import { ChevronDownIcon, ResolvedIcon, ToolsIcon } from "../icons";
 
 import type { DropdownMenuItem } from "../Controls/DropdownMenu";
 import type { FacetInfo } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
@@ -123,22 +123,12 @@ export const FacetSelector = ({
             <div className="flex items-center gap-1 px-2">
               <ToolsIcon className="size-4" />
               <span className="text-sm font-medium">{t`Tools`}</span>
-              <svg
+              <ChevronDownIcon
                 className={clsx(
                   "size-3 shrink-0 text-[var(--theme-fg-secondary)] transition-transform duration-200",
                   isDropdownOpen && "rotate-180",
                 )}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 9l-7 7-7-7"
-                />
-              </svg>
+              />
             </div>
           }
           id="facet-selector-dropdown"

--- a/frontend/src/components/ui/Chat/ModelSelector.tsx
+++ b/frontend/src/components/ui/Chat/ModelSelector.tsx
@@ -8,7 +8,7 @@ import { t } from "@lingui/core/macro";
 import { useMemo, useState } from "react";
 
 import { DropdownMenu } from "../Controls/DropdownMenu";
-import { ResolvedIcon } from "../icons";
+import { ChevronDownIcon, ResolvedIcon } from "../icons";
 
 import type { DropdownMenuItem } from "../Controls/DropdownMenu";
 import type { ChatModel } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
@@ -202,21 +202,11 @@ export const ModelSelector = ({
             >
               {displayName}
             </span>
-            <svg
+            <ChevronDownIcon
               className={`size-3 shrink-0 text-[var(--theme-fg-secondary)] transition-transform duration-200 ${
                 isDropdownOpen ? "rotate-180" : ""
               }`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
+            />
           </div>
         }
         className={`${disabled ? "cursor-not-allowed opacity-50" : ""}`}

--- a/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
+++ b/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
@@ -9,9 +9,12 @@ import { useOutlookMailItem } from "../providers/OutlookMailItemProvider";
 import type { ChatAddMenuExtraContentProps } from "@erato/frontend/library";
 
 const headerClassName =
-  "px-3 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted";
+  "px-[var(--theme-spacing-dropdown-padding-x)] pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted";
+// Same row recipe as the shared "+" menu / DropdownMenu item channel, so
+// customer themes retune these injected rows together with every other menu.
 const rowClassName =
-  "flex w-full items-start justify-between gap-3 rounded-[var(--theme-radius-control)] px-3 py-2 text-left transition-colors hover:bg-theme-bg-hover disabled:cursor-not-allowed disabled:opacity-50";
+  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
+const infoRowClassName = "dropdown-item-geometry text-xs";
 
 function formatFileSize(size: number): string {
   if (!Number.isFinite(size) || size <= 0) {
@@ -160,7 +163,7 @@ export function AddinChatAddMenuExtraContent({
       </div>
 
       {isLoadingEmailBody && (
-        <div className="px-3 py-2 text-xs text-theme-fg-muted">
+        <div className={`${infoRowClassName} text-theme-fg-muted`}>
           {t({
             id: "officeAddin.fileSource.loadingEmailThread",
             message: "Loading email thread...",
@@ -169,7 +172,7 @@ export function AddinChatAddMenuExtraContent({
       )}
 
       {!isLoadingEmailBody && emailThreadLoadError && (
-        <div className="px-3 py-2 text-xs text-theme-error-fg">
+        <div className={`${infoRowClassName} text-theme-error-fg`}>
           {t({
             id: "officeAddin.fileSource.emailThreadLoadError",
             message:
@@ -194,7 +197,7 @@ export function AddinChatAddMenuExtraContent({
               className={rowClassName}
             >
               <div className="min-w-0">
-                <div className="truncate text-sm font-medium text-theme-fg-primary">
+                <div className="truncate text-sm font-medium">
                   {t({
                     id: "officeAddin.fileSource.emailThread",
                     message: "Email thread",
@@ -222,7 +225,7 @@ export function AddinChatAddMenuExtraContent({
         })()}
 
       {isLoadingAttachments && (
-        <div className="px-3 py-2 text-xs text-theme-fg-muted">
+        <div className={`${infoRowClassName} text-theme-fg-muted`}>
           {t({
             id: "officeAddin.fileSource.loadingAttachments",
             message: "Loading attachments...",
@@ -256,7 +259,7 @@ export function AddinChatAddMenuExtraContent({
             className={rowClassName}
           >
             <div className="min-w-0">
-              <div className="truncate text-sm font-medium text-theme-fg-primary">
+              <div className="truncate text-sm font-medium">
                 {attachment.name}
               </div>
               <div className="truncate text-xs text-theme-fg-muted">

--- a/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
+++ b/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
@@ -10,9 +10,11 @@ import { useTeamsChatPicker } from "../providers/TeamsChatPickerProvider";
 import type { ChatAddMenuExtraContentProps } from "@erato/frontend/library";
 
 const headerClassName =
-  "px-3 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted";
+  "px-[var(--theme-spacing-dropdown-padding-x)] pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted";
+// Same row recipe as the shared "+" menu / DropdownMenu item channel, so
+// customer themes retune these injected rows together with every other menu.
 const rowClassName =
-  "flex w-full items-start justify-between gap-3 rounded-[var(--theme-radius-control)] px-3 py-2 text-left transition-colors hover:bg-theme-bg-hover disabled:cursor-not-allowed disabled:opacity-50";
+  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
 
 /**
  * Teams contribution to the unified chat "+" menu: one row that opens the chat
@@ -62,7 +64,7 @@ export function TeamsChatAddMenuExtraContent({
         }}
       >
         <div className="min-w-0">
-          <div className="truncate text-sm font-medium text-theme-fg-primary">
+          <div className="truncate text-sm font-medium">
             {t({
               id: "officeAddin.teams.fileSource.chats",
               message: "Teams chats…",


### PR DESCRIPTION
Converts the chat "+" menu (and the Outlook/Teams add-in rows injected into it) to the canonical DropdownMenu theme-token channel (ERMAIN-607):

- Rows use `dropdown-item-geometry` + `theme-transition` with the canonical fg-secondary→fg-primary hover/focus recipe, including the previously missing focus ring; the check icon moves from `fg-accent` to `fg-primary`.
- Panel geometry comes from `dropdown-panel-chrome-geometry` and the `--theme-layout-dropdown-*` tokens instead of hardcoded `p-1` / `w-[min(20rem,…)]`; section headers take their inline padding from the padding-x token. Customer themes that retune the kebab menus now reach the "+" menu identically.
- Action rows adopt DropdownMenu's 100 ms delayed close-on-select. Host-injected content (`extraContent`) keeps an immediate close — hosts open dialogs on selection, and a delayed close would let AnchoredPopover's focus-return steal focus from the open modal (same convention as DropdownMenu's confirm dialogs). Opening the menu cancels any pending close timer, and rows swallow re-activations during the linger.
- `AddinChatAddMenuExtraContent` (Outlook) and `TeamsChatAddMenuExtraContent` restyled to the same recipe.
- `ModelSelector`/`FacetSelector` drop their hand-rolled chevron SVGs for the shared `ChevronDownIcon`