### PR TITLE
Highlight tracked assistant mentions behind the composer text (ERMAIN-629)

### DIFF
--- a/frontend/src/components/ui/Chat/AssistantMentionBackdrop.test.tsx
+++ b/frontend/src/components/ui/Chat/AssistantMentionBackdrop.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it } from "vitest";
+
+import { resolveMentionedAssistantIds } from "@/utils/chat/assistantMentions";
+
+import { AssistantMentionBackdrop } from "./AssistantMentionBackdrop";
+
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
+
+const researcher: AssistantMention = { id: "a1", name: "Researcher" };
+const dataAssistant: AssistantMention = { id: "a2", name: "Data" };
+const dataAnalyst: AssistantMention = { id: "a3", name: "Data Analyst" };
+
+function Composer({
+  text,
+  tracked,
+  dimmed,
+}: {
+  text: string;
+  tracked: AssistantMention[];
+  dimmed?: boolean;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  return (
+    <div>
+      <AssistantMentionBackdrop
+        text={text}
+        tracked={tracked}
+        textareaRef={textareaRef}
+        dimmed={dimmed}
+      />
+      <textarea
+        ref={textareaRef}
+        value={text}
+        readOnly
+        data-testid="composer-textarea"
+      />
+    </div>
+  );
+}
+
+const backdrop = () => screen.getByTestId("chat-input-mention-backdrop");
+const highlights = () =>
+  screen.queryAllByTestId("chat-input-mention-highlight");
+
+describe("AssistantMentionBackdrop", () => {
+  it("highlights a tracked mention and leaves a look-alike alone", () => {
+    render(
+      <Composer text="@Researcher and @Ghost please" tracked={[researcher]} />,
+    );
+
+    expect(highlights().map((span) => span.textContent)).toEqual([
+      "@Researcher",
+    ]);
+  });
+
+  it("highlights nothing while no mention is tracked", () => {
+    render(<Composer text="@Researcher please" tracked={[]} />);
+
+    expect(highlights()).toHaveLength(0);
+  });
+
+  it("highlights every repetition of the same mention", () => {
+    render(<Composer text="@Data then @Data" tracked={[dataAssistant]} />);
+
+    expect(highlights().map((span) => span.textContent)).toEqual([
+      "@Data",
+      "@Data",
+    ]);
+  });
+
+  it("highlights the same assistants the composer would submit", () => {
+    const text = "@Data and @Data Analyst and @Ghost";
+    const tracked = [dataAssistant, dataAnalyst];
+    render(<Composer text={text} tracked={tracked} />);
+
+    expect(highlights().map((span) => span.textContent)).toEqual([
+      "@Data",
+      "@Data Analyst",
+    ]);
+    expect(new Set(highlights().map((span) => span.dataset.mentionId))).toEqual(
+      new Set(resolveMentionedAssistantIds(text, tracked)),
+    );
+  });
+
+  // The mirror only stays aligned while it holds character-for-character what
+  // the textarea holds; anything else is a highlight over the wrong glyphs.
+  it.each([
+    ["@Researcher please", "plain"],
+    ["@Researcher\nsecond line", "newline"],
+    ["@Researcher done\n", "trailing newline"],
+    ["  spaced   out  @Researcher ", "runs of spaces"],
+    ["<script>alert(1)</script> @Researcher & co", "markup and entities"],
+  ])("mirrors the textarea value exactly (%s)", (text) => {
+    render(<Composer text={text} tracked={[researcher]} />);
+
+    expect(backdrop().textContent).toBe(
+      screen.getByTestId<HTMLTextAreaElement>("composer-textarea").value,
+    );
+  });
+
+  it("escapes markup instead of injecting it", () => {
+    render(
+      <Composer
+        text={'<script>alert("x")</script> @Researcher <b>& co</b>'}
+        tracked={[researcher]}
+      />,
+    );
+
+    expect(backdrop().querySelector("script")).toBeNull();
+    expect(backdrop().querySelector("b")).toBeNull();
+    expect(highlights().map((span) => span.textContent)).toEqual([
+      "@Researcher",
+    ]);
+  });
+
+  it("re-mirrors the value as it changes", () => {
+    const { rerender } = render(
+      <Composer text="@Res" tracked={[researcher]} />,
+    );
+    expect(highlights()).toHaveLength(0);
+
+    rerender(<Composer text="@Researcher hi" tracked={[researcher]} />);
+
+    expect(backdrop().textContent).toBe("@Researcher hi");
+    expect(highlights()).toHaveLength(1);
+  });
+
+  // The composer surface is the only background the pill ever sits on, and the
+  // fill is a few percent away from it there; without the outline the pill is a
+  // wash rather than a mark.
+  it("outlines the pill as well as filling it, both from theme tokens", () => {
+    render(<Composer text="@Researcher please" tracked={[researcher]} />);
+
+    expect(highlights()[0]).toHaveClass(
+      "bg-theme-info-bg",
+      "shadow-[inset_0_0_0_1px_var(--theme-info-border)]",
+    );
+  });
+
+  it("fades with the composer while it is locked", () => {
+    const { rerender } = render(
+      <Composer text="@Researcher please" tracked={[researcher]} />,
+    );
+    expect(backdrop()).not.toHaveClass("opacity-50");
+
+    rerender(
+      <Composer text="@Researcher please" tracked={[researcher]} dimmed />,
+    );
+
+    expect(backdrop()).toHaveClass("opacity-50");
+  });
+
+  it("follows the textarea's scroll offset", () => {
+    render(
+      <Composer text={"@Researcher\n".repeat(40)} tracked={[researcher]} />,
+    );
+    const textarea = screen.getByTestId("composer-textarea");
+    // jsdom has no layout, so neither element scrolls on its own.
+    const applied: number[] = [];
+    Object.defineProperty(textarea, "scrollTop", {
+      configurable: true,
+      value: 128,
+    });
+    Object.defineProperty(backdrop(), "scrollTop", {
+      configurable: true,
+      set: (value: number) => {
+        applied.push(value);
+      },
+      get: () => applied[applied.length - 1] ?? 0,
+    });
+
+    fireEvent.scroll(textarea);
+
+    expect(applied.at(-1)).toBe(128);
+  });
+});

--- a/frontend/src/components/ui/Chat/AssistantMentionBackdrop.tsx
+++ b/frontend/src/components/ui/Chat/AssistantMentionBackdrop.tsx
@@ -1,0 +1,135 @@
+import clsx from "clsx";
+import { Fragment, useCallback, useEffect, useMemo, useRef } from "react";
+
+import { findMentionRanges } from "@/utils/chat/assistantMentions";
+
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
+import type { RefObject } from "react";
+
+export interface AssistantMentionBackdropProps {
+  text: string;
+  tracked: AssistantMention[];
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  /** The textarea fades its own glyphs when locked; the mirror is a sibling. */
+  dimmed?: boolean;
+}
+
+interface MentionSegment {
+  start: number;
+  text: string;
+  id: string | null;
+}
+
+/**
+ * Paints a fill behind every tracked `@Name` in the composer, so that the rule
+ * "only a picked mention delegates" is visible: a hand-typed token reads the
+ * same as a picked one otherwise.
+ *
+ * It mirrors the textarea's text with `color: transparent` and only backs the
+ * mention spans, rather than the more common inversion where the mirror shows
+ * the text and the textarea hides it. A mirror that drifts then offsets a patch
+ * of colour instead of what the user is typing.
+ *
+ * Alignment therefore depends on the mirror matching the textarea's box: same
+ * padding class, inherited font metrics, the same wrapping, and the same
+ * scroll offset.
+ */
+export function AssistantMentionBackdrop({
+  text,
+  tracked,
+  textareaRef,
+  dimmed = false,
+}: AssistantMentionBackdropProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  const segments = useMemo(() => {
+    const parts: MentionSegment[] = [];
+    let cursor = 0;
+    for (const range of findMentionRanges(text, tracked)) {
+      if (range.start > cursor) {
+        parts.push({
+          start: cursor,
+          text: text.slice(cursor, range.start),
+          id: null,
+        });
+      }
+      parts.push({
+        start: range.start,
+        text: text.slice(range.start, range.end),
+        id: range.id,
+      });
+      cursor = range.end;
+    }
+    if (cursor < text.length) {
+      parts.push({ start: cursor, text: text.slice(cursor), id: null });
+    }
+    return parts;
+  }, [text, tracked]);
+
+  const syncViewport = useCallback(() => {
+    const textarea = textareaRef.current;
+    const backdrop = backdropRef.current;
+    if (!textarea || !backdrop) {
+      return;
+    }
+    backdrop.scrollTop = textarea.scrollTop;
+    // A scrollbar narrows the textarea's content box once the draft outgrows
+    // the field; the mirror wraps a character late unless it loses the same
+    // width.
+    backdrop.style.width = `${textarea.clientWidth}px`;
+  }, [textareaRef]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    syncViewport();
+    textarea.addEventListener("scroll", syncViewport);
+    const observer = new ResizeObserver(syncViewport);
+    observer.observe(textarea);
+    return () => {
+      textarea.removeEventListener("scroll", syncViewport);
+      observer.disconnect();
+    };
+  }, [syncViewport, textareaRef]);
+
+  useEffect(syncViewport, [syncViewport, text]);
+
+  return (
+    <div
+      ref={backdropRef}
+      aria-hidden="true"
+      className={clsx(
+        "pointer-events-none absolute inset-0 -z-10 select-none overflow-hidden",
+        "chat-input-textarea-geometry",
+        "max-h-[200px] whitespace-pre-wrap break-words",
+        "text-base text-transparent",
+        dimmed && "opacity-50",
+      )}
+      data-testid="chat-input-mention-backdrop"
+    >
+      {segments.map((segment) =>
+        segment.id === null ? (
+          <Fragment key={segment.start}>{segment.text}</Fragment>
+        ) : (
+          <span
+            key={segment.start}
+            // On the composer's own surface the fill alone is a ~4% luminance
+            // step, so the outline is what makes the pill a shape. Inset rather
+            // than a border: a border box widens the span and walks the mirrored
+            // glyphs out of line with the textarea's.
+            className="rounded-[var(--theme-radius-control)] bg-theme-info-bg box-decoration-clone shadow-[inset_0_0_0_1px_var(--theme-info-border)]"
+            data-mention-id={segment.id}
+            data-testid="chat-input-mention-highlight"
+          >
+            {segment.text}
+          </span>
+        ),
+      )}
+      {/* The textarea keeps a line box for a trailing newline; the mirror only
+          gets one from an explicit break. */}
+      <br />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -1035,7 +1035,7 @@ describe("ChatInput", () => {
     const textarea = container.querySelector("textarea");
 
     expect(shell?.firstElementChild).toBe(inlinePreview);
-    expect(inlinePreview?.nextElementSibling).toBe(textarea);
+    expect(inlinePreview?.nextElementSibling).toContainElement(textarea);
   });
 
   // Guard against the prop chain silently breaking. The Outlook add-in
@@ -4122,6 +4122,9 @@ describe("ChatInput", () => {
       expect(
         screen.queryByTestId("chat-input-mention-option-assistant-research"),
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-mention-backdrop"),
+      ).not.toBeInTheDocument();
       expect(mockFacetSelector).not.toHaveBeenCalled();
     });
 
@@ -4310,6 +4313,45 @@ describe("ChatInput", () => {
       );
     });
 
+    // The highlight exists to show which tokens actually delegate, so it has to
+    // mark exactly what the send resolves — never a hand-typed look-alike.
+    it("highlights the picked mention only, matching what it sends", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const textarea = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "@Editor please");
+
+      expect(
+        screen.queryAllByTestId("chat-input-mention-highlight"),
+      ).toHaveLength(0);
+
+      typeWithCaretAtEnd(textarea, "@Editor please @Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+
+      expect(textarea).toHaveValue("@Editor please @Researcher ");
+      expect(
+        screen
+          .getAllByTestId("chat-input-mention-highlight")
+          .map((span) => span.textContent),
+      ).toEqual(["@Researcher"]);
+      expect(
+        screen.getByTestId("chat-input-mention-backdrop").textContent,
+      ).toBe("@Editor please @Researcher ");
+
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Editor please @Researcher",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
     it("drops the mention when its token is deleted from the text", async () => {
       enableDelegation();
       const onSendMessage = vi.fn();
@@ -4426,6 +4468,103 @@ describe("ChatInput", () => {
         undefined,
         [],
         ["assistant-research"],
+      );
+    });
+
+    // The tracked list is restored from the draft and outlives the assistant
+    // query, so a highlight gated on that query would leave a token that still
+    // delegates reading as plain text.
+    it("keeps highlighting a restored mention while the assistant list is unavailable", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (mountKey: number) => (
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              key={mountKey}
+              onSendMessage={onSendMessage}
+              chatId="chat-1"
+            />
+          </I18nProvider>
+        </QueryClientProvider>
+      );
+      const { rerender } = render(ui(1));
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, "@Researcher please review");
+
+      // The cached list is gone by the time the composer comes back, so the
+      // mention affordances have nothing to offer.
+      mockUseListAssistants.mockReturnValue({ data: undefined });
+      mockUseFrequentAssistants.mockReturnValue({ data: undefined });
+      rerender(ui(2));
+
+      const remounted = screen.getByPlaceholderText("Type a message...");
+      expect(remounted).toHaveValue("@Researcher please review");
+      expect(
+        screen
+          .getAllByTestId("chat-input-mention-highlight")
+          .map((span) => span.textContent),
+      ).toEqual(["@Researcher"]);
+
+      fireEvent.keyDown(remounted, { key: "Enter", shiftKey: false });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please review",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("fades the highlight with the composer text while the draft is locked", async () => {
+      enableDelegation();
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (disabled: boolean) => (
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <ChatInput
+              onSendMessage={vi.fn()}
+              chatId="chat-1"
+              disabled={disabled}
+            />
+          </I18nProvider>
+        </QueryClientProvider>
+      );
+      const { rerender } = render(ui(false));
+
+      const textarea = screen.getByPlaceholderText("Type a message...");
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      expect(screen.getByTestId("chat-input-mention-backdrop")).not.toHaveClass(
+        "opacity-50",
+      );
+
+      rerender(ui(true));
+
+      expect(textarea).toBeDisabled();
+      expect(screen.getByTestId("chat-input-mention-backdrop")).toHaveClass(
+        "opacity-50",
       );
     });
 

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -76,6 +76,7 @@ import {
   VoiceIcon,
 } from "../icons";
 import { AssistantBrowserModal } from "./AssistantBrowserModal";
+import { AssistantMentionBackdrop } from "./AssistantMentionBackdrop";
 import { AssistantMentionPopover } from "./AssistantMentionPopover";
 import { ChatInputAddControls } from "./ChatInputAddControls";
 import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
@@ -2532,57 +2533,73 @@ export const ChatInput = ({
           )}
 
           {!isAudioMode && (
-            <textarea
-              ref={textareaRef}
-              value={message}
-              onChange={(e) => {
-                setMessage(e.target.value);
-                syncMentionTrigger(e.target);
-              }}
-              onSelect={(e) => syncMentionTrigger(e.currentTarget)}
-              onClick={(e) => syncMentionTrigger(e.currentTarget)}
-              onKeyUp={(e) => syncMentionTrigger(e.currentTarget)}
-              onPaste={handleTextareaPaste}
-              onKeyDown={(e) => {
-                // The open picker owns Enter, Tab and the arrows — it has to
-                // run before Enter reaches send/queue.
-                if (mentionPopoverRef.current?.handleComposerKeyDown(e)) {
-                  return;
-                }
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  // While a turn is generating, Enter queues the draft to
-                  // auto-send when the turn finishes (ERMAIN-470); otherwise it
-                  // submits normally.
-                  if (enqueueCurrentMessage()) {
+            // isolate keeps the backdrop's negative layer above the shell's own
+            // background instead of behind it; flex keeps the textarea from
+            // gaining an inline-block descender now that it is wrapped.
+            <div className="relative isolate flex w-full">
+              {/* Gated on the tracked list, not on the mention affordances: the
+                  list is restored from the draft and outlives the assistant
+                  query, and whatever it holds is what submit delegates to. */}
+              {mentionedAssistants.length > 0 && (
+                <AssistantMentionBackdrop
+                  text={message}
+                  tracked={mentionedAssistants}
+                  textareaRef={textareaRef}
+                  dimmed={composeLocked}
+                />
+              )}
+              <textarea
+                ref={textareaRef}
+                value={message}
+                onChange={(e) => {
+                  setMessage(e.target.value);
+                  syncMentionTrigger(e.target);
+                }}
+                onSelect={(e) => syncMentionTrigger(e.currentTarget)}
+                onClick={(e) => syncMentionTrigger(e.currentTarget)}
+                onKeyUp={(e) => syncMentionTrigger(e.currentTarget)}
+                onPaste={handleTextareaPaste}
+                onKeyDown={(e) => {
+                  // The open picker owns Enter, Tab and the arrows — it has to
+                  // run before Enter reaches send/queue.
+                  if (mentionPopoverRef.current?.handleComposerKeyDown(e)) {
                     return;
                   }
-                  handleSubmit(e);
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    // While a turn is generating, Enter queues the draft to
+                    // auto-send when the turn finishes (ERMAIN-470); otherwise it
+                    // submits normally.
+                    if (enqueueCurrentMessage()) {
+                      return;
+                    }
+                    handleSubmit(e);
+                  }
+                }}
+                placeholder={
+                  isAnyTokenLimitExceeded
+                    ? t`Message exceeds token limit. Please reduce length or remove files.`
+                    : placeholder
                 }
-              }}
-              placeholder={
-                isAnyTokenLimitExceeded
-                  ? t`Message exceeds token limit. Please reduce length or remove files.`
-                  : placeholder
-              }
-              rows={1}
-              disabled={composeLocked}
-              tabIndex={0}
-              autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
-              className={clsx(
-                "w-full resize-none overflow-y-auto",
-                "chat-input-textarea-geometry",
-                "bg-transparent",
-                "text-[var(--theme-fg-primary)] placeholder:text-[var(--theme-fg-muted)]",
-                "focus:outline-none",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                "max-h-[200px]",
-                "text-base",
-                "scrollbar-auto-hide",
-                isAnyTokenLimitExceeded &&
-                  "border-[var(--theme-error)] placeholder:text-[var(--theme-error-fg)]",
-              )}
-            />
+                rows={1}
+                disabled={composeLocked}
+                tabIndex={0}
+                autoFocus={shouldAutofocus} // eslint-disable-line jsx-a11y/no-autofocus -- Controlled by feature config to prevent unwanted scrolling
+                className={clsx(
+                  "w-full resize-none overflow-y-auto",
+                  "chat-input-textarea-geometry",
+                  "bg-transparent",
+                  "text-[var(--theme-fg-primary)] placeholder:text-[var(--theme-fg-muted)]",
+                  "focus:outline-none",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                  "max-h-[200px]",
+                  "text-base",
+                  "scrollbar-auto-hide",
+                  isAnyTokenLimitExceeded &&
+                    "border-[var(--theme-error)] placeholder:text-[var(--theme-error-fg)]",
+                )}
+              />
+            </div>
           )}
 
           <div

--- a/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
+++ b/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   applyMentionSelection,
   detectMentionTrigger,
+  findMentionRanges,
   mentionToken,
   pruneTrackedMentions,
   resolveMentionedAssistantIds,
@@ -100,6 +101,81 @@ describe("applyMentionSelection", () => {
       text: "hello @Data ",
       caret: 12,
     });
+  });
+});
+
+describe("findMentionRanges", () => {
+  it("finds nothing for a name nobody tracked", () => {
+    expect(findMentionRanges("@Researcher please", [])).toEqual([]);
+  });
+
+  it("finds a mention at the very start", () => {
+    expect(findMentionRanges("@Data now", [dataAssistant])).toEqual([
+      { start: 0, end: 5, id: "a2", name: "Data" },
+    ]);
+  });
+
+  it("finds a mention mid-sentence", () => {
+    expect(findMentionRanges("please ask @Data now", [dataAssistant])).toEqual([
+      { start: 11, end: 16, id: "a2", name: "Data" },
+    ]);
+  });
+
+  it("skips an address-like @", () => {
+    expect(findMentionRanges("mail me@Data now", [dataAssistant])).toEqual([]);
+  });
+
+  it("returns one range per repetition", () => {
+    expect(
+      findMentionRanges("@Data and @Data", [dataAssistant]).map(
+        (range) => range.start,
+      ),
+    ).toEqual([0, 10]);
+  });
+
+  it("spans a name with spaces", () => {
+    expect(findMentionRanges("@Data Analyst please", [dataAnalyst])).toEqual([
+      { start: 0, end: 13, id: "a3", name: "Data Analyst" },
+    ]);
+  });
+
+  it("gives an overlapping span to the longer name", () => {
+    expect(
+      findMentionRanges("@Data Analyst please", [dataAssistant, dataAnalyst]),
+    ).toEqual([{ start: 0, end: 13, id: "a3", name: "Data Analyst" }]);
+  });
+
+  it("treats regex metacharacters in a name literally", () => {
+    expect(findMentionRanges("ping @C++ (v1.0)", [regexName])).toEqual([
+      { start: 5, end: 16, id: "a4", name: "C++ (v1.0)" },
+    ]);
+    expect(findMentionRanges("ping @Cxx (v1x0)", [regexName])).toEqual([]);
+  });
+
+  it("orders ranges by position rather than by tracked order", () => {
+    expect(
+      findMentionRanges("@Data then @Researcher", [
+        researcher,
+        dataAssistant,
+      ]).map((range) => range.id),
+    ).toEqual(["a2", "a1"]);
+  });
+
+  it("bounds every range to exactly its token", () => {
+    const text = "ask @Data Analyst and @Researcher.";
+    expect(
+      findMentionRanges(text, [researcher, dataAssistant, dataAnalyst]).map(
+        (range) => text.slice(range.start, range.end),
+      ),
+    ).toEqual(["@Data Analyst", "@Researcher"]);
+  });
+
+  it("agrees with the ids the composer submits", () => {
+    const text = "@Data and @Data Analyst and @Researcher";
+    const tracked = [researcher, dataAssistant, dataAnalyst];
+    expect(new Set(findMentionRanges(text, tracked).map((r) => r.id))).toEqual(
+      new Set(resolveMentionedAssistantIds(text, tracked)),
+    );
   });
 });
 

