### PR TITLE
Pin continuestream tool scope, share the generation task lifecycle (ERMAIN-628)

### DIFF
--- a/backend/erato/src/models/chat.rs
+++ b/backend/erato/src/models/chat.rs
@@ -258,11 +258,14 @@ pub async fn create_delegated_chat(
         .await?)
 }
 
-/// Counts reported by [`seed_chat_lineage`].
+/// What [`seed_chat_lineage`] wrote.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SeedStats {
     pub messages_copied: usize,
     pub files_linked: usize,
+    /// Last copy written, i.e. the head the target chat's own turns continue
+    /// from. `None` when the lineage was empty.
+    pub lineage_tip_id: Option<Uuid>,
 }
 
 /// Copies the message lineage from `source_message_id` back to its root into
@@ -352,6 +355,7 @@ pub async fn seed_chat_lineage(
     Ok(SeedStats {
         messages_copied: lineage.len(),
         files_linked,
+        lineage_tip_id: previous_new_id,
     })
 }
 

--- a/backend/erato/src/server/api/v1beta/file_resolution.rs
+++ b/backend/erato/src/server/api/v1beta/file_resolution.rs
@@ -4,7 +4,7 @@ use crate::models::message::{ContentPart, ContentPartText, GenerationInputMessag
 use crate::server::api::v1beta::message_streaming::FileContent;
 use crate::services::file_processing_cached::get_file_cached;
 use crate::services::file_storage::{SharepointContext, is_missing_permissions_error};
-use crate::services::prompt_composition::transforms::render_action_facet_template;
+use crate::services::prompt_composition::transforms::render_placeholder_template;
 use crate::state::AppState;
 use eyre::Report;
 use sea_orm::EntityTrait;
@@ -151,7 +151,7 @@ pub(crate) fn resolve_action_facet_markers_in_generation_input(
                     );
                     return None;
                 };
-                let rendered = render_action_facet_template(&config.template, &marker.args);
+                let rendered = render_placeholder_template(&config.template, &marker.args);
                 if rendered.is_empty() {
                     return None;
                 }

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -31,7 +31,8 @@ use crate::server::api::v1beta::message_streaming_file_extraction::{
     parse_content_filter_error_from_mcp_tool_result, post_process_mcp_tool_result,
 };
 use crate::services::background_tasks::{
-    StreamingEvent, StreamingTask, TaskCleanupGuard, ToolCallStatus as BgToolCallStatus,
+    BackgroundTaskManager, StreamingEvent, StreamingTask, TaskCleanupGuard,
+    ToolCallStatus as BgToolCallStatus,
 };
 use crate::services::client_tools::{ClientToolDelivery, ClientToolOutcome};
 use crate::services::genai::{build_chat_options_for_completion, build_chat_options_for_summary};
