### PR TITLE
Sidebar & search UI polish: default icons, collapse animation, aligned search input (ERMAIN-612)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -16,12 +16,13 @@ import { createLogger } from "@/utils/debugLogger";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { DropdownMenu } from "../Controls/DropdownMenu";
 import {
-  LogOutIcon,
+  EditIcon,
   ResolvedIcon,
   MultiplePagesIcon,
   PinIcon,
   PinSlashIcon,
   ShareIcon,
+  Trash,
 } from "../icons";
 
 import type { ChatSession } from "@/types/chat";
@@ -292,7 +293,7 @@ const ChatHistoryListItem = memo<{
                             id: "chat.history.menu.rename",
                             message: "Rename",
                           }),
-                          icon: <MultiplePagesIcon className="size-4" />,
+                          icon: <EditIcon className="size-4" />,
                           onClick: onEditTitle,
                           disabled: !canEdit,
                         },
@@ -300,7 +301,8 @@ const ChatHistoryListItem = memo<{
                     : []),
                   {
                     label: t`Remove`,
-                    icon: <LogOutIcon className="size-4" />,
+                    icon: <Trash className="size-4" />,
+                    variant: "danger",
                     onClick: onArchive ?? (() => {}),
                     confirmAction: true,
                     confirmTitle: t`Confirm Removal`,

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
@@ -1,5 +1,5 @@
 import { I18nProvider } from "@lingui/react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -239,7 +239,10 @@ describe("ChatHistorySidebar", () => {
     fireEvent.click(recentToggle);
 
     expect(recentToggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByTestId("history-list")).not.toBeInTheDocument();
+    // The list leaves the DOM once the collapse transition has played out.
+    await waitFor(() =>
+      expect(screen.queryByTestId("history-list")).not.toBeInTheDocument(),
+    );
     expect(
       localStorage.getItem("erato.sidebar.recentChatsSectionExpanded"),
     ).toBe("false");
@@ -478,20 +481,27 @@ describe("ChatHistorySidebar", () => {
     historyListProps.length = 0;
     fireEvent.click(screen.getByRole("button", { name: "Collapse Older" }));
 
-    // Only today's rows remain, and the load-more sentinel moved to them.
-    expect(screen.getAllByTestId("history-list")).toHaveLength(1);
-    expect(historyListProps).toHaveLength(1);
+    // The load-more sentinel moves to today's rows immediately; the collapsed
+    // list itself only leaves the DOM after the collapse transition.
+    expect(historyListProps).toHaveLength(2);
     expect(historyListProps[0].sessions.map((s) => s.id)).toEqual([
       "chat-today",
     ]);
     expect(historyListProps[0].hasMore).toBe(true);
+    expect(historyListProps[1].sessions.map((s) => s.id)).toEqual(["chat-old"]);
+    expect(historyListProps[1].hasMore).toBe(false);
+    await waitFor(() =>
+      expect(screen.getAllByTestId("history-list")).toHaveLength(1),
+    );
 
     fireEvent.click(
       screen.getByRole("button", { name: `Collapse ${todayLabel}` }),
     );
 
     // All groups collapsed: no list, hence no sentinel anywhere.
-    expect(screen.queryByTestId("history-list")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByTestId("history-list")).not.toBeInTheDocument(),
+    );
 
     historyListProps.length = 0;
     fireEvent.click(screen.getByRole("button", { name: "Expand Older" }));

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -51,12 +51,14 @@ import {
 } from "./SidebarResizeHandle";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { Button } from "../Controls/Button";
+import { Collapse, COLLAPSE_DURATION_MS } from "../Controls/Collapse";
 import { UserProfileThemeDropdown } from "../Controls/UserProfileThemeDropdown";
 import { CopyErrorButton } from "../Feedback/CopyErrorButton";
 import {
   SidebarToggleIcon,
   SearchIcon,
   EditIcon,
+  PlusIcon,
   ResolvedIcon,
   ChevronRightIcon,
 } from "../icons";
@@ -321,7 +323,7 @@ const NewChatItem = memo<{
       >
         <ResolvedIcon
           iconId={newChatIconId}
-          fallbackIcon={EditIcon}
+          fallbackIcon={PlusIcon}
           className="size-4 shrink-0 text-theme-fg-secondary"
         />
         <span
@@ -547,6 +549,24 @@ const CollapsibleSection = memo<{
       useState(defaultExpanded);
     const isExpanded = expanded ?? uncontrolledExpanded;
     const setIsExpanded = onExpandedChange ?? setUncontrolledExpanded;
+    // Collapsed children must leave the DOM (the load-more sentinel may not
+    // linger inside a zero-height clip box), but only after the height
+    // transition has landed — an immediate unmount would snap the section
+    // closed with nothing to animate.
+    const [renderCollapsedChildren, setRenderCollapsedChildren] =
+      useState(isExpanded);
+
+    useEffect(() => {
+      if (isExpanded) {
+        setRenderCollapsedChildren(true);
+        return;
+      }
+      const timeout = setTimeout(
+        () => setRenderCollapsedChildren(false),
+        COLLAPSE_DURATION_MS,
+      );
+      return () => clearTimeout(timeout);
+    }, [isExpanded]);
 
     return (
       <div className={className}>
@@ -587,7 +607,11 @@ const CollapsibleSection = memo<{
         {/* The chat-list inset lives on this host-owned wrapper rather than
             inside ChatHistoryList, which customers replace wholesale via the
             registry slot. */}
-        {isExpanded && <div className={sidebarInsetClassName}>{children}</div>}
+        <Collapse isOpen={isExpanded}>
+          {(isExpanded || renderCollapsedChildren) && (
+            <div className={sidebarInsetClassName}>{children}</div>
+          )}
+        </Collapse>
       </div>
     );
   },

--- a/frontend/src/components/ui/Controls/Collapse.tsx
+++ b/frontend/src/components/ui/Controls/Collapse.tsx
@@ -2,6 +2,10 @@ import clsx from "clsx";
 
 import type { ReactNode } from "react";
 
+/** Matches the `duration-300` transition class below, for callers that need
+ * to defer work (e.g. unmounting children) until the collapse has landed. */
+export const COLLAPSE_DURATION_MS = 300;
+
 export interface CollapseProps {
   /** When true, the children are rendered at full height. */
   isOpen: boolean;
@@ -18,7 +22,7 @@ export interface CollapseProps {
  */
 export const Collapse = ({ isOpen, className, children }: CollapseProps) => (
   <div
-    className="grid transition-[grid-template-rows] duration-300 ease-out"
+    className="grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none"
     style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
   >
     <div className={clsx("min-w-0 overflow-hidden", className)}>{children}</div>

--- a/frontend/src/components/ui/MessageList/MessageList.tsx
+++ b/frontend/src/components/ui/MessageList/MessageList.tsx
@@ -637,14 +637,13 @@ export const MessageList = memo<MessageListProps>(
     });
 
     // Set up pagination for message data
-    const { visibleData, hasMore, loadMore, isNewlyLoaded, paginationStats } =
-      usePaginatedData({
-        data: messageOrder,
-        initialCount: pageSize,
-        pageSize: pageSize,
-        enabled: hasOlderMessages,
-        direction: "backward", // Use backward pagination for chat (older messages first)
-      });
+    const { visibleData, hasMore, loadMore, isNewlyLoaded } = usePaginatedData({
+      data: messageOrder,
+      initialCount: pageSize,
+      pageSize: pageSize,
+      enabled: hasOlderMessages,
+      direction: "backward", // Use backward pagination for chat (older messages first)
+    });
 
     // Add a message when user scrolls back down to new messages
     useEffect(() => {
@@ -784,7 +783,6 @@ export const MessageList = memo<MessageListProps>(
           handleLoadMore={handleLoadMore}
           isPending={isPending}
           showBeginningIndicator={showBeginningIndicator}
-          paginationStats={paginationStats}
         />
       );
     }, [
@@ -793,7 +791,6 @@ export const MessageList = memo<MessageListProps>(
       isPending,
       messageOrder.length,
       handleLoadMore,
-      paginationStats,
     ]);
 
     // Add optimized container class based on state

--- a/frontend/src/components/ui/MessageList/MessageListHeader.test.tsx
+++ b/frontend/src/components/ui/MessageList/MessageListHeader.test.tsx
@@ -11,7 +11,6 @@ describe("MessageListHeader", () => {
         handleLoadMore={vi.fn()}
         isPending={false}
         showBeginningIndicator={false}
-        paginationStats={{ displayed: 0, total: 0 }}
       />,
     );
 

--- a/frontend/src/components/ui/MessageList/MessageListHeader.tsx
+++ b/frontend/src/components/ui/MessageList/MessageListHeader.tsx
@@ -1,20 +1,11 @@
-import { t } from "@lingui/core/macro";
-
 import { ConversationIndicator } from "../Message/ConversationIndicator";
 import { LoadMoreButton } from "../Message/LoadMoreButton";
-
-import type { ChatMessagesResponse } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
 interface MessageListHeaderProps {
   showLoadMoreButton: boolean;
   handleLoadMore: () => void;
   isPending: boolean;
   showBeginningIndicator: boolean;
-  apiMessagesResponse?: ChatMessagesResponse;
-  paginationStats: {
-    displayed: number;
-    total: number;
-  };
 }
 
 /**
@@ -25,8 +16,6 @@ export const MessageListHeader = ({
   handleLoadMore,
   isPending,
   showBeginningIndicator,
-  apiMessagesResponse,
-  paginationStats,
 }: MessageListHeaderProps) => {
   return (
     <div
@@ -38,24 +27,6 @@ export const MessageListHeader = ({
         <LoadMoreButton onClick={handleLoadMore} isPending={isPending} />
       )}
       {showBeginningIndicator && <ConversationIndicator type="beginning" />}
-
-      {/* Debug info in development */}
-      {process.env.NODE_ENV === "development" && (
-        <div className="sticky right-0 top-12 z-10 text-right text-xs opacity-50">
-          {t`Showing`}{" "}
-          {apiMessagesResponse
-            ? Math.min(
-                apiMessagesResponse.stats.current_offset +
-                  apiMessagesResponse.stats.returned_count,
-                apiMessagesResponse.stats.total_count,
-              )
-            : paginationStats.displayed}{" "}
-          {t`of`}{" "}
-          {apiMessagesResponse?.stats.total_count ?? paginationStats.total}{" "}
-          {t`messages`}
-          {apiMessagesResponse?.stats.has_more && t` (more available)`}
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/hooks/ui/useThemedIcon.ts
+++ b/frontend/src/hooks/ui/useThemedIcon.ts
@@ -25,7 +25,7 @@ const DEFAULT_ICONS = {
   },
   navigation: {
     assistants: "GridXmark",
-    newChat: "EditPencil",
+    newChat: "Plus",
     search: "Search",
   },
 } as const;

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -3664,8 +3664,8 @@ msgstr "Nicht unterstützter Dateityp(en): {filenames}"
 # Unstable IDs
 # ==============================
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid " (more available)"
-msgstr " (weitere verfügbar)"
+#~ msgid " (more available)"
+#~ msgstr " (weitere verfügbar)"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid " File attachments account for {fileTokensFormatted} tokens."
@@ -4528,8 +4528,8 @@ msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Nachricht überschreitet Token-Limit. Bitte kürzen Sie die Nachricht oder entfernen Sie Dateien."
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "messages"
-msgstr "Nachrichten"
+#~ msgid "messages"
+#~ msgstr "Nachrichten"
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 #~ msgid "Microphone {0}"
@@ -4630,8 +4630,8 @@ msgstr "Rauschunterdrückung: {noiseSuppression}"
 #~ msgstr ""
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "of"
-msgstr "von"
+#~ msgid "of"
+#~ msgstr "von"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "Older messages are not included."
@@ -4889,8 +4889,8 @@ msgid "Show tool calls"
 msgstr "Tool-Aufrufe anzeigen"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "Showing"
-msgstr "Anzeige"
+#~ msgid "Showing"
+#~ msgstr "Anzeige"
 
 #: src/pages/SearchPage.tsx
 msgid "Showing {resultsCount} recent chats"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -3664,8 +3664,8 @@ msgstr "Unsupported file type(s): {filenames}"
 # Unstable IDs
 # ==============================
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid " (more available)"
-msgstr " (more available)"
+#~ msgid " (more available)"
+#~ msgstr " (more available)"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid " File attachments account for {fileTokensFormatted} tokens."
@@ -4528,8 +4528,8 @@ msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Message exceeds token limit. Please reduce length or remove files."
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "messages"
-msgstr "messages"
+#~ msgid "messages"
+#~ msgstr "messages"
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 #~ msgid "Microphone {0}"
@@ -4630,8 +4630,8 @@ msgstr "noise suppression: {noiseSuppression}"
 #~ msgstr "Not set"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "of"
-msgstr "of"
+#~ msgid "of"
+#~ msgstr "of"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "Older messages are not included."
@@ -4889,8 +4889,8 @@ msgid "Show tool calls"
 msgstr "Show tool calls"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "Showing"
-msgstr "Showing"
+#~ msgid "Showing"
+#~ msgstr "Showing"
 
 #: src/pages/SearchPage.tsx
 msgid "Showing {resultsCount} recent chats"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -3664,8 +3664,8 @@ msgstr "Tipo(s) de archivo no compatible(s): {filenames}"
 # Unstable IDs
 # ==============================
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid " (more available)"
-msgstr " (más disponibles)"
+#~ msgid " (more available)"
+#~ msgstr " (más disponibles)"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid " File attachments account for {fileTokensFormatted} tokens."
@@ -4528,8 +4528,8 @@ msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "El mensaje excede el límite de tokens. Por favor, reduzca la longitud o elimine archivos."
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "messages"
-msgstr "mensajes"
+#~ msgid "messages"
+#~ msgstr "mensajes"
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 #~ msgid "Microphone {0}"
@@ -4630,8 +4630,8 @@ msgstr "supresión de ruido: {noiseSuppression}"
 #~ msgstr ""
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "of"
-msgstr "de"
+#~ msgid "of"
+#~ msgstr "de"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "Older messages are not included."
@@ -4889,8 +4889,8 @@ msgid "Show tool calls"
 msgstr "Mostrar llamadas de herramientas"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "Showing"
-msgstr "Mostrando"
+#~ msgid "Showing"
+#~ msgstr "Mostrando"
 
 #: src/pages/SearchPage.tsx
 msgid "Showing {resultsCount} recent chats"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -3664,8 +3664,8 @@ msgstr "Type(s) de fichier non pris en charge : {filenames}"
 # Unstable IDs
 # ==============================
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid " (more available)"
-msgstr " (plus disponibles)"
+#~ msgid " (more available)"
+#~ msgstr " (plus disponibles)"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid " File attachments account for {fileTokensFormatted} tokens."
@@ -4528,8 +4528,8 @@ msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Le message dépasse la limite de tokens. Veuillez réduire la longueur ou supprimer des fichiers."
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "messages"
-msgstr "messages"
+#~ msgid "messages"
+#~ msgstr "messages"
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 #~ msgid "Microphone {0}"
@@ -4630,8 +4630,8 @@ msgstr "réduction du bruit : {noiseSuppression}"
 #~ msgstr ""
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "of"
-msgstr "sur"
+#~ msgid "of"
+#~ msgstr "sur"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "Older messages are not included."
@@ -4889,8 +4889,8 @@ msgid "Show tool calls"
 msgstr "Afficher les appels d'outils"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "Showing"
-msgstr "Affichage de"
+#~ msgid "Showing"
+#~ msgstr "Affichage de"
 
 #: src/pages/SearchPage.tsx
 msgid "Showing {resultsCount} recent chats"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -3664,8 +3664,8 @@ msgstr "Nieobsługiwany typ(y) pliku: {filenames}"
 # Unstable IDs
 # ==============================
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid " (more available)"
-msgstr " (więcej dostępnych)"
+#~ msgid " (more available)"
+#~ msgstr " (więcej dostępnych)"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid " File attachments account for {fileTokensFormatted} tokens."
@@ -4528,8 +4528,8 @@ msgid "Message exceeds token limit. Please reduce length or remove files."
 msgstr "Wiadomość przekracza limit tokenów. Proszę skrócić lub usunąć pliki."
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "messages"
-msgstr "wiadomości"
+#~ msgid "messages"
+#~ msgstr "wiadomości"
 
 #: src/hooks/audio/useAudioInputDevicePreference.ts
 #~ msgid "Microphone {0}"
@@ -4630,8 +4630,8 @@ msgstr "redukcja szumów: {noiseSuppression}"
 #~ msgstr ""
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "of"
-msgstr "z"
+#~ msgid "of"
+#~ msgstr "z"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "Older messages are not included."
@@ -4889,8 +4889,8 @@ msgid "Show tool calls"
 msgstr "Pokaż wywołania narzędzi"
 
 #: src/components/ui/MessageList/MessageListHeader.tsx
-msgid "Showing"
-msgstr "Pokazuje"
+#~ msgid "Showing"
+#~ msgstr "Pokazuje"
 
 #: src/pages/SearchPage.tsx
 msgid "Showing {resultsCount} recent chats"

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -8,14 +8,16 @@ import { useDebounce } from "use-debounce";
 import { ChatShareDialog } from "@/components/ui/Chat/ChatShareDialog";
 import { EditChatTitleDialog } from "@/components/ui/Chat/EditChatTitleDialog";
 import { PageHeader } from "@/components/ui/Container/PageHeader";
+import { Button } from "@/components/ui/Controls/Button";
 import { DropdownMenu } from "@/components/ui/Controls/DropdownMenu";
+import { Input } from "@/components/ui/Input/Input";
 import { MessageTimestamp } from "@/components/ui/Message/MessageTimestamp";
 import {
   SearchIcon,
   CloseIcon,
-  LogOutIcon,
-  MultiplePagesIcon,
+  EditIcon,
   ShareIcon,
+  Trash,
 } from "@/components/ui/icons";
 import { usePageAlignment } from "@/hooks/ui";
 import {
@@ -236,11 +238,14 @@ export default function SearchPage() {
       >
         {/* Match search input width to results width */}
         <div className={clsx("w-full", contentContainerClasses)}>
-          <div className="relative">
-            <SearchIcon className="absolute left-4 top-1/2 size-5 -translate-y-1/2 text-theme-fg-muted" />
-            <input
+          <div className="flex items-center gap-2">
+            <SearchIcon
+              className="size-5 shrink-0 text-theme-fg-muted"
+              aria-hidden="true"
+            />
+            <Input
               data-ui="search-input"
-              type="text"
+              type="search"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
@@ -249,18 +254,17 @@ export default function SearchPage() {
                 }
               }}
               placeholder={t`Search chat titles...`}
+              aria-label={t`Search chat titles...`}
               autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
-              className="w-full rounded-xl border border-theme-border bg-theme-bg-secondary px-12 py-4 text-lg text-theme-fg-primary placeholder:text-theme-fg-muted focus:border-theme-border-focus focus:outline-none focus:ring-2 focus:ring-theme-focus"
             />
             {searchQuery && (
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                geometry="icon"
+                icon={<CloseIcon className="size-4" />}
                 onClick={clearSearch}
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-theme-fg-muted hover:text-theme-fg-primary"
                 aria-label={t`Clear search`}
-              >
-                <CloseIcon className="size-5" />
-              </button>
+              />
             )}
           </div>
         </div>
@@ -364,14 +368,15 @@ export default function SearchPage() {
                                 id: "chat.history.menu.rename",
                                 message: "Rename",
                               }),
-                              icon: <MultiplePagesIcon className="size-4" />,
+                              icon: <EditIcon className="size-4" />,
                               onClick: () =>
                                 setTitleDialogChatId(result.chatId),
                               disabled: !result.canEdit,
                             },
                             {
                               label: t`Remove`,
-                              icon: <LogOutIcon className="size-4" />,
+                              icon: <Trash className="size-4" />,
+                              variant: "danger",
                               onClick: () => {
                                 void handleArchiveResult(result.chatId);
                               },

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -282,7 +282,7 @@ Add an `icons` section to your `theme.json`:
     },
     "navigation": {
       "assistants": "PeopleTag",
-      "newChat": "EditPencil",
+      "newChat": "Plus",
       "search": "Search"
     }
   }


### PR DESCRIPTION
Implements [ERMAIN-612](https://linear.app/erato-labs/issue/ERMAIN-612): batch of small UI polish changes in the chat history sidebar and search surfaces.

## Changes

- **New Chat → plus icon**: swapped in both wiring points — the `useThemedIcon` default (`navigation.newChat`) and the `ResolvedIcon` fallback in `ChatHistorySidebar` — plus the theming docs example. Themes keep their `theme.json` override channel.
- **Rename → pencil icon** in both hand-duplicated chat-item menus (`ChatHistoryList`, `SearchPage`).
- **Remove → trash icon** in the same two menus, now with `variant: "danger"` per the canonical DropdownMenu pattern (also turns the confirm-dialog button red). Unused `LogOutIcon`/`MultiplePagesIcon` imports pruned.
- **Animated collapse for sidebar history groups**: `CollapsibleSection` reuses the shared `Collapse` primitive (grid-rows 0fr↔1fr, 300ms) and unmounts children after the transition via the newly exported `COLLAPSE_DURATION_MS` — so the load-more sentinel never lingers inside a zero-height clip box and the collapsed-children-leave-the-DOM test contract holds. `Collapse` gained the missing `motion-reduce:transition-none` guard.
- **Removed the dev-only "Showing X of Y messages" readout** and its two orphaned props; the 4 orphaned msgids are marked obsolete across all 5 locales via `lingui extract`. The `data-ui="chat-header"` wrapper and `usePaginatedData`'s public return shape are untouched.
- **Search page input aligned with the shared `Input`** (`type="search"`, theme spacing/radius/border tokens): search icon and ghost clear button sit as flex siblings outside the field (Teams picker precedent), avoiding the `Input` padding-shorthand trap. `data-ui="search-input"`, conditional autofocus, and Escape-clears preserved