### PR TITLE
delegate_to_assistant: tool offer, dispatch branch, awaited child run (ERMAIN-622)

### DIFF
--- a/backend/erato/src/models/chat.rs
+++ b/backend/erato/src/models/chat.rs
@@ -211,6 +211,46 @@ pub async fn get_or_create_chat_by_previous_message_id(
     }
 }
 
+/// True when the chat is a delegated run (provenance kind `delegation`).
+/// Unparseable configurations count as not delegated; they fail loudly on the
+/// paths that need the assistant itself.
+pub fn chat_is_delegated_run(chat: &chats::Model) -> bool {
+    parse_assistant_configuration(chat)
+        .ok()
+        .flatten()
+        .and_then(|configuration| configuration.provenance)
+        .is_some_and(|provenance| provenance.kind == ChatProvenanceKind::Delegation)
+}
+
+/// Create a chat owned by `owner_user_id`, bound to `assistant_id`, carrying a
+/// provenance envelope. The caller must have access-checked the assistant (the
+/// `POST /me/chats` pattern) — this function only authorizes chat creation.
+pub async fn create_delegated_chat(
+    conn: &DatabaseConnection,
+    policy: &PolicyEngine,
+    subject: &Subject,
+    owner_user_id: &str,
+    assistant_id: Uuid,
+    provenance: ChatProvenance,
+    title: String,
+) -> Result<chats::Model, Report> {
+    authorize!(policy, subject, &Resource::ChatSingleton, Action::Create)?;
+
+    let configuration = AssistantConfiguration {
+        assistant_id,
+        provenance: Some(provenance),
+    };
+    let new_chat = chats::ActiveModel {
+        owner_user_id: ActiveValue::Set(owner_user_id.to_owned()),
+        assistant_configuration: ActiveValue::Set(Some(configuration.to_json()?)),
+        title_by_user_provided: ActiveValue::Set(Some(title)),
+        ..Default::default()
+    };
+    Ok(chats::Entity::insert(new_chat)
+        .exec_with_returning(conn)
+        .await?)
+}
+
 /// Counts reported by [`seed_chat_lineage`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SeedStats {

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1618,12 +1618,70 @@ pub struct PreparedChatRequest {
     chat_request: ChatRequest,
     // Prepared `genai` `ChatOptions` (e.g. reasoning effort)
     chat_options: ChatOptions,
+    // Validated delegation targets whose ids the `delegate_to_assistant`
+    // dispatch accepts for this request.
+    delegation_targets: Vec<crate::services::delegation::DelegationTarget>,
+    // Parent-chat file ids enumerated in the delegation tool offer; the
+    // dispatch validates requested `file_ids` against this set.
+    delegation_offered_file_ids: Vec<Uuid>,
 }
 
 impl PreparedChatRequest {
     pub(crate) fn chat_request(&self) -> &ChatRequest {
         &self.chat_request
     }
+}
+
+/// The generic error frame a delegated child run broadcasts on failure, so a
+/// user watching the child chat resolves instead of seeing a silent end —
+/// same shape as the submit wrapper's failure broadcast.
+pub(crate) fn delegated_run_failure_error_value() -> Option<JsonValue> {
+    let error_event = MessageSubmitStreamingResponseError {
+        message_id: None,
+        error: GenerationErrorType::InternalError {
+            error_description: "The message could not be generated.".to_string(),
+        },
+    };
+    serde_json::to_value(MessageSubmitStreamingResponseMessage::Error(error_event)).ok()
+}
+
+impl MessageSubmitRequest {
+    /// Synthetic request driving a delegated child run through the same task
+    /// machinery as a user submit.
+    pub(crate) fn for_delegated_run(
+        chat_id: Uuid,
+        user_message: String,
+        input_files_ids: Vec<Uuid>,
+        previous_message_id: Option<Uuid>,
+    ) -> Self {
+        Self {
+            previous_message_id,
+            existing_chat_id: Some(chat_id),
+            user_message,
+            input_files_ids,
+            chat_provider_id: None,
+            assistant_id: None,
+            title_by_user_provided: None,
+            selected_facet_ids: Vec::new(),
+            action_facet: None,
+            mentioned_assistant_ids: None,
+        }
+    }
+}
+
+/// Everything the tool-dispatch loop needs to run a delegated child assistant
+/// for a `delegate_to_assistant` call.
+pub(crate) struct DelegationDispatchContext<'a> {
+    /// The origin user; the child chat and its messages are owned by them.
+    pub me_user: &'a MeProfile,
+    /// Targets validated for this turn — the only accepted `assistant_id`s.
+    pub targets: &'a [crate::services::delegation::DelegationTarget],
+    /// Parent-chat file ids enumerated in the tool offer.
+    pub offered_file_ids: &'a [Uuid],
+    /// The chat this generation runs in.
+    pub origin_chat: &'a chats::Model,
+    /// The turn's user message; seeding source and provenance anchor.
+    pub origin_user_message_id: Uuid,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -2217,12 +2275,20 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         generation_mcp_tools.clone(),
         effective_model_settings.compat_omit_strict,
     );
+    // A delegated child run has no interactive client on its own chat: the
+    // parent awaits it, so every client-interaction affordance would burn its
+    // park budget against nobody. Suppression acts HERE, at the offering
+    // site, across every source (client-action tool, global/facet/action
+    // client-tool allowlists) — a security control derived from the durable
+    // chat row, not caller-remembered state.
+    let is_delegated_run = crate::models::chat::chat_is_delegated_run(chat);
     // Offer the synthetic client-action tool only when the current request's
     // action facet declares client actions. The tool is handled in the tool
     // call loop instead of being dispatched to an MCP server. If an MCP tool
     // already claims the same name, it wins — adding a duplicate tool name
     // would be rejected by providers and ambiguous to dispatch.
-    if let Some(action_facet) = user_input.action_facet.as_ref()
+    if !is_delegated_run
+        && let Some(action_facet) = user_input.action_facet.as_ref()
         && let Some(facet_config) = app_state.config.action_facets.facets.get(&action_facet.id)
         && !facet_config.client_actions.is_empty()
     {
@@ -2265,7 +2331,7 @@ pub(crate) async fn prepare_chat_request_with_adapters(
     // timeouts from here instead of re-finding config entries by bare name.
     let mut offered_client_tool_timeouts: std::collections::HashMap<String, Option<u64>> =
         std::collections::HashMap::new();
-    if !client_tool_allowlist.is_empty() {
+    if !client_tool_allowlist.is_empty() && !is_delegated_run {
         let allowlist_matched: Vec<&crate::config::ClientToolConfig> = app_state
             .config
             .client_tools
@@ -2338,6 +2404,46 @@ pub(crate) async fn prepare_chat_request_with_adapters(
             ));
         }
     }
+    // Offer the `delegate_to_assistant` tool when the turn carries validated
+    // assistant mentions. Request-scoped like the client-action tool, and
+    // never offered inside a delegated run itself — delegation depth stays at
+    // one even if a user mentions assistants inside a delegated chat. If an
+    // MCP tool claims the name, it wins (same precedence as the other
+    // synthetic tools).
+    let mut delegation_offered_file_ids: Vec<Uuid> = Vec::new();
+    if !user_input.delegation_targets.is_empty() && !is_delegated_run {
+        let name_taken_by_mcp_tool = generation_mcp_tools.iter().any(|tool| {
+            tool.tool.name == crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME
+        });
+        if name_taken_by_mcp_tool {
+            tracing::warn!(
+                "Not offering the delegation tool: an MCP tool already uses the name '{}'",
+                crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME
+            );
+        } else {
+            let offered_files = crate::models::file_upload::get_chat_file_uploads(
+                &app_state.db,
+                policy,
+                &me_profile_input.subject,
+                &chat.id,
+            )
+            .await?
+            .into_iter()
+            .map(|file| crate::services::delegation::DelegationOfferedFile {
+                id: file.id,
+                filename: file.filename,
+            })
+            .collect::<Vec<_>>();
+            delegation_offered_file_ids = offered_files.iter().map(|file| file.id).collect();
+            chat_request_tools.push(
+                crate::services::delegation::build_delegate_to_assistant_tool(
+                    &user_input.delegation_targets,
+                    &offered_files,
+                    effective_model_settings.compat_omit_strict,
+                ),
+            );
+        }
+    }
     if !chat_request_tools.is_empty() {
         chat_request.tools = Some(chat_request_tools);
     } else {
@@ -2391,6 +2497,8 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         offered_client_tool_timeouts,
         chat_request,
         chat_options,
+        delegation_targets: user_input.delegation_targets.clone(),
+        delegation_offered_file_ids,
     })
 }
 
@@ -2643,6 +2751,8 @@ async fn stream_generate_chat_completion<
     streaming_task: Option<&Arc<StreamingTask>>,
     assistant_id: Option<Uuid>,
     initial_message_content: Vec<ContentPart>,
+    is_delegated_run: bool,
+    delegation: Option<DelegationDispatchContext<'_>>,
 ) -> Result<(Vec<ContentPart>, Option<GenerationMetadata>), Report> {
     // Record the real assistant message id on the streaming task. `start_task`
     // only had a placeholder id; client-tool results are routed to a task by
@@ -3075,15 +3185,140 @@ async fn stream_generate_chat_completion<
                 continue;
             }
 