@@ -1126,7 +1127,7 @@ where
 }
 
 struct SharedResumeState {
-    manager: crate::services::background_tasks::BackgroundTaskManager,
+    manager: BackgroundTaskManager,
     generation_id: Uuid,
     last_event_id: i64,
     pending: VecDeque<StreamingEvent>,
@@ -1134,7 +1135,7 @@ struct SharedResumeState {
 }
 
 fn shared_generation_event_stream(
-    manager: crate::services::background_tasks::BackgroundTaskManager,
+    manager: BackgroundTaskManager,
     generation_id: Uuid,
 ) -> impl Stream<Item = Result<StreamingEvent, Report>> + Send {
     futures::stream::unfold(
@@ -1636,10 +1637,11 @@ impl PreparedChatRequest {
     }
 }
 
-/// The generic error frame a delegated child run broadcasts on failure, so a
-/// user watching the child chat resolves instead of seeing a silent end —
-/// same shape as the submit wrapper's failure broadcast.
-pub(crate) fn delegated_run_failure_error_value() -> Option<JsonValue> {
+/// The frame a failed generation broadcasts to every listener — the original
+/// stream AND any resume — so the client resolves instead of waiting for a
+/// completion that will never arrive. The detailed error is captured
+/// server-side; the client gets only a generic message.
+fn generation_failure_error_value() -> Option<JsonValue> {
     let error_event = MessageSubmitStreamingResponseError {
         message_id: None,
         error: GenerationErrorType::InternalError {
@@ -1647,6 +1649,106 @@ pub(crate) fn delegated_run_failure_error_value() -> Option<JsonValue> {
         },
     };
     serde_json::to_value(MessageSubmitStreamingResponseMessage::Error(error_event)).ok()
+}
+
+/// Runs a generation inside the lifecycle a user submit and a delegated child
+/// share: a cleanup guard around the run, the failure frame, the closing stream
+/// end, and the terminal outcome on the chat's generation lease. The edit,
+/// regenerate and continue paths run their own tail instead — each owns its
+/// request's response channel and forwards a failure over that, so neither the
+/// broadcast failure frame nor a stream end applies to them.
+///
+/// A failure is captured even where the caller absorbs it: delegation turns a
+/// failed child into a `failed` envelope the parent recovers from in prose, and
+/// that recovery does not make the run any less broken.
+pub(crate) async fn with_generation_task_lifecycle<F>(
+    background_tasks: &BackgroundTaskManager,
+    task: &Arc<StreamingTask>,
+    chat_id: Uuid,
+    run: F,
+) -> Result<(), Report>
+where
+    F: std::future::Future<Output = Result<(), Report>>,
+{
+    let mut cleanup_guard =
+        TaskCleanupGuard::new(background_tasks.clone(), chat_id, task.generation_id);
+
+    let result = run.await;
+
+    match &result {
+        Ok(()) => tracing::info!(%chat_id, "Generation task completed"),
+        Err(error) => {
+            tracing::error!(%chat_id, error = ?error, "Generation task failed");
+            capture_report(error);
+            send_background_event(
+                task,
+                StreamingEvent::Error {
+                    error: generation_failure_error_value(),
+                },
+                "broadcast generation failure",
+            )
+            .await;
+        }
+    }
+
+    send_background_event(task, StreamingEvent::StreamEnd, "broadcast stream end").await;
+    let outcome = task.derive_outcome(result.is_err());
+    task.mark_completed();
+    cleanup_guard.disarm();
+    background_tasks
+        .remove_task(&chat_id, task.generation_id, outcome)
+        .await;
+
+    result
+}
+
+#[cfg(test)]
+mod generation_task_lifecycle_tests {
+    use super::*;
+    use crate::config::GenerationStatusConfig;
+
+    async fn events_of_run(
+        run: Result<(), Report>,
+    ) -> (Vec<StreamingEvent>, BackgroundTaskManager, Uuid) {
+        let background_tasks = BackgroundTaskManager::new(None, GenerationStatusConfig::default());
+        let chat_id = Uuid::new_v4();
+        let (_receiver, task) = background_tasks.start_task(chat_id, Uuid::new_v4()).await;
+
+        let _ =
+            with_generation_task_lifecycle(&background_tasks, &task, chat_id, async move { run })
+                .await;
+
+        (task.get_event_history().await, background_tasks, chat_id)
+    }
+
+    #[tokio::test]
+    async fn a_failed_run_broadcasts_the_generic_frame_and_then_the_stream_end() {
+        let (events, background_tasks, chat_id) =
+            events_of_run(Err(eyre!("the generation blew up"))).await;
+
+        let [StreamingEvent::Error { error }, StreamingEvent::StreamEnd] = events.as_slice() else {
+            panic!("Expected a failure frame closed by a single stream end, got: {events:?}");
+        };
+        let error = error.as_ref().expect("Expected an error payload");
+        assert_eq!(error["message_type"], "error");
+        assert_eq!(error["error_type"], "internal_error");
+        assert_eq!(
+            error["error_description"],
+            "The message could not be generated."
+        );
+        assert!(background_tasks.get_task(&chat_id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_successful_run_closes_with_the_stream_end_alone() {
+        let (events, background_tasks, chat_id) = events_of_run(Ok(())).await;
+
+        assert!(
+            matches!(events.as_slice(), [StreamingEvent::StreamEnd]),
+            "Got: {events:?}"
+        );
+        assert!(background_tasks.get_task(&chat_id).await.is_none());
+    }
 }
 
 impl MessageSubmitRequest {
@@ -6993,80 +7095,24 @@ pub async fn message_submit_sse(
     // Spawn the background generation task
     tokio::spawn(
         async move {
-            let mut cleanup_guard = TaskCleanupGuard::new(
-                app_state_bg.background_tasks.clone(),
-                chat_id,
-                task_clone.generation_id,
-            );
             tracing::info!("Starting background task for chat_id: {}", chat_id);
-            let result = run_message_submit_task(
+            let _ = with_generation_task_lifecycle(
+                &app_state_bg.background_tasks,
                 &task_clone,
-                &app_state_bg,
-                &policy_bg,
-                &me_user_bg,
-                &request_clone,
-                generation_request_context,
                 chat_id,
-                chat_was_created,
-                delegation_targets,
+                run_message_submit_task(
+                    &task_clone,
+                    &app_state_bg,
+                    &policy_bg,
+                    &me_user_bg,
+                    &request_clone,
+                    generation_request_context,
+                    chat_id,
+                    chat_was_created,
+                    delegation_targets,
+                ),
             )
             .await;
-
-            let generation_failed = result.is_err();
-            match result {
-                Ok(()) => {
-                    tracing::info!(
-                        "Background task completed successfully for chat_id: {}",
-                        chat_id
-                    );
-                }
-                Err(e) => {
-                    tracing::error!(
-                        chat_id = %chat_id,
-                        error = ?e,
-                        "Background task failed"
-                    );
-                    capture_report(&e);
-
-                    // Tell every listener — the original stream AND any resume —
-                    // that this turn is dead, so the client resolves instead of
-                    // waiting for a completion that will never arrive. The
-                    // detailed error is captured server-side above; the client
-                    // gets only a generic message.
-                    let error_event = MessageSubmitStreamingResponseError {
-                        message_id: None,
-                        error: GenerationErrorType::InternalError {
-                            error_description: "The message could not be generated.".to_string(),
-                        },
-                    };
-                    let error = serde_json::to_value(MessageSubmitStreamingResponseMessage::Error(
-                        error_event,
-                    ))
-                    .ok();
-                    send_background_event(
-                        &task_clone,
-                        StreamingEvent::Error { error },
-                        "broadcast submit task failure",
-                    )
-                    .await;
-                }
-            }
-
-            // Send final stream_end event
-            send_background_event(
-                &task_clone,
-                StreamingEvent::StreamEnd,
-                "broadcast submit stream end",
-            )
-            .await;
-            // Mark task as completed
-            let outcome = task_clone.derive_outcome(generation_failed);
-            task_clone.mark_completed();
-            cleanup_guard.disarm();
-            app_state_bg
-                .background_tasks
-                .remove_task(&chat_id, task_clone.generation_id, outcome)
-                .await;
         }
         .in_current_span(),
     );
@@ -8257,7 +8303,7 @@ pub(crate) async fn run_message_submit_task(
     )
     .await?;
 
-    // Note: stream_end event is sent in the spawning wrapper in message_submit_sse
+    // Note: the stream_end event is sent by the spawning task lifecycle wrapper
 
     Ok(())
 }
@@ -9612,6 +9658,10 @@ async fn run_continue_message_task(
         .map(|tools| tools.iter().map(|tool| tool.name.to_string()).collect())
         .unwrap_or_default();
     let headers_context = ChatProviderHeadersContext::new(&me_user.id, &me_user.id_token_claims);
+    // The tool set above is MCP discovery only, so a continued turn carries no
+    // delegation offer and no dispatch context to honour one with: the
+    // arguments a delegate call needs are request-scoped and are not persisted
+    // with the parked message.
     let (end_content, generation_metadata) =
         stream_generate_chat_completion::<MessageSubmitStreamingResponseMessage>(
             tx.clone(),

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -10,6 +10,7 @@ use genai::chat::ToolName as GenaiToolName;
 use sea_orm::prelude::Uuid;
 use serde_json::json;
 use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+use tracing::Instrument;
 
 /// Name of the synthetic tool offered to the model when the current turn
 /// carries validated assistant mentions.
@@ -505,7 +506,7 @@ fn render_delegation_preamble(
             .map(|value| format!("\nConstraints:\n{value}\n"))
             .unwrap_or_default(),
     );
-    crate::services::prompt_composition::transforms::render_action_facet_template(
+    crate::services::prompt_composition::transforms::render_placeholder_template(
         preamble_template,
         &args,
     )
@@ -520,8 +521,7 @@ fn delegated_chat_title(task: &str) -> String {
     title
 }
 
-/// Wrapper mirroring the submit path's spawned task: cleanup guard, the run,
-/// stream end, outcome persistence.
+/// Runs a delegated child through the shared generation-task lifecycle.
 ///
 /// Returns an explicitly boxed future: the child generation nests the whole
 /// streaming machinery inside the parent's dispatch loop, which would
@@ -535,45 +535,30 @@ fn run_delegated_child(
     request: crate::server::api::v1beta::message_streaming::MessageSubmitRequest,
     chat_id: Uuid,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), eyre::Report>> + Send>> {
-    Box::pin(async move {
-        let mut cleanup_guard = crate::services::background_tasks::TaskCleanupGuard::new(
-            app_state.background_tasks.clone(),
-            chat_id,
-            child_task.generation_id,
-        );
-        let result = crate::server::api::v1beta::message_streaming::run_message_submit_task(
-            &child_task,
-            &app_state,
-            &policy,
-            &me_user,
-            &request,
-            crate::models::message::GenerationRequestContext { platform: None },
-            chat_id,
-            true,
-            Vec::new(),
-        )
-        .await;
-        let generation_failed = result.is_err();
-        if let Err(error) = &result {
-            tracing::warn!(child_chat_id = %chat_id, error = ?error, "Delegated child run failed");
-            let _ = child_task
-                .send_event(crate::services::background_tasks::StreamingEvent::Error {
-                    error: crate::server::api::v1beta::message_streaming::delegated_run_failure_error_value(),
-                })
-                .await;
+    Box::pin(
+        async move {
+            crate::server::api::v1beta::message_streaming::with_generation_task_lifecycle(
+                &app_state.background_tasks,
+                &child_task,
+                chat_id,
+                crate::server::api::v1beta::message_streaming::run_message_submit_task(
+                    &child_task,
+                    &app_state,
+                    &policy,
+                    &me_user,
+                    &request,
+                    crate::models::message::GenerationRequestContext { platform: None },
+                    chat_id,
+                    true,
+                    Vec::new(),
+                ),
+            )
+            .await
         }
-        let _ = child_task
-            .send_event(crate::services::background_tasks::StreamingEvent::StreamEnd)
-            .await;
-        let outcome = child_task.derive_outcome(generation_failed);
-        child_task.mark_completed();
-        cleanup_guard.disarm();
-        app_state
-            .background_tasks
-            .remove_task(&chat_id, child_task.generation_id, outcome)
-            .await;
-        result
-    })
+        // The shared lifecycle logs a bare chat id, which reads the same for a
+        // parent turn; the span is what tells a child's failure apart.
+        .instrument(tracing::info_span!("delegated_child", child_chat_id = %chat_id)),
+    )
 }
 
 /// Reads the delegate's final answer and builds the result envelope. The
@@ -601,11 +586,25 @@ async fn build_result_envelope(
     // newest-row scanning, so neither seeded parent copies nor a concurrent
     // interloping run on the child chat can masquerade as the delegate's
     // result. Rows predating the spawn are seeded copies by construction.
-    let assistant_row = crate::db::entity::messages::Entity::find_by_id(child_assistant_message_id)
-        .one(&app_state.db)
-        .await
-        .ok()
-        .flatten()
+    let assistant_row =
+        match crate::db::entity::messages::Entity::find_by_id(child_assistant_message_id)
+            .one(&app_state.db)
+            .await
+        {
+            Ok(row) => row,
+            Err(error) => {
+                // A read failure is indistinguishable from an unanswered run
+                // below, so a delegate that did answer is reported as failed.
+                tracing::error!(
+                    %error,
+                    %child_chat_id,
+                    %child_assistant_message_id,
+                    "Failed to read the delegate's answer"
+                );
+                None
+            }
+        };
+    let assistant_row = assistant_row
         .filter(|row| row.chat_id == child_chat_id && row.created_at > spawned_at)
         .filter(|row| {
             row.raw_message
@@ -687,7 +686,7 @@ async fn prepare_delegated_chat(
     file_ids: &[Uuid],
     include_conversation_context: bool,
 ) -> Result<Option<Uuid>, String> {
-    use sea_orm::{ActiveValue, ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+    use sea_orm::{ActiveValue, EntityTrait};
 
     for file_id in file_ids {
         let join_row = crate::db::entity::chat_file_uploads::ActiveModel {
@@ -708,31 +707,29 @@ async fn prepare_delegated_chat(
         return Ok(None);
     }
 
-    let anchor_id = crate::db::entity::messages::Entity::find_by_id(context.origin_user_message_id)
-        .one(&app_state.db)
-        .await
-        .ok()
-        .flatten()
-        .and_then(|row| row.previous_message_id);
-    let Some(anchor_id) = anchor_id else {
+    // A read failure is indistinguishable from a mention turn that opens the
+    // chat, so it has to refuse rather than fall through to seeding nothing and
+    // letting the delegate answer without the context it was promised.
+    let origin_row =
+        crate::db::entity::messages::Entity::find_by_id(context.origin_user_message_id)
+            .one(&app_state.db)
+            .await
+            .map_err(|error| {
+                tracing::warn!(%error, "Failed to resolve the delegated chat's seeding anchor");
+                "Failed to pass the conversation context to the delegate.".to_string()
+            })?;
+    let Some(anchor_id) = origin_row.and_then(|row| row.previous_message_id) else {
         return Ok(None);
     };
 
-    crate::models::chat::seed_chat_lineage(&app_state.db, &child_chat_id, &anchor_id)
+    let seeded = crate::models::chat::seed_chat_lineage(&app_state.db, &child_chat_id, &anchor_id)
         .await
         .map_err(|error| {
             tracing::warn!(%error, "Failed to seed delegated chat lineage");
             "Failed to pass the conversation context to the delegate.".to_string()
         })?;
 
-    Ok(crate::db::entity::messages::Entity::find()
-        .filter(crate::db::entity::messages::Column::ChatId.eq(child_chat_id))
-        .order_by_desc(crate::db::entity::messages::Column::CreatedAt)
-        .one(&app_state.db)
-        .await
-        .ok()
-        .flatten()
-        .map(|row| row.id))
+    Ok(seeded.lineage_tip_id)
 }
 
 /// Removes a delegated chat whose run never started. Dispatch creates the chat

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2861,18 +2861,18 @@ mod test_cases {
     }
 
     // ============================================================================
-    // render_action_facet_template tests
+    // render_placeholder_template tests
     // ============================================================================
 
-    mod render_action_facet_template_tests {
-        use super::super::super::transforms::render_action_facet_template;
+    mod render_placeholder_template_tests {
+        use super::super::super::transforms::render_placeholder_template;
         use std::collections::HashMap;
 
         #[test]
         fn basic_substitution() {
             let args = HashMap::from([("name".to_string(), "Alice".to_string())]);
             assert_eq!(
-                render_action_facet_template("Hello {{name}}!", &args),
+                render_placeholder_template("Hello {{name}}!", &args),
                 "Hello Alice!"
             );
         }
@@ -2884,7 +2884,7 @@ mod test_cases {
                 ("name".to_string(), "Bob".to_string()),
             ]);
             assert_eq!(
-                render_action_facet_template("{{greeting}}, {{name}}!", &args),
+                render_placeholder_template("{{greeting}}, {{name}}!", &args),
                 "Hi, Bob!"
             );
         }
@@ -2893,7 +2893,7 @@ mod test_cases {
         fn empty_args_leaves_template_unchanged() {
             let args = HashMap::new();
             assert_eq!(
-                render_action_facet_template("Hello {{name}}!", &args),
+                render_placeholder_template("Hello {{name}}!", &args),
                 "Hello {{name}}!"
             );
         }
@@ -2902,7 +2902,7 @@ mod test_cases {
         fn missing_key_leaves_placeholder() {
             let args = HashMap::from([("other".to_string(), "val".to_string())]);
             assert_eq!(
-                render_action_facet_template("Hello {{name}}!", &args),
+                render_placeholder_template("Hello {{name}}!", &args),
                 "Hello {{name}}!"
             );
         }
@@ -2914,7 +2914,7 @@ mod test_cases {
                 ("first".to_string(), "{{second}}".to_string()),
                 ("second".to_string(), "LEAKED".to_string()),
             ]);
-            let result = render_action_facet_template("Result: {{first}}", &args);
+            let result = render_placeholder_template("Result: {{first}}", &args);
             assert!(
                 !result.contains("LEAKED"),
                 "Value containing {{{{second}}}} was re-expanded: {result}"
@@ -2925,14 +2925,14 @@ mod test_cases {
         #[test]
         fn empty_template_returns_empty() {
             let args = HashMap::from([("k".to_string(), "v".to_string())]);
-            assert_eq!(render_action_facet_template("", &args), "");
+            assert_eq!(render_placeholder_template("", &args), "");
         }
 
         #[test]
         fn value_with_special_chars() {
             let args = HashMap::from([("code".to_string(), "a < b && c > d".to_string())]);
             assert_eq!(
-                render_action_facet_template("Check: {{code}}", &args),
+                render_placeholder_template("Check: {{code}}", &args),
                 "Check: a < b && c > d"
             );
         }

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -804,11 +804,13 @@ fn detect_facet_toggle_states(
     FacetToggleStates { states }
 }
 
-/// Renders an action facet template by replacing `{{key}}` placeholders with argument values.
+/// Renders a configured template by replacing `{{key}}` placeholders with
+/// argument values. Used for action-facet templates and the delegation
+/// preamble.
 ///
 /// Uses single-pass replacement to guarantee that substituted values are never
 /// re-scanned for further `{{…}}` patterns, preventing injection via arg values.
-pub(crate) fn render_action_facet_template(
+pub(crate) fn render_placeholder_template(
     template: &str,
     args: &HashMap<String, String>,
 ) -> String {

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -274,6 +274,11 @@ async fn test_seed_chat_lineage_copies_deep_lineage_and_files(pool: Pool<Postgre
     let target_rows = chat_messages_by_created_at(&app_state.db, target_chat_id).await;
     assert_eq!(source_rows.len(), 12);
     assert_eq!(target_rows.len(), 12);
+    assert_eq!(
+        stats.lineage_tip_id,
+        target_rows.last().map(|row| row.id),
+        "the reported tip is the head the target chat continues from"
+    );
 
     let mut expected_previous: Option<Uuid> = None;
     for (source_row, target_row) in source_rows.iter().zip(target_rows.iter()) {
@@ -1042,6 +1047,29 @@ async fn delegated_child_chat(
         .expect("expected a delegated child chat")
 }
 
+/// The event types a chat's generation left in the shared stream, in order —
+/// what a resume landing on another replica replays.
+async fn shared_generation_event_types(
+    db: &sea_orm::DatabaseConnection,
+    chat_id: Uuid,
+) -> Vec<String> {
+    use sea_orm::{ConnectionTrait, Statement};
+    db.query_all_raw(Statement::from_sql_and_values(
+        sea_orm::DatabaseBackend::Postgres,
+        r#"SELECT event ->> 'message_type' AS message_type
+           FROM temp_chat_generation_events
+           JOIN temp_chat_generations USING (generation_id)
+           WHERE chat_id = $1
+           ORDER BY event_id"#,
+        [chat_id.into()],
+    ))
+    .await
+    .unwrap()
+    .iter()
+    .map(|row| row.try_get::<String>("", "message_type").unwrap())
+    .collect()
+}
+
 /// Happy path: the parent turn calls `delegate_to_assistant`, the child run
 /// completes, the parent receives the envelope and finishes. Also proves the
 /// child's request head carries the delegate prompt + preamble (not the
@@ -1280,6 +1308,14 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
     assert_eq!(provenance.depth, 1);
     assert!(provenance.rebase_cutoff.is_some());
     assert_eq!(child_chat.generation_state.as_deref(), Some("completed"));
+    assert_eq!(
+        shared_generation_event_types(&app_state.db, child_chat.id)
+            .await
+            .last()
+            .map(String::as_str),
+        Some("stream_end"),
+        "a resume tailing the child's shared stream has to see it close"
+    );
 
     // The child's request head: delegate prompt + preamble, no origin head.
     let child_bodies = child_recorder.bodies();
@@ -3674,5 +3710,200 @@ async fn test_submit_into_live_delegated_run_conflicts(pool: Pool<Postgres>) {
     assert!(
         adopted_at.is_string(),
         "a run the user wrote into is recorded as adopted"
+    );
+}
+
+/// A mention-carrying turn that parks on an MCP approval loses the delegation
+/// offer when it is continued: `continuestream` rebuilds the tool set from MCP
+/// discovery alone. A delegate call the model makes anyway is refused per-CALL
+/// by the unoffered-tool guard — which runs before the dispatch branch and its
+/// own "not available" fallback — so nothing is delegated and the turn recovers
+/// in prose.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+/// - `uses-mock-mcp`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_continued_turn_does_not_reoffer_the_delegation_tool(pool: Pool<Postgres>) {
+    const TOOL_RESULT: &str = "approval probe published";
+    const REFUSAL: &str = "not allowed for this request";
+    let parked_turn_recorder = RequestBodyRecorder::new();
+    let continuation_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    // Continuation turn 2: the refusal arrived, answer in prose.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[REFUSAL], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[
+                "CONTINUED-RECOVERED-ANSWER",
+            ]),
+        );
+    });
+    // Continuation turn 1: delegate anyway, without the offer.
+    {
+        let recorder = continuation_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&[TOOL_RESULT], &[REFUSAL]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                    "call_delegate_after_approval",
+                    "delegate_to_assistant",
+                    json!({
+                        "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                        "task": "CONTINUED-TASK-BRIEF",
+                    }),
+                )]),
+            );
+        });
+    }
+    // The parked turn: call the approval-gated tool.
+    {
+        let recorder = parked_turn_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&[], &[TOOL_RESULT, REFUSAL]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                    "call_probe",
+                    "publish_approval_probe",
+                    json!({}),
+                )]),
+            );
+        });
+    }
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.mcp_servers.insert(
+        "mock_mcp_approval".to_string(),
+        erato::config::McpServerConfig {
+            transport_type: "streamable_http".to_string(),
+            url: format!("{}/mcp/approval-policy", mock_mcp_base_url()),
+            http_headers: None,
+            allow_tools: None,
+            exclude_tools: vec![],
+            authentication: erato::config::McpServerAuthenticationConfig::None,
+            max_session_idle_seconds: None,
+        },
+    );
+    app_config.mcp_server_permissions.rules.insert(
+        "allow-mock-mcp".to_string(),
+        erato::config::McpServerPermissionRule::AllowAll {
+            mcp_server_ids: vec!["mock_mcp_approval".to_string()],
+        },
+    );
+    app_config.mcp_servers_global.approval = erato::config::McpToolApprovalConfig {
+        enabled: true,
+        preset: erato::config::McpToolApprovalPreset::Restrictive,
+        allow_always: false,
+    };
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "delegate prompt", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "mention approval question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let chat_id =
+        Uuid::parse_str(&crate::test_utils::extract_chat_id(&events).expect("chat id")).unwrap();
+    let assistant_message_id = Uuid::parse_str(&assistant_message_id_from_events(&events)).unwrap();
+    assert_eq!(
+        erato::db::entity::chats::Entity::find_by_id(chat_id)
+            .one(&app_state.db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state
+            .as_deref(),
+        Some("awaiting_approval")
+    );
+
+    // The parked turn was offered the delegation tool.
+    let parked_bodies = parked_turn_recorder.bodies();
+    assert!(
+        parked_bodies
+            .iter()
+            .any(|body| body.contains("delegate_to_assistant")),
+        "the mention-carrying turn offers the delegation tool"
+    );
+
+    let continued = server
+        .post("/api/v1beta/me/messages/continuestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": assistant_message_id,
+            "decision": "approve",
+        }))
+        .await;
+    continued.assert_status_ok();
+    let continued_events = parse_sse_events(&continued);
+    assert!(extract_full_text_answer(&continued_events).contains("CONTINUED-RECOVERED-ANSWER"));
+
+    let continuation_bodies = continuation_recorder.bodies();
+    assert_eq!(continuation_bodies.len(), 1);
+    assert!(continuation_bodies[0].contains("publish_approval_probe"));
+    assert!(
+        !continuation_bodies[0].contains("delegate_to_assistant"),
+        "the continuation must not re-offer the delegation tool"
+    );
+
+    let refused = erato::db::entity::messages::Entity::find_by_id(assistant_message_id)
+        .one(&app_state.db)
+        .await
+        .unwrap()
+        .expect("the continued assistant message")
+        .raw_message["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|part| part["tool_name"] == "delegate_to_assistant")
+        .expect("the refused delegate call")
+        .clone();
+    assert_eq!(refused["status"], "error");
+    assert!(
+        refused["output"]["error"]
+            .as_str()
+            .is_some_and(|error| error.contains(REFUSAL)),
+        "Got: {}",
+        refused["output"]
+    );
+
+    assert!(
+        erato::db::entity::chats::Entity::find()
+            .filter(erato::db::entity::chats::Column::OriginChatId.eq(chat_id))
+            .one(&app_state.db)
+            .await
+            .unwrap()
+            .is_none(),
+        "a continued turn must not be able to spawn a delegated run"
     );
 }

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -173,6 +173,7 @@ async fn test_message_submit_stream(pool: Pool<Postgres>) {
         has_event_type("assistant_message_completed"),
         "No assistant_message_completed event received"
     );
+    assert!(has_event_type("stream_end"), "No stream_end event received");
 
     // Additionally, verify the content of the assistant_message_completed event
     let assistant_message_completed_event_data = events
@@ -3596,7 +3597,7 @@ async fn test_action_facet_template_literal_values_no_rerendering(pool: Pool<Pos
     // round-trips into the saved JSON unchanged. Re-rendering protection
     // (one-pass template substitution; arg values are NOT re-expanded) now
     // lives in the resolver step at request-build time and is covered by
-    // the unit tests for `render_action_facet_template`.
+    // the unit tests for `render_placeholder_template`.
     let marker = gen_input_value["messages"]
         .as_array()
         .expect("Expected messages array")
@@ -4194,5 +4195,402 @@ async fn test_submit_to_normal_existing_chat_still_succeeds(pool: Pool<Postgres>
     assert!(
         has_event_type(&events, "assistant_message_completed"),
         "Expected a completed assistant response for a normal existing chat",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool approval: the durable park and its `continuestream` continuation.
+// ---------------------------------------------------------------------------
+
+/// Under the restrictive approval preset an open-world MCP tool call stops the
+/// turn durably: the approval request is the last persisted content part, the
+/// chat is parked, and no answer was streamed. `continuestream` with an
+/// approval then calls the tool, replays the call and its result to the model
+/// and finishes the SAME assistant message.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+/// - `uses-mock-mcp`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_continuestream_resumes_a_parked_tool_approval(pool: Pool<Postgres>) {
+    const TOOL_RESULT: &str = "approval probe published";
+    let continuation_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    // The continuation: the tool result arrived, answer in prose.
+    {
+        let recorder = continuation_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&[TOOL_RESULT], &[]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                build_openai_text_streaming_response(&["APPROVAL-CONTINUED-ANSWER"]),
+            );
+        });
+    }
+    // The parked turn: call the approval-gated tool.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[], &[TOOL_RESULT]));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[(
+                "call_probe",
+                "publish_approval_probe",
+                json!({}),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.mcp_servers.insert(
+        "mock_mcp_approval".to_string(),
+        mcp_server_config(
+            &mock_mcp_base_url(),
+            "/mcp/approval-policy",
+            McpServerAuthenticationConfig::None,
+        ),
+    );
+    app_config.mcp_server_permissions.rules.insert(
+        "allow-mock-mcp".to_string(),
+        erato::config::McpServerPermissionRule::AllowAll {
+            mcp_server_ids: vec!["mock_mcp_approval".to_string()],
+        },
+    );
+    app_config.mcp_servers_global.approval = erato::config::McpToolApprovalConfig {
+        enabled: true,
+        preset: erato::config::McpToolApprovalPreset::Restrictive,
+        allow_always: false,
+    };
+    let app_state = test_app_state(app_config, pool).await;
+    get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+    let db = app_state.db.clone();
+    let server = app_server(app_state);
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "user_message": "publish the approval probe" }))
+        .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let chat_id = Uuid::parse_str(&extract_chat_id(&events).expect("Expected chat_id")).unwrap();
+    let assistant_message_id = Uuid::parse_str(&assistant_message_id_from_events(&events)).unwrap();
+    assert_eq!(extract_full_text(&events), "");
+
+    let parked = erato::db::entity::messages::Entity::find_by_id(assistant_message_id)
+        .one(&db)
+        .await
+        .unwrap()
+        .expect("Expected the parked assistant message");
+    let approval_request = parked.raw_message["content"]
+        .as_array()
+        .unwrap()
+        .last()
+        .expect("Expected a persisted content part")
+        .clone();
+    assert_eq!(approval_request["content_type"], "tool_approval_request");
+    assert_eq!(approval_request["tool_name"], "publish_approval_probe");
+    assert_eq!(approval_request["mcp_server_id"], "mock_mcp_approval");
+    assert_eq!(approval_request["preset"], "restrictive");
+    assert_eq!(
+        chats::Entity::find_by_id(chat_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state
+            .as_deref(),
+        Some("awaiting_approval")
+    );
+
+    let continued = server
+        .post("/api/v1beta/me/messages/continuestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": assistant_message_id,
+            "decision": "approve",
+        }))
+        .await;
+    continued.assert_status_ok();
+    let continued_events = parse_sse_events(&continued);
+    assert_eq!(
+        extract_full_text(&continued_events),
+        "APPROVAL-CONTINUED-ANSWER"
+    );
+
+    let continuation_bodies = continuation_recorder.bodies();
+    assert_eq!(continuation_bodies.len(), 1);
+    assert!(continuation_bodies[0].contains("call_probe"));
+
+    // One message, extended in place.
+    let resumed = erato::db::entity::messages::Entity::find_by_id(assistant_message_id)
+        .one(&db)
+        .await
+        .unwrap()
+        .expect("Expected the resumed assistant message");
+    let resumed_content = resumed.raw_message["content"].as_array().unwrap().clone();
+    let content_types: Vec<&str> = resumed_content
+        .iter()
+        .map(|part| part["content_type"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        content_types,
+        vec!["tool_approval_request", "tool_approval", "tool_use", "text"]
+    );
+    assert_eq!(resumed_content[1]["tool_call_id"], "call_probe");
+    assert_eq!(resumed_content[1]["always_allow"], false);
+    assert_eq!(resumed_content[2]["status"], "success");
+    assert!(
+        serde_json::to_string(&resumed_content[2]["output"])
+            .unwrap()
+            .contains(TOOL_RESULT)
+    );
+    assert_eq!(
+        chats::Entity::find_by_id(chat_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state
+            .as_deref(),
+        Some("completed")
+    );
+}
+
+/// The same park continued with a denial: the tool is never called, the
+/// rejection and a failed tool result are persisted in its place, and the model
+/// answers around it. `approve_always` is refused outright while the approval
+/// policy disallows it.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+/// - `uses-mock-mcp`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_continuestream_denies_a_parked_tool_approval(pool: Pool<Postgres>) {
+    const TOOL_RESULT: &str = "approval probe published";
+    const DENIAL: &str = "The user denied this tool call.";
+    let continuation_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    // The continuation: the denial arrived, answer around it.
+    {
+        let recorder = continuation_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&[DENIAL], &[]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                build_openai_text_streaming_response(&["APPROVAL-DENIED-ANSWER"]),
+            );
+        });
+    }
+    // The parked turn: call the approval-gated tool.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&[], &[DENIAL]));
+        mock_llm_sse_response(
+            then,
+            build_openai_tool_calls_streaming_response(&[(
+                "call_probe",
+                "publish_approval_probe",
+                json!({}),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.mcp_servers.insert(
+        "mock_mcp_approval".to_string(),
+        mcp_server_config(
+            &mock_mcp_base_url(),
+            "/mcp/approval-policy",
+            McpServerAuthenticationConfig::None,
+        ),
+    );
+    app_config.mcp_server_permissions.rules.insert(
+        "allow-mock-mcp".to_string(),
+        erato::config::McpServerPermissionRule::AllowAll {
+            mcp_server_ids: vec!["mock_mcp_approval".to_string()],
+        },
+    );
+    app_config.mcp_servers_global.approval = erato::config::McpToolApprovalConfig {
+        enabled: true,
+        preset: erato::config::McpToolApprovalPreset::Restrictive,
+        allow_always: false,
+    };
+    let app_state = test_app_state(app_config, pool).await;
+    get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+    let db = app_state.db.clone();
+    let server = app_server(app_state);
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "user_message": "publish the approval probe" }))
+        .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let chat_id = Uuid::parse_str(&extract_chat_id(&events).expect("Expected chat_id")).unwrap();
+    let assistant_message_id = Uuid::parse_str(&assistant_message_id_from_events(&events)).unwrap();
+
+    let always = server
+        .post("/api/v1beta/me/messages/continuestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": assistant_message_id,
+            "decision": "approve_always",
+        }))
+        .await;
+    always.assert_status(http::StatusCode::BAD_REQUEST);
+
+    let continued = server
+        .post("/api/v1beta/me/messages/continuestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": assistant_message_id,
+            "decision": "reject",
+        }))
+        .await;
+    continued.assert_status_ok();
+    let continued_events = parse_sse_events(&continued);
+    assert_eq!(
+        extract_full_text(&continued_events),
+        "APPROVAL-DENIED-ANSWER"
+    );
+
+    let continuation_bodies = continuation_recorder.bodies();
+    assert_eq!(continuation_bodies.len(), 1);
+    assert!(
+        !continuation_bodies[0].contains(TOOL_RESULT),
+        "a denied tool must not be called"
+    );
+
+    let resumed = erato::db::entity::messages::Entity::find_by_id(assistant_message_id)
+        .one(&db)
+        .await
+        .unwrap()
+        .expect("Expected the resumed assistant message");
+    let resumed_content = resumed.raw_message["content"].as_array().unwrap().clone();
+    let content_types: Vec<&str> = resumed_content
+        .iter()
+        .map(|part| part["content_type"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        content_types,
+        vec![
+            "tool_approval_request",
+            "tool_rejection",
+            "tool_use",
+            "text"
+        ]
+    );
+    assert_eq!(resumed_content[1]["tool_call_id"], "call_probe");
+    assert_eq!(resumed_content[2]["status"], "error");
+    assert_eq!(resumed_content[2]["output"]["status"], "rejected");
+    assert_eq!(resumed_content[2]["output"]["error"], DENIAL);
+    assert_eq!(
+        chats::Entity::find_by_id(chat_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state
+            .as_deref(),
+        Some("completed")
+    );
+}
+
+/// A run that dies before it owns an assistant message to attach an error to
+/// still terminates every listener: the task lifecycle broadcasts the generic
+/// failure frame, closes with a single stream end, and marks the lease errored.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_failed_generation_broadcasts_a_failure_frame_then_stream_end(pool: Pool<Postgres>) {
+    let (app_config, _server) = setup_mock_llm_server(None).await;
+    let app_state = test_app_state(app_config, pool).await;
+    get_or_create_user(&app_state.db, TEST_USER_ISSUER, TEST_USER_SUBJECT, None)
+        .await
+        .expect("Failed to create user");
+    let db = app_state.db.clone();
+    let server = app_server(app_state);
+
+    let first = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "user_message": "a message in another chat" }))
+        .await;
+    first.assert_status_ok();
+    let foreign_message_id = assistant_message_id_from_events(&parse_sse_events(&first));
+
+    let created = server
+        .post("/api/v1beta/me/chats")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({}))
+        .await;
+    created.assert_status_ok();
+    let chat_id = Uuid::parse_str(created.json::<Value>()["chat_id"].as_str().unwrap()).unwrap();
+
+    // Threading a turn off another chat's message: saving the user message
+    // fails, so the run never reaches an assistant message of its own.
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "existing_chat_id": chat_id,
+            "previous_message_id": foreign_message_id,
+            "user_message": "threaded across chats",
+        }))
+        .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let frames: Vec<Value> = events
+        .iter()
+        .filter_map(|event| serde_json::from_str::<Value>(&event.data).ok())
+        .collect();
+    let message_types: Vec<&str> = frames
+        .iter()
+        .filter_map(|frame| frame["message_type"].as_str())
+        .collect();
+    assert_eq!(message_types, vec!["error", "stream_end"]);
+    assert_eq!(frames[0]["error_type"], "internal_error");
+    assert_eq!(
+        frames[0]["error_description"],
+        "The message could not be generated."
+    );
+
+    assert_eq!(
+        chats::Entity::find_by_id(chat_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state
+            .as_deref(),
+        Some("errored")
     );
 }


