### PR TITLE
Mention validation & persistence on submit/edit/regenerate (ERMAIN-621)

### DIFF
--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -50,6 +50,10 @@ pub struct InputParameters {
     /// The action facet arguments supplied with this message, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub action_facet_args: Option<HashMap<String, String>>,
+    /// Assistants the user @-mentioned in this message (delegation targets),
+    /// if any. Persisted so edit and regenerate replay the mentions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mentioned_assistant_ids: Option<Vec<String>>,
 }
 
 /// Request-scoped context captured for a generation request.
@@ -821,6 +825,41 @@ pub fn get_input_action_facet_from_message(
             .map(|id| (id, input_params.action_facet_args.unwrap_or_default())));
     }
     Ok(None)
+}
+
+/// The assistant mentions stored in a user message's input parameters, if any.
+/// Used by regenerate (and edit fallback) to replay the mentions the original
+/// message carried when the request doesn't re-send them. Entries that are not
+/// valid uuids are skipped.
+pub fn get_input_mentioned_assistant_ids_from_message(
+    message: &messages::Model,
+) -> Result<Option<Vec<Uuid>>, Report> {
+    let Some(input_params_json) = &message.input_parameters else {
+        return Ok(None);
+    };
+    let input_params: InputParameters =
+        serde_json::from_value(input_params_json.clone()).map_err(|e| {
+            eyre!(
+                "Failed to parse input parameters for message {}: {}",
+                message.id,
+                e
+            )
+        })?;
+    Ok(input_params.mentioned_assistant_ids.map(|ids| {
+        ids.iter()
+            .filter_map(|id| match Uuid::parse_str(id) {
+                Ok(parsed) => Some(parsed),
+                Err(_) => {
+                    tracing::warn!(
+                        message_id = %message.id,
+                        mentioned_assistant_id = %id,
+                        "Skipping unparseable mentioned assistant id"
+                    );
+                    None
+                }
+            })
+            .collect()
+    }))
 }
 
 /// Resolve a provider for a user message branch by checking the assistant response that follows

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -651,6 +651,11 @@ pub struct MessageSubmitRequest {
     selected_facet_ids: Vec<String>,
     /// Optional action facet to apply during this generation.
     action_facet: Option<ActionFacetRequest>,
+    /// Assistants the user @-mentioned in this message as delegation targets.
+    /// Validated server-side; requires `assistants.delegation.enabled`.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    mentioned_assistant_ids: Option<Vec<Uuid>>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1187,6 +1192,11 @@ pub struct RegenerateMessageRequest {
     selected_facet_ids: Vec<String>,
     /// Optional action facet to apply during this generation.
     action_facet: Option<ActionFacetRequest>,
+    /// Assistants the user @-mentioned in this message as delegation targets.
+    /// Validated server-side; requires `assistants.delegation.enabled`.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    mentioned_assistant_ids: Option<Vec<Uuid>>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1323,6 +1333,11 @@ pub struct EditMessageRequest {
     selected_facet_ids: Vec<String>,
     /// Optional action facet to apply during this generation.
     action_facet: Option<ActionFacetRequest>,
+    /// Assistants the user @-mentioned in this message as delegation targets.
+    /// Validated server-side; requires `assistants.delegation.enabled`.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    mentioned_assistant_ids: Option<Vec<Uuid>>,
 }
 
 #[derive(serde::Deserialize, ToSchema)]