+            // Delegated assistant run: `delegate_to_assistant` executes
+            // server-side as an awaited child chat run and returns a result
+            // envelope. Must stay BEFORE the by-construction client-tool
+            // branch below, which treats every offered non-MCP name as a
+            // client tool. An MCP tool with the same name takes precedence
+            // (the synthetic tool is never offered in that case — see
+            // prepare). Every failure refuses the CALL, never the TURN.
+            if unfinished_tool_call.fn_name
+                == crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME
+                && !available_mcp_tools_by_name
+                    .contains_key(crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME)
+            {
+                let tool_call_started = tool_call_started_at
+                    .remove(&unfinished_tool_call.call_id)
+                    .unwrap_or_else(now_timestamp);
+                let tool_call_parent_observation_id =
+                    tool_call_parent_observation_ids.remove(&unfinished_tool_call.call_id);
+                let outcome = match delegation.as_ref() {
+                    Some(context) => {
+                        crate::services::delegation::dispatch_delegate_tool_call(
+                            app_state,
+                            policy,
+                            context,
+                            &unfinished_tool_call,
+                            streaming_task,
+                        )
+                        .await
+                    }
+                    None => Err("Delegation is not available for this request.".to_string()),
+                };
+                let (status, bg_status, message_status, output_value, response_text) = match outcome
+                {
+                    Ok(envelope) => {
+                        let response_text = envelope.model_response_text();
+                        let output_value = serde_json::to_value(&envelope)
+                            .unwrap_or_else(|_| json!({ "status": "failed" }));
+                        if envelope.status
+                            == crate::services::delegation::DelegationRunStatus::Completed
+                        {
+                            (
+                                ToolCallStatus::Success,
+                                BgToolCallStatus::Success,
+                                MessageToolCallStatus::Success,
+                                output_value,
+                                response_text,
+                            )
+                        } else {
+                            (
+                                ToolCallStatus::Error,
+                                BgToolCallStatus::Error,
+                                MessageToolCallStatus::Error,
+                                output_value,
+                                response_text,
+                            )
+                        }
+                    }
+                    Err(error) => (
+                        ToolCallStatus::Error,
+                        BgToolCallStatus::Error,
+                        MessageToolCallStatus::Error,
+                        json!({ "status": "error", "error": error }),
+                        format!("Delegation refused: {error}"),
+                    ),
+                };
+                let tool_error =
+                    matches!(status, ToolCallStatus::Error).then(|| response_text.clone());
+                let update_event = MessageSubmitStreamingResponseToolCallUpdate {
+                    message_id: assistant_message_id,
+                    content_index: current_message_content.len(),
+                    tool_call_id: unfinished_tool_call.call_id.clone(),
+                    tool_name: unfinished_tool_call.fn_name.clone(),
+                    input: Some(unfinished_tool_call.fn_arguments.clone()),
+                    status,
+                    progress_message: None,
+                    output: Some(output_value.clone()),
+                };
+                if let Some(task) = streaming_task {
+                    send_background_event(
+                        task,
+                        StreamingEvent::ToolCallUpdate {
+                            message_id: assistant_message_id,
+                            content_index: current_message_content.len(),
+                            tool_call_id: unfinished_tool_call.call_id.clone(),
+                            tool_name: unfinished_tool_call.fn_name.clone(),
+                            input: Some(unfinished_tool_call.fn_arguments.clone()),
+                            status: bg_status,
+                            progress_message: None,
+                            output: Some(output_value.clone()),
+                        },
+                        "broadcast delegation tool update",
+                    )
+                    .await;
+                }
+                let message: MSG = update_event.into();
+                send_generation_event(&message, tx.clone()).await?;
+                current_message_content.push(ContentPart::ToolUse(ToolUse {
+                    tool_call_id: unfinished_tool_call.call_id.clone(),
+                    status: message_status,
+                    tool_name: unfinished_tool_call.fn_name.clone(),
+                    input: Some(unfinished_tool_call.fn_arguments.clone()),
+                    progress_message: None,
+                    output: Some(output_value.clone()),
+                    started_at: Some(tool_call_started),
+                    ended_at: Some(now_timestamp()),
+                }));
+                persist_otel_tool_call(
+                    tracing_client.as_ref(),
+                    &unfinished_tool_call,
+                    Some(output_value),
+                    otel_tool_call_start_time,
+                    Some(SystemTime::now()),
+                    tool_call_parent_observation_id,
+                    assistant_id,
+                    &langfuse_trace_enrichment.platform,
+                    tool_error.as_deref(),
+                )
+                .await;
+                current_turn_tool_responses.push(genai::chat::ToolResponse {
+                    call_id: unfinished_tool_call.call_id.clone(),
+                    content: response_text,
+                });
+                continue;
+            }
+
             // Client tool (returning round-trip): the model called a tool the
             // active facet declared as a `client_tool`. It is neither an MCP
             // tool nor the client-action tool, so it must be EXECUTED ON THE
             // CLIENT. We emit a `client_tool_call`, SUSPEND this turn on a
             // per-call channel, and resume when the client POSTs the result —
             // like an MCP tool, but executed on the client. By construction
-            // anything offered that is not an MCP tool and not the client
-            // action is a client tool; hallucinated names were already rejected
-            // by the `allowed_tool_names` check above.
+            // anything offered that is not an MCP tool, not the client action,
+            // and not `delegate_to_assistant` is a client tool; hallucinated
+            // names were already rejected by the `allowed_tool_names` check
+            // above.
             if !available_mcp_tools_by_name.contains_key(unfinished_tool_call.fn_name.as_str()) {
                 let call_id = unfinished_tool_call.call_id.clone();
                 let tool_name = unfinished_tool_call.fn_name.clone();
@@ -3379,6 +3614,34 @@ async fn stream_generate_chat_completion<
                         false
                     };
 
