### PR TITLE
Focus rings: keyboard-only, inset on sidebar rows, aligned trailing controls

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -469,7 +469,7 @@ export function ChatHistoryFilterMenu({
       trigger={(triggerProps) => (
         <Button
           {...triggerProps}
-          variant="icon-only"
+          variant="sidebar-icon"
           size="sm"
           aria-label={t({
             id: "chat.history.filterMenu.trigger",
@@ -478,7 +478,8 @@ export function ChatHistoryFilterMenu({
           data-testid="chat-history-filter-menu-trigger"
           className={clsx(
             "relative",
-            isOpen && "bg-theme-bg-hover text-theme-fg-primary",
+            isOpen &&
+              "bg-[var(--theme-shell-sidebar-hover)] text-theme-fg-primary",
             className,
           )}
           icon={<FilterSortIcon className="size-4" />}

--- a/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
@@ -191,7 +191,7 @@ describe("ChatHistoryList", () => {
       '[data-chat-id="chat-1"]',
     ) as HTMLElement;
 
-    expect(firstSessionLink).toHaveClass("focus-ring-tight");
+    expect(firstSessionLink).toHaveClass("focus-ring-inset");
     expect(firstSessionLink).toHaveAttribute("aria-current", "page");
     expect(firstSessionItem).not.toHaveAttribute("role");
     expect(firstSessionItem).not.toHaveAttribute("tabindex");

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -234,7 +234,7 @@ const ChatHistoryListItem = memo<{
           useDiv={true}
           showFocusRing={false}
           className={clsx(
-            "sidebar-content-col-geometry sidebar-row-geometry theme-transition flex flex-col py-1.5 pb-3.5 pr-1.5 text-left",
+            "sidebar-content-col-geometry sidebar-trailing-col-geometry sidebar-row-geometry theme-transition flex flex-col py-1.5 pb-3.5 text-left",
             isActive
               ? "sidebar-row-selected"
               : "hover:bg-[var(--theme-shell-sidebar-hover)]",
@@ -259,6 +259,7 @@ const ChatHistoryListItem = memo<{
               }}
             >
               <DropdownMenu
+                triggerButtonVariant="sidebar-icon"
                 items={[
                   ...(onPin
                     ? [

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -28,8 +28,10 @@ import type { ChatSession } from "@/types/chat";
 import type { ChatAttentionStatus } from "@/utils/chatHistoryGrouping";
 
 const logger = createLogger("UI", "ChatHistoryList");
+// Inset ring: the outside-drawn variant gets clipped by the sidebar
+// scrollport whenever the themeable row inset is below the ring width.
 const sidebarRowLinkClassName =
-  "focus-ring-tight block rounded-[var(--theme-radius-shell)]";
+  "focus-ring-inset block rounded-[var(--theme-radius-shell)]";
 
 /**
  * Row title: a real backend title, else the recorded user-message hint, else

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -72,8 +72,10 @@ const sidebarItemClassName = "sidebar-row-geometry";
 const activeSidebarItemClassName = "sidebar-row-geometry sidebar-row-selected";
 // Horizontal inset for every row surface; see .sidebar-inset-geometry.
 const sidebarInsetClassName = "sidebar-inset-geometry";
+// Inset ring for the same reason as the chat rows: the row inset is
+// themeable and can be narrower than an outside-drawn ring.
 const sidebarLinkClassName =
-  "focus-ring-tight block rounded-[var(--theme-radius-shell)]";
+  "focus-ring-inset block rounded-[var(--theme-radius-shell)]";
 
 const RECENT_CHATS_SECTION_EXPANDED_STORAGE_KEY =
   "erato.sidebar.recentChatsSectionExpanded";
@@ -307,13 +309,14 @@ const NewChatItem = memo<{
     <div className={clsx(sidebarInsetClassName, "py-1")}>
       <InteractiveContainer
         useDiv={true}
+        showFocusRing={false}
         onClick={() => {
           logger.log("[CHAT_FLOW] New chat item clicked");
           onNewChat?.();
         }}
         className={clsx(
           sidebarItemClassName,
-          "theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
+          "focus-ring-inset theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
           "sidebar-content-col-geometry gap-3 py-2 pr-3",
         )}
         aria-label={t`New Chat`}

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -584,7 +584,9 @@ const CollapsibleSection = memo<{
             />
           </button>
           {actions != null && (
-            <div className="flex shrink-0 items-center">{actions}</div>
+            <div className="sidebar-trailing-col-geometry flex shrink-0 items-center">
+              {actions}
+            </div>
           )}
         </div>
         {/* The chat-list inset lives on this host-owned wrapper rather than
@@ -1199,7 +1201,7 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
                         <div
                           className={clsx(
                             sidebarInsetClassName,
-                            "flex items-center justify-end py-1",
+                            "sidebar-trailing-col-geometry flex items-center justify-end py-1",
                           )}
                           data-ui="chat-history-filter-row"
                         >

--- a/frontend/src/components/ui/Chat/StarterPromptsSection.tsx
+++ b/frontend/src/components/ui/Chat/StarterPromptsSection.tsx
@@ -44,7 +44,7 @@ export function DefaultStarterPromptsSection({
             "group rounded-2xl border p-4 text-center",
             "[background:var(--theme-starter-prompt-bg)] [border-color:var(--theme-starter-prompt-border)]",
             "transition-colors hover:[background:var(--theme-starter-prompt-hover-bg)] hover:[border-color:var(--theme-starter-prompt-hover-border)]",
-            "focus:outline-none focus:ring-2 focus:ring-[var(--theme-starter-prompt-focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--theme-starter-prompt-focus-offset)]",
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme-starter-prompt-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--theme-starter-prompt-focus-offset)]",
           )}
           data-testid={`starter-prompt-${starterPrompt.id}`}
         >

--- a/frontend/src/components/ui/CloudFilePicker/CloudFilePicker.tsx
+++ b/frontend/src/components/ui/CloudFilePicker/CloudFilePicker.tsx
@@ -209,7 +209,7 @@ export const CloudFilePicker = memo<CloudFilePickerProps>(
         onKeyDown={handleKeyDown}
         tabIndex={-1}
       >
-        <div className="theme-transition flex max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-theme-bg-primary shadow-xl focus:outline-none focus:ring-2 focus:ring-theme-focus focus:ring-offset-2 sm:max-h-[80vh]">
+        <div className="theme-transition flex max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-theme-bg-primary shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2 sm:max-h-[80vh]">
           {/* Header */}
           <div className="flex items-center justify-between border-b border-theme-border px-4 py-3 sm:px-6 sm:py-4">
             <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">

--- a/frontend/src/components/ui/Controls/Button.tsx
+++ b/frontend/src/components/ui/Controls/Button.tsx
@@ -74,8 +74,11 @@ const VARIANT_STYLES = {
     "text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary theme-transition",
   danger:
     "border border-theme-error-border bg-theme-error-bg text-theme-error-fg hover:brightness-95 theme-transition",
+  // Hovers with the sidebar's own hover token: the generic --theme-bg-hover
+  // can equal the sidebar background (it does in the default theme), which
+  // makes the hover state invisible on sidebar surfaces.
   "sidebar-icon":
-    "text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary theme-transition",
+    "text-theme-fg-secondary hover:bg-[var(--theme-shell-sidebar-hover)] hover:text-theme-fg-primary theme-transition",
   "list-item":
     "w-full text-sm text-left text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary theme-transition",
   "icon-only":

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -323,7 +323,7 @@ export default function SearchPage() {
                       e.preventDefault();
                       handleResultClick(result);
                     }}
-                    className="block cursor-pointer rounded-lg border border-theme-border bg-theme-bg-primary p-4 transition-all hover:border-theme-border-focus hover:bg-theme-bg-hover focus:bg-theme-bg-hover focus:outline-none focus:ring-2 focus:ring-theme-focus"
+                    className="block cursor-pointer rounded-lg border border-theme-border bg-theme-bg-primary p-4 transition-all hover:border-theme-border-focus hover:bg-theme-bg-hover focus:bg-theme-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus"
                     aria-label={result.chatTitle}
                   >
                     <div className="flex items-center gap-4">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -457,17 +457,19 @@ body {
   letter-spacing: var(--theme-letter-spacing-base, 0em);
 }
 
-/* Add global helper classes */
+/* Add global helper classes.
+   Rings are keyed to :focus-visible only, so mouse clicks never leave a
+   lingering ring; keyboard navigation still gets the full indicator. */
 .focus-ring {
-  @apply focus:outline-none focus:ring-2 focus:ring-theme-focus focus:ring-offset-2 focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2;
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2;
 }
 
 .focus-ring-tight {
-  @apply focus:outline-none focus:ring-2 focus:ring-theme-focus focus-visible:ring-2 focus-visible:ring-theme-focus;
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus;
 }
 
 .focus-ring-inset {
-  @apply focus:outline-none focus:ring-2 focus:ring-inset focus:ring-theme-focus focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-theme-focus;
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-theme-focus;
 }
 
 /* Geometry classes for controls — placed in @layer components so

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -738,6 +738,15 @@ body {
   );
 }
 
+/* Trailing-control column: chat rows and section headers host the same
+   sm icon control on their right edge (the "⋮" row menu, the filter/sort
+   trigger). They share this padding — and the control its geometry — so the
+   controls sit on one vertical centerline; the padding also keeps the control
+   box clear of the row's --theme-radius-shell corner rounding. */
+.sidebar-trailing-col-geometry {
+  padding-right: 0.375rem;
+}
+
 /* Square icon controls (header toggle, slim logo, footer avatar trigger):
    the margin puts the control box's center on the rail line. The box never
    renders smaller than its content (--sidebar-icon-col-content; the avatar

--- a/office-addin/src/outlook/components/AddinChatInput.tsx
+++ b/office-addin/src/outlook/components/AddinChatInput.tsx
@@ -917,7 +917,7 @@ export const AddinChatInput = forwardRef<
       {shouldShowEmailSourcePreview && (
         <div className="mx-auto w-full max-w-[var(--theme-layout-chat-input-max-width)] overflow-hidden overscroll-none px-2 pb-1 sm:px-4">
           <div
-            className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus:ring-2 focus:ring-theme-focus"
+            className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus"
             role="region"
             // The attachment preview is a bounded scroll area in the task pane;
             // keyboard users need a focus target before arrow/page scrolling.

--- a/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
+++ b/office-addin/src/teams/components/TeamsAttachmentsPreview.tsx
@@ -110,7 +110,7 @@ export function TeamsAttachmentsPreview(props: FileAttachmentsPreviewProps) {
   return (
     <>
       <div
-        className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus:ring-2 focus:ring-theme-focus"
+        className="max-h-[40vh] overflow-y-auto overscroll-none pr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus"
         role="region"
         // A bounded scroll area needs a focus target before a keyboard user can
         // arrow or page through it.


### PR DESCRIPTION
Three related sidebar/focus polish changes:

## Focus rings only for keyboard focus

The global `.focus-ring` / `.focus-ring-tight` / `.focus-ring-inset` utilities applied their ring on plain `:focus`, so every mouse click left a lingering gray ring on the clicked element (chat history rows, dropdown triggers, modal panels). The utilities now key the ring to `:focus-visible` only — mouse clicks never show it, keyboard navigation keeps the full indicator. Three inline stragglers (starter-prompt tiles, cloud-file-picker panel, search-result cards) and two office add-in scroll containers were converted to match; form fields (`Input`, `Textarea`, checkboxes) and the deliberate keyboard-active dropdown-row recipe (`ring-1 ring-inset`) are untouched.

## Inset rings on sidebar rows

The outside-drawn 2px ring gets clipped by the sidebar scrollport whenever the themeable row inset (`--theme-spacing-shell-compact-padding-x`) is narrower than the ring. Sidebar row surfaces (chat rows, nav links, New Chat) now use the inset ring so it can never be clipped.

## Trailing-control alignment + visible hover

The section-header filter/sort trigger and the chat-row "⋮" triggers sat 8px apart horizontally (6px from a hardcoded row `pr-1.5` the header lacked, 2px from mismatched button geometries) and their hover state was invisible on the sidebar (`--theme-bg-hover` equals `--theme-bg-sidebar` in the default theme). Fix extends the ERMAIN-608 geometry contract: a shared `.sidebar-trailing-col-geometry` class owns the trailing column padding in all three host sites, both triggers use `variant="sidebar-icon"` (identical square icon geometry), and the `sidebar-icon` variant hovers with `--theme-shell-sidebar-hover` — visible on any theme by construction (also fixes the same invisible hover on the sidebar toggle/logo buttons).