### PR TITLE
Composer assistant mentions: @-picker, add-menu and Tools sections (ERMAIN-618)

### DIFF
--- a/frontend/src/app/env.ts
+++ b/frontend/src/app/env.ts
@@ -24,6 +24,7 @@ export type Env = {
   chatInputEmptyStateLayout: "bottom" | "centered";
   disableLogout: boolean;
   assistantsEnabled: boolean;
+  assistantsDelegationEnabled: boolean;
   assistantsEnableEditSharing?: boolean;
   assistantsShowRecentItems: boolean;
   assistantsShowRecentItemsCollapsible: boolean;
@@ -84,6 +85,7 @@ declare global {
     CHAT_INPUT_EMPTY_STATE_LAYOUT?: string;
     DISABLE_LOGOUT?: boolean;
     ASSISTANTS_ENABLED?: boolean;
+    ASSISTANTS_DELEGATION_ENABLED?: boolean;
     ASSISTANTS_ENABLE_EDIT_SHARING?: boolean;
     ASSISTANTS_SHOW_RECENT_ITEMS?: boolean;
     ASSISTANTS_SHOW_RECENT_ITEMS_COLLAPSIBLE?: boolean;
@@ -222,6 +224,10 @@ export const env = (): Env => {
     import.meta.env.VITE_ASSISTANTS_ENABLED === "true"
       ? true
       : (window.ASSISTANTS_ENABLED ?? false);
+  const assistantsDelegationEnabled =
+    import.meta.env.VITE_ASSISTANTS_DELEGATION_ENABLED === "true"
+      ? true
+      : (window.ASSISTANTS_DELEGATION_ENABLED ?? false);
   const assistantsEnableEditSharing =
     import.meta.env.VITE_ASSISTANTS_ENABLE_EDIT_SHARING === "false"
       ? false
@@ -404,6 +410,7 @@ export const env = (): Env => {
     chatInputEmptyStateLayout,
     disableLogout,
     assistantsEnabled,
+    assistantsDelegationEnabled,
     assistantsEnableEditSharing,
     assistantsShowRecentItems,
     assistantsShowRecentItemsCollapsible,

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -32,6 +32,7 @@ const createMockEnv = (overrides: Partial<Env> = {}): Env => ({
   chatInputEmptyStateLayout: "bottom",
   disableLogout: false,
   assistantsEnabled: false,
+  assistantsDelegationEnabled: false,
   assistantsShowRecentItems: false,
   assistantsShowRecentItemsCollapsible: false,
   assistantContextWarningThreshold: 0.5,

--- a/frontend/src/components/ui/Chat/AssistantBrowserModal.tsx
+++ b/frontend/src/components/ui/Chat/AssistantBrowserModal.tsx
@@ -1,0 +1,134 @@
+import { t } from "@lingui/core/macro";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Input } from "@/components/ui/Input/Input";
+import { useFuzzySearch } from "@/hooks/search/useFuzzySearch";
+
+import { ModalBase } from "../Modal/ModalBase";
+
+import type { MentionableAssistant } from "@/hooks/chat/useMentionableAssistants";
+
+const SEARCH_KEYS = ["name", "description"];
+
+export interface AssistantBrowserModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  assistants: MentionableAssistant[];
+  onSelect: (assistant: MentionableAssistant) => void;
+}
+
+/**
+ * Full accessible-assistant list behind the picker's "Browse" row. Filtering is
+ * client-side: the list is already loaded for the picker, so a round trip per
+ * keystroke would only add latency.
+ */
+export function AssistantBrowserModal({
+  isOpen,
+  onClose,
+  assistants,
+  onSelect,
+}: AssistantBrowserModalProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+  const matches = useFuzzySearch({
+    items: assistants,
+    keys: SEARCH_KEYS,
+    query: searchQuery,
+    // A single character is a legitimate filter here: the list is short and the
+    // user is narrowing it, not searching prose.
+    minMatchCharLength: 1,
+  });
+
+  // The surface that opened this dialog is a popover closing in the same
+  // interaction, and its focus-return to its own trigger lands after the
+  // dialog's. Claiming focus a frame later puts the caret in the search box
+  // rather than behind the overlay.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => searchRef.current?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  const closeAndReset = useCallback(() => {
+    setSearchQuery("");
+    onClose();
+  }, [onClose]);
+
+  const handleSelect = (assistant: MentionableAssistant) => {
+    onSelect(assistant);
+    closeAndReset();
+  };
+
+  return (
+    <ModalBase
+      isOpen={isOpen}
+      onClose={closeAndReset}
+      title={t({
+        id: "chatInput.mentions.browseTitle",
+        message: "Mention an assistant",
+      })}
+      contentClassName="max-w-lg"
+    >
+      {/* Single return keeps the input mounted across every result state, so
+          typing never loses focus. */}
+      <div className="mb-3">
+        <Input
+          ref={searchRef}
+          type="search"
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          placeholder={t({
+            id: "chatInput.mentions.searchPlaceholder",
+            message: "Search assistants...",
+          })}
+          aria-label={t({
+            id: "chatInput.mentions.searchPlaceholder",
+            message: "Search assistants...",
+          })}
+          data-testid="chat-input-mention-browse-search"
+        />
+      </div>
+
+      <div className="max-h-64 overflow-y-auto rounded-lg border border-theme-border">
+        {matches.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-sm text-theme-fg-muted">
+              {t({
+                id: "chatInput.mentions.noResults",
+                message: "No assistants match your search",
+              })}
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-theme-border">
+            {matches.map((assistant) => (
+              <button
+                key={assistant.id}
+                type="button"
+                onClick={() => handleSelect(assistant)}
+                data-testid={`chat-input-mention-browse-option-${assistant.id}`}
+                className="theme-transition focus-ring-tight flex w-full flex-col items-start gap-1 px-4 py-3 text-left hover:bg-theme-bg-hover"
+              >
+                <span className="w-full truncate font-medium text-theme-fg-primary">
+                  {assistant.name}
+                </span>
+                {assistant.description && (
+                  <span className="w-full truncate text-sm text-theme-fg-secondary">
+                    {assistant.description}
+                  </span>
+                )}
+                {assistant.ownerEmail && (
+                  <span className="w-full truncate text-xs text-theme-fg-muted">
+                    {assistant.ownerEmail}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </ModalBase>
+  );
+}

--- a/frontend/src/components/ui/Chat/AssistantMentionPopover.tsx
+++ b/frontend/src/components/ui/Chat/AssistantMentionPopover.tsx
@@ -1,0 +1,196 @@
+import { t } from "@lingui/core/macro";
+import { useCallback, useEffect, useImperativeHandle, useRef } from "react";
+
+import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
+
+import {
+  ADD_MENU_ITEM_SELECTOR,
+  AddMenuActionRow,
+  addMenuSectionDividerClassName,
+} from "./ChatInputAddMenu";
+import { AnchoredPopover } from "../Controls/AnchoredPopover";
+
+import type { MentionableAssistant } from "@/hooks/chat/useMentionableAssistants";
+import type { KeyboardEvent as ReactKeyboardEvent, Ref } from "react";
+
+export interface AssistantMentionPopoverHandle {
+  /**
+   * True when the open picker consumed the key, in which case the composer
+   * must not act on it — notably Enter, which would otherwise send.
+   */
+  handleComposerKeyDown: (
+    event: ReactKeyboardEvent<HTMLTextAreaElement>,
+  ) => boolean;
+}
+
+export interface AssistantMentionPopoverProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  assistants: MentionableAssistant[];
+  onSelect: (assistant: MentionableAssistant) => void;
+  onBrowse: () => void;
+  /**
+   * Called when the panel closes while it holds focus, which only happens after
+   * the user arrowed into it. Focus belongs back in the composer.
+   */
+  onRestoreFocus: () => void;
+  ref?: Ref<AssistantMentionPopoverHandle>;
+}
+
+/**
+ * Suggestion list for an in-progress `@` mention. The panel is anchored to the
+ * composer shell rather than the caret: `AnchoredPopover` measures a real
+ * button, and a caret has no element to measure.
+ *
+ * Unlike every other popover, this one opens while the user is typing, so it
+ * must leave the caret alone: `manageFocus` is off and focus only ever enters
+ * the panel on an explicit arrow key.
+ */
+export function AssistantMentionPopover({
+  isOpen,
+  onOpenChange,
+  assistants,
+  onSelect,
+  onBrowse,
+  onRestoreFocus,
+  ref,
+}: AssistantMentionPopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const panelHasFocusRef = useRef(false);
+  const wasOpenRef = useRef(false);
+  const { focusEdge } = useRovingMenuFocus({
+    containerRef: panelRef,
+    enabled: isOpen,
+    itemSelector: ADD_MENU_ITEM_SELECTOR,
+  });
+
+  useEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      panelHasFocusRef.current = false;
+    }
+    if (!isOpen && wasOpenRef.current && panelHasFocusRef.current) {
+      panelHasFocusRef.current = false;
+      onRestoreFocus();
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, onRestoreFocus]);
+
+  const handleComposerKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (!isOpen) {
+        return false;
+      }
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          focusEdge("first");
+          return true;
+        case "ArrowUp":
+          event.preventDefault();
+          focusEdge("last");
+          return true;
+        case "Enter":
+        case "Tab": {
+          if (event.shiftKey || assistants.length === 0) {
+            return false;
+          }
+          event.preventDefault();
+          onSelect(assistants[0]);
+          return true;
+        }
+        case "Escape":
+          event.preventDefault();
+          onOpenChange(false);
+          return true;
+        default:
+          return false;
+      }
+    },
+    [assistants, focusEdge, isOpen, onOpenChange, onSelect],
+  );
+
+  useImperativeHandle(ref, () => ({ handleComposerKeyDown }), [
+    handleComposerKeyDown,
+  ]);
+
+  // Enter already activates the focused row natively; Tab is the mention
+  // convention for "take this one" and would otherwise leave the panel.
+  const handlePanelKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab" || event.shiftKey) {
+      return;
+    }
+    const focusedRow = document.activeElement;
+    if (
+      focusedRow instanceof HTMLElement &&
+      panelRef.current?.contains(focusedRow)
+    ) {
+      event.preventDefault();
+      focusedRow.click();
+    }
+  };
+
+  return (
+    <AnchoredPopover
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      panelRef={panelRef}
+      role="menu"
+      ariaHasPopup="menu"
+      preferredOrientation={{ vertical: "top", horizontal: "left" }}
+      panelStyle={{
+        maxWidth:
+          "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
+        minWidth: "var(--theme-layout-dropdown-min-width)",
+      }}
+      panelClassName="flex w-80 flex-col"
+      viewportPadding="var(--theme-layout-dropdown-viewport-margin)"
+      dataUi="chat-input-mention-menu"
+      manageFocus={false}
+      ariaLabel={t({
+        id: "chatInput.mentions.pickerLabel",
+        message: "Assistant suggestions",
+      })}
+      // The anchor is geometry, not a control: it is never focused and
+      // activating it would do nothing, so it stays out of the a11y tree and
+      // the panel is named directly instead.
+      trigger={(triggerProps) => (
+        <button
+          {...triggerProps}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="sr-only"
+          data-testid="chat-input-mention-anchor"
+        />
+      )}
+    >
+      <div
+        className="dropdown-panel-chrome-geometry flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+        role="none"
+        onKeyDown={handlePanelKeyDown}
+        onFocus={() => {
+          panelHasFocusRef.current = true;
+        }}
+        data-ui="chat-input-mention-menu-content"
+      >
+        {assistants.map((assistant) => (
+          <AddMenuActionRow
+            key={assistant.id}
+            label={assistant.name}
+            description={assistant.description}
+            testId={`chat-input-mention-option-${assistant.id}`}
+            onActivate={() => onSelect(assistant)}
+          />
+        ))}
+        <div className={addMenuSectionDividerClassName} />
+        <AddMenuActionRow
+          label={t({
+            id: "chatInput.mentions.browse",
+            message: "Browse assistants…",
+          })}
+          testId="chat-input-mention-browse"
+          onActivate={onBrowse}
+        />
+      </div>
+    </AnchoredPopover>
+  );
+}

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -347,12 +347,14 @@ export const Chat = ({
       inputFileIds?: string[],
       modelId?: string,
       selectedFacetIds?: string[],
+      mentionedAssistantIds?: string[],
     ) => {
       logger.log("[CHAT_FLOW] Chat - handleSendMessage called", {
         files: inputFileIds,
         model: modelId,
         assistantId,
         selectedFacetIds,
+        mentionedAssistantIds,
       });
 
       baseHandleSendMessage(
@@ -361,6 +363,7 @@ export const Chat = ({
         modelId,
         assistantId,
         selectedFacetIds,
+        mentionedAssistantIds,
       ).catch((error) => {
         logger.log("[CHAT_FLOW] Error sending message:", error);
       });

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1,5 +1,9 @@
 import { I18nProvider } from "@lingui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  skipToken,
+} from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +17,7 @@ import { messages as enMessages } from "@/locales/en/messages.json";
 import { ChatInput } from "./ChatInput";
 import { useToastStore } from "../Toast/toastStore";
 
+import type { AddMenuSection } from "./ChatInputAddMenu";
 import type { FileAttachmentsPreviewProps } from "@/components/ui/FileUpload/FileAttachmentsPreview";
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { ChatContextValue } from "@/providers/ChatProvider";
@@ -30,6 +35,9 @@ const mockUseChatInputFeature = vi.fn();
 const mockUseAudioTranscriptionFeature = vi.fn();
 const mockUseAudioDictationFeature = vi.fn();
 const mockUseAudioConversationalFeature = vi.fn();
+const mockUseAssistantsFeature = vi.fn();
+const mockUseListAssistants = vi.fn();
+const mockUseFrequentAssistants = vi.fn();
 const mockUseOptionalTranslation = vi.fn();
 const mockUseActiveModelSelection = vi.fn();
 const mockUseTokenManagement = vi.fn();
@@ -42,6 +50,8 @@ const mockFacetSelector = vi.fn();
 const mockFileUploadControl = vi.fn();
 const mockUseAudioDictationRecorder = vi.fn();
 const mockUseAudioTranscriptionRecorder = vi.fn();
+const mockUseIsMobile = vi.fn();
+const mockChatInputAddControls = vi.fn();
 
 vi.mock("@/providers/ChatProvider", () => ({
   useChatContext: () => mockUseChatContext(),
@@ -53,6 +63,7 @@ vi.mock("@/providers/FeatureConfigProvider", () => ({
   useAudioTranscriptionFeature: () => mockUseAudioTranscriptionFeature(),
   useAudioDictationFeature: () => mockUseAudioDictationFeature(),
   useAudioConversationalFeature: () => mockUseAudioConversationalFeature(),
+  useAssistantsFeature: () => mockUseAssistantsFeature(),
   useErrorReportFeature: () => ({
     showVerboseAssistantErrors: false,
     showCopyErrorReport: false,
@@ -90,6 +101,9 @@ vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
   fetchGetFile: (...args: unknown[]) => mockFetchGetFile(...args),
   useCreateChat: (...args: unknown[]) => mockUseCreateChat(...args),
   useFacets: (...args: unknown[]) => mockUseFacets(...args),
+  useListAssistants: (...args: unknown[]) => mockUseListAssistants(...args),
+  useFrequentAssistants: (...args: unknown[]) =>
+    mockUseFrequentAssistants(...args),
 }));
 
 vi.mock("@/components/ui/FileUpload", () => ({
@@ -142,6 +156,19 @@ vi.mock("./ChatInputTokenUsage", () => ({
   ChatInputTokenUsage: (props: unknown) => {
     mockChatInputTokenUsage(props);
     return null;
+  },
+}));
+
+vi.mock("@/hooks/useResponsive", () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}));
+
+// The "+" menu's own rendering of the section is covered against the real
+// component in ChatInputAddControls.test.tsx; here only the wiring matters.
+vi.mock("./ChatInputAddControls", () => ({
+  ChatInputAddControls: (props: unknown) => {
+    mockChatInputAddControls(props);
+    return <div data-testid="chat-input-add-controls" />;
   },
 }));
 
@@ -232,7 +259,14 @@ describe("ChatInput", () => {
       cancelMessage: vi.fn(),
     });
 
+    mockUseIsMobile.mockReturnValue(false);
     mockUseUploadFeature.mockReturnValue({ enabled: false });
+    mockUseAssistantsFeature.mockReturnValue({
+      enabled: false,
+      delegationEnabled: false,
+    });
+    mockUseListAssistants.mockReturnValue({ data: undefined });
+    mockUseFrequentAssistants.mockReturnValue({ data: undefined });
     mockUseAudioTranscriptionFeature.mockReturnValue({ enabled: false });
     mockUseAudioDictationFeature.mockReturnValue({ enabled: false });
     mockUseAudioConversationalFeature.mockReturnValue({ enabled: false });
@@ -2597,6 +2631,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
+        [],
       );
       expect(
         mockUseAudioDictationRecorder.mock.calls.at(-1)?.[0],
@@ -2714,6 +2749,7 @@ describe("ChatInput", () => {
         "hello after pause",
         undefined,
         undefined,
+        [],
         [],
       );
       requestSubmitSpy.mockRestore();
@@ -3512,6 +3548,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
+        [],
       );
       expect(
         screen.queryByTestId("chat-input-queued-message"),
@@ -3623,7 +3660,11 @@ describe("ChatInput", () => {
       )[0];
       expect(
         useComposeSessionStore.getState().draftsBySessionId[sessionId!],
-      ).toEqual({ message: "next message", attachedFiles: [] });
+      ).toEqual({
+        message: "next message",
+        attachedFiles: [],
+        mentionedAssistants: [],
+      });
       expect(useMessageQueueStore.getState().queuedBySessionId).toEqual({});
 
       rerender({ isPendingResponse: false }, { remountKey: 2 });
@@ -3756,6 +3797,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
+        [],
       );
     });
 
@@ -3831,6 +3873,7 @@ describe("ChatInput", () => {
         "with attachment",
         ["file-1"],
         undefined,
+        [],
         [],
       );
     });
@@ -3961,6 +4004,597 @@ describe("ChatInput", () => {
         screen.getByTestId("chat-input-queued-message-edit"),
       ).toHaveTextContent("first");
       expect(textarea).toHaveValue("second");
+    });
+  });
+
+  describe("assistant @-mentions (ERMAIN-618)", () => {
+    const RESEARCHER = {
+      id: "assistant-research",
+      name: "Researcher",
+      description: "Finds and cites sources",
+      owner_email: "research@example.com",
+    };
+    const EDITOR = {
+      id: "assistant-editor",
+      name: "Editor",
+      description: "Tightens prose",
+      owner_email: "editor@example.com",
+    };
+
+    const submitHandlerThatSends =
+      (
+        message: string,
+        attachedFiles: FileUploadItem[],
+        innerOnSendMessage: (message: string, inputFileIds?: string[]) => void,
+        isLoading: boolean,
+        disabled: boolean,
+        resetMessage: () => void,
+      ) =>
+      (event: FormEvent) => {
+        event.preventDefault();
+        if (isLoading || disabled) return;
+        const trimmed = message.trim();
+        const fileIds = attachedFiles.map((file) => file.id);
+        if (trimmed || fileIds.length > 0) {
+          innerOnSendMessage(trimmed, fileIds.length > 0 ? fileIds : undefined);
+          resetMessage();
+        }
+      };
+
+    const enableDelegation = () => {
+      mockUseAssistantsFeature.mockReturnValue({
+        enabled: true,
+        delegationEnabled: true,
+      });
+      mockUseListAssistants.mockReturnValue({ data: [RESEARCHER, EDITOR] });
+      mockUseFrequentAssistants.mockReturnValue({
+        data: { assistants: [RESEARCHER, EDITOR] },
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: submitHandlerThatSends,
+      });
+    };
+
+    const renderComposer = async (
+      onSendMessage: () => void,
+      props: { enforceSelectedFacetIds?: boolean } = {},
+    ) => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              onSendMessage={onSendMessage}
+              chatId="chat-1"
+              {...props}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      );
+      return screen.getByPlaceholderText("Type a message...");
+    };
+
+    // The popover primitive places focus one frame after opening, so anything
+    // asserting where the caret ended up has to let that frame run.
+    const flushFrame = async () => {
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+    };
+
+    const typeWithCaretAtEnd = (textarea: HTMLElement, value: string) => {
+      fireEvent.change(textarea, { target: { value } });
+      (textarea as HTMLTextAreaElement).setSelectionRange(
+        value.length,
+        value.length,
+      );
+      fireEvent.select(textarea);
+    };
+
+    beforeEach(() => {
+      useMessageQueueStore.setState({ queuedBySessionId: {} });
+    });
+
+    it("issues no assistant queries and offers no mention surface while delegation is off", async () => {
+      const textarea = await renderComposer(vi.fn());
+
+      expect(mockUseListAssistants).toHaveBeenCalledWith(skipToken);
+      expect(mockUseFrequentAssistants).toHaveBeenCalledWith(skipToken);
+
+      typeWithCaretAtEnd(textarea, "@Res");
+
+      expect(
+        screen.queryByTestId("chat-input-mention-anchor"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-research"),
+      ).not.toBeInTheDocument();
+      expect(mockFacetSelector).not.toHaveBeenCalled();
+    });
+
+    it("opens the picker on a typed @ and inserts the token on selection", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "@Res");
+
+      const option = screen.getByTestId(
+        "chat-input-mention-option-assistant-research",
+      );
+      expect(option).toHaveTextContent("Researcher");
+      expect(option).toHaveTextContent("Finds and cites sources");
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-editor"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(option);
+
+      expect(textarea).toHaveValue("@Researcher ");
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-research"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("announces the open picker to a screen reader without repeating per keystroke", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      const liveRegion = screen.getByRole("status");
+      expect(liveRegion).toHaveTextContent("");
+
+      typeWithCaretAtEnd(textarea, "@Res");
+      expect(liveRegion).toHaveTextContent(/down arrow to browse/i);
+
+      const announced = liveRegion.textContent;
+      typeWithCaretAtEnd(textarea, "@Resea");
+      expect(liveRegion.textContent).toBe(announced);
+
+      typeWithCaretAtEnd(textarea, "@Researcher zzz");
+      expect(liveRegion).toHaveTextContent("");
+    });
+
+    it("does not open the picker for an address-like @", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "mail me at research@ex");
+
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-research"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("selects the top match on Enter instead of sending", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("@Researcher ");
+    });
+
+    it("moves into the picker with the arrows and selects with Enter", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "@");
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      expect(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      ).toHaveFocus();
+
+      fireEvent.keyDown(document.activeElement as HTMLElement, {
+        key: "ArrowDown",
+      });
+      const editorRow = screen.getByTestId(
+        "chat-input-mention-option-assistant-editor",
+      );
+      expect(editorRow).toHaveFocus();
+
+      fireEvent.click(editorRow);
+      expect(textarea).toHaveValue("@Editor ");
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("leaves the caret in the composer while the picker is open", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+      textarea.focus();
+
+      typeWithCaretAtEnd(textarea, "@Res");
+      await flushFrame();
+
+      expect(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      ).toBeInTheDocument();
+      expect(textarea).toHaveFocus();
+    });
+
+    it("closes on Escape and hands focus back to the composer", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "@");
+      expect(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      ).toBeInTheDocument();
+
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      fireEvent.keyDown(document.activeElement as HTMLElement, {
+        key: "Escape",
+      });
+
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-research"),
+      ).not.toBeInTheDocument();
+      expect(textarea).toHaveFocus();
+    });
+
+    // The keyup of the dismissing Escape re-reads the same text and caret, so
+    // without a dismissal latch the picker is back before the key is released.
+    it("stays dismissed for the rest of the key press and lets Enter send", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "ping @Res");
+      fireEvent.keyDown(textarea, { key: "Escape" });
+      fireEvent.keyUp(textarea, { key: "Escape" });
+      fireEvent.select(textarea);
+      await flushFrame();
+
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-research"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "ping @Res",
+        undefined,
+        undefined,
+        [],
+        [],
+      );
+    });
+
+    it("re-arms the picker once the fragment is edited again", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "ping @Res");
+      fireEvent.keyDown(textarea, { key: "Escape" });
+      fireEvent.keyUp(textarea, { key: "Escape" });
+      typeWithCaretAtEnd(textarea, "ping @Rese");
+
+      expect(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      ).toBeInTheDocument();
+    });
+
+    it("sends the mentioned ids resolved from the text", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, "@Researcher please summarize");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please summarize",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("drops the mention when its token is deleted from the text", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, "please summarize");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "please summarize",
+        undefined,
+        undefined,
+        [],
+        [],
+      );
+    });
+
+    it("carries the queued message's mentions through the drain", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (isPendingResponse: boolean) => {
+        mockUseChatContext.mockReturnValue({
+          isPendingResponse,
+          isMessagingLoading: false,
+          isUploading: false,
+          cancelMessage: vi.fn(),
+          messagingError: null,
+        });
+        return (
+          <QueryClientProvider client={queryClient}>
+            <I18nProvider i18n={i18n}>
+              <ChatInput onSendMessage={onSendMessage} chatId="chat-1" />
+            </I18nProvider>
+          </QueryClientProvider>
+        );
+      };
+      const { rerender } = render(ui(true));
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, "@Researcher take over");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(textarea).toHaveValue("");
+
+      rerender(ui(false));
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher take over",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    // The seeded draft carries its mentions; a remount that keeps only the text
+    // would submit an ordinary run behind an unchanged @token.
+    it("keeps a draft's mentions across a remount", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (mountKey: number) => (
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              key={mountKey}
+              onSendMessage={onSendMessage}
+              chatId="chat-1"
+            />
+          </I18nProvider>
+        </QueryClientProvider>
+      );
+      const { rerender } = render(ui(1));
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, "@Researcher hello");
+
+      rerender(ui(2));
+
+      const remounted = screen.getByPlaceholderText("Type a message...");
+      expect(remounted).toHaveValue("@Researcher hello");
+      fireEvent.keyDown(remounted, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher hello",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("inserts a mention picked from the browse dialog", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "@");
+      fireEvent.click(screen.getByTestId("chat-input-mention-browse"));
+
+      fireEvent.change(screen.getByTestId("chat-input-mention-browse-search"), {
+        target: { value: "Editor" },
+      });
+      expect(
+        screen.queryByTestId(
+          "chat-input-mention-browse-option-assistant-research",
+        ),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-browse-option-assistant-editor"),
+      );
+
+      expect(textarea).toHaveValue("@Editor ");
+      expect(
+        screen.queryByTestId("chat-input-mention-browse-search"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("browses the whole accessible list and filters on one character", async () => {
+      enableDelegation();
+      const archivist = {
+        id: "assistant-archivist",
+        name: "Archivist",
+        description: "Keeps the record",
+      };
+      mockUseListAssistants.mockReturnValue({
+        data: [
+          RESEARCHER,
+          EDITOR,
+          ...Array.from({ length: 4 }, (_, index) => ({
+            id: `assistant-extra-${index}`,
+            name: `Extra ${index}`,
+          })),
+          archivist,
+        ],
+      });
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "@");
+      // Only the frequent handful is suggested inline.
+      expect(
+        screen.queryByTestId("chat-input-mention-option-assistant-archivist"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("chat-input-mention-browse"));
+      await flushFrame();
+
+      const search = screen.getByTestId("chat-input-mention-browse-search");
+      expect(search).toHaveFocus();
+      expect(
+        screen.getByTestId(
+          "chat-input-mention-browse-option-assistant-archivist",
+        ),
+      ).toBeInTheDocument();
+
+      fireEvent.change(search, { target: { value: "A" } });
+      fireEvent.click(
+        screen.getByTestId(
+          "chat-input-mention-browse-option-assistant-archivist",
+        ),
+      );
+
+      expect(textarea).toHaveValue("@Archivist ");
+    });
+
+    it("clears the browse filter when the dialog is dismissed", async () => {
+      enableDelegation();
+      const textarea = await renderComposer(vi.fn());
+
+      typeWithCaretAtEnd(textarea, "@");
+      fireEvent.click(screen.getByTestId("chat-input-mention-browse"));
+      fireEvent.change(screen.getByTestId("chat-input-mention-browse-search"), {
+        target: { value: "Editor" },
+      });
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(textarea).toHaveFocus();
+
+      typeWithCaretAtEnd(textarea, "@ ");
+      typeWithCaretAtEnd(textarea, "@");
+      fireEvent.click(screen.getByTestId("chat-input-mention-browse"));
+
+      expect(
+        screen.getByTestId("chat-input-mention-browse-search"),
+      ).toHaveValue("");
+      expect(
+        screen.getByTestId(
+          "chat-input-mention-browse-option-assistant-research",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("feeds the same assistants section into the mobile add menu", async () => {
+      enableDelegation();
+      mockUseIsMobile.mockReturnValue(true);
+      await renderComposer(vi.fn());
+
+      // Neither uploads nor facets are available here: the assistants alone
+      // are what puts the "+" menu on screen.
+      expect(screen.getByTestId("chat-input-add-controls")).toBeInTheDocument();
+      const props = mockChatInputAddControls.mock.calls.at(-1)?.[0] as {
+        assistantSection: AddMenuSection;
+      };
+      expect(props.assistantSection.header).toBe("Assistants");
+      expect(props.assistantSection.items.map((item) => item.label)).toEqual([
+        "Researcher",
+        "Editor",
+        "Browse assistants…",
+      ]);
+    });
+
+    it("gives the desktop tool surface the same assistants section", async () => {
+      enableDelegation();
+      mockUseFacets.mockReturnValue({
+        data: {
+          facets: [{ id: "facet-1", name: "Tool", default_enabled: false }],
+          global_facet_settings: undefined,
+        },
+        error: null,
+      });
+      await renderComposer(vi.fn());
+
+      const section = mockFacetSelector.mock.calls.at(-1)?.[0]
+        .assistantSection as AddMenuSection;
+      expect(section.header).toBe("Assistants");
+      expect(section.items.map((item) => item.label)).toEqual([
+        "Researcher",
+        "Editor",
+        "Browse assistants…",
+      ]);
+    });
+
+    it("keeps the desktop tool surface mounted for assistants when no facet exists", async () => {
+      enableDelegation();
+      await renderComposer(vi.fn());
+
+      expect(screen.getByTestId("facet-selector")).toBeInTheDocument();
+      expect(mockFacetSelector.mock.calls.at(-1)?.[0].facets).toEqual([]);
+    });
+
+    // Enforced facet settings lock the tools; delegating out of that chat is
+    // still allowed, so the gate must not take the whole control down with it.
+    it("locks only the tools when facet settings are enforced", async () => {
+      enableDelegation();
+      mockUseFacets.mockReturnValue({
+        data: {
+          facets: [
+            { id: "facet-1", display_name: "Tool", default_enabled: false },
+          ],
+          global_facet_settings: undefined,
+        },
+        error: null,
+      });
+      await renderComposer(vi.fn(), { enforceSelectedFacetIds: true });
+
+      const props = mockFacetSelector.mock.calls.at(-1)?.[0];
+      expect(props.disabled).toBe(false);
+      expect(props.toolsDisabled).toBe(true);
     });
   });
 });

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -33,6 +33,10 @@ import {
   useComposeSession,
   type ComposeDraftState,
 } from "@/hooks/chat/useComposeSession";
+import {
+  useMentionableAssistants,
+  MENTION_SUGGESTION_LIMIT,
+} from "@/hooks/chat/useMentionableAssistants";
 import { UnsupportedFileTypeError } from "@/hooks/files/errors";
 import { useFileUploadStore } from "@/hooks/files/useFileUploadStore";
 import { useOptionalTranslation } from "@/hooks/i18n";
@@ -51,6 +55,12 @@ import {
   useAudioDictationFeature,
   useAudioConversationalFeature,
 } from "@/providers/FeatureConfigProvider";
+import {
+  applyMentionSelection,
+  detectMentionTrigger,
+  pruneTrackedMentions,
+  resolveMentionedAssistantIds,
+} from "@/utils/chat/assistantMentions";
 import { resolveChatSendErrorMessage } from "@/utils/chatSendErrorMessage";
 import { createLogger } from "@/utils/debugLogger";
 import { disambiguatePastedImageFileNames } from "@/utils/file/disambiguatePastedImageFileNames";
@@ -65,25 +75,34 @@ import {
   StopIcon,
   VoiceIcon,
 } from "../icons";
+import { AssistantBrowserModal } from "./AssistantBrowserModal";
+import { AssistantMentionPopover } from "./AssistantMentionPopover";
 import { ChatInputAddControls } from "./ChatInputAddControls";
 import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
 import { ChatInputTokenUsage } from "./ChatInputTokenUsage";
 import { FacetSelector } from "./FacetSelector";
 import { ModelSelector } from "./ModelSelector";
 import { WaveformButton } from "./WaveformButton";
+import { buildAssistantMentionSection } from "./assistantMentionSection";
 import { Button } from "../Controls/Button";
 import { Alert } from "../Feedback/Alert";
 import { BudgetWarning } from "../Feedback/ChatWarnings/BudgetWarning";
 import { CopyErrorButton } from "../Feedback/CopyErrorButton";
 import { toast } from "../Toast/toast";
 
+import type { AssistantMentionPopoverHandle } from "./AssistantMentionPopover";
 import type { ChatInputControlsHandle } from "./ChatInputControlsContext";
 import type { ToastAction } from "../Toast/types";
 import type { AudioDictationTranscriptChunk } from "@/hooks/audio/useAudioDictationRecorder";
+import type { MentionableAssistant } from "@/hooks/chat/useMentionableAssistants";
 import type {
   FileUploadItem,
   ChatModel,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type {
+  AssistantMention,
+  MentionTrigger,
+} from "@/utils/chat/assistantMentions";
 import type { FileType } from "@/utils/fileTypes";
 import type { ClipboardEvent as ReactClipboardEvent, Ref } from "react";
 
@@ -204,6 +223,7 @@ interface ChatInputProps {
     inputFileIds?: string[],
     modelId?: string,
     selectedFacetIds?: string[],
+    mentionedAssistantIds?: string[],
   ) => void;
   onRegenerate?: () => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
@@ -294,12 +314,21 @@ function mergeComposeDrafts(
       : primaryHasText
         ? primary.message
         : secondary.message;
+  const mentionedIds = new Set(
+    primary.mentionedAssistants.map((mention) => mention.id),
+  );
   return {
     message,
     attachedFiles: mergeUniqueFilesById(
       primary.attachedFiles,
       secondary.attachedFiles,
     ),
+    mentionedAssistants: [
+      ...primary.mentionedAssistants,
+      ...secondary.mentionedAssistants.filter(
+        (mention) => !mentionedIds.has(mention.id),
+      ),
+    ],
   };
 }
 
@@ -611,6 +640,27 @@ export const ChatInput = ({
 
   const [selectedFacetIds, setSelectedFacetIds] = useState<string[]>([]);
 
+  // --- Assistant @-mentions ------------------------------------------------
+  // The message text is the source of truth: this list only remembers which id
+  // each `@Name` token stands for, and a token the user deletes stops counting.
+  const [mentionedAssistants, setMentionedAssistants] = useState<
+    AssistantMention[]
+  >([]);
+  const [mentionTrigger, setMentionTrigger] = useState<MentionTrigger | null>(
+    null,
+  );
+  const dismissedMentionRef = useRef<{
+    startIndex: number;
+    text: string;
+  } | null>(null);
+  const [isAssistantBrowserOpen, setIsAssistantBrowserOpen] = useState(false);
+  const mentionPopoverRef = useRef<AssistantMentionPopoverHandle>(null);
+  const {
+    isAvailable: canMentionAssistants,
+    suggested: suggestedAssistants,
+    all: mentionableAssistants,
+  } = useMentionableAssistants(assistantId);
+
   // --- Queue-the-next-message (ERMAIN-470) ---------------------------------
   // The queued payload lives in the messageQueueStore keyed by the stable
   // compose session (so it survives the new-chat null->real-id rename and stays
@@ -663,6 +713,10 @@ export const ChatInput = ({
     setQueuedBySessionId(composeSessionId, {
       message: trimmedMessage,
       attachedFiles,
+      mentionedAssistants: pruneTrackedMentions(
+        trimmedMessage,
+        mentionedAssistants,
+      ),
     });
     setMessage("");
     handleRemoveAllFiles();
@@ -676,6 +730,7 @@ export const ChatInput = ({
     isCapturingAudio,
     message,
     attachedFiles,
+    mentionedAssistants,
     getQueuedBySessionId,
     setQueuedBySessionId,
     composeSessionId,
@@ -690,6 +745,10 @@ export const ChatInput = ({
       setQueuedBySessionId(composeSessionId, {
         message: trimmedMessage,
         attachedFiles,
+        mentionedAssistants: pruneTrackedMentions(
+          trimmedMessage,
+          mentionedAssistants,
+        ),
       });
       setMessage("");
       handleRemoveAllFiles();
@@ -698,6 +757,7 @@ export const ChatInput = ({
   }, [
     message,
     attachedFiles,
+    mentionedAssistants,
     setQueuedBySessionId,
     composeSessionId,
     handleRemoveAllFiles,
@@ -707,9 +767,14 @@ export const ChatInput = ({
   // merging with whatever the user has typed since so nothing is lost.
   const restoreQueuedToComposer = useCallback(
     (queued: ComposeDraftState) => {
-      const merged = mergeComposeDrafts(queued, { message, attachedFiles });
+      const merged = mergeComposeDrafts(queued, {
+        message,
+        attachedFiles,
+        mentionedAssistants,
+      });
       setMessage(merged.message);
       setAttachedFiles(merged.attachedFiles.slice(0, maxFiles));
+      setMentionedAssistants(merged.mentionedAssistants);
       clearQueuedBySessionId(composeSessionId);
       setIsDrainArmed(false);
       setQueueReplacePending(false);
@@ -717,6 +782,7 @@ export const ChatInput = ({
     [
       message,
       attachedFiles,
+      mentionedAssistants,
       maxFiles,
       setAttachedFiles,
       clearQueuedBySessionId,
@@ -923,8 +989,14 @@ export const ChatInput = ({
     saveComposeDraftBySessionId(activeComposeSessionIdRef.current, {
       message,
       attachedFiles,
+      mentionedAssistants,
     });
-  }, [message, attachedFiles, saveComposeDraftBySessionId]);
+  }, [
+    message,
+    attachedFiles,
+    mentionedAssistants,
+    saveComposeDraftBySessionId,
+  ]);
 
   // Seed the composer from this session's stored draft, so a remount (New Chat
   // bumping ChatProvider's mountKey, or the empty-state → messages layout flip)
@@ -939,6 +1011,9 @@ export const ChatInput = ({
     }
     if (draft.attachedFiles.length) {
       setAttachedFiles(draft.attachedFiles);
+    }
+    if (draft.mentionedAssistants.length) {
+      setMentionedAssistants(draft.mentionedAssistants);
     }
     // Mount-only: later session switches are handled by the switch effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -982,9 +1057,14 @@ export const ChatInput = ({
     // chat (ERMAIN-470): it never auto-sends in the background and reappears in
     // the composer when the user returns.
     const outgoingQueued = getQueuedBySessionId(previousSessionId);
+    const outgoingComposer = {
+      message,
+      attachedFiles,
+      mentionedAssistants,
+    };
     const outgoingDraft = outgoingQueued
-      ? mergeComposeDrafts(outgoingQueued, { message, attachedFiles })
-      : { message, attachedFiles };
+      ? mergeComposeDrafts(outgoingQueued, outgoingComposer)
+      : outgoingComposer;
     saveComposeDraftBySessionId(previousSessionId, outgoingDraft);
     if (outgoingQueued) {
       clearQueuedBySessionId(previousSessionId);
@@ -995,16 +1075,37 @@ export const ChatInput = ({
     activeComposeSessionIdRef.current = composeSessionId;
     setMessage(incoming.message);
     setAttachedFiles(incoming.attachedFiles);
+    setMentionedAssistants(incoming.mentionedAssistants);
   }, [
     composeSessionId,
     message,
     attachedFiles,
+    mentionedAssistants,
     getComposeDraftBySessionId,
     saveComposeDraftBySessionId,
     getQueuedBySessionId,
     clearQueuedBySessionId,
     setAttachedFiles,
   ]);
+
+  const hasReconciledMentionsRef = useRef(false);
+
+  // Deleting a token drops the mention: reconcile against the text on every
+  // change. `pruneTrackedMentions` returns the same array when nothing was
+  // dropped, so this settles in one pass.
+  useEffect(() => {
+    // The mount run still closes over the pre-seed empty text while the seed
+    // above has already restored the draft's mentions, so it would prune every
+    // one of them. The seed changes `message`, which re-runs this in the same
+    // flush against the text they belong to.
+    if (!hasReconciledMentionsRef.current) {
+      hasReconciledMentionsRef.current = true;
+      return;
+    }
+    setMentionedAssistants((tracked) =>
+      tracked.length === 0 ? tracked : pruneTrackedMentions(message, tracked),
+    );
+  }, [message]);
 
   useEffect(() => {
     if (availableFacets.length === 0) {
@@ -1219,6 +1320,11 @@ export const ChatInput = ({
         return;
       }
 
+      const mentionedAssistantIds = resolveMentionedAssistantIds(
+        messageContent,
+        mentionedAssistants,
+      );
+
       logger.log("Submit:", {
         messagePreview:
           messageContent.substring(0, 20) +
@@ -1226,12 +1332,14 @@ export const ChatInput = ({
         files: inputFileIds,
         model: selectedModel?.chat_provider_id,
         selectedFacetIds,
+        mentionedAssistantIds,
       });
       onSendMessage(
         messageContent,
         inputFileIds,
         selectedModel?.chat_provider_id,
         selectedFacetIds,
+        mentionedAssistantIds,
       );
     },
     isLoading ||
@@ -1335,6 +1443,7 @@ export const ChatInput = ({
       setQueueReplacePending(false);
       // Model/facets are read live (not snapshotted at enqueue) so a selection
       // the user changes while the message waits applies to the sent message.
+      // Mentions are the exception: they are part of the queued text.
       onSendMessage(
         stillQueued.message,
         stillQueued.attachedFiles.length > 0
@@ -1342,6 +1451,10 @@ export const ChatInput = ({
           : undefined,
         selectedModel?.chat_provider_id,
         selectedFacetIds,
+        resolveMentionedAssistantIds(
+          stillQueued.message,
+          stillQueued.mentionedAssistants,
+        ),
       );
     }, 0);
     return () => clearTimeout(timer);
@@ -1427,6 +1540,115 @@ export const ChatInput = ({
     ],
   );
 
+  // Keep the caret-derived trigger current: typing moves it, and so does a
+  // plain caret move, which can leave or re-enter a half-typed mention.
+  const syncMentionTrigger = useCallback(
+    (element: HTMLTextAreaElement) => {
+      if (!canMentionAssistants) {
+        return;
+      }
+      const trigger = detectMentionTrigger(
+        element.value.slice(0, element.selectionStart),
+      );
+      const dismissed = dismissedMentionRef.current;
+      const isDismissed =
+        trigger !== null &&
+        dismissed !== null &&
+        dismissed.startIndex === trigger.startIndex &&
+        dismissed.text === element.value;
+      setMentionTrigger(isDismissed ? null : trigger);
+    },
+    [canMentionAssistants],
+  );
+
+  // Escape and click-outside dismiss the picker for one fragment. Without
+  // remembering which, the keyup of that very Escape — or any later caret move
+  // over the same untouched text — re-detects it and pops the picker back.
+  const dismissMentionTrigger = useCallback(() => {
+    dismissedMentionRef.current = mentionTrigger
+      ? { startIndex: mentionTrigger.startIndex, text: message }
+      : null;
+    setMentionTrigger(null);
+  }, [mentionTrigger, message]);
+
+  const insertAssistantMention = useCallback(
+    (assistant: MentionableAssistant) => {
+      // Without a live trigger the mention was picked from a menu rather than
+      // typed, so it lands at the end of the draft instead of at the caret.
+      const hasTrigger = mentionTrigger !== null;
+      const text =
+        hasTrigger || message.length === 0 || /\s$/.test(message)
+          ? message
+          : `${message} `;
+      const caret = hasTrigger
+        ? (textareaRef.current?.selectionStart ?? text.length)
+        : text.length;
+      const trigger = mentionTrigger ?? { query: "", startIndex: text.length };
+      const next = applyMentionSelection(text, caret, trigger, assistant.name);
+
+      setMessage(next.text);
+      setMentionedAssistants((tracked) =>
+        tracked.some(
+          (mention) =>
+            mention.id === assistant.id && mention.name === assistant.name,
+        )
+          ? tracked
+          : [...tracked, { id: assistant.id, name: assistant.name }],
+      );
+      setMentionTrigger(null);
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current;
+        if (!textarea) {
+          return;
+        }
+        textarea.focus();
+        textarea.setSelectionRange(next.caret, next.caret);
+      });
+    },
+    [message, mentionTrigger],
+  );
+
+  // A typed query searches everything accessible; an empty one shows the
+  // suggestions, which is what the menus offer too.
+  const mentionMatches = useMemo(() => {
+    if (!mentionTrigger) {
+      return [];
+    }
+    const query = mentionTrigger.query.toLowerCase();
+    if (!query) {
+      return suggestedAssistants;
+    }
+    return mentionableAssistants
+      .filter((assistant) => assistant.name.toLowerCase().includes(query))
+      .slice(0, MENTION_SUGGESTION_LIMIT);
+  }, [mentionTrigger, mentionableAssistants, suggestedAssistants]);
+
+  // The browse dialog is opened from the picker and keeps the in-progress
+  // trigger alive, so that a pick there still replaces the typed fragment.
+  const isMentionPickerOpen =
+    canMentionAssistants &&
+    !composeLocked &&
+    !isAssistantBrowserOpen &&
+    mentionMatches.length > 0;
+
+  const assistantMentionSection = useMemo(
+    () =>
+      canMentionAssistants
+        ? buildAssistantMentionSection({
+            assistants: suggestedAssistants,
+            onSelect: insertAssistantMention,
+            onBrowse: () => setIsAssistantBrowserOpen(true),
+            disabled: composeLocked,
+          })
+        : undefined,
+    [
+      canMentionAssistants,
+      composeLocked,
+      insertAssistantMention,
+      suggestedAssistants,
+    ],
+  );
+
   // Collapse the file-upload button and the Tools dropdown into a single "+"
   // menu (ChatInputAddControls): on mobile, or whenever a host registers extra
   // add-menu content (e.g. the Outlook add-in's email-content sources, which
@@ -1440,7 +1662,10 @@ export const ChatInput = ({
   const useUnifiedMobileMenu =
     (isMobile || hasAddMenuExtraContent) &&
     componentRegistry.ChatFileSourceSelector == null &&
-    (canUploadFiles || hasFacets || hasAddMenuExtraContent);
+    (canUploadFiles ||
+      hasFacets ||
+      hasAddMenuExtraContent ||
+      canMentionAssistants);
 
   // Add token limit exceeded to disabled state for the send button
   const isSendDisabled =
@@ -2232,9 +2457,23 @@ export const ChatInput = ({
           confirmButtonVariant="danger"
         />
 
+        {canMentionAssistants && (
+          <AssistantBrowserModal
+            isOpen={isAssistantBrowserOpen}
+            onClose={() => {
+              setIsAssistantBrowserOpen(false);
+              // Dismissing the dialog leaves focus nowhere; a pick lands the
+              // caret after the inserted token instead.
+              focusInput();
+            }}
+            assistants={mentionableAssistants}
+            onSelect={insertAssistantMention}
+          />
+        )}
+
         <div
           className={clsx(
-            "w-full",
+            "relative w-full",
             "border border-[var(--theme-border-chat-input)]",
             "theme-transition focus-within:border-[var(--theme-border-chat-input-focus)]",
             "flex flex-col",
@@ -2243,6 +2482,43 @@ export const ChatInput = ({
           )}
           data-ui="chat-input-shell"
         >
+          {/* Out of flow on purpose: the shell is a gapped flex column, so an
+              in-flow anchor would add a row of spacing to every composer. */}
+          {canMentionAssistants && (
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-0">
+              <AssistantMentionPopover
+                ref={mentionPopoverRef}
+                isOpen={isMentionPickerOpen}
+                onOpenChange={(open) => {
+                  if (!open) {
+                    dismissMentionTrigger();
+                  }
+                }}
+                assistants={mentionMatches}
+                onSelect={insertAssistantMention}
+                onBrowse={() => setIsAssistantBrowserOpen(true)}
+                onRestoreFocus={focusInput}
+              />
+            </div>
+          )}
+
+          {/* The picker leaves the caret in the textarea, so nothing else tells
+              a screen reader it opened or that Enter now inserts instead of
+              sending. Mounted unconditionally because a live region only
+              announces content that changes after it exists, and deliberately
+              countless so filtering does not re-announce on every keystroke. */}
+          {canMentionAssistants && (
+            <div className="sr-only" role="status" aria-live="polite">
+              {isMentionPickerOpen
+                ? t({
+                    id: "chatInput.mentions.pickerAnnouncement",
+                    message:
+                      "Assistant suggestions available. Press the down arrow to browse them, or Enter to mention the first.",
+                  })
+                : ""}
+            </div>
+          )}
+
           {ChatInputAttachmentPreview && (
             <ChatInputAttachmentPreview
               attachedFiles={attachedFiles}
@@ -2259,9 +2535,20 @@ export const ChatInput = ({
             <textarea
               ref={textareaRef}
               value={message}
-              onChange={(e) => setMessage(e.target.value)}
+              onChange={(e) => {
+                setMessage(e.target.value);
+                syncMentionTrigger(e.target);
+              }}
+              onSelect={(e) => syncMentionTrigger(e.currentTarget)}
+              onClick={(e) => syncMentionTrigger(e.currentTarget)}
+              onKeyUp={(e) => syncMentionTrigger(e.currentTarget)}
               onPaste={handleTextareaPaste}
               onKeyDown={(e) => {
+                // The open picker owns Enter, Tab and the arrows — it has to
+                // run before Enter reaches send/queue.
+                if (mentionPopoverRef.current?.handleComposerKeyDown(e)) {
+                  return;
+                }
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault();
                   // While a turn is generating, Enter queues the draft to
@@ -2328,6 +2615,7 @@ export const ChatInput = ({
                     facets={availableFacets}
                     selectedFacetIds={selectedFacetIds}
                     onToggleFacet={toggleFacetId}
+                    assistantSection={assistantMentionSection}
                     disabled={composeLocked}
                     uploadDisabled={attachedFiles.length >= maxFiles}
                     toolsDisabled={enforceSelectedFacetIds}
@@ -2361,10 +2649,12 @@ export const ChatInput = ({
                         }
                       />
                     )}
-                    {availableFacets.length > 0 && (
+                    {(availableFacets.length > 0 ||
+                      assistantMentionSection) && (
                       <FacetSelector
                         facets={availableFacets}
                         selectedFacetIds={selectedFacetIds}
+                        assistantSection={assistantMentionSection}
                         onSelectionChange={(nextSelectedFacetIds) => {
                           userSelectedFacetsSessionRef.current =
                             composeSessionId;
@@ -2378,7 +2668,8 @@ export const ChatInput = ({
                           globalFacetSettings?.show_facet_indicator_with_display_name ??
                           false
                         }
-                        disabled={composeLocked || enforceSelectedFacetIds}
+                        disabled={composeLocked}
+                        toolsDisabled={enforceSelectedFacetIds}
                       />
                     )}
                   </>

--- a/frontend/src/components/ui/Chat/ChatInputAddControls.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddControls.tsx
@@ -9,7 +9,7 @@ import { ResolvedIcon } from "../icons";
 import { ChatInputAddMenu } from "./ChatInputAddMenu";
 import { getFacetDisplayName } from "./FacetSelector";
 
-import type { AddMenuToolItem } from "./ChatInputAddMenu";
+import type { AddMenuSection, AddMenuToolItem } from "./ChatInputAddMenu";
 import type { UseChatFileSourcesParams } from "@/hooks/files/useChatFileSources";
 import type { FacetInfo } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
@@ -28,6 +28,12 @@ export interface ChatInputAddControlsProps {
   facets: FacetInfo[];
   selectedFacetIds: string[];
   onToggleFacet: (facetId: string) => void;
+
+  /**
+   * Extra group appended below the tools — the same section the desktop tool
+   * dropdown renders, so both hosts offer identical assistant rows.
+   */
+  assistantSection?: AddMenuSection;
 
   /** Disable the whole control (general composer-disabled state). */
   disabled?: boolean;
@@ -49,6 +55,7 @@ export function ChatInputAddControls({
   facets,
   selectedFacetIds,
   onToggleFacet,
+  assistantSection,
   disabled = false,
   uploadDisabled = false,
   toolsDisabled = false,
@@ -105,6 +112,7 @@ export function ChatInputAddControls({
       <ChatInputAddMenu
         fileSources={canUpload ? fileSourceItems : []}
         tools={tools}
+        extraSections={assistantSection ? [assistantSection] : undefined}
         extraContent={
           ExtraContent
             ? ({ close }) => (

--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -32,6 +32,12 @@ export interface AddMenuItemBase {
 export interface AddMenuActionItem extends AddMenuItemBase {
   /** Optional secondary line (e.g. file size, provider hint). */
   description?: React.ReactNode;
+  /**
+   * Skip the close delay. Required of any row that opens a dialog: the delayed
+   * close returns focus to the trigger *after* the dialog has focused itself,
+   * pulling focus out from under the overlay.
+   */
+  closesImmediately?: boolean;
   onSelect: () => void;
 }
 
@@ -94,7 +100,7 @@ export interface ChatInputAddMenuProps {
 // visible for a beat before the menu dismisses.
 const CLOSE_ON_SELECT_DELAY_MS = 100;
 
-const sectionDivider = "my-1 h-px bg-theme-border";
+export const addMenuSectionDividerClassName = "my-1 h-px bg-theme-border";
 
 // Rows share DropdownMenu's item channel — geometry class, typography and
 // hover/focus colors — so customer themes retune every menu surface together.
@@ -104,7 +110,64 @@ const rowClassName =
 // CSS selector for the menu's navigable rows; natively-disabled rows are
 // excluded from roving focus (aria-disabled tool rows stay reachable).
 // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS selector, not user-facing
-const NAVIGABLE_ITEM_SELECTOR = "[data-add-menu-item]:not([disabled])";
+export const ADD_MENU_ITEM_SELECTOR = "[data-add-menu-item]:not([disabled])";
+
+export interface AddMenuActionRowProps {
+  label: React.ReactNode;
+  /** Optional secondary line (e.g. file size, assistant description). */
+  description?: React.ReactNode;
+  icon?: React.ReactNode;
+  disabled?: boolean;
+  testId?: string;
+  onActivate: () => void;
+}
+
+/**
+ * One activatable menu row. Exported so surfaces outside this menu — the
+ * composer's mention picker — present identical rows without re-deriving the
+ * item channel or the roving-focus contract.
+ */
+export function AddMenuActionRow({
+  label,
+  description,
+  icon,
+  disabled = false,
+  testId,
+  onActivate,
+}: AddMenuActionRowProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      tabIndex={-1}
+      data-add-menu-item=""
+      onClick={onActivate}
+      disabled={disabled}
+      data-testid={testId}
+      className={clsx(
+        rowClassName,
+        "disabled:cursor-not-allowed disabled:opacity-50",
+      )}
+    >
+      {icon && (
+        <span
+          className="flex size-5 shrink-0 items-center justify-center"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate">{label}</span>
+        {description && (
+          <span className="block truncate text-xs text-theme-fg-muted">
+            {description}
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
 
 function SectionHeader({
   id,
@@ -158,7 +221,7 @@ export function ChatInputAddMenu({
   useRovingMenuFocus({
     containerRef: panelRef,
     enabled: isOpen,
-    itemSelector: NAVIGABLE_ITEM_SELECTOR,
+    itemSelector: ADD_MENU_ITEM_SELECTOR,
   });
 
   const cancelPendingClose = useCallback(() => {
@@ -198,45 +261,27 @@ export function ChatInputAddMenu({
   useEffect(() => () => clearTimeout(closeTimerRef.current), []);
 
   const renderActionRow = (item: AddMenuActionItem, testId: string) => (
-    <button
+    <AddMenuActionRow
       key={item.id}
-      type="button"
-      role="menuitem"
-      tabIndex={-1}
-      data-add-menu-item=""
-      onClick={() => {
+      label={item.label}
+      description={item.description}
+      icon={item.icon}
+      disabled={isBusy || item.disabled}
+      testId={testId}
+      onActivate={() => {
         // A pending close means a selection already ran; the row stays
         // mounted through the close delay, so swallow re-activations.
         if (closeTimerRef.current !== undefined) {
           return;
         }
         item.onSelect();
+        if (item.closesImmediately) {
+          closeNow();
+          return;
+        }
         closeAfterSelect();
       }}
-      disabled={isBusy || item.disabled}
-      data-testid={testId}
-      className={clsx(
-        rowClassName,
-        "disabled:cursor-not-allowed disabled:opacity-50",
-      )}
-    >
-      {item.icon && (
-        <span
-          className="flex size-5 shrink-0 items-center justify-center"
-          aria-hidden="true"
-        >
-          {item.icon}
-        </span>
-      )}
-      <span className="min-w-0 flex-1">
-        <span className="block truncate">{item.label}</span>
-        {item.description && (
-          <span className="block truncate text-xs text-theme-fg-muted">
-            {item.description}
-          </span>
-        )}
-      </span>
-    </button>
+    />
   );
 
   const renderExtraSection = (section: AddMenuSection) => {
@@ -366,7 +411,7 @@ export function ChatInputAddMenu({
       ariaHasPopup="menu"
       role="menu"
       preferredOrientation={{ vertical: "top", horizontal: "left" }}
-      initialFocusSelector={NAVIGABLE_ITEM_SELECTOR}
+      initialFocusSelector={ADD_MENU_ITEM_SELECTOR}
       panelStyle={{
         maxWidth:
           "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
@@ -417,7 +462,7 @@ export function ChatInputAddMenu({
       >
         {blocks.map((block, index) => (
           <Fragment key={block.key}>
-            {index > 0 && <div className={sectionDivider} />}
+            {index > 0 && <div className={addMenuSectionDividerClassName} />}
             {block.node}
           </Fragment>
         ))}

--- a/frontend/src/components/ui/Chat/FacetSelector.tsx
+++ b/frontend/src/components/ui/Chat/FacetSelector.tsx
@@ -152,16 +152,19 @@ export const FacetSelector = ({
   // Without facets the control carries assistants alone, so the trigger has to
   // say so — the delegation surface must stay reachable on a facet-less deployment.
   const isAssistantsOnly = facets.length === 0;
+  // Locked tools leave the menu worth opening only for the assistants; with no
+  // assistants group every row is dead, so the trigger goes inert instead.
+  const isMenuInert = disabled || (toolsDisabled && !assistantSection);
 
   return (
     <div
       className={clsx(
         "flex items-center gap-1",
-        disabled && "cursor-not-allowed opacity-50",
+        isMenuInert && "cursor-not-allowed opacity-50",
         className,
       )}
     >
-      <div className={clsx(disabled && "pointer-events-none")}>
+      <div className={clsx(isMenuInert && "pointer-events-none")}>
         <DropdownMenu
           items={dropdownItems}
           align="right"

--- a/frontend/src/components/ui/Chat/FacetSelector.tsx
+++ b/frontend/src/components/ui/Chat/FacetSelector.tsx
@@ -5,8 +5,9 @@ import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/Controls/Button";
 
 import { DropdownMenu } from "../Controls/DropdownMenu";
-import { ChevronDownIcon, ResolvedIcon, ToolsIcon } from "../icons";
+import { AtSignIcon, ChevronDownIcon, ResolvedIcon, ToolsIcon } from "../icons";
 
+import type { AddMenuSection } from "./ChatInputAddMenu";
 import type { DropdownMenuItem } from "../Controls/DropdownMenu";
 import type { FacetInfo } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
@@ -16,7 +17,19 @@ interface FacetSelectorProps {
   onSelectionChange: (selectedFacetIds: string[]) => void;
   onlySingleFacet: boolean;
   showFacetIndicatorWithDisplayName: boolean;
+  /**
+   * Extra group appended below the tools — the same section the mobile "+"
+   * menu renders, so both hosts offer identical assistant rows.
+   */
+  assistantSection?: AddMenuSection;
+  /** Disable the whole control (composer lock). */
   disabled?: boolean;
+  /**
+   * Extra gate for the facet rows alone (enforced facet settings). The
+   * assistants group stays live: a chat whose tools are locked may still
+   * delegate.
+   */
+  toolsDisabled?: boolean;
   className?: string;
 }
 
@@ -37,7 +50,9 @@ export const FacetSelector = ({
   onSelectionChange,
   onlySingleFacet,
   showFacetIndicatorWithDisplayName,
+  assistantSection,
   disabled = false,
+  toolsDisabled = false,
   className = "",
 }: FacetSelectorProps) => {
   // Keep this! Meant as placeholder for docs.
@@ -55,7 +70,7 @@ export const FacetSelector = ({
 
   const toggleFacetSelection = useCallback(
     (facetId: string) => {
-      if (disabled) {
+      if (disabled || toolsDisabled) {
         return;
       }
 
@@ -81,6 +96,7 @@ export const FacetSelector = ({
     },
     [
       disabled,
+      toolsDisabled,
       facets,
       onSelectionChange,
       onlySingleFacet,
@@ -90,19 +106,52 @@ export const FacetSelector = ({
   );
 
   const dropdownItems: DropdownMenuItem[] = useMemo(() => {
-    return facets.map((facet) => {
+    const facetItems = facets.map((facet) => {
       return {
+        id: facet.id,
         label: getFacetDisplayName(facet),
         icon: <ResolvedIcon iconId={facet.icon} className="size-4" />,
         onClick: () => toggleFacetSelection(facet.id),
         checked: selectedFacetIdsSet.has(facet.id),
+        disabled: toolsDisabled,
       };
     });
-  }, [facets, selectedFacetIdsSet, toggleFacetSelection]);
 
-  if (facets.length === 0) {
+    if (!assistantSection) {
+      return facetItems;
+    }
+
+    // The group label is only worth a row when there is something above it to
+    // separate the assistants from.
+    return [
+      ...facetItems,
+      ...assistantSection.items.map((item, index) => ({
+        id: item.id,
+        label: item.label,
+        onClick: item.onSelect,
+        disabled: item.disabled,
+        closesImmediately: item.closesImmediately,
+        sectionHeader:
+          index === 0 && facetItems.length > 0
+            ? assistantSection.header
+            : undefined,
+      })),
+    ];
+  }, [
+    assistantSection,
+    facets,
+    selectedFacetIdsSet,
+    toggleFacetSelection,
+    toolsDisabled,
+  ]);
+
+  if (facets.length === 0 && !assistantSection) {
     return null;
   }
+
+  // Without facets the control carries assistants alone, so the trigger has to
+  // say so — the delegation surface must stay reachable on a facet-less deployment.
+  const isAssistantsOnly = facets.length === 0;
 
   return (
     <div
@@ -121,8 +170,19 @@ export const FacetSelector = ({
           noWrapItems
           triggerIcon={
             <div className="flex items-center gap-1 px-2">
-              <ToolsIcon className="size-4" />
-              <span className="text-sm font-medium">{t`Tools`}</span>
+              {isAssistantsOnly ? (
+                <AtSignIcon className="size-4" />
+              ) : (
+                <ToolsIcon className="size-4" />
+              )}
+              <span className="text-sm font-medium">
+                {isAssistantsOnly
+                  ? t({
+                      id: "chatInput.mentions.sectionHeader",
+                      message: "Assistants",
+                    })
+                  : t`Tools`}
+              </span>
               <ChevronDownIcon
                 className={clsx(
                   "size-3 shrink-0 text-[var(--theme-fg-secondary)] transition-transform duration-200",
@@ -145,7 +205,7 @@ export const FacetSelector = ({
               type="button"
               variant="ghost"
               size="sm"
-              disabled={disabled}
+              disabled={disabled || toolsDisabled}
               onClick={() => toggleFacetSelection(facet.id)}
               icon={<ResolvedIcon iconId={facet.icon} className="size-4" />}
               data-testid={`selected-facet-${facet.id}`}

--- a/frontend/src/components/ui/Chat/__tests__/ChatInputAddControls.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/ChatInputAddControls.test.tsx
@@ -4,7 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { componentRegistry } from "@/config/componentRegistry";
 
 import { ChatInputAddControls } from "../ChatInputAddControls";
+import { buildAssistantMentionSection } from "../assistantMentionSection";
 
+import type { AddMenuSection } from "../ChatInputAddMenu";
 import type { ChatAddMenuExtraContentProps } from "@/config/componentRegistry";
 
 vi.mock("@/hooks/files/useChatFileSources", () => ({
@@ -24,7 +26,12 @@ function ProbeExtraContent(props: ChatAddMenuExtraContentProps) {
   return <div data-testid="probe-extra-content" />;
 }
 
-function renderControls(props: Partial<{ uploadDisabled: boolean }> = {}) {
+function renderControls(
+  props: Partial<{
+    uploadDisabled: boolean;
+    assistantSection: AddMenuSection;
+  }> = {},
+) {
   return render(
     <ChatInputAddControls
       canUpload
@@ -69,5 +76,46 @@ describe("ChatInputAddControls", () => {
     const props = seenExtraContentProps.at(-1);
     expect(props?.uploadDisabled).toBe(false);
     expect(props?.disabled).toBe(false);
+  });
+
+  it("renders the assistants section as menu rows", () => {
+    const onSelect = vi.fn();
+    renderControls({
+      assistantSection: buildAssistantMentionSection({
+        assistants: [{ id: "a-1", name: "Researcher" }],
+        onSelect,
+        onBrowse: vi.fn(),
+      }),
+    });
+    fireEvent.click(screen.getByTestId("chat-input-add-menu-trigger"));
+
+    expect(screen.getByText("Assistants")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("chat-input-add-menu-extra-browse-assistants"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("chat-input-add-menu-extra-a-1"));
+    expect(onSelect).toHaveBeenCalledWith({ id: "a-1", name: "Researcher" });
+  });
+
+  // The browse row opens a dialog that focuses itself: the menu's usual
+  // delayed close would return focus to the "+" trigger behind the overlay.
+  it("closes without the select delay when browse opens the dialog", () => {
+    const onBrowse = vi.fn();
+    renderControls({
+      assistantSection: buildAssistantMentionSection({
+        assistants: [{ id: "a-1", name: "Researcher" }],
+        onSelect: vi.fn(),
+        onBrowse,
+      }),
+    });
+    fireEvent.click(screen.getByTestId("chat-input-add-menu-trigger"));
+
+    fireEvent.click(
+      screen.getByTestId("chat-input-add-menu-extra-browse-assistants"),
+    );
+
+    expect(onBrowse).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/Chat/__tests__/FacetSelector.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/FacetSelector.test.tsx
@@ -123,4 +123,17 @@ describe("FacetSelector", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Researcher" }));
     expect(onSelect).toHaveBeenCalledWith(RESEARCHER);
   });
+
+  // Without delegation there is nothing left to pick, so enforcement keeps the
+  // whole control inert rather than opening a menu of dead rows.
+  it("locks the trigger when the tools are locked and no assistant is offered", () => {
+    renderSelector({
+      facets: [WEB_SEARCH],
+      toolsDisabled: true,
+      withAssistants: false,
+    });
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    expect(trigger.closest(".pointer-events-none")).not.toBeNull();
+  });
 });

--- a/frontend/src/components/ui/Chat/__tests__/FacetSelector.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/FacetSelector.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FacetSelector } from "../FacetSelector";
+import { buildAssistantMentionSection } from "../assistantMentionSection";
+
+import type { FacetInfo } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+const WEB_SEARCH: FacetInfo = {
+  id: "facet-1",
+  display_name: "Web search",
+  default_enabled: false,
+};
+
+const RESEARCHER = { id: "assistant-research", name: "Researcher" };
+
+function renderSelector({
+  facets = [] as FacetInfo[],
+  toolsDisabled = false,
+  onSelect = vi.fn(),
+  onBrowse = vi.fn(),
+  onSelectionChange = vi.fn(),
+  withAssistants = true,
+} = {}) {
+  render(
+    <FacetSelector
+      facets={facets}
+      selectedFacetIds={[]}
+      onSelectionChange={onSelectionChange}
+      onlySingleFacet={false}
+      showFacetIndicatorWithDisplayName={false}
+      toolsDisabled={toolsDisabled}
+      assistantSection={
+        withAssistants
+          ? buildAssistantMentionSection({
+              assistants: [RESEARCHER],
+              onSelect,
+              onBrowse,
+            })
+          : undefined
+      }
+    />,
+  );
+  return { onSelect, onBrowse, onSelectionChange };
+}
+
+describe("FacetSelector", () => {
+  it("renders nothing without facets or assistants", () => {
+    const { container } = render(
+      <FacetSelector
+        facets={[]}
+        selectedFacetIds={[]}
+        onSelectionChange={vi.fn()}
+        onlySingleFacet={false}
+        showFacetIndicatorWithDisplayName={false}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // A deployment without facets must still reach delegation from the composer.
+  it("carries the assistants alone when no facet is configured", async () => {
+    const { onSelect } = renderSelector();
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    expect(trigger).toHaveTextContent("Assistants");
+
+    fireEvent.click(trigger);
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Browse assistants…" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Researcher" }));
+    expect(onSelect).toHaveBeenCalledWith(RESEARCHER);
+  });
+
+  // The dialog focuses itself; the dropdown's usual delayed close would hand
+  // focus back to the trigger behind the overlay.
+  it("closes without the select delay when browse opens the dialog", async () => {
+    const { onBrowse } = renderSelector();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Browse assistants…" }),
+    );
+
+    expect(onBrowse).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("labels the assistants as their own group below the tools", async () => {
+    renderSelector({ facets: [WEB_SEARCH] });
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    expect(trigger).toHaveTextContent("Tools");
+    fireEvent.click(trigger);
+
+    const group = await screen.findByRole("group", { name: "Assistants" });
+    expect(
+      within(group)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual(["Researcher", "Browse assistants…"]);
+  });
+
+  // Enforced facet settings lock the tools, not delegation to other assistants.
+  it("keeps the assistants selectable while the facet rows are locked", async () => {
+    const { onSelect, onSelectionChange } = renderSelector({
+      facets: [WEB_SEARCH],
+      toolsDisabled: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const facetRow = await screen.findByRole("menuitem", {
+      name: "Web search",
+    });
+    expect(facetRow).toBeDisabled();
+    fireEvent.click(facetRow);
+    expect(onSelectionChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Researcher" }));
+    expect(onSelect).toHaveBeenCalledWith(RESEARCHER);
+  });
+});

--- a/frontend/src/components/ui/Chat/assistantMentionSection.ts
+++ b/frontend/src/components/ui/Chat/assistantMentionSection.ts
@@ -1,0 +1,55 @@
+import { t } from "@lingui/core/macro";
+
+import type { AddMenuSection } from "./ChatInputAddMenu";
+import type { MentionableAssistant } from "@/hooks/chat/useMentionableAssistants";
+
+export const ASSISTANT_MENTION_SECTION_ID = "assistant-mentions";
+export const ASSISTANT_MENTION_BROWSE_ITEM_ID = "browse-assistants";
+
+interface AssistantMentionSectionOptions {
+  assistants: MentionableAssistant[];
+  onSelect: (assistant: MentionableAssistant) => void;
+  onBrowse: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * The "Assistants" group in its host-neutral form. Both composer surfaces —
+ * the mobile "+" menu and the desktop tool dropdown — render this same data,
+ * so the offered assistants and their order never diverge between hosts.
+ */
+export function buildAssistantMentionSection({
+  assistants,
+  onSelect,
+  onBrowse,
+  disabled = false,
+}: AssistantMentionSectionOptions): AddMenuSection {
+  return {
+    id: ASSISTANT_MENTION_SECTION_ID,
+    header: t({
+      id: "chatInput.mentions.sectionHeader",
+      message: "Assistants",
+    }),
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- AddMenuSection placement enum
+    placement: "belowTools",
+    items: [
+      ...assistants.map((assistant) => ({
+        id: assistant.id,
+        label: assistant.name,
+        description: assistant.description,
+        disabled,
+        onSelect: () => onSelect(assistant),
+      })),
+      {
+        id: ASSISTANT_MENTION_BROWSE_ITEM_ID,
+        label: t({
+          id: "chatInput.mentions.browse",
+          message: "Browse assistants…",
+        }),
+        disabled,
+        closesImmediately: true,
+        onSelect: onBrowse,
+      },
+    ],
+  };
+}

--- a/frontend/src/components/ui/Controls/AnchoredPopover.tsx
+++ b/frontend/src/components/ui/Controls/AnchoredPopover.tsx
@@ -46,6 +46,15 @@ export interface AnchoredPopoverProps {
   ariaHasPopup?: AnchoredPopoverTriggerProps["aria-haspopup"];
   preferredOrientation?: Orientation;
   initialFocusSelector?: string;
+  /**
+   * Focus-on-open and focus-return-on-close assume the open was initiated at
+   * the trigger. A popover opened from elsewhere — a typeahead driven by the
+   * caret, say — must set this false and place focus itself, or the panel steals
+   * the caret out of whatever the user is typing into.
+   */
+  manageFocus?: boolean;
+  /** Panel accessible name, for triggers that carry none. */
+  ariaLabel?: string;
   dataUi?: string;
 }
 
@@ -94,6 +103,8 @@ export function AnchoredPopover({
   ariaHasPopup,
   preferredOrientation,
   initialFocusSelector,
+  manageFocus = true,
+  ariaLabel,
   dataUi = "anchored-popover-panel",
 }: AnchoredPopoverProps) {
   const reactId = useId();
@@ -274,7 +285,7 @@ export function AnchoredPopover({
   }, [getPanelElement, isOpen, onOpenChange]);
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!isOpen || !manageFocus) {
       return;
     }
 
@@ -298,15 +309,15 @@ export function AnchoredPopover({
         focusTarget.focus();
       }
     });
-  }, [getPanelElement, initialFocusSelector, isOpen]);
+  }, [getPanelElement, initialFocusSelector, isOpen, manageFocus]);
 
   useEffect(() => {
-    if (wasOpenRef.current && !isOpen) {
+    if (manageFocus && wasOpenRef.current && !isOpen) {
       triggerRef.current?.focus();
     }
 
     wasOpenRef.current = isOpen;
-  }, [isOpen]);
+  }, [isOpen, manageFocus]);
 
   const triggerProps: AnchoredPopoverTriggerProps = {
     ref: triggerRef,
@@ -356,7 +367,8 @@ export function AnchoredPopover({
         visibility: isPositioned ? "visible" : "hidden",
       }}
       role={role}
-      aria-labelledby={triggerId}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabel ? undefined : triggerId}
       data-ui={dataUi}
     >
       {children}

--- a/frontend/src/components/ui/Controls/DropdownMenu.tsx
+++ b/frontend/src/components/ui/Controls/DropdownMenu.tsx
@@ -1,6 +1,15 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
-import { useState, useRef, useCallback, memo, useEffect } from "react";
+import {
+  useState,
+  useRef,
+  useCallback,
+  useId,
+  useMemo,
+  memo,
+  useEffect,
+  Fragment,
+} from "react";
 
 import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 import { useKeyboard } from "@/hooks/useKeyboard";
@@ -26,6 +35,14 @@ export interface DropdownMenuItem {
   confirmMessage?: string;
   confirmButtonVariant?: ButtonVariant;
   checked?: boolean;
+  /**
+   * Skip the close delay. Required of any row that opens a dialog: the delayed
+   * close returns focus to the trigger *after* the dialog has focused itself,
+   * pulling focus out from under the overlay.
+   */
+  closesImmediately?: boolean;
+  /** Group label rendered above this row, opening a new section. */
+  sectionHeader?: React.ReactNode;
 }
 
 export interface DropdownMenuProps {
@@ -141,6 +158,7 @@ export const DropdownMenu = memo(
     const [isProcessingClick, setIsProcessingClick] = useState(false);
     const clickTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
     const menuRef = useRef<HTMLDivElement>(null);
+    const baseId = useId();
     const [confirmingItem, setConfirmingItem] =
       useState<DropdownMenuItem | null>(null);
 
@@ -158,6 +176,12 @@ export const DropdownMenu = memo(
         if (item.confirmAction) {
           setConfirmingItem(item);
           setIsOpen(false); // Close the dropdown immediately
+          return;
+        }
+
+        if (item.closesImmediately) {
+          setIsOpen(false);
+          item.onClick();
           return;
         }
 
@@ -192,6 +216,26 @@ export const DropdownMenu = memo(
     const handleCancelConfirm = useCallback(() => {
       setConfirmingItem(null); // Just close the confirmation dialog
     }, []);
+
+    const sections = useMemo(() => {
+      const grouped: {
+        key: string;
+        header?: React.ReactNode;
+        items: { item: DropdownMenuItem; index: number }[];
+      }[] = [];
+      items.forEach((item, index) => {
+        const isNewSection = grouped.length === 0 || item.sectionHeader != null;
+        if (isNewSection) {
+          grouped.push({
+            key: item.id ?? String(index),
+            header: item.sectionHeader,
+            items: [],
+          });
+        }
+        grouped[grouped.length - 1].items.push({ item, index });
+      });
+      return grouped;
+    }, [items]);
 
     // ArrowUp/Down/Home/End roving nav across enabled items (WAI-ARIA
     // menu-button pattern). Escape-close + focus-return live in AnchoredPopover;
@@ -273,14 +317,47 @@ export const DropdownMenu = memo(
             className="dropdown-panel-chrome-geometry min-h-0 flex-1 overflow-y-auto overscroll-contain"
             role="none"
           >
-            {items.map((item, index) => (
-              <MenuItem
-                key={item.id ?? String(index)}
-                item={item}
-                noWrap={noWrapItems}
-                onSelect={(e: React.MouseEvent) => handleMenuItemClick(item, e)}
-              />
-            ))}
+            {sections.map((section, sectionIndex) => {
+              const rows = section.items.map(({ item, index }) => (
+                <MenuItem
+                  key={item.id ?? String(index)}
+                  item={item}
+                  noWrap={noWrapItems}
+                  onSelect={(e: React.MouseEvent) =>
+                    handleMenuItemClick(item, e)
+                  }
+                />
+              ));
+
+              if (section.header == null) {
+                return <Fragment key={section.key}>{rows}</Fragment>;
+              }
+
+              // A labelled run is a group, not just a styled line: without the
+              // wrapper the label is orphan text a menu reader never reaches.
+              // eslint-disable-next-line lingui/no-unlocalized-strings -- internal DOM id suffix
+              const headerId = `${baseId}-section-${sectionIndex}`;
+              return (
+                <Fragment key={section.key}>
+                  {sectionIndex > 0 && (
+                    <div
+                      role="separator"
+                      className="my-1 h-px bg-theme-border"
+                    />
+                  )}
+                  <div role="group" aria-labelledby={headerId}>
+                    <div
+                      id={headerId}
+                      role="presentation"
+                      className="px-[var(--theme-spacing-dropdown-padding-x)] pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-theme-fg-muted"
+                    >
+                      {section.header}
+                    </div>
+                    {rows}
+                  </div>
+                </Fragment>
+              );
+            })}
           </div>
         </AnchoredPopover>
 

--- a/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DropdownMenu.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { DropdownMenu } from "../DropdownMenu";
@@ -245,6 +251,59 @@ describe("DropdownMenu", () => {
       expect(document.querySelector('[data-ui="dropdown-panel"]')).toBeNull();
     });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("exposes a section header as the label of a menu group", async () => {
+    render(
+      <DropdownMenu
+        items={[
+          { id: "tool", label: "Web search", onClick: vi.fn() },
+          {
+            id: "researcher",
+            label: "Researcher",
+            onClick: vi.fn(),
+            sectionHeader: "Assistants",
+          },
+          { id: "browse", label: "Browse assistants…", onClick: vi.fn() },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const group = await screen.findByRole("group", { name: "Assistants" });
+    expect(
+      within(group)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual(["Researcher", "Browse assistants…"]);
+    expect(screen.getByRole("separator")).toBeInTheDocument();
+  });
+
+  it("closes without the select delay for a row that opens a dialog", async () => {
+    const onClick = vi.fn();
+    render(
+      <DropdownMenu
+        items={[
+          {
+            id: "browse",
+            label: "Browse assistants…",
+            onClick,
+            closesImmediately: true,
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Browse assistants…" }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // A dialog opened by the row focuses itself immediately; a delayed close
+    // would take that focus back to the trigger.
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
   it("takes its geometry from the shared control token, not a caller override", () => {

--- a/frontend/src/components/ui/icons/index.tsx
+++ b/frontend/src/components/ui/icons/index.tsx
@@ -1,4 +1,5 @@
 import {
+  AtSign,
   Copy,
   EditPencil,
   ThumbsUp,
@@ -355,6 +356,10 @@ export const PinIcon = ({ className, ...props }: IconProps) => (
 
 export const PinSlashIcon = ({ className, ...props }: IconProps) => (
   <PinSlash className={className} {...props} />
+);
+
+export const AtSignIcon = ({ className, ...props }: IconProps) => (
+  <AtSign className={className} {...props} />
 );
 
 // Iconoir has no "sliders" glyph; CandlestickChart is its vertical-sliders

--- a/frontend/src/config/__tests__/themeConfig.test.ts
+++ b/frontend/src/config/__tests__/themeConfig.test.ts
@@ -45,6 +45,7 @@ describe("themeConfig", () => {
     chatInputEmptyStateLayout: "bottom",
     disableLogout: false,
     assistantsEnabled: false,
+    assistantsDelegationEnabled: false,
     assistantsShowRecentItems: false,
     assistantsShowRecentItemsCollapsible: false,
     assistantContextWarningThreshold: 0.5,

--- a/frontend/src/hooks/chat/__tests__/useComposeSession.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useComposeSession.test.ts
@@ -72,6 +72,7 @@ describe("useComposeSession", () => {
     result.current.saveDraft(sessionA, {
       message: "unsent draft",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
 
     // Leaving via the New Chat button parks us on the sentinel before we
@@ -83,6 +84,7 @@ describe("useComposeSession", () => {
     expect(result.current.getDraft(result.current.sessionId)).toEqual({
       message: "unsent draft",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
   });
 
@@ -95,11 +97,13 @@ describe("useComposeSession", () => {
     result.current.saveDraft(id, {
       message: "hello",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
 
     expect(result.current.getDraft(id)).toEqual({
       message: "hello",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
   });
 
@@ -111,6 +115,7 @@ describe("useComposeSession", () => {
     expect(result.current.getDraft("never-saved")).toEqual({
       message: "",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
   });
 

--- a/frontend/src/hooks/chat/store/__tests__/messageQueueStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/messageQueueStore.test.ts
@@ -14,10 +14,15 @@ describe("messageQueueStore", () => {
   });
 
   it("stores, reads, and clears a queued message per session", () => {
-    store().setQueued("session-a", { message: "queued", attachedFiles: [] });
+    store().setQueued("session-a", {
+      message: "queued",
+      attachedFiles: [],
+      mentionedAssistants: [],
+    });
     expect(store().getQueued("session-a")).toEqual({
       message: "queued",
       attachedFiles: [],
+      mentionedAssistants: [],
     });
 
     store().clearQueued("session-a");
@@ -25,7 +30,11 @@ describe("messageQueueStore", () => {
   });
 
   it("isolates queues per session", () => {
-    store().setQueued("session-a", { message: "a", attachedFiles: [] });
+    store().setQueued("session-a", {
+      message: "a",
+      attachedFiles: [],
+      mentionedAssistants: [],
+    });
     expect(store().getQueued("session-b")).toBeNull();
     expect(store().getQueued("session-a")?.message).toBe("a");
   });

--- a/frontend/src/hooks/chat/store/composeSessionStore.ts
+++ b/frontend/src/hooks/chat/store/composeSessionStore.ts
@@ -25,6 +25,7 @@ interface ComposeSessionStore {
 export const EMPTY_COMPOSE_DRAFT: ComposeDraftState = Object.freeze({
   message: "",
   attachedFiles: [],
+  mentionedAssistants: [],
 });
 
 export const useComposeSessionStore = create<ComposeSessionStore>()(

--- a/frontend/src/hooks/chat/useChatActions.ts
+++ b/frontend/src/hooks/chat/useChatActions.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { createLogger } from "@/utils/debugLogger";
 
+import type { ActionFacetRequest } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { MessageAction } from "@/types/message-controls";
 
 const logger = createLogger("HOOK", "useChatActions");
@@ -14,6 +15,8 @@ interface UseChatActionsProps {
     modelId?: string,
     assistantId?: string,
     selectedFacetIds?: string[],
+    actionFacet?: ActionFacetRequest,
+    mentionedAssistantIds?: string[],
   ) => Promise<string | undefined>;
   onMessageAction?: (action: MessageAction) => Promise<boolean>;
 }
@@ -57,6 +60,7 @@ export function useChatActions({
       modelId?: string,
       assistantId?: string,
       selectedFacetIds?: string[],
+      mentionedAssistantIds?: string[],
     ) => {
       if (message.trim() || (inputFileIds && inputFileIds.length > 0)) {
         return sendMessage(
@@ -65,6 +69,8 @@ export function useChatActions({
           modelId,
           assistantId,
           selectedFacetIds,
+          undefined,
+          mentionedAssistantIds,
         );
       }
       return Promise.resolve(undefined);

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1373,6 +1373,7 @@ export function useChatMessaging(
       assistantId?: string,
       selectedFacetIds?: string[],
       actionFacet?: ActionFacetRequest,
+      mentionedAssistantIds?: string[],
     ): Promise<string | undefined> => {
       // Prevent duplicate submissions
       if (isSubmittingForKey(streamKey)) {
@@ -1487,6 +1488,7 @@ export function useChatMessaging(
           assistantId,
           selectedFacetIds,
           actionFacet,
+          mentionedAssistantIds,
         );
 
         logger.log("[DEBUG_STREAMING] sendMessage: Sending requestBody:", {

--- a/frontend/src/hooks/chat/useComposeSession.ts
+++ b/frontend/src/hooks/chat/useComposeSession.ts
@@ -3,10 +3,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useComposeSessionStore } from "@/hooks/chat/store/composeSessionStore";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 
 export interface ComposeDraftState {
   message: string;
   attachedFiles: FileUploadItem[];
+  /**
+   * Unlike the model and facet selections — read live at send time — mentions
+   * are part of the text they were typed into, so they travel with it.
+   */
+  mentionedAssistants: AssistantMention[];
 }
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- internal sentinel key, never user-facing

--- a/frontend/src/hooks/chat/useMentionableAssistants.ts
+++ b/frontend/src/hooks/chat/useMentionableAssistants.ts
@@ -1,0 +1,101 @@
+import { skipToken } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  useFrequentAssistants,
+  useListAssistants,
+} from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import { useAssistantsFeature } from "@/providers/FeatureConfigProvider";
+
+import type { Assistant } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+export interface MentionableAssistant {
+  id: string;
+  name: string;
+  description?: string;
+  ownerEmail?: string;
+}
+
+/** Rows offered without a search term, on every surface. */
+export const MENTION_SUGGESTION_LIMIT = 5;
+
+export interface MentionableAssistants {
+  /** Every mention affordance is gated on this. */
+  isAvailable: boolean;
+  /** Most-used first, falling back to list order when usage is unknown. */
+  suggested: MentionableAssistant[];
+  /** Everything the user may delegate to, for the browse surface. */
+  all: MentionableAssistant[];
+}
+
+function toMentionable(assistant: Assistant): MentionableAssistant {
+  return {
+    id: assistant.id,
+    name: assistant.name,
+    description: assistant.description,
+    ownerEmail: assistant.owner_email,
+  };
+}
+
+/**
+ * A mention is plain text, so two assistants sharing a name are
+ * indistinguishable once typed — only the first of a name is offered.
+ */
+function toOfferableMentions(
+  assistants: Assistant[],
+  excludedAssistantId: string | undefined,
+): MentionableAssistant[] {
+  const seenNames = new Set<string>();
+  const offerable: MentionableAssistant[] = [];
+  for (const assistant of assistants) {
+    if (assistant.id === excludedAssistantId || assistant.archived_at) {
+      continue;
+    }
+    if (seenNames.has(assistant.name)) {
+      continue;
+    }
+    seenNames.add(assistant.name);
+    offerable.push(toMentionable(assistant));
+  }
+  return offerable;
+}
+
+/**
+ * Assistants the composer may @-mention. Both queries stay unissued while the
+ * feature is off, so a deployment without delegation pays nothing for it.
+ */
+export function useMentionableAssistants(
+  boundAssistantId?: string,
+): MentionableAssistants {
+  const { enabled, delegationEnabled } = useAssistantsFeature();
+  const isGateOpen = enabled && delegationEnabled;
+
+  const { data: allAssistants } = useListAssistants(
+    isGateOpen ? {} : skipToken,
+  );
+  // One over the display limit, so excluding the chat's own assistant still
+  // leaves a full set of suggestions.
+  const { data: frequentAssistants } = useFrequentAssistants(
+    isGateOpen
+      ? { queryParams: { limit: MENTION_SUGGESTION_LIMIT + 1 } }
+      : skipToken,
+  );
+
+  return useMemo(() => {
+    const all = toOfferableMentions(allAssistants ?? [], boundAssistantId);
+    const frequent = toOfferableMentions(
+      frequentAssistants?.assistants ?? [],
+      boundAssistantId,
+    );
+    const browsable = all.length > 0 ? all : frequent;
+
+    return {
+      isAvailable: isGateOpen && browsable.length > 0,
+      suggested: (frequent.length > 0 ? frequent : all).slice(
+        0,
+        MENTION_SUGGESTION_LIMIT,
+      ),
+      all: browsable,
+    };
+  }, [allAssistants, frequentAssistants, boundAssistantId, isGateOpen]);
+}

--- a/frontend/src/hooks/search/useFuzzySearch.ts
+++ b/frontend/src/hooks/search/useFuzzySearch.ts
@@ -18,6 +18,11 @@ export interface FuzzySearchOptions<T> {
   query: string;
   /** Match threshold: 0 (exact) to 1 (match anything). Default: 0.3 */
   threshold?: number;
+  /**
+   * Shortest pattern fuse will match. Queries below it match nothing at all,
+   * so lists meant to be narrowed one keystroke at a time want 1. Default: 2
+   */
+  minMatchCharLength?: number;
   /** Custom sort function to apply after fuzzy search (should be memoized in parent) */
   sortFn?: (a: T, b: T) => number;
 }
@@ -39,6 +44,7 @@ export function useFuzzySearch<T>({
   keys,
   query,
   threshold = 0.3,
+  minMatchCharLength = 2,
   sortFn,
 }: FuzzySearchOptions<T>): T[] {
   // Create fuse instance
@@ -48,9 +54,9 @@ export function useFuzzySearch<T>({
         keys,
         threshold,
         ignoreLocation: true, // Don't care where in string the match occurs
-        minMatchCharLength: 2, // Need at least 2 characters to match
+        minMatchCharLength,
       }),
-    [items, keys, threshold],
+    [items, keys, threshold, minMatchCharLength],
   );
 
   // Perform search and apply custom sorting if provided

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1856,6 +1856,43 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Dateien und Tools hinzufügen"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+#: src/components/ui/Chat/assistantMentionSection.ts
+msgid "chatInput.mentions.browse"
+msgstr "Assistenten durchsuchen…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.browseTitle"
+msgstr "Assistenten erwähnen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.noResults"
+msgstr "Keine passenden Assistenten gefunden"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "chatInput.mentions.pickerAnnouncement"
+msgstr "Assistentenvorschläge verfügbar. Drücken Sie die Pfeiltaste nach unten, um sie zu durchsuchen, oder die Eingabetaste, um den ersten zu erwähnen."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+msgid "chatInput.mentions.pickerLabel"
+msgstr "Assistentenvorschläge"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.searchPlaceholder"
+msgstr "Assistenten suchen..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/assistantMentionSection.ts
+#: src/components/ui/Chat/FacetSelector.tsx
+msgid "chatInput.mentions.sectionHeader"
+msgstr "Assistenten"
+
+#. js-lingui-explicit-id
 #: src/components/ui/CloudFilePicker/CloudDriveList.tsx
 msgid "cloudDriveList.driveKind.businessLibrary"
 msgstr ""

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1856,6 +1856,43 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Add files and tools"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+#: src/components/ui/Chat/assistantMentionSection.ts
+msgid "chatInput.mentions.browse"
+msgstr "Browse assistants…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.browseTitle"
+msgstr "Mention an assistant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.noResults"
+msgstr "No assistants match your search"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "chatInput.mentions.pickerAnnouncement"
+msgstr "Assistant suggestions available. Press the down arrow to browse them, or Enter to mention the first."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+msgid "chatInput.mentions.pickerLabel"
+msgstr "Assistant suggestions"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.searchPlaceholder"
+msgstr "Search assistants..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/assistantMentionSection.ts
+#: src/components/ui/Chat/FacetSelector.tsx
+msgid "chatInput.mentions.sectionHeader"
+msgstr "Assistants"
+
+#. js-lingui-explicit-id
 #: src/components/ui/CloudFilePicker/CloudDriveList.tsx
 msgid "cloudDriveList.driveKind.businessLibrary"
 msgstr "Business library"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1856,6 +1856,43 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Agregar archivos y herramientas"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+#: src/components/ui/Chat/assistantMentionSection.ts
+msgid "chatInput.mentions.browse"
+msgstr "Explorar asistentes…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.browseTitle"
+msgstr "Mencionar un asistente"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.noResults"
+msgstr "No se encontraron asistentes coincidentes"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "chatInput.mentions.pickerAnnouncement"
+msgstr "Sugerencias de asistentes disponibles. Pulsa la flecha abajo para explorarlas o Intro para mencionar el primero."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+msgid "chatInput.mentions.pickerLabel"
+msgstr "Sugerencias de asistentes"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.searchPlaceholder"
+msgstr "Buscar asistentes..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/assistantMentionSection.ts
+#: src/components/ui/Chat/FacetSelector.tsx
+msgid "chatInput.mentions.sectionHeader"
+msgstr "Asistentes"
+
+#. js-lingui-explicit-id
 #: src/components/ui/CloudFilePicker/CloudDriveList.tsx
 msgid "cloudDriveList.driveKind.businessLibrary"
 msgstr ""

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1856,6 +1856,43 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Ajouter des fichiers et des outils"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+#: src/components/ui/Chat/assistantMentionSection.ts
+msgid "chatInput.mentions.browse"
+msgstr "Parcourir les assistants…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.browseTitle"
+msgstr "Mentionner un assistant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.noResults"
+msgstr "Aucun assistant correspondant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "chatInput.mentions.pickerAnnouncement"
+msgstr "Suggestions d’assistants disponibles. Appuyez sur la flèche vers le bas pour les parcourir, ou sur Entrée pour mentionner le premier."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+msgid "chatInput.mentions.pickerLabel"
+msgstr "Suggestions d'assistants"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.searchPlaceholder"
+msgstr "Rechercher des assistants..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/assistantMentionSection.ts
+#: src/components/ui/Chat/FacetSelector.tsx
+msgid "chatInput.mentions.sectionHeader"
+msgstr "Assistants"
+
+#. js-lingui-explicit-id
 #: src/components/ui/CloudFilePicker/CloudDriveList.tsx
 msgid "cloudDriveList.driveKind.businessLibrary"
 msgstr ""

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1856,6 +1856,43 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Dodaj pliki i narzędzia"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+#: src/components/ui/Chat/assistantMentionSection.ts
+msgid "chatInput.mentions.browse"
+msgstr "Przeglądaj asystentów…"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.browseTitle"
+msgstr "Wspomnij asystenta"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.noResults"
+msgstr "Nie znaleziono pasujących asystentów"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatInput.tsx
+msgid "chatInput.mentions.pickerAnnouncement"
+msgstr "Dostępne sugestie asystentów. Naciśnij strzałkę w dół, aby je przejrzeć, lub Enter, aby wspomnieć pierwszego."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantMentionPopover.tsx
+msgid "chatInput.mentions.pickerLabel"
+msgstr "Sugestie asystentów"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/AssistantBrowserModal.tsx
+msgid "chatInput.mentions.searchPlaceholder"
+msgstr "Szukaj asystentów..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/assistantMentionSection.ts
+#: src/components/ui/Chat/FacetSelector.tsx
+msgid "chatInput.mentions.sectionHeader"
+msgstr "Asystenci"
+
+#. js-lingui-explicit-id
 #: src/components/ui/CloudFilePicker/CloudDriveList.tsx
 msgid "cloudDriveList.driveKind.businessLibrary"
 msgstr ""

--- a/frontend/src/providers/ChatProvider.tsx
+++ b/frontend/src/providers/ChatProvider.tsx
@@ -82,6 +82,7 @@ export interface ChatContextValue {
     assistantId?: string,
     selectedFacetIds?: string[],
     actionFacet?: { id: string; args?: Record<string, string> },
+    mentionedAssistantIds?: string[],
   ) => Promise<string | undefined>;
   editMessage: (
     messageId: string,

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -84,6 +84,8 @@ interface AuthFeatureConfig {
 interface AssistantsFeatureConfig {
   /** Whether the assistants feature is enabled */
   enabled: boolean;
+  /** Whether a message may delegate to other assistants via @-mentions */
+  delegationEnabled: boolean;
   /** Whether assistants may be shared with edit access */
   enableEditSharing: boolean;
   /** Whether recent assistants should be shown in the sidebar */
@@ -267,6 +269,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   },
   assistants: {
     enabled: false,
+    delegationEnabled: false,
     enableEditSharing: true,
     showRecentItems: false,
     showRecentItemsCollapsible: false,
@@ -376,6 +379,7 @@ function createFeatureConfig(
     },
     assistants: {
       enabled: environment.assistantsEnabled,
+      delegationEnabled: Boolean(environment.assistantsDelegationEnabled),
       enableEditSharing: environment.assistantsEnableEditSharing ?? true,
       showRecentItems: environment.assistantsShowRecentItems,
       showRecentItemsCollapsible:

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -157,6 +157,7 @@ describe("FeatureConfigProvider", () => {
         },
         assistants: {
           enabled: false,
+          delegationEnabled: false,
           enableEditSharing: true,
           showRecentItems: false,
           showRecentItemsCollapsible: false,
@@ -838,6 +839,7 @@ describe("FeatureConfigProvider", () => {
 
       expect(result.current).toEqual({
         enabled: false,
+        delegationEnabled: false,
         enableEditSharing: true,
         showRecentItems: false,
         showRecentItemsCollapsible: false,
@@ -886,6 +888,7 @@ describe("FeatureConfigProvider", () => {
 
       expect(result.current).toEqual({
         enabled: true,
+        delegationEnabled: false,
         enableEditSharing: true,
         showRecentItems: true,
         showRecentItemsCollapsible: true,

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -81,6 +81,7 @@ export { ArchiveIcon } from "@/components/ui/icons/index";
 export { ArrowLeftIcon } from "@/components/ui/icons/index";
 export { ArrowUp } from "@/components/ui/icons/index";
 export { ArrowUpIcon } from "@/components/ui/icons/index";
+export { AtSignIcon } from "@/components/ui/icons/index";
 export { BrainIcon } from "@/components/ui/icons/index";
 export { Check } from "@/components/ui/icons/index";
 export { CheckCircle } from "@/components/ui/icons/index";

--- a/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
+++ b/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  applyMentionSelection,
+  detectMentionTrigger,
+  mentionToken,
+  pruneTrackedMentions,
+  resolveMentionedAssistantIds,
+} from "../assistantMentions";
+
+import type { AssistantMention } from "../assistantMentions";
+
+const researcher: AssistantMention = { id: "a1", name: "Researcher" };
+const dataAssistant: AssistantMention = { id: "a2", name: "Data" };
+const dataAnalyst: AssistantMention = { id: "a3", name: "Data Analyst" };
+const regexName: AssistantMention = { id: "a4", name: "C++ (v1.0)" };
+
+describe("detectMentionTrigger", () => {
+  it("triggers on an @ at the very start", () => {
+    expect(detectMentionTrigger("@")).toEqual({ query: "", startIndex: 0 });
+  });
+
+  it("triggers mid-sentence after whitespace", () => {
+    expect(detectMentionTrigger("ask @res")).toEqual({
+      query: "res",
+      startIndex: 4,
+    });
+  });
+
+  it("triggers after a newline", () => {
+    expect(detectMentionTrigger("first line\n@re")).toEqual({
+      query: "re",
+      startIndex: 11,
+    });
+  });
+
+  it("does not trigger inside an email address", () => {
+    expect(detectMentionTrigger("mail a@b.com")).toBeNull();
+    expect(detectMentionTrigger("mail a@")).toBeNull();
+  });
+
+  it("does not trigger on consecutive @", () => {
+    expect(detectMentionTrigger("@@")).toBeNull();
+    expect(detectMentionTrigger("hi @@re")).toBeNull();
+  });
+
+  it("does not trigger once a second @ follows the query", () => {
+    expect(detectMentionTrigger("@user@host")).toBeNull();
+  });
+
+  it("stops triggering once the query passes the length cap", () => {
+    expect(detectMentionTrigger(`@${"x".repeat(40)}`)).not.toBeNull();
+    expect(detectMentionTrigger(`@${"x".repeat(41)}`)).toBeNull();
+  });
+
+  it("stops triggering once a space follows the @", () => {
+    expect(detectMentionTrigger("@Data ")).toBeNull();
+  });
+
+  it("reports the index of the @ within the full text", () => {
+    const text = "please ask @dat about it";
+    const caret = "please ask @dat".length;
+    const trigger = detectMentionTrigger(text.slice(0, caret));
+    expect(trigger?.startIndex).toBe(11);
+    expect(text[trigger?.startIndex ?? -1]).toBe("@");
+  });
+});
+
+describe("applyMentionSelection", () => {
+  it("replaces the query fragment and leaves one trailing space", () => {
+    const text = "@res";
+    const trigger = detectMentionTrigger(text);
+    expect(
+      applyMentionSelection(text, text.length, trigger!, "Researcher"),
+    ).toEqual({ text: "@Researcher ", caret: 12 });
+  });
+
+  it("inserts mid-sentence without doubling the following space", () => {
+    const text = "ask @res about it";
+    const caret = "ask @res".length;
+    const trigger = detectMentionTrigger(text.slice(0, caret));
+    expect(applyMentionSelection(text, caret, trigger!, "Researcher")).toEqual({
+      text: "ask @Researcher about it",
+      caret: "ask @Researcher ".length,
+    });
+  });
+
+  it("keeps names with spaces intact", () => {
+    const text = "@dat";
+    const trigger = detectMentionTrigger(text);
+    expect(
+      applyMentionSelection(text, text.length, trigger!, "Data Analyst"),
+    ).toEqual({ text: "@Data Analyst ", caret: 14 });
+  });
+
+  it("expands a bare @ with no query", () => {
+    const text = "hello @";
+    const trigger = detectMentionTrigger(text);
+    expect(applyMentionSelection(text, text.length, trigger!, "Data")).toEqual({
+      text: "hello @Data ",
+      caret: 12,
+    });
+  });
+});
+
+describe("resolveMentionedAssistantIds", () => {
+  it("returns nothing when no token survives in the text", () => {
+    expect(resolveMentionedAssistantIds("plain text", [researcher])).toEqual(
+      [],
+    );
+  });
+
+  it("drops a mention whose token was deleted", () => {
+    expect(
+      resolveMentionedAssistantIds("@Resear please help", [researcher]),
+    ).toEqual([]);
+  });
+
+  it("preserves tracked order rather than text order", () => {
+    expect(
+      resolveMentionedAssistantIds("@Data then @Researcher", [
+        researcher,
+        dataAssistant,
+      ]),
+    ).toEqual(["a1", "a2"]);
+  });
+
+  it("dedupes an assistant mentioned twice", () => {
+    expect(
+      resolveMentionedAssistantIds("@Researcher and @Researcher", [
+        researcher,
+        researcher,
+      ]),
+    ).toEqual(["a1"]);
+  });
+
+  it("does not let a prefix name ride along on a longer one", () => {
+    expect(
+      resolveMentionedAssistantIds("@Data Analyst please", [
+        dataAssistant,
+        dataAnalyst,
+      ]),
+    ).toEqual(["a3"]);
+  });
+
+  it("resolves both when the prefix name is mentioned on its own too", () => {
+    expect(
+      resolveMentionedAssistantIds("@Data and @Data Analyst", [
+        dataAssistant,
+        dataAnalyst,
+      ]),
+    ).toEqual(["a2", "a3"]);
+  });
+
+  it("treats names with regex metacharacters literally", () => {
+    expect(resolveMentionedAssistantIds("@C++ (v1.0) hi", [regexName])).toEqual(
+      ["a4"],
+    );
+    expect(resolveMentionedAssistantIds("@Cxx (v1x0) hi", [regexName])).toEqual(
+      [],
+    );
+  });
+
+  it("ignores a token glued to the end of a word", () => {
+    expect(
+      resolveMentionedAssistantIds("mail me@Data now", [dataAssistant]),
+    ).toEqual([]);
+  });
+
+  it("ignores a token that continues into a longer word", () => {
+    expect(
+      resolveMentionedAssistantIds("check the @Database rows", [dataAssistant]),
+    ).toEqual([]);
+    expect(
+      resolveMentionedAssistantIds("@Researchers meeting", [researcher]),
+    ).toEqual([]);
+  });
+
+  it("counts a token closed by punctuation", () => {
+    expect(
+      resolveMentionedAssistantIds("@Data, please help", [dataAssistant]),
+    ).toEqual(["a2"]);
+    expect(
+      resolveMentionedAssistantIds("ask @Researcher.", [researcher]),
+    ).toEqual(["a1"]);
+  });
+});
+
+describe("pruneTrackedMentions", () => {
+  it("keeps the array identity when nothing was dropped", () => {
+    const tracked = [researcher, dataAssistant];
+    expect(pruneTrackedMentions("@Researcher @Data", tracked)).toBe(tracked);
+  });
+
+  it("drops entries whose token is gone", () => {
+    expect(
+      pruneTrackedMentions("@Researcher only", [researcher, dataAssistant]),
+    ).toEqual([researcher]);
+  });
+
+  it("drops an entry whose token grew into a longer word", () => {
+    expect(pruneTrackedMentions("@Database rows", [dataAssistant])).toEqual([]);
+  });
+
+  it("collapses a duplicate tracking entry", () => {
+    expect(
+      pruneTrackedMentions("@Researcher and @Researcher", [
+        researcher,
+        researcher,
+      ]),
+    ).toEqual([researcher]);
+  });
+});
+
+describe("mentionToken", () => {
+  it("is the rendering that insertion and reconciliation share", () => {
+    const text = applyMentionSelection(
+      "@d",
+      2,
+      detectMentionTrigger("@d")!,
+      dataAnalyst.name,
+    ).text;
+    expect(text.startsWith(mentionToken(dataAnalyst.name))).toBe(true);
+    expect(resolveMentionedAssistantIds(text, [dataAnalyst])).toEqual(["a3"]);
+  });
+});

--- a/frontend/src/utils/chat/assistantMentions.ts
+++ b/frontend/src/utils/chat/assistantMentions.ts
@@ -1,0 +1,140 @@
+export interface AssistantMention {
+  id: string;
+  name: string;
+}
+
+export interface MentionTrigger {
+  query: string;
+  /** Index of the `@` in the full text, not in the slice passed to the detector. */
+  startIndex: number;
+}
+
+/**
+ * Requiring start-or-whitespace before the `@` is what keeps `a@b.com` from
+ * opening the picker; excluding `@` from the query keeps a second `@` from
+ * re-arming it mid-address. The length cap bounds how far a stray `@` can keep
+ * the picker alive while the user types prose.
+ */
+const MENTION_TRIGGER = /(^|\s)@([^\s@]{0,40})$/;
+
+export function mentionToken(name: string): string {
+  return `@${name}`;
+}
+
+export function detectMentionTrigger(
+  textBeforeCaret: string,
+): MentionTrigger | null {
+  const match = MENTION_TRIGGER.exec(textBeforeCaret);
+  if (!match) {
+    return null;
+  }
+  return {
+    query: match[2],
+    startIndex: match.index + match[1].length,
+  };
+}
+
+export function applyMentionSelection(
+  text: string,
+  caret: number,
+  trigger: MentionTrigger,
+  assistantName: string,
+): { text: string; caret: number } {
+  const before = text.slice(0, trigger.startIndex);
+  const rest = text.slice(caret);
+  const token = `${mentionToken(assistantName)} `;
+  const after = rest.startsWith(" ") ? rest.slice(1) : rest;
+  return {
+    text: `${before}${token}${after}`,
+    caret: before.length + token.length,
+  };
+}
+
+function isAtWordStart(text: string, index: number): boolean {
+  return index === 0 || /\s/.test(text[index - 1]);
+}
+
+/**
+ * Punctuation ends a mention (`@Data, please`), a further letter does not:
+ * `@Bobby` names nobody when only "Bob" is tracked. Asymmetric with the leading
+ * side on purpose — there only whitespace may precede, or `me@Data` would count.
+ */
+function isAtWordEnd(text: string, index: number): boolean {
+  return index >= text.length || !/[\p{L}\p{N}_]/u.test(text[index]);
+}
+
+/**
+ * A token only counts where it is not the leading fragment of a longer tracked
+ * name at the same position: with both "Data" and "Data Analyst" tracked, the
+ * text `@Data Analyst` must resolve to the latter alone.
+ */
+function isMentionPresent(
+  text: string,
+  mention: AssistantMention,
+  tracked: AssistantMention[],
+): boolean {
+  const token = mentionToken(mention.name);
+  const shadowingTokens = tracked
+    .filter(
+      (other) =>
+        other.name.length > mention.name.length &&
+        other.name.startsWith(mention.name),
+    )
+    .map((other) => mentionToken(other.name));
+
+  let searchFrom = 0;
+  for (;;) {
+    const index = text.indexOf(token, searchFrom);
+    if (index < 0) {
+      return false;
+    }
+    const shadowed = shadowingTokens.some((shadowing) =>
+      text.startsWith(shadowing, index),
+    );
+    if (
+      !shadowed &&
+      isAtWordStart(text, index) &&
+      isAtWordEnd(text, index + token.length)
+    ) {
+      return true;
+    }
+    searchFrom = index + 1;
+  }
+}
+
+/** The ids the composer should submit: tracked order, deduped, text wins. */
+export function resolveMentionedAssistantIds(
+  text: string,
+  tracked: AssistantMention[],
+): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const mention of tracked) {
+    if (seen.has(mention.id) || !isMentionPresent(text, mention, tracked)) {
+      continue;
+    }
+    seen.add(mention.id);
+    ids.push(mention.id);
+  }
+  return ids;
+}
+
+/**
+ * Returns the same array reference when nothing was dropped, so callers can
+ * feed the result straight back into state without looping.
+ */
+export function pruneTrackedMentions(
+  text: string,
+  tracked: AssistantMention[],
+): AssistantMention[] {
+  const seen = new Set<string>();
+  const next = tracked.filter((mention) => {
+    const key = JSON.stringify([mention.id, mention.name]);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return isMentionPresent(text, mention, tracked);
+  });
+  return next.length === tracked.length ? tracked : next;
+}

--- a/frontend/src/utils/chat/messageUtils.test.ts
+++ b/frontend/src/utils/chat/messageUtils.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 
-import { collectSupersededMessageIds } from "./messageUtils";
+import {
+  collectSupersededMessageIds,
+  constructSubmitStreamRequestBody,
+} from "./messageUtils";
 
 import type { Message } from "@/types/chat";
 
@@ -57,5 +60,46 @@ describe("collectSupersededMessageIds", () => {
     expect(
       collectSupersededMessageIds(conversation(), "temp-user-999"),
     ).toEqual(["temp-user-999"]);
+  });
+});
+
+describe("constructSubmitStreamRequestBody", () => {
+  it("carries mentioned assistants", () => {
+    const body = constructSubmitStreamRequestBody(
+      "ask @Researcher",
+      undefined,
+      undefined,
+      "chat-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ["assistant-1", "assistant-2"],
+    );
+
+    expect(body.mentioned_assistant_ids).toEqual([
+      "assistant-1",
+      "assistant-2",
+    ]);
+  });
+
+  it("omits the field when there are no mentions", () => {
+    expect(constructSubmitStreamRequestBody("plain")).not.toHaveProperty(
+      "mentioned_assistant_ids",
+    );
+
+    expect(
+      constructSubmitStreamRequestBody(
+        "plain",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [],
+      ),
+    ).not.toHaveProperty("mentioned_assistant_ids");
   });
 });

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -114,6 +114,7 @@ export interface SubmitStreamRequestBody {
   assistant_id?: string;
   selected_facet_ids?: string[];
   action_facet?: ActionFacetRequest;
+  mentioned_assistant_ids?: string[];
 }
 
 /**
@@ -124,6 +125,7 @@ export interface SubmitStreamRequestBody {
  * @param currentChatId Optional existing chat ID (could be active or silent chat ID).
  * @param modelId Optional chat provider ID for model selection.
  * @param assistantId Optional assistant ID to associate with the chat.
+ * @param mentionedAssistantIds Optional assistants to delegate this turn to.
  * @returns The request body object.
  */
 export function constructSubmitStreamRequestBody(
@@ -135,6 +137,7 @@ export function constructSubmitStreamRequestBody(
   assistantId?: string,
   selectedFacetIds?: string[],
   actionFacet?: ActionFacetRequest,
+  mentionedAssistantIds?: string[],
 ): SubmitStreamRequestBody {
   const body: SubmitStreamRequestBody = {
     user_message: userMessageContent,
@@ -160,6 +163,9 @@ export function constructSubmitStreamRequestBody(
   }
   if (actionFacet) {
     body.action_facet = actionFacet;
+  }
+  if (mentionedAssistantIds && mentionedAssistantIds.length > 0) {
+    body.mentioned_assistant_ids = mentionedAssistantIds;
   }
 
   return body;

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -63,6 +63,7 @@ export interface AddinChatInputRenderProps {
     selectedFacetIds?: string[],
     actionFacet?: ActionFacetRequest,
     hostContextIdentity?: string | null,
+    mentionedAssistantIds?: string[],
   ) => void;
   onFilePreview: (file: FileUploadItem) => void;
   handleFileAttachments: (files: FileUploadItem[]) => void;
@@ -235,6 +236,7 @@ function useAddinChatController({
       selectedFacetIds,
       actionFacet,
       hostContextIdentity,
+      mentionedAssistantIds,
     ) => {
       hostCallbacksRef.current.beforeSend?.(hostContextIdentity);
       void chat
@@ -245,6 +247,7 @@ function useAddinChatController({
           assistantId,
           selectedFacetIds,
           actionFacet,
+          mentionedAssistantIds,
         )
         .then(() => chat.refetchHistory());
     },
@@ -444,7 +447,28 @@ function NeutralAddinChatHost({ controller }: AddinChatHostProps) {
       controller={controller}
       dropzone={dropzone}
       showDropOverlay={dropzone.isDragActive && dropzone.isDragAccept}
-      renderInput={(props) => <AddinChatInputCore {...props} />}
+      renderInput={(props) => (
+        <AddinChatInputCore
+          {...props}
+          onSendMessage={(
+            message,
+            inputFileIds,
+            modelId,
+            selectedFacetIds,
+            mentionedAssistantIds,
+          ) =>
+            props.onSendMessage(
+              message,
+              inputFileIds,
+              modelId,
+              selectedFacetIds,
+              undefined,
+              undefined,
+              mentionedAssistantIds,
+            )
+          }
+        />
+      )}
       renderSettings={(props) => <AddinSettingsDialogCore {...props} />}
     />
   );

--- a/office-addin/src/core/AddinChatInputCore.tsx
+++ b/office-addin/src/core/AddinChatInputCore.tsx
@@ -13,6 +13,7 @@ export interface AddinChatInputCoreProps {
     inputFileIds?: string[],
     modelId?: string,
     selectedFacetIds?: string[],
+    mentionedAssistantIds?: string[],
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;

--- a/office-addin/src/outlook/components/AddinChatInput.tsx
+++ b/office-addin/src/outlook/components/AddinChatInput.tsx
@@ -83,6 +83,7 @@ interface AddinChatInputProps {
      * (the completion's artifact is treated as stale, never unguarded).
      */
     sendItemIdentity?: string | null,
+    mentionedAssistantIds?: string[],
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;
@@ -662,6 +663,7 @@ export const AddinChatInput = forwardRef<
       inputFileIds?: string[],
       modelId?: string,
       selectedFacetIds?: string[],
+      mentionedAssistantIds?: string[],
     ) => {
       // Capture the item identity BEFORE any await: the uploads below can
       // take long enough for the user to switch emails, and the wrong-item
@@ -810,6 +812,7 @@ export const AddinChatInput = forwardRef<
           selectedFacetIds,
           actionFacet,
           sendItemIdentity,
+          mentionedAssistantIds,
         );
         return;
       }
@@ -832,6 +835,7 @@ export const AddinChatInput = forwardRef<
             selectedFacetIds,
             actionFacet,
             sendItemIdentity,
+            mentionedAssistantIds,
           );
           // No upload was attempted (e.g. only dismissed drops remain) and
           // nothing failed, so the staged drops are safe to clear.
@@ -872,6 +876,7 @@ export const AddinChatInput = forwardRef<
         selectedFacetIds,
         actionFacet,
         sendItemIdentity,
+        mentionedAssistantIds,
       );
 
       // Clear the drops only when their files actually uploaded. On a failed
@@ -1027,12 +1032,19 @@ export const AddinChatInput = forwardRef<
         ref={ref}
         chatId={chatId}
         {...chatInputProps}
-        onSendMessage={(message, inputFileIds, modelId, selectedFacetIds) => {
+        onSendMessage={(
+          message,
+          inputFileIds,
+          modelId,
+          selectedFacetIds,
+          mentionedAssistantIds,
+        ) => {
           void wrappedOnSendMessage(
             message,
             inputFileIds,
             modelId,
             selectedFacetIds,
+            mentionedAssistantIds,
           );
         }}
         disabled={


### PR DESCRIPTION
**Part 1/3 of the delegation frontend stack**, on top of #982. Review bottom-up; this layer's diff is against the listing layer.

Stack: #978 config → #979 provenance/primitives → #980 mention validation → #981 runtime → #982 listing → #984 composer mentions → #985 in-chat trace → #986 delegated-runs view.

This is the layer that closes the loop on #978–#982. Until a client can produce `mentioned_assistant_ids`, the delegation tool is never offered and the whole dispatch branch is unreachable — so this is worth merging in the same batch as the backend stack rather than letting it land dark.

Two equal entry paths into delegation, both producing the same state.

## What changes

- **`@`-autocomplete in the composer.** Typing `@` opens an assistant picker anchored to the composer shell (not the caret — shell anchoring degrades better in the 320–450px add-in pane). Selection inserts `@{Name}`. Up to 5 most-recently-used assistants from `/frequent_assistants`, falling back to the accessible list, excluding the chat's own bound assistant.
- **Text is the source of truth.** `mentioned_assistant_ids` at send are the ids whose token still occurs in the message, so deleting `@Name` drops the mention. No token editor, no contenteditable. Matching requires a word boundary on both sides, so `@Bobby` does not resolve an assistant tracked as "Bob", and a longer tracked name shadows a shorter prefix of it.
- **One "Assistants" section, two presentations.** Contributed once in core and rendered both in `ChatInputAddMenu` (mobile and add-in) and the desktop `FacetSelector` Tools dropdown — no host fork. Rows go through an extracted `AddMenuActionRow`, so both surfaces and the mention picker share the dropdown item channel rather than re-deriving geometry, hover and focus styling.
- **"Browse assistants…"** opens a modal over the full accessible list with filter-as-you-type (client-side; no server-side assistant search exists).
- **Send-path threading**, following the `selectedFacetIds` precedent: a new trailing parameter from `ChatInputProps.onSendMessage` through `Chat` → `useChatActions` → `useChatMessaging` → `mentioned_assistant_ids`, omitted from the body when empty. Both send sites carry it, including the #841/#846 queue drain, which resolves from the **queued draft's** mentions against the queued text rather than live state — mentions belong to the text they were typed into, unlike model and facets.
- `ComposeDraftState` gains `mentionedAssistants` so a queued or restored draft keeps its mentions across enqueue, drain, chat switch and remount.
- `ASSISTANTS_DELEGATION_ENABLED` is read through `env.ts` → `FeatureConfigProvider`; every affordance is gated on assistants + delegation + a non-empty accessible list, and no assistant list is fetched when the gate is off. Enforcement remains server-side.
- **Add-in send path widened** so mentions are not silently dropped. This surfaced a real bug: `NeutralAddinChatHost` forwarded its render props as a bare spread, and TypeScript accepts a wider function where the extra parameters are optional — so a 7-parameter `onSendMessage` reached `ChatInput`, whose 5th argument is now `mentionedAssistantIds` but whose 5th slot there is `actionFacet`. Now an explicit adapter.
- Shared primitives gain backwards-compatible options, all defaulting to today's behaviour: `AnchoredPopover.manageFocus` (a caret-driven typeahead must not pull focus out of the textarea) and `ariaLabel`; `DropdownMenu` section headers as labelled `role="group"` with a separator, plus `closesImmediately` for rows that open a dialog (the delayed close otherwise returns focus to the trigger after the dialog has focused itself); `useFuzzySearch.minMatchCharLength` so a one-character query narrows instead of matching nothing.
- Because focus deliberately stays in the textarea while the picker is open, an `sr-only` live region announces it — nothing else would tell a screen-reader user that a picker opened or that Enter now inserts instead of sends. Deliberately count-free so filtering does not re-announce on every keystroke.

## Testing

Trigger detection including the address-like `@` that must not fire; text-truth reconciliation at send; the word-boundary and name-shadowing cases; draft and queue preservation across enqueue, drain and remount; gating on and off; both menu surfaces including the add-in path; the browse modal's focus, filtering and dismissal; Escape staying dismissed through its own keyup so Enter still sends; and the live-region announcement. Frontend suite and the Office add-in suite both green, the latter against a library tarball built from this branch.