+                if !has_active_always_allow && is_delegated_run {
+                    // A delegated child run must never park on approval — the
+                    // parent awaits it, and the durable stop would surface a
+                    // half-done ToolApprovalRequest tail as the delegate's
+                    // result. Refuse the CALL so the child completes in prose.
+                    let error_message = format!(
+                        "The tool '{}' requires user approval, which is unavailable in a delegated run; the call was not executed.",
+                        unfinished_tool_call.fn_name
+                    );
+                    let tool_call_started = tool_call_started_at
+                        .remove(&unfinished_tool_call.call_id)
+                        .unwrap_or_else(now_timestamp);
+                    current_message_content.push(ContentPart::ToolUse(ToolUse {
+                        tool_call_id: unfinished_tool_call.call_id.clone(),
+                        status: MessageToolCallStatus::Error,
+                        tool_name: unfinished_tool_call.fn_name.clone(),
+                        input: Some(unfinished_tool_call.fn_arguments.clone()),
+                        progress_message: None,
+                        output: Some(json!({ "status": "rejected", "error": error_message })),
+                        started_at: Some(tool_call_started),
+                        ended_at: Some(now_timestamp()),
+                    }));
+                    current_turn_tool_responses.push(genai::chat::ToolResponse {
+                        call_id: unfinished_tool_call.call_id.clone(),
+                        content: error_message,
+                    });
+                    continue;
+                }
                 if !has_active_always_allow {
                     current_message_content
                         .push(ContentPart::ToolApprovalRequest(approval_request));
@@ -6457,7 +6720,7 @@ pub async fn message_submit_sse(
     validate_action_facet(&app_state.config, request.action_facet.as_ref(), platform)?;
 
     // Determine the chat_id first so we can use it as the background task key
-    let (chat_id, chat_was_created, chat_assistant_id) =
+    let (chat_id, chat_was_created, chat_assistant_id, chat_is_delegated) =
         if let Some(existing_chat_id) = request.existing_chat_id {
             let (chat, _) = get_or_create_chat(
                 &app_state.db,
@@ -6487,7 +6750,12 @@ pub async fn message_submit_sse(
                 }
             })?;
             reject_if_archived(&chat)?;
-            (existing_chat_id, false, chat.assistant_id)
+            (
+                existing_chat_id,
+                false,
+                chat.assistant_id,
+                crate::models::chat::chat_is_delegated_run(&chat),
+            )
         } else {
             // Need to get or create chat to determine the chat_id
             let (chat, chat_status) = get_or_create_chat_by_previous_message_id(
@@ -6527,17 +6795,18 @@ pub async fn message_submit_sse(
                 app_state.global_policy_engine.invalidate_data().await;
             }
 
-            (chat.id, was_created, chat.assistant_id)
+            (chat.id, was_created, chat.assistant_id, false)
         };
 
     // Validate assistant mentions before spawning (returns HTTP 400 on failure).
     // The validated targets feed the delegation tool offer.
-    let _delegation_targets = crate::services::delegation::validate_mentioned_assistants(
+    let delegation_targets = crate::services::delegation::validate_mentioned_assistants(
         &app_state,
         &policy,
         &me_user.to_subject(),
         request.mentioned_assistant_ids.as_deref(),
         chat_assistant_id,
+        chat_is_delegated,
     )
     .await?;
 
@@ -6572,6 +6841,7 @@ pub async fn message_submit_sse(
                 generation_request_context,
                 chat_id,
                 chat_was_created,
+                delegation_targets,
             )
             .await;
 
@@ -7462,7 +7732,7 @@ mod generation_failure_diagnostic_tests {
 
 /// Run the message submission task in the background
 #[allow(clippy::too_many_arguments)]
-async fn run_message_submit_task(
+pub(crate) async fn run_message_submit_task(
     task: &Arc<StreamingTask>,
     app_state: &AppState,
     policy: &PolicyEngine,
@@ -7471,6 +7741,7 @@ async fn run_message_submit_task(
     generation_request_context: GenerationRequestContext,
     chat_id: Uuid,
     chat_was_created: bool,
+    delegation_targets: Vec<crate::services::delegation::DelegationTarget>,
 ) -> Result<(), Report> {
     tracing::info!("run_message_submit_task started for chat_id: {}", chat_id);
 
@@ -7566,6 +7837,7 @@ async fn run_message_submit_task(
                 args: af.args.clone(),
             }
         }),
+        delegation_targets,
     };
     let PreparedChatRequest {
         chat_request,
@@ -7576,6 +7848,8 @@ async fn run_message_submit_task(
         mcp_servers_unavailable,
         available_mcp_tools,
         offered_client_tool_timeouts,
+        delegation_targets,
+        delegation_offered_file_ids,
     } = prepare_chat_request(
         app_state,
         policy,
@@ -7590,7 +7864,9 @@ async fn run_message_submit_task(
     // Spawn chat summary generation if needed. Use the composed prompt input
     // so summary generation sees the same first-turn structure as chat
     // completion, then extracts only the actual user text from it.
-    if chat_was_created || request.previous_message_id.is_none() {
+    if (chat_was_created || request.previous_message_id.is_none())
+        && !crate::models::chat::chat_is_delegated_run(&chat)
+    {
         let app_state_clone = app_state.clone();
         let policy_clone = policy.clone();
         let me_user_clone = me_user.clone();
@@ -7724,6 +8000,14 @@ async fn run_message_submit_task(
         Some(task),
         chat.assistant_id,
         vec![],
+        crate::models::chat::chat_is_delegated_run(&chat),
+        Some(DelegationDispatchContext {
+            me_user,
+            targets: &delegation_targets,
+            offered_file_ids: &delegation_offered_file_ids,
+            origin_chat: &chat,
+            origin_user_message_id: saved_user_message.id,
+        }),
     );
 
     let (end_content, generation_metadata) = match generation_task.await {
@@ -7875,7 +8159,8 @@ pub async fn regenerate_message_sse(
     // absent, fall back to the mentions persisted on the turn's user message,
     // re-validated softly for replay stability. The resolved targets feed the
     // delegation tool offer.
-    let _delegation_targets = match request.mentioned_assistant_ids.clone() {
+    let chat_is_delegated = crate::models::chat::chat_is_delegated_run(&chat);
+    let delegation_targets_for_offer = match request.mentioned_assistant_ids.clone() {
         Some(ids) => {
             crate::services::delegation::validate_mentioned_assistants(
                 &app_state,
@@ -7883,6 +8168,7 @@ pub async fn regenerate_message_sse(
                 &me_user.to_subject(),
                 Some(&ids),
                 chat.assistant_id,
+                chat_is_delegated,
             )
             .await?
         }
@@ -7900,6 +8186,7 @@ pub async fn regenerate_message_sse(
                 &me_user.to_subject(),
                 persisted.as_deref(),
                 chat.assistant_id,
+                chat_is_delegated,
             )
             .await
         }
@@ -8001,6 +8288,7 @@ pub async fn regenerate_message_sse(
                             args: af.args.clone(),
                         },
                     ),
+                delegation_targets: delegation_targets_for_offer,
             };
             let PreparedChatRequest {
                 chat_request,
@@ -8011,6 +8299,8 @@ pub async fn regenerate_message_sse(
                 mcp_servers_unavailable,
                 available_mcp_tools,
                 offered_client_tool_timeouts,
+                delegation_targets,
+                delegation_offered_file_ids,
             } = prepare_chat_request(
                 &app_state,
                 &policy,
@@ -8113,6 +8403,14 @@ pub async fn regenerate_message_sse(
                     Some(&task_for_stream),
                     chat.assistant_id,
                     vec![],
+                    crate::models::chat::chat_is_delegated_run(&chat),
+                    Some(DelegationDispatchContext {
+                        me_user: &me_user,
+                        targets: &delegation_targets,
+                        offered_file_ids: &delegation_offered_file_ids,
+                        origin_chat: &chat,
+                        origin_user_message_id: previous_message.id,
+                    }),
                 )
                 .await;
             let (end_content, generation_metadata) = match generation_result {
@@ -8268,20 +8566,24 @@ pub async fn edit_message_sse(
     // softly so mentions that no longer validate are dropped rather than
     // failing the edit. The resolved value is persisted onto the new sibling
     // row and feeds the delegation tool offer.
-    let resolved_mentioned_assistant_ids: Option<Vec<Uuid>> = match request
-        .mentioned_assistant_ids
-        .clone()
-    {
+    let (resolved_mentioned_assistant_ids, delegation_targets_for_offer): (
+        Option<Vec<Uuid>>,
+        Vec<crate::services::delegation::DelegationTarget>,
+    ) = match request.mentioned_assistant_ids.clone() {
         Some(ids) => {
-            crate::services::delegation::validate_mentioned_assistants(
+            let targets = crate::services::delegation::validate_mentioned_assistants(
                 &app_state,
                 &policy,
                 &me_user.to_subject(),
                 Some(&ids),
                 chat.assistant_id,
+                crate::models::chat::chat_is_delegated_run(&chat),
             )
             .await?;
-            Some(crate::services::delegation::dedupe_mentions(&ids))
+            (
+                Some(crate::services::delegation::dedupe_mentions(&ids)),
+                targets,
+            )
         }
         None => {
             let persisted = crate::models::message::get_input_mentioned_assistant_ids_from_message(
@@ -8299,11 +8601,14 @@ pub async fn edit_message_sse(
                         &me_user.to_subject(),
                         Some(&ids),
                         chat.assistant_id,
+                        crate::models::chat::chat_is_delegated_run(&chat),
                     )
                     .await;
-                    (!targets.is_empty()).then(|| targets.iter().map(|target| target.id).collect())
+                    let resolved_ids = (!targets.is_empty())
+                        .then(|| targets.iter().map(|target| target.id).collect());
+                    (resolved_ids, targets)
                 }
-                None => None,
+                None => (None, Vec::new()),
             }
         }
     };
@@ -8448,6 +8753,7 @@ pub async fn edit_message_sse(
                         args: af.args.clone(),
                     }
                 }),
+                delegation_targets: delegation_targets_for_offer,
             };
             let PreparedChatRequest {
                 chat_request,
@@ -8458,6 +8764,8 @@ pub async fn edit_message_sse(
                 mcp_servers_unavailable,
                 available_mcp_tools,
                 offered_client_tool_timeouts,
+                delegation_targets,
+                delegation_offered_file_ids,
             } = prepare_chat_request(
                 &app_state,
                 &policy,
@@ -8560,6 +8868,14 @@ pub async fn edit_message_sse(
                     Some(&task_for_stream),
                     chat.assistant_id,
                     vec![],
+                    crate::models::chat::chat_is_delegated_run(&chat),
+                    Some(DelegationDispatchContext {
+                        me_user: &me_user,
+                        targets: &delegation_targets,
+                        offered_file_ids: &delegation_offered_file_ids,
+                        origin_chat: &chat,
+                        origin_user_message_id: saved_user_message.id,
+                    }),
                 )
                 .await;
             let (end_content, generation_metadata) = match generation_result {
@@ -9150,6 +9466,8 @@ async fn run_continue_message_task(
             Some(task),
             chat.assistant_id,
             parsed.content,
+            crate::models::chat::chat_is_delegated_run(&chat),
+            None,
         )
         .await?;
     if let Some(metadata) = generation_metadata {

--- a/backend/erato/src/server/api/v1beta/token_usage.rs
+++ b/backend/erato/src/server/api/v1beta/token_usage.rs
@@ -582,6 +582,7 @@ pub async fn token_usage_estimate(
                     args: af.args.clone(),
                 }
             }),
+            delegation_targets: Vec::new(),
         };
         let me_profile_input = MeProfileChatRequestInput::from_me_profile(&me_user);
 

--- a/backend/erato/src/services/client_tools.rs
+++ b/backend/erato/src/services/client_tools.rs
@@ -81,7 +81,9 @@ pub fn select_client_tools<'a>(
 
     for tool in matched {
         let name = tool.name.as_str();
-        if name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME {
+        if name == crate::services::client_actions::CLIENT_ACTION_TOOL_NAME
+            || name == crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME
+        {
             skipped.push((tool, ClientToolSkip::ReservedName));
             continue;
         }

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -3,7 +3,112 @@
 use crate::policy::prelude::*;
 use crate::state::AppState;
 use axum::http::StatusCode;
+use genai::chat::Tool as GenaiTool;
+use genai::chat::ToolName as GenaiToolName;
 use sea_orm::prelude::Uuid;
+use serde_json::json;
+
+/// Name of the synthetic tool offered to the model when the current turn
+/// carries validated assistant mentions.
+pub use erato_config::config::DELEGATE_TO_ASSISTANT_TOOL_NAME;
+
+/// A parent-chat attachment enumerated in the delegation tool offer, so the
+/// model can pass files to the delegate by reference.
+#[derive(Debug, Clone)]
+pub struct DelegationOfferedFile {
+    pub id: Uuid,
+    pub filename: String,
+}
+
+/// Build the `delegate_to_assistant` tool for the validated targets of this
+/// turn. The `assistant_id` (and any `file_ids`) are enum-constrained to what
+/// was validated/offered, and the description enumerates targets and
+/// attachments so the model selects them informed.
+pub fn build_delegate_to_assistant_tool(
+    targets: &[DelegationTarget],
+    offered_files: &[DelegationOfferedFile],
+    omit_tool_strict: bool,
+) -> GenaiTool {
+    let target_ids: Vec<String> = targets.iter().map(|target| target.id.to_string()).collect();
+    let target_lines: String = targets
+        .iter()
+        .map(|target| {
+            let description = target
+                .description
+                .as_deref()
+                .filter(|description| !description.trim().is_empty())
+                .unwrap_or("no description");
+            format!("- {} → {} — {}", target.id, target.name, description)
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut description = format!(
+        "Delegate a task to one of the assistants the user mentioned in their message. \
+         The delegate works on the task in its own chat run and this tool returns its final \
+         answer as the result; the run may take a while. Give a self-contained task brief — \
+         the delegate does not see this conversation unless you set \
+         include_conversation_context. Available assistants:\n{target_lines}"
+    );
+
+    let mut properties = json!({
+        "assistant_id": {
+            "type": "string",
+            "enum": target_ids,
+            "description": "The mentioned assistant to delegate to.",
+        },
+        "task": {
+            "type": "string",
+            "description": "Self-contained description of the task the delegate should complete.",
+        },
+        "expected_output": {
+            "type": "string",
+            "description": "Optional description of the expected shape or content of the result.",
+        },
+        "constraints": {
+            "type": "string",
+            "description": "Optional constraints the delegate must respect while working the task.",
+        },
+        "include_conversation_context": {
+            "type": "boolean",
+            "default": false,
+            "description": "Pass the conversation so far to the delegate as context.",
+        },
+    });
+
+    if !offered_files.is_empty() {
+        let file_ids: Vec<String> = offered_files
+            .iter()
+            .map(|file| file.id.to_string())
+            .collect();
+        let file_lines: String = offered_files
+            .iter()
+            .map(|file| format!("- {} → {}", file.id, file.filename))
+            .collect::<Vec<_>>()
+            .join("\n");
+        description.push_str(&format!(
+            "\nAttachments of this chat that can be passed to the delegate by file_id:\n{file_lines}"
+        ));
+        properties["file_ids"] = json!({
+            "type": "array",
+            "items": { "type": "string", "enum": file_ids },
+            "description": "Attachments of this chat to make available to the delegate.",
+        });
+    }
+
+    GenaiTool {
+        name: GenaiToolName::Custom(DELEGATE_TO_ASSISTANT_TOOL_NAME.to_string()),
+        description: Some(description),
+        schema: Some(json!({
+            "type": "object",
+            "properties": properties,
+            "required": ["assistant_id", "task"],
+            "additionalProperties": false,
+        })),
+        strict: if omit_tool_strict { None } else { Some(false) },
+        config: None,
+    }
+}
 
 /// Deduplicates mentioned assistant ids preserving first-mention order.
 pub fn dedupe_mentions(ids: &[Uuid]) -> Vec<Uuid> {
@@ -36,6 +141,7 @@ pub async fn validate_mentioned_assistants(
     subject: &Subject,
     mentioned_assistant_ids: Option<&[Uuid]>,
     chat_bound_assistant_id: Option<Uuid>,
+    chat_is_delegated_run: bool,
 ) -> Result<Vec<DelegationTarget>, (StatusCode, String)> {
     let Some(ids) = mentioned_assistant_ids else {
         return Ok(Vec::new());
@@ -49,6 +155,16 @@ pub async fn validate_mentioned_assistants(
         return Err((
             StatusCode::BAD_REQUEST,
             "Assistant delegation is not enabled".to_string(),
+        ));
+    }
+
+    // Depth stays at one: a delegated run never offers the tool, so mentions
+    // inside one would validate and then silently do nothing. Reject them
+    // explicitly instead.
+    if chat_is_delegated_run {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Assistants cannot be mentioned inside a delegated run".to_string(),
         ));
     }
 
@@ -110,6 +226,7 @@ pub async fn resolve_persisted_mentions(
     subject: &Subject,
     persisted_ids: Option<&[Uuid]>,
     chat_bound_assistant_id: Option<Uuid>,
+    chat_is_delegated_run: bool,
 ) -> Vec<DelegationTarget> {
     match validate_mentioned_assistants(
         app_state,
@@ -117,6 +234,7 @@ pub async fn resolve_persisted_mentions(
         subject,
         persisted_ids,
         chat_bound_assistant_id,
+        chat_is_delegated_run,
     )
     .await
     {
@@ -126,4 +244,494 @@ pub async fn resolve_persisted_mentions(
             Vec::new()
         }
     }
+}
+
+/// Terminal status of a delegated child run, as reported to the origin model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegationRunStatus {
+    Completed,
+    Failed,
+    Timeout,
+    Cancelled,
+}
+
+/// Compact result envelope pushed as the `delegate_to_assistant` tool result.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DelegationResultEnvelope {
+    pub status: DelegationRunStatus,
+    pub assistant_id: Uuid,
+    pub assistant_name: String,
+    pub delegate_chat_id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    pub truncated: bool,
+}
+
+impl DelegationResultEnvelope {
+    /// The tool-response content the origin model receives.
+    pub fn model_response_text(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            format!(
+                "{{\"status\":\"failed\",\"delegate_chat_id\":\"{}\"}}",
+                self.delegate_chat_id
+            )
+        })
+    }
+}
+
+/// Arguments of a `delegate_to_assistant` call.
+#[derive(Debug, serde::Deserialize)]
+struct DelegateToolArgs {
+    assistant_id: String,
+    task: String,
+    #[serde(default)]
+    expected_output: Option<String>,
+    #[serde(default)]
+    constraints: Option<String>,
+    #[serde(default)]
+    file_ids: Option<Vec<String>>,
+    #[serde(default)]
+    include_conversation_context: bool,
+}
+
+/// How long an aborted/timed-out child run gets to wind down and persist
+/// before its future is cancelled outright.
+const CHILD_ABORT_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
+async fn parent_abort_signal(
+    parent_task: Option<&std::sync::Arc<crate::services::background_tasks::StreamingTask>>,
+) {
+    match parent_task {
+        Some(task) => task.wait_for_abort().await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+/// Renders the configured delegation preamble, filling the optional
+/// structured-brief sections.
+fn render_delegation_preamble(
+    preamble_template: &str,
+    expected_output: Option<&str>,
+    constraints: Option<&str>,
+) -> String {
+    let mut args = std::collections::HashMap::new();
+    args.insert(
+        "expected_output_section".to_string(),
+        expected_output
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| format!("\nExpected output:\n{value}\n"))
+            .unwrap_or_default(),
+    );
+    args.insert(
+        "constraints_section".to_string(),
+        constraints
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| format!("\nConstraints:\n{value}\n"))
+            .unwrap_or_default(),
+    );
+    crate::services::prompt_composition::transforms::render_action_facet_template(
+        preamble_template,
+        &args,
+    )
+}
+
+fn delegated_chat_title(task: &str) -> String {
+    let trimmed = task.trim();
+    let mut title: String = trimmed.chars().take(80).collect();
+    if trimmed.chars().count() > 80 {
+        title.push('…');
+    }
+    title
+}
+
+/// Wrapper mirroring the submit path's spawned task: cleanup guard, the run,
+/// stream end, outcome persistence.
+///
+/// Returns an explicitly boxed future: the child generation nests the whole
+/// streaming machinery inside the parent's dispatch loop, which would
+/// otherwise make the parent's future recursively sized (and trips the
+/// worker-stack limit `main.rs` documents).
+fn run_delegated_child(
+    app_state: AppState,
+    policy: PolicyEngine,
+    me_user: crate::server::api::v1beta::me_profile_middleware::MeProfile,
+    child_task: std::sync::Arc<crate::services::background_tasks::StreamingTask>,
+    request: crate::server::api::v1beta::message_streaming::MessageSubmitRequest,
+    chat_id: Uuid,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), eyre::Report>> + Send>> {
+    Box::pin(async move {
+        let mut cleanup_guard = crate::services::background_tasks::TaskCleanupGuard::new(
+            app_state.background_tasks.clone(),
+            chat_id,
+            child_task.generation_id,
+        );
+        let result = crate::server::api::v1beta::message_streaming::run_message_submit_task(
+            &child_task,
+            &app_state,
+            &policy,
+            &me_user,
+            &request,
+            crate::models::message::GenerationRequestContext { platform: None },
+            chat_id,
+            true,
+            Vec::new(),
+        )
+        .await;
+        let generation_failed = result.is_err();
+        if let Err(error) = &result {
+            tracing::warn!(child_chat_id = %chat_id, error = ?error, "Delegated child run failed");
+            let _ = child_task
+                .send_event(crate::services::background_tasks::StreamingEvent::Error {
+                    error: crate::server::api::v1beta::message_streaming::delegated_run_failure_error_value(),
+                })
+                .await;
+        }
+        let _ = child_task
+            .send_event(crate::services::background_tasks::StreamingEvent::StreamEnd)
+            .await;
+        let outcome = child_task.derive_outcome(generation_failed);
+        child_task.mark_completed();
+        cleanup_guard.disarm();
+        app_state
+            .background_tasks
+            .remove_task(&chat_id, child_task.generation_id, outcome)
+            .await;
+        result
+    })
+}
+
+/// Reads the delegate's final answer and builds the result envelope. The
+/// requested status is downgraded to `failed` when the child produced no
+/// answer, errored, or — defensively — stopped on an approval request.
+#[allow(clippy::too_many_arguments)]
+async fn build_result_envelope(
+    app_state: &AppState,
+    child_chat_id: Uuid,
+    child_assistant_message_id: Uuid,
+    spawned_at: sea_orm::prelude::DateTimeWithTimeZone,
+    assistant_id: Uuid,
+    assistant_name: String,
+    requested_status: DelegationRunStatus,
+    result_max_chars: usize,
+) -> DelegationResultEnvelope {
+    use sea_orm::EntityTrait;
+
+    let mut status = requested_status;
+    let mut result_text: Option<String> = None;
+    let mut truncated = false;
+
+    // The answer is the assistant message the child's own generation wrote —
+    // identified by the id recorded on its streaming task, never by
+    // newest-row scanning, so neither seeded parent copies nor a concurrent
+    // interloping run on the child chat can masquerade as the delegate's
+    // result. Rows predating the spawn are seeded copies by construction.
+    let assistant_row = crate::db::entity::messages::Entity::find_by_id(child_assistant_message_id)
+        .one(&app_state.db)
+        .await
+        .ok()
+        .flatten()
+        .filter(|row| row.chat_id == child_chat_id && row.created_at > spawned_at)
+        .filter(|row| {
+            row.raw_message
+                .get("role")
+                .and_then(|role| role.as_str())
+                .is_some_and(|role| role == "assistant")
+        });
+    let assistant_row = assistant_row.as_ref();
+
+    if let Some(row) = assistant_row {
+        let content = row
+            .raw_message
+            .get("content")
+            .and_then(|content| content.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let stopped_on_approval = content
+            .last()
+            .and_then(|part| part.get("content_type"))
+            .and_then(|content_type| content_type.as_str())
+            .is_some_and(|content_type| content_type == "tool_approval_request");
+        if stopped_on_approval && status == DelegationRunStatus::Completed {
+            status = DelegationRunStatus::Failed;
+        }
+        let has_metadata_error = row
+            .generation_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("error"))
+            .is_some_and(|error| !error.is_null());
+        if has_metadata_error && status == DelegationRunStatus::Completed {
+            status = DelegationRunStatus::Failed;
+        }
+        let text = content
+            .iter()
+            .filter(|part| {
+                part.get("content_type")
+                    .and_then(|content_type| content_type.as_str())
+                    .is_some_and(|content_type| content_type == "text")
+            })
+            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !text.trim().is_empty() {
+            if text.chars().count() > result_max_chars {
+                result_text = Some(text.chars().take(result_max_chars).collect());
+                truncated = true;
+            } else {
+                result_text = Some(text);
+            }
+        }
+    }
+
+    if result_text.is_none() && status == DelegationRunStatus::Completed {
+        status = DelegationRunStatus::Failed;
+    }
+
+    DelegationResultEnvelope {
+        status,
+        assistant_id,
+        assistant_name,
+        delegate_chat_id: child_chat_id,
+        result: result_text,
+        truncated,
+    }
+}
+
+/// Dispatches a `delegate_to_assistant` call: validates the arguments against
+/// what this turn offered, creates the delegated child chat (owned by the
+/// origin user, full provenance envelope), runs the delegate as an awaited
+/// child run, and returns the result envelope. `Err` is a refusal message for
+/// the model — the caller refuses the call, never the turn.
+pub(crate) async fn dispatch_delegate_tool_call(
+    app_state: &AppState,
+    policy: &PolicyEngine,
+    context: &crate::server::api::v1beta::message_streaming::DelegationDispatchContext<'_>,
+    tool_call: &genai::chat::ToolCall,
+    parent_task: Option<&std::sync::Arc<crate::services::background_tasks::StreamingTask>>,
+) -> Result<DelegationResultEnvelope, String> {
+    use sea_orm::{ActiveValue, EntityTrait, QueryOrder};
+
+    let config = app_state.config.assistants.delegation.clone();
+    if !config.enabled {
+        return Err("Assistant delegation is not enabled.".to_string());
+    }
+
+    let args: DelegateToolArgs = serde_json::from_value(tool_call.fn_arguments.clone())
+        .map_err(|error| format!("Invalid delegate_to_assistant arguments: {error}"))?;
+    if args.task.trim().is_empty() {
+        return Err("The 'task' argument must not be empty.".to_string());
+    }
+    let assistant_id = Uuid::parse_str(&args.assistant_id)
+        .map_err(|_| format!("Invalid assistant id '{}'.", args.assistant_id))?;
+    if !context
+        .targets
+        .iter()
+        .any(|target| target.id == assistant_id)
+    {
+        return Err(format!(
+            "Assistant {assistant_id} was not offered for delegation on this turn."
+        ));
+    }
+
+    let mut file_ids: Vec<Uuid> = Vec::new();
+    for raw_id in args.file_ids.iter().flatten() {
+        let file_id =
+            Uuid::parse_str(raw_id).map_err(|_| format!("Invalid file id '{raw_id}'."))?;
+        if !context.offered_file_ids.contains(&file_id) {
+            return Err(format!("File {file_id} is not an attachment of this chat."));
+        }
+        let join_row = crate::db::entity::chat_file_uploads::Entity::find_by_id((
+            context.origin_chat.id,
+            file_id,
+        ))
+        .one(&app_state.db)
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "Failed to verify delegation file attachment");
+            "Failed to verify the file attachment.".to_string()
+        })?;
+        if join_row.is_none() {
+            return Err(format!("File {file_id} is not an attachment of this chat."));
+        }
+        if !file_ids.contains(&file_id) {
+            file_ids.push(file_id);
+        }
+    }
+
+    // Re-resolve the target access-checked (revocation or archiving between
+    // submit-time validation and dispatch), as the origin chat's owner. Every
+    // generation path requires chat ownership, so owner == requester; if a
+    // non-owner path to generation is ever added, this subject choice becomes
+    // an escalation and must switch to the requester.
+    let owner_subject = Subject::User(context.origin_chat.owner_user_id.clone());
+    let assistant = crate::models::assistant::get_assistant_by_id(
+        &app_state.db,
+        policy,
+        &owner_subject,
+        assistant_id,
+    )
+    .await
+    .map_err(|error| {
+        tracing::debug!(%assistant_id, %error, "Delegation target no longer resolvable");
+        "The mentioned assistant is no longer available.".to_string()
+    })?;
+
+    let parent_depth = crate::models::chat::parse_assistant_configuration(context.origin_chat)
+        .ok()
+        .flatten()
+        .and_then(|configuration| configuration.provenance)
+        .map(|provenance| provenance.depth)
+        .unwrap_or(0);
+    let spawned_at: sea_orm::prelude::DateTimeWithTimeZone = sqlx::types::chrono::Utc::now().into();
+    let provenance = crate::models::chat::ChatProvenance {
+        kind: crate::models::chat::ChatProvenanceKind::Delegation,
+        origin_chat_id: Some(context.origin_chat.id),
+        origin_message_id: Some(context.origin_user_message_id),
+        origin_assistant_id: context.origin_chat.assistant_id,
+        rebase_cutoff: Some(spawned_at),
+        depth: parent_depth + 1,
+    };
+    let child_chat = crate::models::chat::create_delegated_chat(
+        &app_state.db,
+        policy,
+        &owner_subject,
+        &context.origin_chat.owner_user_id,
+        assistant_id,
+        provenance,
+        delegated_chat_title(&args.task),
+    )
+    .await
+    .map_err(|error| {
+        tracing::warn!(%error, "Failed to create delegated chat");
+        "Failed to create the delegated chat.".to_string()
+    })?;
+    app_state.global_policy_engine.invalidate_data().await;
+
+    for file_id in &file_ids {
+        let join_row = crate::db::entity::chat_file_uploads::ActiveModel {
+            chat_id: ActiveValue::Set(child_chat.id),
+            file_upload_id: ActiveValue::Set(*file_id),
+            ..Default::default()
+        };
+        if let Err(error) = crate::db::entity::chat_file_uploads::Entity::insert(join_row)
+            .exec(&app_state.db)
+            .await
+        {
+            tracing::warn!(%error, "Failed to attach file to delegated chat");
+            return Err("Failed to attach a file to the delegated chat.".to_string());
+        }
+    }
+
+    // Context transfer seeds from the origin turn's replay anchor — the
+    // history BEFORE the mention message. The mention message itself is
+    // represented by the task brief; a seeded user message after the last
+    // snapshot would be dropped by composition anyway.
+    let mut previous_message_id: Option<Uuid> = None;
+    if args.include_conversation_context {
+        let anchor_id =
+            crate::db::entity::messages::Entity::find_by_id(context.origin_user_message_id)
+                .one(&app_state.db)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|row| row.previous_message_id);
+        if let Some(anchor_id) = anchor_id {
+            crate::models::chat::seed_chat_lineage(&app_state.db, &child_chat.id, &anchor_id)
+                .await
+                .map_err(|error| {
+                    tracing::warn!(%error, "Failed to seed delegated chat lineage");
+                    "Failed to pass the conversation context to the delegate.".to_string()
+                })?;
+            previous_message_id = {
+                use sea_orm::{ColumnTrait, QueryFilter};
+                crate::db::entity::messages::Entity::find()
+                    .filter(crate::db::entity::messages::Column::ChatId.eq(child_chat.id))
+                    .order_by_desc(crate::db::entity::messages::Column::CreatedAt)
+                    .one(&app_state.db)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|row| row.id)
+            };
+        }
+    }
+
+    let preamble = render_delegation_preamble(
+        &config.preamble,
+        args.expected_output.as_deref(),
+        args.constraints.as_deref(),
+    );
+    let child_user_message = format!(
+        "{}\n\n<system-reminder>\n{}\n</system-reminder>",
+        args.task.trim(),
+        preamble.trim()
+    );
+
+    let (_child_rx, child_task) = app_state
+        .background_tasks
+        .start_task(child_chat.id, Uuid::new_v4())
+        .await;
+    let child_request =
+        crate::server::api::v1beta::message_streaming::MessageSubmitRequest::for_delegated_run(
+            child_chat.id,
+            child_user_message,
+            file_ids,
+            previous_message_id,
+        );
+    let mut handle = tokio::spawn(run_delegated_child(
+        app_state.clone(),
+        policy.clone(),
+        context.me_user.clone(),
+        child_task.clone(),
+        child_request,
+        child_chat.id,
+    ));
+
+    let status = tokio::select! {
+        joined = &mut handle => match joined {
+            Ok(Ok(())) => DelegationRunStatus::Completed,
+            Ok(Err(_)) => DelegationRunStatus::Failed,
+            Err(join_error) => {
+                tracing::warn!(?join_error, "Delegated child run panicked");
+                DelegationRunStatus::Failed
+            }
+        },
+        _ = parent_abort_signal(parent_task) => {
+            child_task.request_abort();
+            if tokio::time::timeout(CHILD_ABORT_GRACE, &mut handle).await.is_err() {
+                // Never hard-cancel: the child's cleanup tail (stream end,
+                // outcome persistence, task removal) must run, or its command
+                // listener and lease leak. The cooperative abort stops the run
+                // at the next stream chunk or turn boundary; until then it
+                // winds down detached.
+                tracing::warn!(
+                    child_chat_id = %child_chat.id,
+                    "Delegated child did not stop within the abort grace; detaching"
+                );
+            }
+            DelegationRunStatus::Cancelled
+        },
+        _ = tokio::time::sleep(std::time::Duration::from_secs(config.run_timeout_seconds)) => {
+            child_task.request_abort();
+            if tokio::time::timeout(CHILD_ABORT_GRACE, &mut handle).await.is_err() {
+                tracing::warn!(
+                    child_chat_id = %child_chat.id,
+                    "Delegated child did not stop within the timeout grace; detaching"
+                );
+            }
+            DelegationRunStatus::Timeout
+        }
+    };
+
+    Ok(build_result_envelope(
+        app_state,
+        child_chat.id,
+        child_task.message_id(),
+        spawned_at,
+        assistant_id,
+        assistant.name,
+        status,
+        config.result_max_chars,
+    )
+    .await)
 }

--- a/backend/erato/src/services/prompt_composition/types.rs
+++ b/backend/erato/src/services/prompt_composition/types.rs
@@ -29,6 +29,11 @@ pub struct PromptCompositionUserInput {
 
     /// Optional action facet requested by the user for this generation.
     pub action_facet: Option<ActionFacetUserInput>,
+
+    /// Validated delegation targets from the user's assistant mentions.
+    /// Non-empty only on mention-carrying turns; drives the request-scoped
+    /// `delegate_to_assistant` tool offer.
+    pub delegation_targets: Vec<crate::services::delegation::DelegationTarget>,
 }
 
 /// Action facet input for prompt composition.

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -628,6 +628,28 @@ async fn submit_with_mentions(
         .await
 }
 
+async fn submit_with_mentions_with_previous(
+    server: &TestServer,
+    chat_id: &str,
+    previous_message_id: Option<&str>,
+    text: &str,
+    mentioned_assistant_ids: &[&str],
+) -> axum_test::TestResponse {
+    let mut body = json!({
+        "existing_chat_id": chat_id,
+        "user_message": text,
+        "mentioned_assistant_ids": mentioned_assistant_ids,
+    });
+    if let Some(previous) = previous_message_id {
+        body["previous_message_id"] = json!(previous);
+    }
+    server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&body)
+        .await
+}
+
 fn delegation_enabled_config() -> erato::config::AppConfig {
     let mut app_config = crate::test_utils::hermetic_app_config(None, None);
     app_config.assistants.delegation.enabled = true;
@@ -920,4 +942,1613 @@ async fn test_regenerate_and_edit_replay_persisted_mentions(pool: Pool<Postgres>
         }))
         .await;
     bad_edit.assert_status(axum::http::StatusCode::BAD_REQUEST);
+}
+
+const DELEGATE_ASSISTANT_FIXED_ID: &str = "00000000-0000-4000-8000-00000000d001";
+
+async fn insert_fixed_delegate_assistant(
+    db: &sea_orm::DatabaseConnection,
+    owner_user_id: Uuid,
+    prompt: &str,
+    mcp_server_ids: Option<Vec<String>>,
+) -> Uuid {
+    let id = Uuid::parse_str(DELEGATE_ASSISTANT_FIXED_ID).unwrap();
+    let now: sea_orm::prelude::DateTimeWithTimeZone = sqlx::types::chrono::Utc::now().into();
+    let assistant = erato::db::entity::assistants::ActiveModel {
+        id: ActiveValue::Set(id),
+        owner_user_id: ActiveValue::Set(owner_user_id),
+        name: ActiveValue::Set("Fixed Delegate".to_string()),
+        description: ActiveValue::Set(Some("A delegate assistant with a fixed id".to_string())),
+        prompt: ActiveValue::Set(prompt.to_string()),
+        mcp_server_ids: ActiveValue::Set(mcp_server_ids),
+        default_chat_provider: ActiveValue::Set(None),
+        archived_at: ActiveValue::Set(None),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+        facet_ids: ActiveValue::Set(None),
+        enforce_facet_settings: ActiveValue::Set(false),
+    };
+    erato::db::entity::assistants::Entity::insert(assistant)
+        .exec(db)
+        .await
+        .expect("insert fixed delegate assistant");
+    id
+}
+
+fn find_tool_call_update_output(events: &[Event], tool_name: &str) -> Value {
+    events
+        .iter()
+        .filter_map(|event| serde_json::from_str::<Value>(&event.data).ok())
+        .find(|json| json["message_type"] == "tool_call_update" && json["tool_name"] == tool_name)
+        .map(|json| json["output"].clone())
+        .expect("expected a tool_call_update for the tool")
+}
+
+fn extract_full_text_answer(events: &[Event]) -> String {
+    crate::test_utils::extract_full_text(events)
+}
+
+async fn delegated_child_chat(
+    db: &sea_orm::DatabaseConnection,
+    origin_chat_id: Uuid,
+) -> erato::db::entity::chats::Model {
+    erato::db::entity::chats::Entity::find()
+        .filter(erato::db::entity::chats::Column::OriginChatId.eq(origin_chat_id))
+        .one(db)
+        .await
+        .unwrap()
+        .expect("expected a delegated child chat")
+}
+
+/// Happy path: the parent turn calls `delegate_to_assistant`, the child run
+/// completes, the parent receives the envelope and finishes. Also proves the
+/// child's request head carries the delegate prompt + preamble (not the
+/// origin head) and that globally allowlisted client tools are suppressed in
+/// the child while offered to the parent.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<Postgres>) {
+    let parent_first_recorder = RequestBodyRecorder::new();
+    let child_recorder = RequestBodyRecorder::new();
+    let parent_final_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    {
+        let recorder = child_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["CHILD-TASK-BRIEF"],
+                    &["delegate_chat_id"],
+                ))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_text_streaming_response(&[
+                    "CHILD-ANSWER forty-two",
+                ]),
+            );
+        });
+    }
+    {
+        let recorder = parent_final_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_text_streaming_response(&[
+                    "PARENT-FINAL-ANSWER using the delegate result",
+                ]),
+            );
+        });
+    }
+    {
+        let recorder = parent_first_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["parent question alpha"],
+                    &["CHILD-TASK-BRIEF", "delegate_chat_id"],
+                ))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                    "call_delegate_1",
+                    "delegate_to_assistant",
+                    json!({
+                        "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                        "task": "CHILD-TASK-BRIEF: summarize the numbers",
+                    }),
+                )]),
+            );
+        });
+    }
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    // A globally allowlisted client tool: offered to the parent request,
+    // suppressed in the delegated child run.
+    app_config.client_tools.tools.insert(
+        "probe".to_string(),
+        erato::config::ClientToolConfig {
+            name: "probe_client_tool".to_string(),
+            namespace: None,
+            description: "A probe client tool".to_string(),
+            parameters: r#"{"type":"object","properties":{}}"#.to_string(),
+            timeout_ms: None,
+        },
+    );
+    app_config.experimental_facets.tool_call_allowlist = vec!["client/*".to_string()];
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, &delegate_prompt(), None).await;
+    let server = app_server(app_state.clone());
+
+    let origin_assistant = create_assistant(
+        &server,
+        "Origin Assistant",
+        &format!("{ORIGIN_PROMPT_SENTINEL} answer with the delegate's help."),
+    )
+    .await;
+    let parent_chat = create_chat(&server, Some(&origin_assistant)).await;
+
+    let response = submit_with_mentions(
+        &server,
+        Some(&parent_chat),
+        "parent question alpha",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    // Envelope on the SSE tool_call_update.
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert_eq!(output["assistant_name"], "Fixed Delegate");
+    assert_eq!(output["truncated"], false);
+    assert!(
+        output["result"]
+            .as_str()
+            .unwrap()
+            .contains("CHILD-ANSWER forty-two")
+    );
+    let delegate_chat_id = Uuid::parse_str(output["delegate_chat_id"].as_str().unwrap()).unwrap();
+
+    // The parent's final answer reacted to the result.
+    assert!(extract_full_text_answer(&events).contains("PARENT-FINAL-ANSWER"));
+
+    // Persisted tool_use part carries the envelope.
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let messages_response = server
+        .get(&format!("/api/v1beta/chats/{parent_chat}/messages"))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    messages_response.assert_status_ok();
+    let messages_json = messages_response.json::<Value>();
+    let parent_assistant_message = messages_json["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["id"] == assistant_message_id.as_str())
+        .expect("parent assistant message");
+    let tool_use = parent_assistant_message["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|part| part["content_type"] == "tool_use")
+        .expect("tool_use part");
+    assert_eq!(tool_use["tool_name"], "delegate_to_assistant");
+    assert_eq!(tool_use["status"], "success");
+    assert_eq!(tool_use["output"]["status"], "completed");
+    assert_eq!(
+        tool_use["output"]["delegate_chat_id"],
+        delegate_chat_id.to_string()
+    );
+
+    // Child chat: bound to the delegate, full provenance, title = brief.
+    let child_chat =
+        delegated_child_chat(&app_state.db, Uuid::parse_str(&parent_chat).unwrap()).await;
+    assert_eq!(child_chat.id, delegate_chat_id);
+    assert_eq!(child_chat.owner_user_id, me.id.to_string());
+    assert_eq!(
+        child_chat.title_by_user_provided.as_deref(),
+        Some("CHILD-TASK-BRIEF: summarize the numbers")
+    );
+    let configuration = erato::models::chat::AssistantConfiguration::from_json(
+        child_chat.assistant_configuration.as_ref().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        configuration.assistant_id,
+        Uuid::parse_str(DELEGATE_ASSISTANT_FIXED_ID).unwrap()
+    );
+    let provenance = configuration.provenance.unwrap();
+    assert_eq!(provenance.kind, ChatProvenanceKind::Delegation);
+    assert_eq!(
+        provenance.origin_chat_id,
+        Some(Uuid::parse_str(&parent_chat).unwrap())
+    );
+    assert!(provenance.origin_message_id.is_some());
+    assert_eq!(provenance.depth, 1);
+    assert!(provenance.rebase_cutoff.is_some());
+    assert_eq!(child_chat.generation_state.as_deref(), Some("completed"));
+
+    // The child's request head: delegate prompt + preamble, no origin head.
+    let child_bodies = child_recorder.bodies();
+    assert_eq!(child_bodies.len(), 1);
+    let child_body: Value = serde_json::from_str(&child_bodies[0]).unwrap();
+    let child_messages = child_body["messages"].as_array().unwrap();
+    assert_eq!(child_messages[0]["role"], "system");
+    assert!(
+        child_messages[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains(DELEGATE_PROMPT_SENTINEL)
+    );
+    assert!(!child_bodies[0].contains(ORIGIN_PROMPT_SENTINEL));
+    assert!(child_bodies[0].contains("delegating conversation"));
+    assert!(child_bodies[0].contains("system-reminder"));
+
+    // Client-tool suppression: offered to the parent, absent in the child.
+    // The recorder also sees the parent's chat-summary request (no tools), so
+    // pick the completion request by its tool offer.
+    let parent_bodies = parent_first_recorder.bodies();
+    let parent_completion_body = parent_bodies
+        .iter()
+        .find(|body| body.contains("delegate_to_assistant"))
+        .expect("parent completion request with the delegation tool offer");
+    assert!(parent_completion_body.contains("probe_client_tool"));
+    assert!(!child_bodies[0].contains("probe_client_tool"));
+    // The delegation tool itself is never offered to the child.
+    assert!(!child_bodies[0].contains("delegate_to_assistant"));
+}
+
+/// A call naming an assistant that was not offered refuses the call and the
+/// turn recovers in prose.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_unoffered_target_refused_turn_recovers(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["Delegation refused"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[
+                "PARENT-UNOFFERED-RECOVERED",
+            ]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["unoffered question"],
+                &["Delegation refused"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_bad",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": "00000000-0000-4000-8000-00000000dead",
+                    "task": "should never run",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "delegate prompt", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "unoffered question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "error");
+    assert!(
+        output["error"]
+            .as_str()
+            .unwrap()
+            .contains("not offered for delegation")
+    );
+    assert!(extract_full_text_answer(&events).contains("PARENT-UNOFFERED-RECOVERED"));
+
+    // No child chat was created.
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let children = erato::db::entity::chats::Entity::find()
+        .filter(
+            erato::db::entity::chats::Column::OriginChatId.eq(Uuid::parse_str(&chat_id).unwrap()),
+        )
+        .all(&app_state.db)
+        .await
+        .unwrap();
+    assert!(children.is_empty());
+}
+
+const FIXED_FILE_ID: &str = "00000000-0000-4000-8000-00000000f001";
+
+async fn insert_fixed_parent_file(
+    db: &sea_orm::DatabaseConnection,
+    owner_user_id: &str,
+    parent_chat_id: Uuid,
+) -> Uuid {
+    let id = Uuid::parse_str(FIXED_FILE_ID).unwrap();
+    let now: sea_orm::prelude::DateTimeWithTimeZone = sqlx::types::chrono::Utc::now().into();
+    let file = erato::db::entity::file_uploads::ActiveModel {
+        id: ActiveValue::Set(id),
+        filename: ActiveValue::Set("fixture.txt".to_string()),
+        file_storage_provider_id: ActiveValue::Set("seaweedfs".to_string()),
+        file_storage_path: ActiveValue::Set("delegation-test/missing-fixture.txt".to_string()),
+        created_at: ActiveValue::Set(now),
+        updated_at: ActiveValue::Set(now),
+        owner_user_id: ActiveValue::Set(owner_user_id.to_string()),
+        audio_transcription: ActiveValue::Set(None),
+    };
+    erato::db::entity::file_uploads::Entity::insert(file)
+        .exec(db)
+        .await
+        .expect("insert fixture file");
+    let join_row = erato::db::entity::chat_file_uploads::ActiveModel {
+        chat_id: ActiveValue::Set(parent_chat_id),
+        file_upload_id: ActiveValue::Set(id),
+        ..Default::default()
+    };
+    erato::db::entity::chat_file_uploads::Entity::insert(join_row)
+        .exec(db)
+        .await
+        .expect("insert fixture join row");
+    id
+}
+
+/// `file_ids`: a named parent attachment is copied to the child chat; a file
+/// id that is not a parent attachment refuses the call and the turn recovers.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_file_ids_copied_and_foreign_file_refused(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-FILE-TASK"],
+                &["delegate_chat_id", "Delegation refused"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["CHILD-FILE-ANSWER"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-FILE-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["Delegation refused"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-FILE-RECOVERED"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["attachedfile question"],
+                &["CHILD-FILE-TASK", "delegate_chat_id", "Delegation refused"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_file",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-FILE-TASK read the attachment",
+                    "file_ids": [FIXED_FILE_ID],
+                }),
+            )]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["foreignfile question"],
+                &["delegate_chat_id", "Delegation refused"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_foreign",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-FOREIGN-TASK must not run",
+                    "file_ids": ["00000000-0000-4000-8000-00000000feed"],
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "delegate prompt", None).await;
+    let server = app_server(app_state.clone());
+
+    // Named parent attachment is passed by reference.
+    let parent_chat = create_chat(&server, None).await;
+    let parent_chat_id = Uuid::parse_str(&parent_chat).unwrap();
+    let file_id = insert_fixed_parent_file(&app_state.db, &me.id.to_string(), parent_chat_id).await;
+
+    let response = submit_with_mentions(
+        &server,
+        Some(&parent_chat),
+        "attachedfile question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert!(extract_full_text_answer(&events).contains("PARENT-FILE-FINAL"));
+
+    let child_chat = delegated_child_chat(&app_state.db, parent_chat_id).await;
+    let child_join_row =
+        erato::db::entity::chat_file_uploads::Entity::find_by_id((child_chat.id, file_id))
+            .one(&app_state.db)
+            .await
+            .unwrap();
+    assert!(
+        child_join_row.is_some(),
+        "file join row copied to the child"
+    );
+    let child_rows = chat_messages_by_created_at(&app_state.db, child_chat.id).await;
+    let child_user_row = child_rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "user")
+        .unwrap();
+    assert_eq!(
+        child_user_row.input_file_uploads.as_deref(),
+        Some(&[file_id][..])
+    );
+
+    // Foreign file id: refused, no child chat, turn recovers.
+    let foreign_chat = create_chat(&server, None).await;
+    let response = submit_with_mentions(
+        &server,
+        Some(&foreign_chat),
+        "foreignfile question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "error");
+    assert!(
+        output["error"]
+            .as_str()
+            .unwrap()
+            .contains("is not an attachment of this chat")
+    );
+    assert!(extract_full_text_answer(&events).contains("PARENT-FILE-RECOVERED"));
+    let children = erato::db::entity::chats::Entity::find()
+        .filter(
+            erato::db::entity::chats::Column::OriginChatId
+                .eq(Uuid::parse_str(&foreign_chat).unwrap()),
+        )
+        .all(&app_state.db)
+        .await
+        .unwrap();
+    assert!(children.is_empty());
+}
+
+/// `include_conversation_context`: the child is seeded with the origin
+/// lineage and its first request carries the delegate head over the seeded
+/// history (ContextRebase applied inside the delegated run).
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_context_seeding_rebases_child(pool: Pool<Postgres>) {
+    let child_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    {
+        let recorder = child_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["CHILD-CTX-TASK"],
+                    &["delegate_chat_id"],
+                ))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_text_streaming_response(&["CHILD-CTX-ANSWER"]),
+            );
+        });
+    }
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-CTX-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["please delegate with context"],
+                &["CHILD-CTX-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_ctx",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-CTX-TASK continue from the context",
+                    "include_conversation_context": true,
+                }),
+            )]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["seed context alpha"],
+                &[
+                    "please delegate with context",
+                    "CHILD-CTX-TASK",
+                    "delegate_chat_id",
+                ],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["ORIGIN-CONTEXT-ANSWER"]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, &delegate_prompt(), None).await;
+    let server = app_server(app_state.clone());
+
+    let origin_assistant = create_assistant(
+        &server,
+        "Origin Assistant",
+        &format!("{ORIGIN_PROMPT_SENTINEL} answer tersely."),
+    )
+    .await;
+    let parent_chat = create_chat(&server, Some(&origin_assistant)).await;
+    let first_events =
+        submit_message(&server, &parent_chat, None, "seed context alpha", vec![]).await;
+    let first_assistant_message = assistant_message_id_from_events(&first_events);
+
+    let response = submit_with_mentions_with_previous(
+        &server,
+        &parent_chat,
+        Some(&first_assistant_message),
+        "please delegate with context",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert!(extract_full_text_answer(&events).contains("PARENT-CTX-FINAL"));
+
+    let parent_chat_id = Uuid::parse_str(&parent_chat).unwrap();
+    let child_chat = delegated_child_chat(&app_state.db, parent_chat_id).await;
+    // Seeded copies (the replay anchor's lineage: seed user + seed answer),
+    // then the task-brief user message and the child's answer.
+    let child_rows = chat_messages_by_created_at(&app_state.db, child_chat.id).await;
+    assert_eq!(child_rows.len(), 4);
+
+    let child_bodies = child_recorder.bodies();
+    assert_eq!(child_bodies.len(), 1);
+    let child_body: Value = serde_json::from_str(&child_bodies[0]).unwrap();
+    let child_messages = child_body["messages"].as_array().unwrap();
+    assert_eq!(child_messages[0]["role"], "system");
+    assert!(
+        child_messages[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains(DELEGATE_PROMPT_SENTINEL)
+    );
+    assert!(!child_bodies[0].contains(ORIGIN_PROMPT_SENTINEL));
+    assert!(child_bodies[0].contains("seed context alpha"));
+    assert!(child_bodies[0].contains("ORIGIN-CONTEXT-ANSWER"));
+}
+
+fn mock_mcp_base_url() -> String {
+    std::env::var("TEST_MOCK_MCP_SERVER_BASE_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:44321".to_string())
+}
+
+/// A delegate whose MCP tool is approval-gated under the `restrictive` preset
+/// has the gated call refused in-run: the child completes in prose, the
+/// envelope is `completed`, and the child chat is NOT parked awaiting
+/// approval.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+/// - `uses-mock-mcp`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_refuses_approval_gated_mcp_in_child(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    // Child turn 2: the refusal tool response arrived; answer in prose.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["approval, which is unavailable in a delegated run"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[
+                "CHILD-MCP-DONE without the gated tool",
+            ]),
+        );
+    });
+    // Child turn 1: call the approval-gated MCP tool.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-MCP-TASK"],
+                &["delegate_chat_id", "approval, which is unavailable"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_probe",
+                "publish_approval_probe",
+                json!({}),
+            )]),
+        );
+    });
+    // Parent final turn.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-MCP-FINAL"]),
+        );
+    });
+    // Parent turn 1: delegate.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["mcp delegation question"],
+                &["CHILD-MCP-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_mcp",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-MCP-TASK publish the probe",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.mcp_servers.insert(
+        "mock_mcp_approval".to_string(),
+        erato::config::McpServerConfig {
+            transport_type: "streamable_http".to_string(),
+            url: format!("{}/mcp/approval-policy", mock_mcp_base_url()),
+            http_headers: None,
+            allow_tools: None,
+            exclude_tools: vec![],
+            authentication: erato::config::McpServerAuthenticationConfig::None,
+            max_session_idle_seconds: None,
+        },
+    );
+    app_config.mcp_server_permissions.rules.insert(
+        "allow-mock-mcp".to_string(),
+        erato::config::McpServerPermissionRule::AllowAll {
+            mcp_server_ids: vec!["mock_mcp_approval".to_string()],
+        },
+    );
+    app_config.mcp_servers_global.approval = erato::config::McpToolApprovalConfig {
+        enabled: true,
+        preset: erato::config::McpToolApprovalPreset::Restrictive,
+        allow_always: false,
+    };
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(
+        &app_state.db,
+        me.id,
+        "delegate with mcp",
+        Some(vec!["mock_mcp_approval".to_string()]),
+    )
+    .await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "mcp delegation question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert!(
+        output["result"]
+            .as_str()
+            .unwrap()
+            .contains("CHILD-MCP-DONE")
+    );
+    assert!(extract_full_text_answer(&events).contains("PARENT-MCP-FINAL"));
+
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let child_chat = delegated_child_chat(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    // Not parked: the durable approval stop was pre-empted by the refusal.
+    assert_eq!(child_chat.generation_state.as_deref(), Some("completed"));
+
+    let child_rows = chat_messages_by_created_at(&app_state.db, child_chat.id).await;
+    let child_assistant_row = child_rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "assistant")
+        .unwrap();
+    let content = child_assistant_row.raw_message["content"]
+        .as_array()
+        .unwrap();
+    assert!(
+        content
+            .iter()
+            .all(|part| part["content_type"] != "tool_approval_request"),
+        "the child must not carry an approval request part"
+    );
+    let gated_tool_use = content
+        .iter()
+        .find(|part| {
+            part["content_type"] == "tool_use" && part["tool_name"] == "publish_approval_probe"
+        })
+        .expect("gated MCP call recorded as a refused tool_use");
+    assert_eq!(gated_tool_use["status"], "error");
+    assert!(
+        gated_tool_use["output"]["error"]
+            .as_str()
+            .unwrap()
+            .contains("approval")
+    );
+}
+
+/// A slow child run hits `run_timeout_seconds`: the envelope reports
+/// `timeout`, the parent turn completes, and the child is not left running.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_timeout_aborts_child_and_parent_completes(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    // Child: stall for far longer than the run timeout.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-SLOW-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            vec![
+                BodyAction::Delay(std::time::Duration::from_secs(30)),
+                BodyAction::Bytes("data: [DONE]\n\n".into()),
+            ],
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-TIMEOUT-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["slow delegation question"],
+                &["CHILD-SLOW-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_slow",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-SLOW-TASK take your time",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.run_timeout_seconds = 1;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "slow delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "slow delegation question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "timeout");
+    assert!(extract_full_text_answer(&events).contains("PARENT-TIMEOUT-FINAL"));
+
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let child_chat = delegated_child_chat(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    // The child was aborted; give its cleanup a moment, then require a
+    // terminal state (never a live lease).
+    for _ in 0..50 {
+        let row = erato::db::entity::chats::Entity::find_by_id(child_chat.id)
+            .one(&app_state.db)
+            .await
+            .unwrap()
+            .unwrap();
+        if row.generation_state.as_deref() != Some("running") {
+            assert!(matches!(
+                row.generation_state.as_deref(),
+                Some("completed") | Some("errored")
+            ));
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("child chat still running after timeout");
+}
+
+/// Aborting the parent mid-delegation forwards the abort to the child and the
+/// envelope reports `cancelled`.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_abort_forwarding_cancels_child(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-ABORT-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            vec![
+                BodyAction::Delay(std::time::Duration::from_secs(30)),
+                BodyAction::Bytes("data: [DONE]\n\n".into()),
+            ],
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["abort delegation question"],
+                &["CHILD-ABORT-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_abort",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-ABORT-TASK wait for it",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "abortable delegate", None).await;
+
+    // Real TCP server so the abort can run concurrently with the stream.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let app: Router = erato::server::router::router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state.clone());
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{server_addr}");
+
+    // Known parent chat id so the abort can target it.
+    let create_response = client
+        .post(format!("{base_url}/api/v1beta/me/chats"))
+        .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(create_response.status().is_success());
+    let parent_chat = create_response.json::<Value>().await.unwrap()["chat_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parent_chat_id = Uuid::parse_str(&parent_chat).unwrap();
+
+    let submit_client = client.clone();
+    let submit_base = base_url.clone();
+    let submit_chat = parent_chat.clone();
+    let submit_handle = tokio::spawn(async move {
+        let response = submit_client
+            .post(format!("{submit_base}/api/v1beta/me/messages/submitstream"))
+            .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+            .json(&json!({
+                "existing_chat_id": submit_chat,
+                "user_message": "abort delegation question",
+                "mentioned_assistant_ids": [DELEGATE_ASSISTANT_FIXED_ID],
+            }))
+            .send()
+            .await
+            .expect("submit request");
+        assert!(response.status().is_success());
+        response.text().await.expect("submit body")
+    });
+
+    // Wait until the delegated child chat exists (the child run is in flight).
+    let mut child_exists = false;
+    for _ in 0..100 {
+        let children = erato::db::entity::chats::Entity::find()
+            .filter(erato::db::entity::chats::Column::OriginChatId.eq(parent_chat_id))
+            .all(&app_state.db)
+            .await
+            .unwrap();
+        if !children.is_empty() {
+            child_exists = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(child_exists, "delegated child chat never appeared");
+
+    let abort_response = client
+        .post(format!("{base_url}/api/v1beta/me/messages/abortstream"))
+        .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+        .json(&json!({ "chat_id": parent_chat }))
+        .send()
+        .await
+        .unwrap();
+    assert!(abort_response.status().is_success());
+
+    let body = tokio::time::timeout(std::time::Duration::from_secs(20), submit_handle)
+        .await
+        .expect("parent stream should close after abort")
+        .unwrap();
+    assert!(
+        body.contains("\"status\":\"cancelled\""),
+        "expected a cancelled envelope in the parent stream"
+    );
+}
+
+/// A child answer longer than `result_max_chars` is truncated and flagged.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_result_truncated_at_cap(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-LONG-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[
+                "CHILD-LONG-ANSWER with ünïcödé and plenty of filler to exceed the configured cap",
+            ]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-LONG-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["long answer question"],
+                &["CHILD-LONG-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_long",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-LONG-TASK produce a long answer",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.result_max_chars = 32;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "long delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "long answer question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert_eq!(output["truncated"], true);
+    let result = output["result"].as_str().unwrap();
+    assert_eq!(result.chars().count(), 32);
+    assert!(result.starts_with("CHILD-LONG-ANSWER with ünïcödé"));
+}
+
+/// A child run that completes without producing an answer is reported as
+/// `failed`, never as an empty `completed` result.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_empty_child_answer_reports_failed(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-EMPTY-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[""]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-EMPTY-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["empty answer question"],
+                &["CHILD-EMPTY-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_empty",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-EMPTY-TASK say nothing",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "empty delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "empty answer question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "failed");
+    assert!(output["result"].is_null());
+    assert!(extract_full_text_answer(&events).contains("PARENT-EMPTY-FINAL"));
+}
+
+/// Mentions submitted into a chat that is itself a delegated run validate,
+/// but the delegation tool is never offered there — depth stays at one.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_no_delegation_offer_inside_a_delegated_run(pool: Pool<Postgres>) {
+    let recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    {
+        let recorder = recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post().path("/v1/chat/completions").matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_text_streaming_response(&["depth guard answer"]),
+            );
+        });
+    }
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "depth delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    // A chat that is itself a delegated run, bound to another assistant.
+    let bound_assistant = create_assistant(&server, "Bound Assistant", "bound prompt").await;
+    let origin_chat = create_chat(&server, Some(&bound_assistant)).await;
+    let delegated_chat = create_chat(&server, Some(&bound_assistant)).await;
+    write_delegation_provenance(
+        &app_state.db,
+        Uuid::parse_str(&delegated_chat).unwrap(),
+        Uuid::parse_str(&bound_assistant).unwrap(),
+        Uuid::parse_str(&origin_chat).unwrap(),
+        None,
+    )
+    .await;
+
+    // Mentions inside a delegated run are rejected outright (depth stays 1).
+    let response = submit_with_mentions(
+        &server,
+        Some(&delegated_chat),
+        "mention inside a delegated run",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
+
+    // A plain submit into the delegated run works and offers no delegation
+    // tool (nor any client tools).
+    let events = submit_message(
+        &server,
+        &delegated_chat,
+        None,
+        "plain message inside a delegated run",
+        vec![],
+    )
+    .await;
+    assert!(extract_full_text_answer(&events).contains("depth guard answer"));
+    for body in recorder.bodies() {
+        assert!(
+            !body.contains("delegate_to_assistant"),
+            "the delegation tool must never be offered inside a delegated run"
+        );
+    }
+}
+
+/// Regenerating a mention-carrying turn re-offers the delegation tool from
+/// the persisted mentions; an empty task argument is refused and the turn
+/// recovers.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_reoffers_tool_and_empty_task_refused(pool: Pool<Postgres>) {
+    let recorder = RequestBodyRecorder::new();
+    let mut mocks = MockSet::new();
+    // Empty-task call on the regenerated turn → refusal → recovery in prose.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["Delegation refused"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["REGEN-RECOVERED"]),
+        );
+    });
+    {
+        let recorder = recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["regen offer question"],
+                    &["Delegation refused"],
+                ))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                    "call_delegate_regen",
+                    "delegate_to_assistant",
+                    json!({
+                        "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                        "task": "   ",
+                    }),
+                )]),
+            );
+        });
+    }
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "regen delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "regen offer question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    // The submit turn already refused the empty task and recovered.
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "error");
+    assert!(
+        output["error"]
+            .as_str()
+            .unwrap()
+            .contains("must not be empty")
+    );
+    let assistant_message_id = assistant_message_id_from_events(&events);
+
+    // Regenerate WITHOUT the field: the persisted mentions must re-offer the
+    // tool (recorder sees a second offering request).
+    let offers_before = recorder
+        .bodies()
+        .iter()
+        .filter(|body| body.contains("delegate_to_assistant"))
+        .count();
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "current_message_id": assistant_message_id }))
+        .await;
+    regenerate_response.assert_status_ok();
+    let offers_after = recorder
+        .bodies()
+        .iter()
+        .filter(|body| {
+            let parsed: Value = serde_json::from_str(body).unwrap_or_default();
+            parsed["tools"].as_array().is_some_and(|tools| {
+                tools
+                    .iter()
+                    .any(|tool| tool["function"]["name"] == "delegate_to_assistant")
+            })
+        })
+        .count();
+    assert!(
+        offers_after > offers_before.min(offers_after - 1),
+        "regenerate must re-offer the delegation tool from persisted mentions"
+    );
+    assert!(
+        offers_after >= 2,
+        "submit and regenerate should both offer the tool"
+    );
+}
+
+/// Archiving the delegate between submit-time validation and dispatch is
+/// caught by the dispatch-time re-resolution: the call is refused, no child
+/// chat is created, and the turn recovers.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_delegation_dispatch_refuses_target_archived_after_validation(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["Delegation refused"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["ARCHIVE-RECOVERED"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["archive race question"],
+                &["Delegation refused"],
+            ));
+        // Stall long enough for the test to archive the delegate mid-turn.
+        let mut actions = vec![BodyAction::Delay(std::time::Duration::from_secs(2))];
+        actions.extend(
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_archived",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "should be refused",
+                }),
+            )]),
+        );
+        mock_llm_sse_response(then, actions);
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "archived delegate", None).await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let app: Router = erato::server::router::router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state.clone());
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{server_addr}");
+    let submit_client = client.clone();
+    let submit_base = base_url.clone();
+    let submit_handle = tokio::spawn(async move {
+        let response = submit_client
+            .post(format!("{submit_base}/api/v1beta/me/messages/submitstream"))
+            .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+            .json(&json!({
+                "user_message": "archive race question",
+                "mentioned_assistant_ids": [DELEGATE_ASSISTANT_FIXED_ID],
+            }))
+            .send()
+            .await
+            .expect("submit request");
+        assert!(response.status().is_success());
+        response.text().await.expect("submit body")
+    });
+
+    // Validation has passed once the submit is accepted; archive the delegate
+    // while the parent model is still "thinking".
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    let archive_response = client
+        .post(format!(
+            "{base_url}/api/v1beta/assistants/{DELEGATE_ASSISTANT_FIXED_ID}/archive"
+        ))
+        .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(archive_response.status().is_success());
+
+    let body = tokio::time::timeout(std::time::Duration::from_secs(20), submit_handle)
+        .await
+        .expect("parent stream should complete")
+        .unwrap();
+    assert!(body.contains("no longer available"));
+    assert!(body.contains("ARCHIVE-RECOVERED"));
+
+    let children = erato::db::entity::chats::Entity::find()
+        .filter(erato::db::entity::chats::Column::OriginChatId.is_not_null())
+        .all(&app_state.db)
+        .await
+        .unwrap();
+    assert!(children.is_empty(), "no child chat for a refused dispatch");
 }