### PR DESCRIPTION
**On top of #993.** Review bottom-up; this layer's diff is against the tool-offer containment. Last of the three ERMAIN-617 hardening follow-ups.

## Part 1 — continuestream, and a ticket premise that turned out to be wrong

**There was no backend test exercising `continuestream` at all**, and none that drove a real MCP approval park end to end — the only `awaiting_approval` rows in the suite were written by raw SQL to fake a parked chat. Two tests now exist, and the generic one is worth more than the delegation-specific one.

`test_continuestream_resumes_a_parked_tool_approval` drives a real park on a gated MCP tool and asserts the durable stop (no text streamed, the persisted message's last part is `tool_approval_request` carrying tool/server/preset, `generation_state = 'awaiting_approval'`), then that `continuestream` resumes it, that the continuation genuinely replayed the parked call to the model, that the **same** message was extended in place — content is exactly `[tool_approval_request, tool_approval, tool_use, text]` — and that the lease returns to `completed`.

`test_continued_turn_does_not_reoffer_the_delegation_tool` pins the fail-closed scope: the parked turn's request body **did** carry `delegate_to_assistant`, the continuation's does not, and no child chat was created.

**The correction.** The ticket said a hallucinated delegate call on a continuation is refused with "Delegation is not available for this request." It isn't. `run_continue_message_task` derives `allowed_tool_names` from `chat_request.tools` (MCP only), and the unoffered-tool guard runs *before* the delegation dispatch branch — so the model actually gets `Proposed tool call 'delegate_to_assistant' is not allowed for this request`. The `delegation: None` arm is a second line of defence that is unreachable through the API today. Still fail-closed, just refused earlier. The test pins the real message rather than the assumed one.

Delegation is deliberately **not** threaded through the continuation; the call site now records why, which is that the dispatch context is request-scoped and is not persisted with the parked message.

## Part 2 — runtime cleanups

**Shared generation-task lifecycle.** `with_generation_task_lifecycle` replaces the duplicated guard → run → error broadcast → `StreamEnd` → outcome → `remove_task` dance in `message_submit_sse` and `run_delegated_child`. Net −70 lines.

The two had *not* diverged despite ERMAIN-627 moving `start_task` earlier — that call happens outside the wrapper on both sides, so it never entered the shared shape. Only cosmetics differed, and unifying improved both. **One deliberate behaviour change worth a reviewer's eye:** a failed delegated child now goes through `capture_report`, so it reaches Sentry; previously it was `warn!` only and never did.

`regenerate_message_sse`, `edit_message_sse` and `continue_message_sse` were deliberately **not** folded in. They are a second self-consistent family — they stream over an mpsc `tx`, use `forward_error_report` rather than a broadcast `Error` frame, and send no `StreamEnd`. Forcing them through this helper would change their wire behaviour.

**Seed tip.** `SeedStats` gained `lineage_tip_id`, so dispatch stops re-deriving the tip with a `created_at DESC` query that could mis-pick on ties. Honest note: the tie was **not reachable in practice** — each message is written in its own transaction, so Postgres' transaction-scoped `now()` yields distinct timestamps. The value is removing an unpinned invariant, since `seed_chat_lineage` copies `created_at` verbatim and any future writer inserting two messages in one transaction would produce ties resolved arbitrarily. Plus one fewer round trip.

**Swallowed DB errors.** `build_result_envelope` no longer does `.ok().flatten()`; the error arm logs with `child_chat_id` and `child_assistant_message_id`, and records the consequence — a read failure is indistinguishable from an unanswered run downstream, so a delegate that *did* answer gets reported as failed. Review found the same swallow eight lines above in `prepare_delegated_chat`, silently degrading `include_conversation_context` to "no context"; that one is fixed here too.

**Naming.** `render_action_facet_template` → `render_placeholder_template`. It was never action-facet-specific — it is generic single-pass `{{key}}` substitution — so the old name described one caller rather than the function, and now has two.

## Testing

The wrapper's failure branch had zero coverage, which review flagged and this fixes with three layers: unit tests asserting the Err arm emits exactly `[Error, StreamEnd]` with the right error shape and the Ok arm exactly `[StreamEnd]`; an integration test that drives a **real** wrapper Err early enough that no assistant row exists, so the generic frame is the only error frame — the exact blind spot every existing `find_map(message_type == "error")` assertion misses; and caller-level pins on both paths, including the delegated child's persisted shared-stream events ending in `stream_end`, which is the row a cross-replica resume actually polls.

Mutation-checked both ways: removing the `Error` send fails the unit test, removing the `StreamEnd` send fails five tests.

Full backend suite green (748), three clippy feature sets, both codegen `--check`s.

## Flagged, not fixed

`continue_message_sse` calls `start_task` but never broadcasts `StreamEnd`, so a `resumestream` tailing a continuation never sees a terminating frame. Pre-existing and outside this ticket's scope.