@@ -6442,77 +6457,89 @@ pub async fn message_submit_sse(
     validate_action_facet(&app_state.config, request.action_facet.as_ref(), platform)?;
 
     // Determine the chat_id first so we can use it as the background task key
-    let (chat_id, chat_was_created) = if let Some(existing_chat_id) = request.existing_chat_id {
-        let (chat, _) = get_or_create_chat(
-            &app_state.db,
-            &policy,
-            &me_user.to_subject(),
-            Some(&existing_chat_id),
-            &me_user.id,
-            None,
-            None,
-        )
-        .await
-        .map_err(|e| {
-            let s = e.to_string();
-            if s.contains("not found")
-                || s.contains("Access denied")
-                || s.contains("not authorized")
-            {
-                (
-                    axum::http::StatusCode::NOT_FOUND,
-                    "Chat not found".to_string(),
-                )
-            } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to load chat".to_string(),
-                )
+    let (chat_id, chat_was_created, chat_assistant_id) =
+        if let Some(existing_chat_id) = request.existing_chat_id {
+            let (chat, _) = get_or_create_chat(
+                &app_state.db,
+                &policy,
+                &me_user.to_subject(),
+                Some(&existing_chat_id),
+                &me_user.id,
+                None,
+                None,
+            )
+            .await
+            .map_err(|e| {
+                let s = e.to_string();
+                if s.contains("not found")
+                    || s.contains("Access denied")
+                    || s.contains("not authorized")
+                {
+                    (
+                        axum::http::StatusCode::NOT_FOUND,
+                        "Chat not found".to_string(),
+                    )
+                } else {
+                    (
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to load chat".to_string(),
+                    )
+                }
+            })?;
+            reject_if_archived(&chat)?;
+            (existing_chat_id, false, chat.assistant_id)
+        } else {
+            // Need to get or create chat to determine the chat_id
+            let (chat, chat_status) = get_or_create_chat_by_previous_message_id(
+                &app_state.db,
+                &policy,
+                &me_user.to_subject(),
+                request.previous_message_id.as_ref(),
+                &me_user.id,
+                request.assistant_id.as_ref(),
+                request.title_by_user_provided.clone(),
+            )
+            .await
+            .map_err(|e| {
+                let s = e.to_string();
+                if s.contains("not found")
+                    || s.contains("Access denied")
+                    || s.contains("not authorized")
+                {
+                    (
+                        axum::http::StatusCode::NOT_FOUND,
+                        "Chat or previous message not found".to_string(),
+                    )
+                } else {
+                    (
+                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to get or create chat".to_string(),
+                    )
+                }
+            })?;
+
+            // A brand-new chat has archived_at = None, so new-chat creation is
+            // unaffected; only writes resolved onto an existing archived chat 409.
+            reject_if_archived(&chat)?;
+
+            let was_created = chat_status == ChatCreationStatus::Created;
+            if was_created {
+                app_state.global_policy_engine.invalidate_data().await;
             }
-        })?;
-        reject_if_archived(&chat)?;
-        (existing_chat_id, false)
-    } else {
-        // Need to get or create chat to determine the chat_id
-        let (chat, chat_status) = get_or_create_chat_by_previous_message_id(
-            &app_state.db,
-            &policy,
-            &me_user.to_subject(),
-            request.previous_message_id.as_ref(),
-            &me_user.id,
-            request.assistant_id.as_ref(),
-            request.title_by_user_provided.clone(),
-        )
-        .await
-        .map_err(|e| {
-            let s = e.to_string();
-            if s.contains("not found")
-                || s.contains("Access denied")
-                || s.contains("not authorized")
-            {
-                (
-                    axum::http::StatusCode::NOT_FOUND,
-                    "Chat or previous message not found".to_string(),
-                )
-            } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    "Failed to get or create chat".to_string(),
-                )
-            }
-        })?;
 
-        // A brand-new chat has archived_at = None, so new-chat creation is
-        // unaffected; only writes resolved onto an existing archived chat 409.
-        reject_if_archived(&chat)?;
+            (chat.id, was_created, chat.assistant_id)
+        };
 
-        let was_created = chat_status == ChatCreationStatus::Created;
-        if was_created {
-            app_state.global_policy_engine.invalidate_data().await;
-        }
-
-        (chat.id, was_created)
-    };
+    // Validate assistant mentions before spawning (returns HTTP 400 on failure).
+    // The validated targets feed the delegation tool offer.
+    let _delegation_targets = crate::services::delegation::validate_mentioned_assistants(
+        &app_state,
+        &policy,
+        &me_user.to_subject(),
+        request.mentioned_assistant_ids.as_deref(),
+        chat_assistant_id,
+    )
+    .await?;
 
     // Start or get background task for this chat
     let (broadcast_rx, task) = app_state