--- a/backend/erato/tests/integration_tests/config.rs
+++ b/backend/erato/tests/integration_tests/config.rs
@@ -4169,3 +4169,25 @@ model_name = "gpt-4o"
         "erato.template.toml's delegation block drifted from the Rust defaults"
     );
 }
+
+#[test]
+#[should_panic(expected = "is reserved")]
+fn test_client_tool_named_delegate_to_assistant_is_rejected() {
+    build_and_migrate_delegation_config(
+        r#"
+[assistants]
+enabled = true
+
+[client_tools.tools.bad]
+name = "delegate_to_assistant"
+description = "reserved-name probe"
+parameters = "{\"type\":\"object\",\"properties\":{}}"
+
+[chat_provider]
+provider_kind = "openai"
+model_name = "gpt-4o"
+
+[file_storage_providers]
+"#,
+    );
+}

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -19,6 +19,9 @@ use crate::startup_log;
 /// Name reserved for the synthetic client-action tool exposed by the backend.
 pub const CLIENT_ACTION_TOOL_NAME: &str = "propose_client_action";
 
+/// Name reserved for the synthetic assistant-delegation tool exposed by the backend.
+pub const DELEGATE_TO_ASSISTANT_TOOL_NAME: &str = "delegate_to_assistant";
+
 const DEFAULT_PROMPT_OPTIMIZER_PROMPT: &str = r#"
 You are Lyra, a master-level AI prompt optimization specialist.
 Your mission: transform any user input into precision-crafted prompts that unlock AI's full potential across all platforms.