--- a/frontend/src/utils/chat/assistantMentions.ts
+++ b/frontend/src/utils/chat/assistantMentions.ts
@@ -9,6 +9,14 @@ export interface MentionTrigger {
   startIndex: number;
 }
 
+export interface MentionRange {
+  start: number;
+  /** Exclusive, so `text.slice(start, end)` is the whole `@Name` token. */
+  end: number;
+  id: string;
+  name: string;
+}
+
 /**
  * Requiring start-or-whitespace before the `@` is what keeps `a@b.com` from
  * opening the picker; excluding `@` from the query keeps a second `@` from
@@ -63,43 +71,49 @@ function isAtWordEnd(text: string, index: number): boolean {
   return index >= text.length || !/[\p{L}\p{N}_]/u.test(text[index]);
 }
 
-/**
- * A token only counts where it is not the leading fragment of a longer tracked
- * name at the same position: with both "Data" and "Data Analyst" tracked, the
- * text `@Data Analyst` must resolve to the latter alone.
- */
-function isMentionPresent(
-  text: string,
-  mention: AssistantMention,
-  tracked: AssistantMention[],
-): boolean {
-  const token = mentionToken(mention.name);
-  const shadowingTokens = tracked
-    .filter(
-      (other) =>
-        other.name.length > mention.name.length &&
-        other.name.startsWith(mention.name),
-    )
-    .map((other) => mentionToken(other.name));
+function trackedKey(mention: AssistantMention): string {
+  return JSON.stringify([mention.id, mention.name]);
+}
 
-  let searchFrom = 0;
-  for (;;) {
-    const index = text.indexOf(token, searchFrom);
-    if (index < 0) {
-      return false;
+/**
+ * Where each tracked mention stands in the text, in text order and without
+ * overlaps. Matching the longest names first is what makes `@Data Analyst`
+ * claim the span before "Data" can, so the composer highlight and the submitted
+ * ids are two readings of one result rather than two rules that can drift.
+ */
+export function findMentionRanges(
+  text: string,
+  tracked: AssistantMention[],
+): MentionRange[] {
+  const ranges: MentionRange[] = [];
+  const byNameLength = [...tracked].sort(
+    (a, b) => b.name.length - a.name.length,
+  );
+
+  for (const mention of byNameLength) {
+    const token = mentionToken(mention.name);
+    let searchFrom = 0;
+    for (;;) {
+      const start = text.indexOf(token, searchFrom);
+      if (start < 0) {
+        break;
+      }
+      searchFrom = start + 1;
+      const end = start + token.length;
+      const overlapsClaimed = ranges.some(
+        (range) => start < range.end && end > range.start,
+      );
+      if (
+        !overlapsClaimed &&
+        isAtWordStart(text, start) &&
+        isAtWordEnd(text, end)
+      ) {
+        ranges.push({ start, end, id: mention.id, name: mention.name });
+      }
     }
-    const shadowed = shadowingTokens.some((shadowing) =>
-      text.startsWith(shadowing, index),
-    );
-    if (
-      !shadowed &&
-      isAtWordStart(text, index) &&
-      isAtWordEnd(text, index + token.length)
-    ) {
-      return true;
-    }
-    searchFrom = index + 1;
   }
+
+  return ranges.sort((a, b) => a.start - b.start);
 }
 
 /** The ids the composer should submit: tracked order, deduped, text wins. */
@@ -107,10 +121,13 @@ export function resolveMentionedAssistantIds(
   text: string,
   tracked: AssistantMention[],
 ): string[] {
+  const present = new Set(
+    findMentionRanges(text, tracked).map((range) => range.id),
+  );
   const ids: string[] = [];
   const seen = new Set<string>();
   for (const mention of tracked) {
-    if (seen.has(mention.id) || !isMentionPresent(text, mention, tracked)) {
+    if (seen.has(mention.id) || !present.has(mention.id)) {
       continue;
     }
     seen.add(mention.id);
@@ -127,14 +144,15 @@ export function pruneTrackedMentions(
   text: string,
   tracked: AssistantMention[],
 ): AssistantMention[] {
+  const present = new Set(findMentionRanges(text, tracked).map(trackedKey));
   const seen = new Set<string>();
   const next = tracked.filter((mention) => {
-    const key = JSON.stringify([mention.id, mention.name]);
+    const key = trackedKey(mention);
     if (seen.has(key)) {
       return false;
     }
     seen.add(key);
-    return isMentionPresent(text, mention, tracked);
+    return present.has(key);
   });
   return next.length === tracked.length ? tracked : next;
 }


### PR DESCRIPTION
**On top of #986.** Review bottom-up; this layer's diff is against the delegated-runs view.

Stack: #978 config → #979 provenance/primitives → #980 mention validation → #981 runtime → #982 listing → #984 composer mentions → #985 in-chat trace → #986 delegated-runs view → #987 mention highlight.

Paints a fill behind every tracked `@Name` in the composer.

## Why this is a correctness affordance, not decoration

Text is the source of truth, and only mentions the user actually **picked** are tracked — a hand-typed `@Researcher` looks identical and is **silently not delegated**. The pill makes that rule visible before send. Which means the highlight must never disagree with the payload, and most of the work here is guaranteeing that.

## What changes

- **One matcher, two consumers.** `isMentionPresent` is replaced by an exported `findMentionRanges(text, tracked)`; `resolveMentionedAssistantIds` reduces those ranges to ids and the overlay slices the same ranges into spans. There is no second matcher. Pinned by three tests, including one that hand-types an untracked `@Editor` beside a picked `@Researcher` and asserts the pill set and the sent id set agree. The generalised overlap rule subsumes the old prefix-shadow rule; all 28 pre-existing mention tests pass unchanged.
- **The overlay gate is the send gate.** It renders on `mentionedAssistants.length > 0` — exactly the state `resolveMentionedAssistantIds` reads — not on `canMentionAssistants`. Those diverge: a restored draft whose assistant list has not loaded can still delegate, and would otherwise have delegated with no pill. Strictly cheaper too, since with nothing tracked the mirror and its `ResizeObserver` do not mount.
- **Mirrored backdrop, deliberately not inverted.** An `aria-hidden`, `pointer-events-none` div behind the textarea renders the same text at `color: transparent` and backs only the mention spans; the textarea's own glyphs render on top. The commoner inversion hides the textarea's text and shows the mirror's — where a drift or a throw costs the user sight of what they are typing. Here a drift offsets a patch of colour.
- Alignment rides the shared `chat-input-textarea-geometry` class so token-driven padding and the `sm:` breakpoint apply to both boxes; segments are React children so escaping is React's; `box-decoration-clone` keeps a wrapped pill intact; a trailing `<br />` supplies the last line box while keeping `textContent` identical to the value; `scrollTop` is mirrored, and a `ResizeObserver` copies `clientWidth` so a classic scrollbar's gutter cannot make the mirror wrap a character late.

## The pill needed an outline

`--theme-info-bg` alone is a ~1.10:1 step against the composer surface — in the default light theme the fill is effectively invisible. Two independent review lenses caught it. Fixed with an inset `box-shadow` in `--theme-info-border`, which resolves byte-identically to the border the sibling attachment chips and queued-message row already use on this same surface. Inset rather than a real border on purpose: a border box would widen the span and walk the mirrored glyphs out of line.

Coloured mention *text* is not achievable and is out of scope — the visible glyphs belong to the textarea, which has one colour for the whole field.

## Testing

Range-matching edge cases (index 0, mid-sentence, address-like `@`, duplicates, names with spaces or regex metacharacters, a name prefixing another); the highlight/payload agreement tests above; a restored mention still highlighting with the assistant list unavailable; the disabled fade; HTML in the draft escaping rather than injecting; scroll sync. Frontend suite green including `tsc -p tsconfig.lib.json`, which is the typecheck the add-in build depends on.

Alignment was additionally checked in real Chromium across wrapped lines, a broken long word, multiple paragraphs and a scrolled field — jsdom can assert the text mirrors exactly, but not that the pills sit behind the glyphs.

## Not included

The hover card showing the assistant's description. The textarea swallows pointer events, so it needs hit-testing against the span's client rects — several times the cost. Tracked separately.