@@ -7490,14 +7517,26 @@ async fn run_message_submit_task(
 
     // Save user message
     tracing::info!("Saving user message");
+    let mentioned_assistant_ids_for_persistence = request
+        .mentioned_assistant_ids
+        .as_ref()
+        .filter(|ids| !ids.is_empty())
+        .map(|ids| {
+            crate::services::delegation::dedupe_mentions(ids)
+                .iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+        });
     let user_input_parameters =
-        request
-            .action_facet
-            .as_ref()
-            .map(|af| crate::models::message::InputParameters {
-                action_facet_id: Some(af.id.clone()),
-                action_facet_args: Some(af.args.clone()),
-            });
+        if request.action_facet.is_some() || mentioned_assistant_ids_for_persistence.is_some() {
+            Some(crate::models::message::InputParameters {
+                action_facet_id: request.action_facet.as_ref().map(|af| af.id.clone()),
+                action_facet_args: request.action_facet.as_ref().map(|af| af.args.clone()),
+                mentioned_assistant_ids: mentioned_assistant_ids_for_persistence,
+            })
+        } else {
+            None
+        };
     let saved_user_message = bg_stream_save_user_message(
         task,
         app_state,
@@ -7831,6 +7870,40 @@ pub async fn regenerate_message_sse(
         }
     })?;
     reject_if_archived(&chat)?;
+
+    // Assistant mentions: an explicit request value is validated hard (400);
+    // absent, fall back to the mentions persisted on the turn's user message,
+    // re-validated softly for replay stability. The resolved targets feed the
+    // delegation tool offer.
+    let _delegation_targets = match request.mentioned_assistant_ids.clone() {
+        Some(ids) => {
+            crate::services::delegation::validate_mentioned_assistants(
+                &app_state,
+                &policy,
+                &me_user.to_subject(),
+                Some(&ids),
+                chat.assistant_id,
+            )
+            .await?
+        }
+        None => {
+            let persisted = crate::models::message::get_input_mentioned_assistant_ids_from_message(
+                &validation_result.previous_message,
+            )
+            .unwrap_or_else(|error| {
+                warn_and_capture_error("read regenerate fallback assistant mentions", &error);
+                None
+            });
+            crate::services::delegation::resolve_persisted_mentions(
+                &app_state,
+                &policy,
+                &me_user.to_subject(),
+                persisted.as_deref(),
+                chat.assistant_id,
+            )
+            .await
+        }
+    };
 
     // Create a channel for sending events
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Report>>(100);
@@ -8189,6 +8262,52 @@ pub async fn edit_message_sse(
     })?;
     reject_if_archived(&chat)?;
 
+    // Assistant mentions follow the same edit contract as the action facet:
+    // an explicit request value is validated hard (400), an absent one falls
+    // back to the mentions the original user message stored, re-validated
+    // softly so mentions that no longer validate are dropped rather than
+    // failing the edit. The resolved value is persisted onto the new sibling
+    // row and feeds the delegation tool offer.
+    let resolved_mentioned_assistant_ids: Option<Vec<Uuid>> = match request
+        .mentioned_assistant_ids
+        .clone()
+    {
+        Some(ids) => {
+            crate::services::delegation::validate_mentioned_assistants(
+                &app_state,
+                &policy,
+                &me_user.to_subject(),
+                Some(&ids),
+                chat.assistant_id,
+            )
+            .await?;
+            Some(crate::services::delegation::dedupe_mentions(&ids))
+        }
+        None => {
+            let persisted = crate::models::message::get_input_mentioned_assistant_ids_from_message(
+                &message_to_edit,
+            )
+            .unwrap_or_else(|error| {
+                warn_and_capture_error("read edit fallback assistant mentions", &error);
+                None
+            });
+            match persisted {
+                Some(ids) => {
+                    let targets = crate::services::delegation::resolve_persisted_mentions(
+                        &app_state,
+                        &policy,
+                        &me_user.to_subject(),
+                        Some(&ids),
+                        chat.assistant_id,
+                    )
+                    .await;
+                    (!targets.is_empty()).then(|| targets.iter().map(|target| target.id).collect())
+                }
+                None => None,
+            }
+        }
+    };
+
     // Create a channel for sending events
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Report>>(100);
     let (_abort_rx, task) = app_state
@@ -8235,12 +8354,18 @@ pub async fn edit_message_sse(
         ),
     };
     let edit_input_parameters =