@@ -1040,7 +1043,7 @@ impl AppConfig {
                     tool.name
                 );
             }
-            if name == CLIENT_ACTION_TOOL_NAME {
+            if name == CLIENT_ACTION_TOOL_NAME || name == DELEGATE_TO_ASSISTANT_TOOL_NAME {
                 panic!("Client tool named '{}' is reserved.", name);
             }
             let namespace = tool.namespace_or_default();


### PR DESCRIPTION
**Part 4/5 of the ERMAIN-617 delegation stack**, on top of #980. Review bottom-up; this layer's diff is against the validation layer. This is the runtime and deliberately the largest layer — about 1.5k of its lines are integration tests.

The delegation runtime: offering `delegate_to_assistant` on mention-carrying turns, dispatching it, running the mentioned assistant as an awaited child chat run, and returning a compact result envelope the origin model reacts to.

## What changes

**Offer** — on turns with validated mentions, a `delegate_to_assistant` tool is pushed with `assistant_id` enum-constrained to the validated targets, `task`, optional `expected_output`/`constraints` (structured brief), `file_ids` enum-constrained to the parent chat's attachments (pass-by-reference), and `include_conversation_context`. The description enumerates targets and attachments. MCP tools win name collisions (same precedence as the other synthetic tools); the name joins the reserved list for client tools and config validation. Never offered inside a delegated run — delegation depth stays at one, and mentions submitted into a delegated run are rejected with 400.

**Dispatch** — a new branch in the tool-call loop, placed before the by-construction client-tool branch (that branch treats every offered non-MCP name as a client tool). Every failure — unoffered target, bad arguments, foreign file id, target archived or revoked since validation — refuses the call, never the turn, so the model recovers in prose.

**Child run** — re-resolves the target access-checked at dispatch time, creates the child chat owned by the origin user with the full provenance envelope (title from the task brief, no summary spawn), copies named file join rows, optionally seeds the conversation via `seed_chat_lineage` from the turn's replay anchor (ContextRebase then gives it the delegate's head), renders the configured preamble onto the task-brief turn, and drives the run through the same submit-task machinery as a user submit — own generation lease, boxed future (the nested generation would otherwise make the parent's future recursively sized), awaited under `run_timeout_seconds` with parent-abort forwarding. On grace expiry the child is detached, never hard-cancelled, so its cleanup tail always runs. Inside a delegated run, client tools / client actions / further delegation are suppressed at the offering site (derived from the chat row, so it holds on every generation path), and approval-gated MCP calls are refused in-run instead of parking — the parent always receives a terminal envelope (`completed | failed | timeout | cancelled`, result capped at `result_max_chars`), never a half-done approval stop. The result is bound to the child task's own assistant-message id, so seeded history can never masquerade as the delegate's answer.

Accounting: one parent tool-call iteration per delegation; the child has its own cap; tokens land on child messages owned by the origin user.

## Testing

Happy path with request-recorder proofs (child head = delegate prompt + preamble, no origin system plane; client tools offered to the parent but absent in the child); file passing + foreign-file refusal; context seeding; approval-gated MCP refusal (child completes in prose, never left `awaiting_approval`); timeout; abort forwarding via a real TCP server; mid-flight archive race; result truncation; empty-answer → `failed`; depth-1 rejection; regenerate re-offering from persisted mentions; unoffered-target recovery; reserved-name config rejection.