-        resolved_action_facet
-            .as_ref()
-            .map(|af| crate::models::message::InputParameters {
-                action_facet_id: Some(af.id.clone()),
-                action_facet_args: Some(af.args.clone()),
-            });
+        if resolved_action_facet.is_some() || resolved_mentioned_assistant_ids.is_some() {
+            Some(crate::models::message::InputParameters {
+                action_facet_id: resolved_action_facet.as_ref().map(|af| af.id.clone()),
+                action_facet_args: resolved_action_facet.as_ref().map(|af| af.args.clone()),
+                mentioned_assistant_ids: resolved_mentioned_assistant_ids
+                    .as_ref()
+                    .filter(|ids| !ids.is_empty())
+                    .map(|ids| ids.iter().map(|id| id.to_string()).collect()),
+            })
+        } else {
+            None
+        };
     let task_for_stream = task.clone();
     let app_state_for_cleanup = app_state.clone();
     let chat_id_for_cleanup = chat.id;

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -1,0 +1,129 @@
+//! In-chat delegation to @-mentioned assistants.
+
+use crate::policy::prelude::*;
+use crate::state::AppState;
+use axum::http::StatusCode;
+use sea_orm::prelude::Uuid;
+
+/// Deduplicates mentioned assistant ids preserving first-mention order.
+pub fn dedupe_mentions(ids: &[Uuid]) -> Vec<Uuid> {
+    let mut seen = std::collections::HashSet::new();
+    ids.iter().copied().filter(|id| seen.insert(*id)).collect()
+}
+
+/// A validated assistant the current turn may delegate to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationTarget {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// Validates the `mentioned_assistant_ids` of a streaming request and resolves
+/// them into delegation targets.
+///
+/// Rules, all enforced server-side: mentions require
+/// `assistants.delegation.enabled`; ids are deduplicated preserving order;
+/// the deduplicated count is capped by
+/// `assistants.delegation.max_mentions_per_message`; the chat's own bound
+/// assistant cannot be mentioned; every id must resolve through the checked
+/// owner-or-viewer assistant lookup, which also rejects archived assistants.
+/// The error message deliberately does not distinguish missing, archived, and
+/// inaccessible assistants.
+pub async fn validate_mentioned_assistants(
+    app_state: &AppState,
+    policy: &PolicyEngine,
+    subject: &Subject,
+    mentioned_assistant_ids: Option<&[Uuid]>,
+    chat_bound_assistant_id: Option<Uuid>,
+) -> Result<Vec<DelegationTarget>, (StatusCode, String)> {
+    let Some(ids) = mentioned_assistant_ids else {
+        return Ok(Vec::new());
+    };
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let delegation = &app_state.config.assistants.delegation;
+    if !delegation.enabled {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Assistant delegation is not enabled".to_string(),
+        ));
+    }
+
+    let deduped = dedupe_mentions(ids);
+
+    if deduped.len() > delegation.max_mentions_per_message {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "At most {} assistants can be mentioned per message",
+                delegation.max_mentions_per_message
+            ),
+        ));
+    }
+
+    let mut targets = Vec::with_capacity(deduped.len());
+    for assistant_id in deduped {
+        if Some(assistant_id) == chat_bound_assistant_id {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "The chat's own assistant cannot be mentioned for delegation".to_string(),
+            ));
+        }
+        let assistant = crate::models::assistant::get_assistant_by_id(
+            &app_state.db,
+            policy,
+            subject,
+            assistant_id,
+        )
+        .await
+        .map_err(|error| {
+            tracing::debug!(
+                %assistant_id,
+                %error,
+                "Rejecting mentioned assistant"
+            );
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Mentioned assistant {assistant_id} is not available"),
+            )
+        })?;
+        targets.push(DelegationTarget {
+            id: assistant.id,
+            name: assistant.name,
+            description: assistant.description,
+        });
+    }
+
+    Ok(targets)
+}
+
+/// Replay-stable variant for mentions read back from a persisted user message
+/// (regenerate without the request field, edit fallback): validation failures
+/// drop the mentions with a warning instead of failing the turn, mirroring how
+/// a stored action facet that no longer validates is dropped on replay.
+pub async fn resolve_persisted_mentions(
+    app_state: &AppState,
+    policy: &PolicyEngine,
+    subject: &Subject,
+    persisted_ids: Option<&[Uuid]>,
+    chat_bound_assistant_id: Option<Uuid>,
+) -> Vec<DelegationTarget> {
+    match validate_mentioned_assistants(
+        app_state,
+        policy,
+        subject,
+        persisted_ids,
+        chat_bound_assistant_id,
+    )
+    .await
+    {
+        Ok(targets) => targets,
+        Err((_, message)) => {
+            tracing::warn!("Dropping persisted assistant mentions on replay: {message}");
+            Vec::new()
+        }
+    }
+}

--- a/backend/erato/src/services/mod.rs
+++ b/backend/erato/src/services/mod.rs
@@ -3,6 +3,7 @@ pub mod client_actions;
 pub mod client_tools;
 pub mod config_redaction;
 pub mod configuration_reload_listener;
+pub mod delegation;
 pub mod file_parsing;
 pub mod file_processing_cached;
 pub mod file_processor;

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -608,3 +608,316 @@ async fn test_provenance_generated_column_and_legacy_rows(pool: Pool<Postgres>) 
     assert_eq!(provenance.origin_chat_id, Some(plain_chat_id));
     assert_eq!(provenance.depth, 1);
 }
+async fn submit_with_mentions(
+    server: &TestServer,
+    chat_id: Option<&str>,
+    text: &str,
+    mentioned_assistant_ids: &[&str],
+) -> axum_test::TestResponse {
+    let mut body = json!({
+        "user_message": text,
+        "mentioned_assistant_ids": mentioned_assistant_ids,
+    });
+    if let Some(chat_id) = chat_id {
+        body["existing_chat_id"] = json!(chat_id);
+    }
+    server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&body)
+        .await
+}
+
+fn delegation_enabled_config() -> erato::config::AppConfig {
+    let mut app_config = crate::test_utils::hermetic_app_config(None, None);
+    app_config.assistants.delegation.enabled = true;
+    app_config
+}
+
+async fn delegation_enabled_state_with_llm(
+    pool: Pool<Postgres>,
+) -> (erato::state::AppState, mocktail::server::MockServer) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post().path("/v1/chat/completions");
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["mentioned answer"]),
+        );
+    });
+    let (mut app_config, server) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    (app_state, server)
+}
+
+/// Validation matrix for `mentioned_assistant_ids`: server-side gate, mention
+/// cap, archived target, self-mention, and inaccessible target all 400.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_mention_validation_matrix(pool: Pool<Postgres>) {
+    let app_state = test_app_state(delegation_enabled_config(), pool).await;
+    erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    let server = app_server(app_state.clone());
+
+    // Over the default cap of 3.
+    let mut many = Vec::new();
+    for index in 0..4 {
+        many.push(create_assistant(&server, &format!("Cap Assistant {index}"), "prompt").await);
+    }
+    let many_refs: Vec<&str> = many.iter().map(String::as_str).collect();
+    let response = submit_with_mentions(&server, None, "over cap", &many_refs).await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // Archived target.
+    let archived = create_assistant(&server, "Archived Assistant", "prompt").await;
+    server
+        .post(&format!("/api/v1beta/assistants/{archived}/archive"))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({}))
+        .await
+        .assert_status_ok();
+    let response = submit_with_mentions(&server, None, "archived", &[&archived]).await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // Self-mention on an assistant-bound chat.
+    let bound = create_assistant(&server, "Bound Assistant", "prompt").await;
+    let bound_chat = create_chat(&server, Some(&bound)).await;
+    let response = submit_with_mentions(&server, Some(&bound_chat), "self", &[&bound]).await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // Inaccessible target (another user's assistant, no grant).
+    let other_user = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "delegation-other-user",
+        None,
+    )
+    .await
+    .unwrap();
+    let foreign = erato::models::assistant::create_assistant(
+        &app_state.db,
+        &erato::policy::engine::PolicyEngine::new(),
+        &erato::policy::types::Subject::User(other_user.id.to_string()),
+        "Foreign Assistant".to_string(),
+        None,
+        "foreign prompt".to_string(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await
+    .unwrap();
+    let response = submit_with_mentions(&server, None, "foreign", &[&foreign.id.to_string()]).await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // Unknown id.
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "unknown",
+        &["00000000-0000-0000-0000-00000000dead"],
+    )
+    .await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+/// With the delegation gate off, a submit carrying mentions is rejected even
+/// when the mentioned assistant would otherwise be valid.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_mentions_rejected_when_delegation_disabled(pool: Pool<Postgres>) {
+    let app_state = test_app_state(crate::test_utils::hermetic_app_config(None, None), pool).await;
+    erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    let server = app_server(app_state.clone());
+
+    let assistant = create_assistant(&server, "Gated Assistant", "prompt").await;
+    let response = submit_with_mentions(&server, None, "gate off", &[&assistant]).await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // Regenerate with an explicit mention field is gated the same way.
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "current_message_id": Uuid::new_v4(),
+            "mentioned_assistant_ids": [assistant],
+        }))
+        .await;
+    // The unknown message id 400s first; the point is the request shape parses.
+    regenerate_response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+/// A shared assistant (viewer grant) is an accepted mention; the mentions
+/// round-trip into the user message's `input_parameters`, deduplicated.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_shared_viewer_mention_accepted_and_persisted(pool: Pool<Postgres>) {
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    let other_user = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "delegation-sharing-owner",
+        None,
+    )
+    .await
+    .unwrap();
+    let shared = erato::models::assistant::create_assistant(
+        &app_state.db,
+        &erato::policy::engine::PolicyEngine::new(),
+        &erato::policy::types::Subject::User(other_user.id.to_string()),
+        "Shared Assistant".to_string(),
+        None,
+        "shared prompt".to_string(),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await
+    .unwrap();
+    erato::models::share_grant::create_share_grant(
+        &app_state.db,
+        &erato::policy::engine::PolicyEngine::new(),
+        &erato::policy::types::Subject::User(other_user.id.to_string()),
+        "assistant".to_string(),
+        shared.id.to_string(),
+        "user".to_string(),
+        "id".to_string(),
+        me.id.to_string(),
+        "viewer".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let shared_id = shared.id.to_string();
+    // Duplicate mention: accepted and persisted deduplicated.
+    let response =
+        submit_with_mentions(&server, None, "shared mention", &[&shared_id, &shared_id]).await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+
+    let rows = chat_messages_by_created_at(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    let user_row = rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "user")
+        .expect("user message row");
+    let persisted =
+        erato::models::message::get_input_mentioned_assistant_ids_from_message(user_row)
+            .unwrap()
+            .expect("mentions persisted");
+    assert_eq!(persisted, vec![shared.id]);
+}
+
+/// Regenerate without the field re-reads the persisted mentions; edit without
+/// the field carries them onto the new sibling row.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_and_edit_replay_persisted_mentions(pool: Pool<Postgres>) {
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+
+    let target = create_assistant(&server, "Replay Target", "prompt").await;
+    let response = submit_with_mentions(&server, None, "mention on submit", &[&target]).await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let assistant_message_id = assistant_message_id_from_events(&events);
+
+    // Regenerate without the field: the persisted mentions replay (200).
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "current_message_id": assistant_message_id }))
+        .await;
+    regenerate_response.assert_status_ok();
+
+    // Edit without the field: mentions carry onto the new sibling row.
+    let rows = chat_messages_by_created_at(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    let original_user_row = rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "user")
+        .expect("user message row");
+    let edit_response = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_row.id,
+            "replace_user_message": "edited mention message",
+        }))
+        .await;
+    edit_response.assert_status_ok();
+
+    let rows = chat_messages_by_created_at(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    let edited_row = rows
+        .iter()
+        .find(|row| row.raw_message["content"][0]["text"] == "edited mention message")
+        .expect("edited sibling row");
+    let persisted =
+        erato::models::message::get_input_mentioned_assistant_ids_from_message(edited_row)
+            .unwrap()
+            .expect("mentions carried onto the edited row");
+    assert_eq!(persisted, vec![Uuid::parse_str(&target).unwrap()]);
+
+    // Edit with an explicit invalid mention still 400s.
+    let bad_edit = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_row.id,
+            "replace_user_message": "bad mention",
+            "mentioned_assistant_ids": ["00000000-0000-0000-0000-00000000dead"],
+        }))
+        .await;
+    bad_edit.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -5728,6 +5728,14 @@
             "description": "The ID of the chat provider to use for generation. If not provided, will use the highest priority model for the user.",
             "example": "primary"
           },
+          "mentioned_assistant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Assistants the user @-mentioned in this message as delegation targets.\nValidated server-side; requires `assistants.delegation.enabled`."
+          },
           "message_id": {
             "type": "string",
             "format": "uuid",
@@ -6632,6 +6640,14 @@
             "description": "The IDs of any files attached to this message. These files must already be uploaded to the file_uploads table.\nThe files should normally only be provided with the first message they appear in the chat. After that they can assumed to be part of the chat history.",
             "example": "[\"00000000-0000-0000-0000-000000000000\"]"
           },
+          "mentioned_assistant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Assistants the user @-mentioned in this message as delegation targets.\nValidated server-side; requires `assistants.delegation.enabled`."
+          },
           "previous_message_id": {
             "type": [
               "string",
@@ -7457,6 +7473,14 @@
             "format": "uuid",
             "description": "The ID of the message that should have a replacement response generated.",
             "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "mentioned_assistant_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Assistants the user @-mentioned in this message as delegation targets.\nValidated server-side; requires `assistants.delegation.enabled`."
           },
           "selected_facet_ids": {
             "type": "array",

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -1155,6 +1155,11 @@ export type EditMessageRequest = {
    */
   chat_provider_id?: string;
   /**
+   * Assistants the user @-mentioned in this message as delegation targets.
+   * Validated server-side; requires `assistants.delegation.enabled`.
+   */
+  mentioned_assistant_ids?: string[];
+  /**
    * The ID of the message that should be edited with a new response. It will be considered a sibling message to the new message.
    *
    * @format uuid
@@ -1571,6 +1576,11 @@ export type MessageSubmitRequest = {
    */
   input_files_ids?: string[];
   /**
+   * Assistants the user @-mentioned in this message as delegation targets.
+   * Validated server-side; requires `assistants.delegation.enabled`.
+   */
+  mentioned_assistant_ids?: string[];
+  /**
    * The ID of the message that this message is a response to. If this is the first message in the chat, this should be empty.
    *
    * @format uuid
@@ -1970,6 +1980,11 @@ export type RegenerateMessageRequest = {
    * @example 00000000-0000-0000-0000-000000000000
    */
   current_message_id: string;
+  /**
+   * Assistants the user @-mentioned in this message as delegation targets.
+   * Validated server-side; requires `assistants.delegation.enabled`.
+   */
+  mentioned_assistant_ids?: string[];
   /**
    * IDs of facets selected by the user for this generation.
    */


### PR DESCRIPTION
**Part 3/5 of the ERMAIN-617 delegation stack**, on top of #979. Review bottom-up; this layer's diff is against the primitives layer.

Accepts and validates `mentioned_assistant_ids` on the three streaming request paths and persists them for replay. Independently mergeable — the tool offer consumes the validated output in the runtime layer.

## What changes

- `MessageSubmitRequest` / `EditMessageRequest` / `RegenerateMessageRequest` each gain an optional `mentioned_assistant_ids` field (OpenAPI + frontend client regenerated).
- `validate_mentioned_assistants` (new `services/delegation.rs`), called from all three handlers before any task is spawned. Server-side rules: 400 when the delegation gate is off; dedupe preserving order; 400 over `max_mentions_per_message`; 400 for the chat's own bound assistant; every id resolved through the checked owner-or-viewer assistant lookup (the `POST /me/chats` pattern — explicitly not the submitstream bind-time path), which also rejects archived assistants. The rejection message deliberately does not distinguish missing / archived / inaccessible.
- `InputParameters` gains `mentioned_assistant_ids`, persisted on the user message — the same mechanism that keeps action facets stable across edit/regenerate. Regenerate without the field re-reads the persisted value; edit falls back to the original message's mentions and re-persists the resolved value onto the new sibling row. Persisted-fallback validation is soft (drop with a warning) for replay stability; explicit request values fail hard.

## Testing

Validation matrix: gate off, over cap, archived target, self-mention, another user's assistant without a grant, unknown id → all 400; shared-viewer assistant accepted. Persistence: mentions round-trip deduplicated into `input_parameters`; regenerate replays them; edit carries them onto the new sibling row; an explicit invalid mention on edit still 400s.
