### PR TITLE
Compose the delegation preamble instead of storing it in the child's message (ERMAIN-630)

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -357,10 +357,12 @@ chat_provider_ids = ["test-token-limit"]
 # # after cleanup_archived_max_age_days, so this requires cleanup_enabled.
 # # 0 never archives a run automatically (default: 7)
 # auto_archive_after_days = 7
-# # Directive rendered into the delegated chat's first turn. The delegate's own
-# # system prompt is untouched; this is additive. {{expected_output_section}} and
-# # {{constraints_section}} are replaced with formatted blocks when the origin
-# # model supplies the corresponding arguments, and with empty strings otherwise.
+# # Directive composed into every turn of a delegated chat, never stored in its
+# # messages, and dropped once the user writes into the run themselves. The
+# # delegate's own system prompt is untouched; this is additive.
+# # {{expected_output_section}} and {{constraints_section}} are replaced with
+# # formatted blocks when the origin model supplies the corresponding arguments,
+# # and with empty strings otherwise.
 # # The text below is the built-in default.
 # preamble = """
 # You are working on a task that another conversation delegated to you. Your final message is returned to the delegating conversation as the result of this task; it is not shown to a person directly.

--- a/backend/erato/src/models/chat.rs
+++ b/backend/erato/src/models/chat.rs
@@ -72,6 +72,16 @@ pub struct ChatProvenance {
     /// automatic retention pass leaves it alone from then on.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub adopted_at: Option<DateTimeWithTimeZone>,
+    /// Delegation only: the result shape the origin model asked for. Also
+    /// durable in that model's tool-call input, but that copy lives in a chat
+    /// this one cannot read and which may be deleted independently, so a run
+    /// keeps its own — it is what the preamble is rendered from every turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_output: Option<String>,
+    /// Delegation only: the limits the delegate must work within. Same
+    /// reasoning as `expected_output`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub constraints: Option<String>,
 }
 
 impl AssistantConfiguration {

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -270,6 +270,11 @@ pub enum ContentPart {
     /// of *prior-turn* history, the resolver drops it; for the *current
     /// turn* it renders the template against the current config + args.
     ActionFacetMarker(ContentPartActionFacetMarker),
+    /// Reference to the run directive of a delegated chat, resolved the same
+    /// way as `ActionFacetMarker`: metadata in the persisted snapshot, text
+    /// only in the request about to be sent, dropped when the snapshot is
+    /// replayed as prior-turn history.
+    DelegationPreambleMarker(ContentPartDelegationPreambleMarker),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
@@ -327,6 +332,17 @@ pub struct ContentPartActionFacetMarker {
     /// selected text for `outlook_rewrite_selection`, the compose body for
     /// `outlook_review_draft`).
     pub args: HashMap<String, String>,
+}
+
+/// The structured-brief fields of a delegated run, copied from the chat's
+/// provenance envelope at composition time. The preamble template itself is
+/// not carried: it is read from the config in force when the marker resolves.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct ContentPartDelegationPreambleMarker {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_output: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub constraints: Option<String>,
 }
 
 /// Statistics for a list of messages
@@ -456,9 +472,11 @@ impl MessageSchema {
                 ContentPart::TextFilePointer(_) => None,
                 ContentPart::ImageFilePointer(_) => None,
                 ContentPart::Image(_) => None,
-                // Markers are placeholders for the action-facet resolver and
-                // do not contribute to a message's full text representation.
-                ContentPart::ActionFacetMarker(_) => None,
+                // Markers are placeholders for the directive resolver and do
+                // not contribute to a message's full text representation.
+                ContentPart::ActionFacetMarker(_) | ContentPart::DelegationPreambleMarker(_) => {
+                    None
+                }
             })
             .collect::<Vec<&str>>()
             .join(" ")
@@ -1011,8 +1029,10 @@ impl InputMessage {
             ContentPart::TextFilePointer(_) => String::new(),
             ContentPart::ImageFilePointer(_) => String::new(),
             ContentPart::Image(_) => String::new(),
-            // Marker is metadata-only; rendering happens in the resolver.
-            ContentPart::ActionFacetMarker(_) => String::new(),
+            // Markers are metadata-only; rendering happens in the resolver.
+            ContentPart::ActionFacetMarker(_) | ContentPart::DelegationPreambleMarker(_) => {
+                String::new()
+            }
         }
     }
 }

--- a/backend/erato/src/server/api/v1beta/file_resolution.rs
+++ b/backend/erato/src/server/api/v1beta/file_resolution.rs
@@ -108,33 +108,33 @@ pub(crate) async fn resolve_file_pointers_in_generation_input(
     })
 }
 
-/// Sentinel tag wrapping a rendered action-facet directive in the user
-/// turn. Mirrors Claude Code's own `<system-reminder>` convention — the
-/// model has been trained to treat XML-tagged user content as authoritative
-/// guidance rather than ordinary user prose, while keeping the directive
-/// in the user turn (which Anthropic explicitly recommends for per-turn
-/// instructions and which preserves the system prompt cache).
-const ACTION_FACET_SENTINEL_OPEN: &str = "<system-reminder>";
-const ACTION_FACET_SENTINEL_CLOSE: &str = "</system-reminder>";
+/// Sentinel tag wrapping a rendered per-turn directive in the user turn.
+/// Mirrors Claude Code's own `<system-reminder>` convention — the model has
+/// been trained to treat XML-tagged user content as authoritative guidance
+/// rather than ordinary user prose, while keeping the directive in the user
+/// turn (which Anthropic explicitly recommends for per-turn instructions and
+/// which preserves the system prompt cache).
+const DIRECTIVE_SENTINEL_OPEN: &str = "<system-reminder>";
+const DIRECTIVE_SENTINEL_CLOSE: &str = "</system-reminder>";
 
-/// Resolve `ContentPart::ActionFacetMarker` entries by rendering the
-/// referenced facet template against the current `AppConfig` using the
-/// args captured at request time.
+/// Resolve the per-turn directive markers — `ContentPart::ActionFacetMarker`
+/// and `ContentPart::DelegationPreambleMarker` — by rendering their templates
+/// against the current `AppConfig`, using the arguments captured on the marker
+/// at composition time.
 ///
 /// Mirrors `resolve_file_pointers_in_generation_input` — the saved
 /// `generation_input_messages` carries metadata-only markers; rendering
 /// happens lazily here, immediately before the chat-request hits the LLM.
 ///
-/// Prior-turn markers are stripped earlier in
-/// `compose_prompt_messages`'s historical-replay step, so any marker that
-/// reaches this resolver belongs to the current turn and gets rendered.
-/// If the referenced facet config is missing (renamed/deleted), the
-/// marker is dropped with a warning rather than rendering empty text.
+/// Prior-turn markers are stripped earlier in `compose_prompt_messages`'s
+/// historical-replay step, so any marker that reaches this resolver belongs to
+/// the current turn and gets rendered. A marker whose template has gone
+/// missing (a renamed or deleted facet) is dropped with a warning rather than
+/// rendered as empty text.
 ///
-/// Output is wrapped in a `<system-reminder>` sentinel in the user turn
-/// (the marker carries `MessageRole::User`); see that comment for
-/// reasoning.
-pub(crate) fn resolve_action_facet_markers_in_generation_input(
+/// Output is wrapped in a `<system-reminder>` sentinel in the user turn (both
+/// markers carry `MessageRole::User`); see that comment for reasoning.
+pub(crate) fn resolve_directive_markers_in_generation_input(
     app_state: &AppState,
     generation_input_messages: GenerationInputMessages,
 ) -> GenerationInputMessages {
@@ -142,29 +142,37 @@ pub(crate) fn resolve_action_facet_markers_in_generation_input(
     let resolved_messages = generation_input_messages
         .messages
         .into_iter()
-        .filter_map(|input_message| match input_message.content {
-            ContentPart::ActionFacetMarker(marker) => {
-                let Some(config) = action_facet_configs.get(&marker.facet_id) else {
-                    tracing::warn!(
-                        facet_id = %marker.facet_id,
-                        "Action-facet config not found while resolving marker — dropping",
-                    );
-                    return None;
-                };
-                let rendered = render_placeholder_template(&config.template, &marker.args);
-                if rendered.is_empty() {
-                    return None;
+        .filter_map(|input_message| {
+            let rendered = match &input_message.content {
+                ContentPart::ActionFacetMarker(marker) => {
+                    let Some(config) = action_facet_configs.get(&marker.facet_id) else {
+                        tracing::warn!(
+                            facet_id = %marker.facet_id,
+                            "Action-facet config not found while resolving marker — dropping",
+                        );
+                        return None;
+                    };
+                    render_placeholder_template(&config.template, &marker.args)
                 }
-                let wrapped = format!(
-                    "{}\n{}\n{}",
-                    ACTION_FACET_SENTINEL_OPEN, rendered, ACTION_FACET_SENTINEL_CLOSE,
-                );
-                Some(InputMessage {
-                    role: input_message.role,
-                    content: ContentPart::Text(ContentPartText { text: wrapped }),
-                })
+                ContentPart::DelegationPreambleMarker(marker) => {
+                    crate::services::delegation::render_delegation_preamble(
+                        &app_state.config.assistants.delegation.preamble,
+                        marker.expected_output.as_deref(),
+                        marker.constraints.as_deref(),
+                    )
+                }
+                _ => return Some(input_message),
+            };
+            let rendered = rendered.trim();
+            if rendered.is_empty() {
+                return None;
             }
-            _ => Some(input_message),
+            let wrapped =
+                format!("{DIRECTIVE_SENTINEL_OPEN}\n{rendered}\n{DIRECTIVE_SENTINEL_CLOSE}");
+            Some(InputMessage {
+                role: input_message.role,
+                content: ContentPart::Text(ContentPartText { text: wrapped }),
+            })
         })
         .collect();
     GenerationInputMessages {

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -24,7 +24,7 @@ use crate::policy::engine::PolicyEngine;
 use crate::policy::types::Subject;
 use crate::server::api::v1beta::ChatMessage;
 use crate::server::api::v1beta::file_resolution::{
-    resolve_action_facet_markers_in_generation_input, resolve_file_pointers_in_generation_input,
+    resolve_directive_markers_in_generation_input, resolve_file_pointers_in_generation_input,
 };
 use crate::server::api::v1beta::me_profile_middleware::MeProfile;
 use crate::server::api::v1beta::message_streaming_file_extraction::{
@@ -2344,12 +2344,12 @@ pub(crate) async fn prepare_chat_request_with_adapters(
     )
     .await?;
 
-    // Render any ActionFacetMarker entries against the current config.
+    // Render any per-turn directive markers against the current config.
     // Saved snapshot keeps the markers; only the about-to-be-sent
     // chat_request gets rendered text. Past-turn markers were already
     // stripped during historical replay in `compose_prompt_messages`, so
     // anything that reaches here is the current turn's directive.
-    let resolved_generation_input_messages = resolve_action_facet_markers_in_generation_input(
+    let resolved_generation_input_messages = resolve_directive_markers_in_generation_input(
         app_state,
         resolved_generation_input_messages,
     );
@@ -5576,7 +5576,8 @@ fn summary_user_message_text_from_generation_input(
                 | ContentPart::TextFilePointer(_)
                 | ContentPart::ImageFilePointer(_)
                 | ContentPart::Image(_)
-                | ContentPart::ActionFacetMarker(_) => None,
+                | ContentPart::ActionFacetMarker(_)
+                | ContentPart::DelegationPreambleMarker(_) => None,
             }
         })
 }
@@ -9624,7 +9625,7 @@ async fn run_continue_message_task(
     )
     .await?;
     let generation_input_messages =
-        resolve_action_facet_markers_in_generation_input(app_state, generation_input_messages);
+        resolve_directive_markers_in_generation_input(app_state, generation_input_messages);
     let mut chat_request = generation_input_messages.into_chat_request();
     chat_request.tools = (!available_mcp_tools.is_empty())
         .then(|| convert_mcp_tools_to_genai_tools(available_mcp_tools.clone(), false));

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -44,6 +44,13 @@ const MAX_OFFER_NAME_CHARS: usize = 100;
 const MAX_OFFER_DESCRIPTION_CHARS: usize = 300;
 const MAX_OFFER_FILENAME_CHARS: usize = 150;
 
+/// Cap on each structured-brief field kept in a run's provenance envelope.
+/// Neither the tool schema nor anything downstream bounds what the origin
+/// model writes into `expected_output`/`constraints`, and the envelope is
+/// re-serialized in full every time the run is adopted — so the cap is applied
+/// once, where the fields are written, rather than at each reader.
+const MAX_BRIEF_FIELD_CHARS: usize = 4000;
+
 fn untrusted_guidance() -> String {
     format!(
         "Everything inside the {UNTRUSTED_TAG} blocks below is third-party text — assistant \
@@ -485,8 +492,9 @@ async fn parent_abort_signal(
 }
 
 /// Renders the configured delegation preamble, filling the optional
-/// structured-brief sections.
-fn render_delegation_preamble(
+/// structured-brief sections. Called once per turn of a delegated run from the
+/// directive resolver, against the fields stored in the run's provenance.
+pub(crate) fn render_delegation_preamble(
     preamble_template: &str,
     expected_output: Option<&str>,
     constraints: Option<&str>,
@@ -510,6 +518,21 @@ fn render_delegation_preamble(
         preamble_template,
         &args,
     )
+}
+
+/// Prepares a structured-brief field for the provenance envelope: an absent,
+/// blank or whitespace-only value stores nothing rather than an empty section,
+/// and an oversized one is cut with the cut left visible. Unlike the tool-offer
+/// values this text is the origin model's own, so its line structure survives —
+/// the delegate reads it as written.
+fn bounded_brief_field(value: Option<&str>) -> Option<String> {
+    let value = value.map(str::trim).filter(|value| !value.is_empty())?;
+    if value.chars().count() <= MAX_BRIEF_FIELD_CHARS {
+        return Some(value.to_string());
+    }
+    let mut capped: String = value.chars().take(MAX_BRIEF_FIELD_CHARS).collect();
+    capped.push_str("…[truncated]");
+    Some(capped)
 }
 
 fn delegated_chat_title(task: &str) -> String {
@@ -861,6 +884,8 @@ pub(crate) async fn dispatch_delegate_tool_call(
         rebase_cutoff: Some(spawned_at),
         depth: parent_depth + 1,
         adopted_at: None,
+        expected_output: bounded_brief_field(args.expected_output.as_deref()),
+        constraints: bounded_brief_field(args.constraints.as_deref()),
     };
     let child_chat = crate::models::chat::create_delegated_chat(
         &app_state.db,
@@ -902,16 +927,11 @@ pub(crate) async fn dispatch_delegate_tool_call(
         }
     };
 
-    let preamble = render_delegation_preamble(
-        &config.preamble,
-        args.expected_output.as_deref(),
-        args.constraints.as_deref(),
-    );
-    let child_user_message = format!(
-        "{}\n\n<system-reminder>\n{}\n</system-reminder>",
-        args.task.trim(),
-        preamble.trim()
-    );
+    // The child's user message is the brief and nothing else. The run
+    // directive is rendered into the child's turns at composition time from
+    // the provenance written above — a message a person opens should not be
+    // one written for a model.
+    let child_user_message = args.task.trim().to_string();
 
     let child_request =
         crate::server::api::v1beta::message_streaming::MessageSubmitRequest::for_delegated_run(
@@ -1279,5 +1299,39 @@ mod tests {
             schema["properties"]["file_ids"]["items"]["enum"],
             json!([file_id.to_string()])
         );
+    }
+
+    #[test]
+    fn a_blank_brief_field_is_stored_as_nothing() {
+        assert_eq!(bounded_brief_field(None), None);
+        assert_eq!(bounded_brief_field(Some("   \n ")), None);
+        assert_eq!(
+            bounded_brief_field(Some("  A bullet list.\nOne per file.  ")),
+            Some("A bullet list.\nOne per file.".to_string())
+        );
+    }
+
+    #[test]
+    fn an_oversized_brief_field_is_cut_visibly() {
+        let capped = bounded_brief_field(Some(&"x".repeat(MAX_BRIEF_FIELD_CHARS + 500)))
+            .expect("a long value is kept, not dropped");
+
+        assert!(capped.ends_with("…[truncated]"));
+        assert_eq!(
+            capped.chars().filter(|character| *character == 'x').count(),
+            MAX_BRIEF_FIELD_CHARS
+        );
+    }
+
+    #[test]
+    fn the_preamble_renders_only_the_sections_it_was_given() {
+        let template = "Directive.{{expected_output_section}}{{constraints_section}}";
+
+        let bare = render_delegation_preamble(template, None, Some(" "));
+        assert_eq!(bare, "Directive.");
+
+        let full = render_delegation_preamble(template, Some("A list."), Some("Attachments only."));
+        assert!(full.contains("Expected output:\nA list."));
+        assert!(full.contains("Constraints:\nAttachments only."));
     }
 }

--- a/backend/erato/src/services/genai.rs
+++ b/backend/erato/src/services/genai.rs
@@ -117,11 +117,11 @@ impl From<ContentPart> for GenAiMessageContent {
                 );
                 GenAiMessageContent::from_parts(vec![binary_part])
             }
-            ContentPart::ActionFacetMarker(_) => {
-                // Should never reach here after resolve_action_facet_markers_in_generation_input.
+            ContentPart::ActionFacetMarker(_) | ContentPart::DelegationPreambleMarker(_) => {
+                // Should never reach here after resolve_directive_markers_in_generation_input.
                 // Log error and return empty text rather than panicking.
                 tracing::error!(
-                    "ActionFacetMarker found during LLM conversion - should have been resolved"
+                    "Directive marker found during LLM conversion - should have been resolved"
                 );
                 GenAiMessageContent::from_text(String::new())
             }

--- a/backend/erato/src/services/genai_langfuse.rs
+++ b/backend/erato/src/services/genai_langfuse.rs
@@ -172,6 +172,13 @@ pub fn convert_content_parts_to_json(content_parts: &[ContentPart]) -> Result<Js
                     "args": marker.args,
                 }));
             }
+            ContentPart::DelegationPreambleMarker(marker) => {
+                output_parts.push(json!({
+                    "type": "delegation_preamble_marker",
+                    "expected_output": marker.expected_output,
+                    "constraints": marker.constraints,
+                }));
+            }
             ContentPart::ToolApprovalRequest(request) => {
                 output_parts.push(json!({
                     "type": "tool_approval_request",

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2613,7 +2613,7 @@ mod test_cases {
         assert!(matches!(resolved.messages[2].role, MessageRole::User));
 
         // The action facet prompt is now an ActionFacetMarker — rendering
-        // happens later in `resolve_action_facet_markers_in_generation_input`.
+        // happens later in `resolve_directive_markers_in_generation_input`.
         // Here we verify the marker is structurally present with the right
         // facet_id and args, which is what gets persisted to the DB.
         match &resolved.messages[1].content {
@@ -2837,7 +2837,7 @@ mod test_cases {
 
         // Verify action facet marker is present in a User-role message
         // (rendering happens later in
-        // `resolve_action_facet_markers_in_generation_input`).
+        // `resolve_directive_markers_in_generation_input`).
         let has_action_facet = resolved2.messages.iter().any(|m| {
             matches!(m.role, MessageRole::User)
                 && matches!(
@@ -2858,6 +2858,294 @@ mod test_cases {
             "Expected 5 messages (base_system + action_facet + user1 + assistant + user2), found {}",
             resolved2.messages.len()
         );
+    }
+
+    // ============================================================================
+    // Delegation preamble composition
+    // ============================================================================
+
+    /// A chat row carrying a delegation provenance envelope, as
+    /// `create_delegated_chat` writes it.
+    fn create_delegated_test_chat(
+        expected_output: Option<&str>,
+        constraints: Option<&str>,
+        adopted: bool,
+    ) -> chats::Model {
+        delegated_test_chat_with_kind(
+            crate::models::chat::ChatProvenanceKind::Delegation,
+            expected_output,
+            constraints,
+            adopted,
+        )
+    }
+
+    fn delegated_test_chat_with_kind(
+        kind: crate::models::chat::ChatProvenanceKind,
+        expected_output: Option<&str>,
+        constraints: Option<&str>,
+        adopted: bool,
+    ) -> chats::Model {
+        let assistant_id = Uuid::new_v4();
+        let configuration = crate::models::chat::AssistantConfiguration {
+            assistant_id,
+            provenance: Some(crate::models::chat::ChatProvenance {
+                kind,
+                origin_chat_id: Some(Uuid::new_v4()),
+                origin_message_id: None,
+                origin_assistant_id: None,
+                rebase_cutoff: None,
+                depth: 1,
+                adopted_at: adopted.then(|| chrono::Utc::now().into()),
+                expected_output: expected_output.map(str::to_string),
+                constraints: constraints.map(str::to_string),
+            }),
+        };
+        let mut chat = create_test_chat();
+        chat.assistant_id = Some(assistant_id);
+        chat.assistant_configuration = Some(configuration.to_json().unwrap());
+        chat
+    }
+
+    fn delegation_preamble_markers(
+        resolved: &ResolvedChatSequence,
+    ) -> Vec<&crate::models::message::ContentPartDelegationPreambleMarker> {
+        resolved
+            .messages
+            .iter()
+            .filter_map(|message| match &message.content {
+                ContentPart::DelegationPreambleMarker(marker) => Some(marker),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn delegated_run_composes_its_preamble_from_provenance() {
+        // The brief is the user message and stays untouched; the run directive
+        // is a separate marker built from the chat row's envelope.
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_delegated_test_chat(
+            Some("A bullet list of file names."),
+            Some("Do not open anything outside the attachments."),
+            false,
+        );
+        let config = create_test_chat_provider_config();
+
+        let msg_id = Uuid::new_v4();
+        message_repo.add_message(msg_id, None, MessageRole::User, "List the mock files");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        let markers = delegation_preamble_markers(&resolved);
+        assert_eq!(markers.len(), 1, "expected exactly one preamble marker");
+        assert_eq!(
+            markers[0].expected_output.as_deref(),
+            Some("A bullet list of file names.")
+        );
+        assert_eq!(
+            markers[0].constraints.as_deref(),
+            Some("Do not open anything outside the attachments.")
+        );
+
+        // The directive sits in the user turn, ahead of the brief, and the
+        // brief itself carries none of it.
+        let preamble_index = resolved
+            .messages
+            .iter()
+            .position(|message| matches!(message.content, ContentPart::DelegationPreambleMarker(_)))
+            .unwrap();
+        assert!(matches!(
+            resolved.messages[preamble_index].role,
+            MessageRole::User
+        ));
+        let brief_index = resolved
+            .messages
+            .iter()
+            .position(|message| {
+                matches!(&message.content, ContentPart::Text(text) if text.text == "List the mock files")
+            })
+            .expect("the brief is the child's user message");
+        assert!(preamble_index < brief_index);
+    }
+
+    #[tokio::test]
+    async fn delegated_run_without_a_structured_brief_still_composes_the_preamble() {
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+
+        let chat = create_delegated_test_chat(None, None, false);
+        let config = create_test_chat_provider_config();
+
+        let msg_id = Uuid::new_v4();
+        message_repo.add_message(msg_id, None, MessageRole::User, "List the mock files");
+
+        let abstract_seq = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build abstract sequence");
+        let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve sequence");
+
+        let markers = delegation_preamble_markers(&resolved);
+        assert_eq!(markers.len(), 1);
+        assert!(markers[0].expected_output.is_none());
+        assert!(markers[0].constraints.is_none());
+    }
+
+    #[tokio::test]
+    async fn adopted_run_and_non_delegated_chats_compose_no_preamble() {
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+        let config = create_test_chat_provider_config();
+
+        // Adoption ends the directive: the delegate is answering the owner now.
+        let adopted = create_delegated_test_chat(Some("A list."), None, true);
+        // A handoff carries provenance too, and must not pick this up.
+        let handoff = delegated_test_chat_with_kind(
+            crate::models::chat::ChatProvenanceKind::HandoffBranch,
+            Some("A list."),
+            None,
+            false,
+        );
+        // A chat the user started has no provenance at all.
+        let plain = create_test_chat();
+
+        for chat in [adopted, handoff, plain] {
+            let mut message_repo = MockMessageRepository::new();
+            let msg_id = Uuid::new_v4();
+            message_repo.add_message(msg_id, None, MessageRole::User, "Hello");
+
+            let abstract_seq = build_abstract_sequence(
+                &message_repo,
+                &prompt_provider,
+                &chat,
+                &msg_id,
+                vec![],
+                &config,
+                &ExperimentalFacetsConfig::default(),
+                &[],
+                None,
+            )
+            .await
+            .expect("Failed to build abstract sequence");
+            let (resolved, _) = resolve_sequence(abstract_seq, &message_repo, &file_resolver)
+                .await
+                .expect("Failed to resolve sequence");
+
+            assert!(delegation_preamble_markers(&resolved).is_empty());
+            // System + user, exactly as before delegation existed.
+            assert_eq!(resolved.messages.len(), 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn adopting_a_run_also_drops_the_preamble_replayed_from_its_first_turn() {
+        // Turn 1 runs as a delegate and persists a snapshot carrying the
+        // marker. Turn 2 is the owner writing in, which adopts the run — the
+        // directive must be gone from the composed input, not just uninjected.
+        let mut message_repo = MockMessageRepository::new();
+        let file_resolver = MockFileResolver::new();
+        let prompt_provider = MockPromptProvider::new().with_system_prompt("You are helpful.");
+        let config = create_test_chat_provider_config();
+
+        let chat = create_delegated_test_chat(Some("A list."), None, false);
+
+        let msg1_id = Uuid::new_v4();
+        message_repo.add_message(msg1_id, None, MessageRole::User, "List the mock files");
+        let abstract_seq1 = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &chat,
+            &msg1_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build first abstract sequence");
+        let (resolved1, _) = resolve_sequence(abstract_seq1, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve first sequence");
+        assert_eq!(delegation_preamble_markers(&resolved1).len(), 1);
+
+        let msg2_id = Uuid::new_v4();
+        message_repo.add_message(msg2_id, Some(msg1_id), MessageRole::Assistant, "Done.");
+        message_repo.update_generation_input_messages(
+            msg2_id,
+            &GenerationInputMessages {
+                messages: resolved1.messages.clone(),
+            },
+        );
+
+        let adopted_chat = {
+            let mut adopted = chat.clone();
+            let mut configuration = crate::models::chat::parse_assistant_configuration(&adopted)
+                .unwrap()
+                .unwrap();
+            configuration.provenance.as_mut().unwrap().adopted_at = Some(chrono::Utc::now().into());
+            adopted.assistant_configuration = Some(configuration.to_json().unwrap());
+            adopted
+        };
+
+        let msg3_id = Uuid::new_v4();
+        message_repo.add_message(msg3_id, Some(msg2_id), MessageRole::User, "Now sort them");
+        let abstract_seq2 = build_abstract_sequence(
+            &message_repo,
+            &prompt_provider,
+            &adopted_chat,
+            &msg3_id,
+            vec![],
+            &config,
+            &ExperimentalFacetsConfig::default(),
+            &[],
+            None,
+        )
+        .await
+        .expect("Failed to build second abstract sequence");
+        let (resolved2, _) = resolve_sequence(abstract_seq2, &message_repo, &file_resolver)
+            .await
+            .expect("Failed to resolve second sequence");
+
+        assert!(
+            delegation_preamble_markers(&resolved2).is_empty(),
+            "the replayed snapshot must not carry the first turn's directive"
+        );
+        // The rest of the first turn still replays.
+        assert!(resolved2.messages.iter().any(|message| {
+            matches!(&message.content, ContentPart::Text(text) if text.text == "List the mock files")
+        }));
     }
 
     // ============================================================================

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -14,9 +14,9 @@ use crate::config::ExperimentalFacetsConfig;
 use crate::db::entity::chats;
 use crate::db::entity::messages;
 use crate::models::message::{
-    ContentPart, ContentPartActionFacetMarker, ContentPartImageFilePointer, ContentPartText,
-    ContentPartTextFilePointer, GenerationInputMessages, GenerationParameters, InputMessage,
-    MessageRole, MessageSchema,
+    ContentPart, ContentPartActionFacetMarker, ContentPartDelegationPreambleMarker,
+    ContentPartImageFilePointer, ContentPartText, ContentPartTextFilePointer,
+    GenerationInputMessages, GenerationParameters, InputMessage, MessageRole, MessageSchema,
 };
 use eyre::Report;
 use sea_orm::prelude::Uuid;
@@ -132,8 +132,10 @@ pub async fn build_abstract_sequence_with_facet_tool_expansions(
     // system messages once a new head exists). Self-retiring: the first
     // generation after the cutoff persists its own snapshot, which post-dates
     // the cutoff and replays normally.
-    let rebase_cutoff = crate::models::chat::parse_assistant_configuration(chat)?
-        .and_then(|config| config.provenance)
+    let provenance = crate::models::chat::parse_assistant_configuration(chat)?
+        .and_then(|config| config.provenance);
+    let rebase_cutoff = provenance
+        .as_ref()
         .and_then(|provenance| provenance.rebase_cutoff);
     let anchor_predates_rebase_cutoff = matches!(
         (most_recent_history_message, rebase_cutoff),
@@ -293,6 +295,26 @@ pub async fn build_abstract_sequence_with_facet_tool_expansions(
         sequence.push(AbstractChatSequencePart::ActionFacetPrompt {
             facet_id: af.id.clone(),
             args: af.args.clone(),
+        });
+    }
+
+    // 9.7 Inject the delegated run's directive, derived from the chat row on
+    // every turn rather than persisted into the child's first user message —
+    // which is a brief written for a model that a person ends up reading.
+    //
+    // Re-derivation makes this an every-turn directive, where riding the
+    // message made it first-turn-only. The two only differ once a run has more
+    // than one turn, and a run reaches a second turn only by the owner writing
+    // into it — which adopts it, and adoption switches the directive off: the
+    // run is theirs now, and telling a delegate not to address the end user is
+    // wrong once the end user is who it is talking to.
+    if let Some(provenance) = provenance.as_ref()
+        && provenance.kind == crate::models::chat::ChatProvenanceKind::Delegation
+        && provenance.adopted_at.is_none()
+    {
+        sequence.push(AbstractChatSequencePart::DelegationPreamble {
+            expected_output: provenance.expected_output.clone(),
+            constraints: provenance.constraints.clone(),
         });
     }
 
@@ -534,6 +556,25 @@ pub async fn resolve_sequence(
                 });
             }
 
+            AbstractChatSequencePart::DelegationPreamble {
+                expected_output,
+                constraints,
+            } => {
+                // Same shape as the action-facet directive: a marker in the
+                // user turn, never setting `has_system_message` — the preamble
+                // is additive to the delegate's own head, not a replacement
+                // for it.
+                input_messages.push(InputMessage {
+                    role: MessageRole::User,
+                    content: ContentPart::DelegationPreambleMarker(
+                        ContentPartDelegationPreambleMarker {
+                            expected_output,
+                            constraints,
+                        },
+                    ),
+                });
+            }
+
             AbstractChatSequencePart::HistoricMessagesFromGenerationInputMessages {
                 message_id,
             } => {
@@ -545,14 +586,11 @@ pub async fn resolve_sequence(
                         Ok(gen_input) => {
                             let include_system = !has_system_message;
                             for input_msg in gen_input.messages {
-                                // Strip prior-turn action-facet directives so
-                                // they don't replay alongside the current
-                                // turn's directive. Two filters:
-                                //   • new format → ContentPart::ActionFacetMarker
-                                //   • legacy rendered text (pre-marker rows
-                                //     in the DB) → System message whose text
-                                //     starts with "FOR THIS MESSAGE ONLY:"
-                                if is_prior_turn_action_facet_message(&input_msg)
+                                // Strip prior-turn per-turn directives so they
+                                // don't replay alongside (or against) the ones
+                                // this turn derives — see
+                                // `is_prior_turn_directive_message`.
+                                if is_prior_turn_directive_message(&input_msg)
                                     || is_client_action_tool_use_message(&input_msg)
                                 {
                                     continue;
@@ -666,21 +704,30 @@ fn normalize_historical_input_message(input_msg: InputMessage) -> InputMessage {
     input_msg
 }
 
-/// True when an `InputMessage` represents an action-facet directive emitted
-/// by a prior turn. Action facets are request-scoped ("FOR THIS MESSAGE
-/// ONLY") — replaying them turns conflicting format directives into a noisy
-/// chat history and the model drifts.
+/// True when an `InputMessage` carries a per-turn directive emitted by a
+/// prior turn. Both directive kinds are request-scoped and both are re-derived
+/// for the current turn, so a replayed copy is at best duplication and at
+/// worst a contradiction: action facets ("FOR THIS MESSAGE ONLY") turn into
+/// conflicting format instructions the model drifts between, and a delegation
+/// preamble outlives the condition it describes — the current turn stops
+/// emitting it once the run is adopted, and a replayed one would keep telling
+/// a delegate not to address the user who is now writing to it.
 ///
-/// Two shapes need stripping:
-///   * New format: `ContentPart::ActionFacetMarker` (any role).
-///   * Legacy format: `System` messages whose text starts with the literal
-///     `"FOR THIS MESSAGE ONLY:"` prefix from the rendered template — for
-///     `generation_input_messages` rows persisted before the marker
-///     migration. The prefix is stable across all current action-facet
+/// Three shapes need stripping:
+///   * `ContentPart::ActionFacetMarker` (any role).
+///   * `ContentPart::DelegationPreambleMarker` (any role).
+///   * Legacy action-facet format: `System` messages whose text starts with
+///     the literal `"FOR THIS MESSAGE ONLY:"` prefix from the rendered
+///     template — for `generation_input_messages` rows persisted before the
+///     marker migration. The prefix is stable across all current action-facet
 ///     templates (`config.rs`).
-fn is_prior_turn_action_facet_message(input_msg: &InputMessage) -> bool {
+///
+/// Delegated runs persisted before the preamble moved out of the child's user
+/// message keep it in the message row itself, which no filter here can reach;
+/// they are left as they are rather than pattern-matched on prompt text.
+fn is_prior_turn_directive_message(input_msg: &InputMessage) -> bool {
     match &input_msg.content {
-        ContentPart::ActionFacetMarker(_) => true,
+        ContentPart::ActionFacetMarker(_) | ContentPart::DelegationPreambleMarker(_) => true,
         ContentPart::Text(ContentPartText { text }) => {
             matches!(input_msg.role, MessageRole::System)
                 && text.trim_start().starts_with("FOR THIS MESSAGE ONLY:")

--- a/backend/erato/src/services/prompt_composition/types.rs
+++ b/backend/erato/src/services/prompt_composition/types.rs
@@ -87,6 +87,14 @@ pub enum AbstractChatSequencePart {
         args: HashMap<String, String>,
     },
 
+    /// Run directive of a delegated chat, carrying the structured-brief fields
+    /// off the chat's provenance envelope. Rendered in the resolver step from
+    /// the configured template, for the same reason as `ActionFacetPrompt`.
+    DelegationPreamble {
+        expected_output: Option<String>,
+        constraints: Option<String>,
+    },
+
     /// File attached to the current user input
     UserFile { file_id: Uuid },
 

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -158,6 +158,8 @@ async fn write_delegation_provenance(
             rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
             depth: 1,
             adopted_at: None,
+            expected_output: None,
+            constraints: None,
         }),
     };
     let chat = erato::db::entity::chats::Entity::find_by_id(chat_id)
@@ -1139,6 +1141,8 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
                     json!({
                         "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
                         "task": "CHILD-TASK-BRIEF: summarize the numbers",
+                        "expected_output": "EXPECTED-OUTPUT-SENTINEL: one number per line",
+                        "constraints": "CONSTRAINTS-SENTINEL: use only the attached figures",
                     }),
                 )]),
             );
@@ -1307,6 +1311,16 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
     assert!(provenance.origin_message_id.is_some());
     assert_eq!(provenance.depth, 1);
     assert!(provenance.rebase_cutoff.is_some());
+    // The structured brief lives in the envelope, not only in the parent's
+    // tool-call input — that copy sits in a chat the child cannot read.
+    assert_eq!(
+        provenance.expected_output.as_deref(),
+        Some("EXPECTED-OUTPUT-SENTINEL: one number per line")
+    );
+    assert_eq!(
+        provenance.constraints.as_deref(),
+        Some("CONSTRAINTS-SENTINEL: use only the attached figures")
+    );
     assert_eq!(child_chat.generation_state.as_deref(), Some("completed"));
     assert_eq!(
         shared_generation_event_types(&app_state.db, child_chat.id)
@@ -1316,6 +1330,45 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
         Some("stream_end"),
         "a resume tailing the child's shared stream has to see it close"
     );
+
+    // The child's stored first message is the brief a person would read, with
+    // none of the run directive in it.
+    let child_messages_response = server
+        .get(&format!("/api/v1beta/chats/{}/messages", child_chat.id))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    child_messages_response.assert_status_ok();
+    let child_messages_json = child_messages_response.json::<Value>();
+    let child_user_message = child_messages_json["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "user")
+        .expect("the child's user message");
+    let child_answer_message_id = child_messages_json["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "assistant")
+        .expect("the child's answer")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let child_user_text = child_user_message["content"][0]["text"].as_str().unwrap();
+    assert_eq!(child_user_text, "CHILD-TASK-BRIEF: summarize the numbers");
+    for machinery in [
+        "system-reminder",
+        "delegating conversation",
+        "Expected output:",
+        "Constraints:",
+    ] {
+        assert!(
+            !serde_json::to_string(child_user_message)
+                .unwrap()
+                .contains(machinery),
+            "the stored child message must not carry '{machinery}'"
+        );
+    }
 
     // The child's request head: delegate prompt + preamble, no origin head.
     let child_bodies = child_recorder.bodies();
@@ -1332,6 +1385,21 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
     assert!(!child_bodies[0].contains(ORIGIN_PROMPT_SENTINEL));
     assert!(child_bodies[0].contains("delegating conversation"));
     assert!(child_bodies[0].contains("system-reminder"));
+    // …and the composed request is where the structured brief reaches the
+    // model, rendered from the envelope rather than replayed from the message.
+    let child_directive = child_messages
+        .iter()
+        .find(|message| {
+            message["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("<system-reminder>"))
+        })
+        .expect("the composed run directive");
+    assert_eq!(child_directive["role"], "user");
+    let child_directive_text = child_directive["content"].as_str().unwrap();
+    assert!(child_directive_text.contains("EXPECTED-OUTPUT-SENTINEL: one number per line"));
+    assert!(child_directive_text.contains("CONSTRAINTS-SENTINEL: use only the attached figures"));
+    assert!(!child_directive_text.contains("CHILD-TASK-BRIEF"));
 
     // Client-tool suppression: offered to the parent, absent in the child.
     // The recorder also sees the parent's chat-summary request (no tools), so
@@ -1367,6 +1435,39 @@ async fn test_delegation_happy_path_runs_child_and_returns_envelope(pool: Pool<P
             "the trace must never reach the origin model"
         );
     }
+
+    // Taking the run over ends the run directive: the owner is who the
+    // delegate is answering now, so it is neither re-derived for this turn nor
+    // replayed out of the first turn's snapshot.
+    let child_follow_up = submit_message(
+        &server,
+        &child_chat.id.to_string(),
+        Some(&child_answer_message_id),
+        "owner follow-up inside the run",
+        vec![],
+    )
+    .await;
+    assert!(extract_full_text_answer(&child_follow_up).contains("CHILD-ANSWER"));
+    let child_follow_up_body = child_recorder
+        .bodies()
+        .into_iter()
+        .find(|body| body.contains("owner follow-up inside the run"))
+        .expect("the adopted run's request");
+    for machinery in [
+        "system-reminder",
+        "delegating conversation",
+        "EXPECTED-OUTPUT-SENTINEL",
+        "CONSTRAINTS-SENTINEL",
+    ] {
+        assert!(
+            !child_follow_up_body.contains(machinery),
+            "an adopted run must not carry '{machinery}'"
+        );
+    }
+    assert!(
+        child_follow_up_body.contains("CHILD-TASK-BRIEF"),
+        "the brief itself still replays — it is a real message"
+    );
 }
 
 /// A call naming an assistant that was not offered refuses the call and the
@@ -2448,6 +2549,8 @@ async fn test_listing_hides_delegated_runs_and_exposes_provenance(pool: Pool<Pos
                 rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
                 depth: 1,
                 adopted_at: None,
+                expected_output: None,
+                constraints: None,
             },
             format!("Delegated run {index}"),
         )
@@ -2621,6 +2724,8 @@ async fn test_parked_delegated_chat_stays_reachable(pool: Pool<Postgres>) {
             rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
             depth: 1,
             adopted_at: None,
+            expected_output: None,
+            constraints: None,
         },
         "Parked delegated run".to_string(),
     )
@@ -3190,6 +3295,8 @@ async fn spawn_delegated_run(
             rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
             depth: 1,
             adopted_at: None,
+            expected_output: None,
+            constraints: None,
         },
         title.to_string(),
     )
@@ -3220,6 +3327,8 @@ async fn spawn_handoff_branch(
             rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
             depth: 1,
             adopted_at: None,
+            expected_output: None,
+            constraints: None,
         },
         "Handoff branch".to_string(),
     )
@@ -3607,6 +3716,8 @@ async fn test_submit_into_live_delegated_run_conflicts(pool: Pool<Postgres>) {
             rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
             depth: 1,
             adopted_at: None,
+            expected_output: None,
+            constraints: None,
         },
         "Continuable run".to_string(),
     )

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -2790,12 +2790,14 @@ pub struct AssistantsDelegationConfig {
     #[serde(default = "default_delegation_auto_archive_after_days")]
     pub auto_archive_after_days: u32,
 
-    // Directive rendered into the delegated chat's first turn, telling the
+    // Directive composed into every turn of a delegated chat, telling the
     // delegate it runs as a delegated worker and that its final message is
-    // returned to the origin chat as the task result. `{{expected_output_section}}`
-    // and `{{constraints_section}}` are replaced with formatted blocks when the
-    // origin model supplies the corresponding tool arguments, and with empty
-    // strings otherwise.
+    // returned to the origin chat as the task result. It is never stored in the
+    // chat's messages, and it stops once the user writes into the run
+    // themselves — from then on the delegate is talking to them.
+    // `{{expected_output_section}}` and `{{constraints_section}}` are replaced
+    // with formatted blocks when the origin model supplies the corresponding
+    // tool arguments, and with empty strings otherwise.
     #[serde(default = "default_delegation_preamble")]
     pub preamble: String,
 }

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -5095,6 +5095,29 @@
               }
             ],
             "description": "Reference to an action-facet directive that will be rendered fresh\nat request-build time. Persisted in `generation_input_messages` as a\nmetadata-only marker (facet id + invocation args) instead of the\nrendered template text — mirrors the `TextFilePointer` pattern.\nAction facets are request-scoped: when this marker is loaded as part\nof *prior-turn* history, the resolver drops it; for the *current\nturn* it renders the template against the current config + args."
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContentPartDelegationPreambleMarker",
+                "description": "Reference to the run directive of a delegated chat, resolved the same\nway as `ActionFacetMarker`: metadata in the persisted snapshot, text\nonly in the request about to be sent, dropped when the snapshot is\nreplayed as prior-turn history."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "content_type"
+                ],
+                "properties": {
+                  "content_type": {
+                    "type": "string",
+                    "enum": [
+                      "delegation_preamble_marker"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Reference to the run directive of a delegated chat, resolved the same\nway as `ActionFacetMarker`: metadata in the persisted snapshot, text\nonly in the request about to be sent, dropped when the snapshot is\nreplayed as prior-turn history."
           }
         ]
       },
@@ -5118,6 +5141,24 @@
           "facet_id": {
             "type": "string",
             "description": "Identifier of the action facet whose template should be rendered."
+          }
+        }
+      },
+      "ContentPartDelegationPreambleMarker": {
+        "type": "object",
+        "description": "The structured-brief fields of a delegated run, copied from the chat's\nprovenance envelope at composition time. The preamble template itself is\nnot carried: it is read from the config in force when the marker resolves.",
+        "properties": {
+          "constraints": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expected_output": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/backend/mock-llm-server/src/mocks/mod.rs
+++ b/backend/mock-llm-server/src/mocks/mod.rs
@@ -1195,12 +1195,11 @@ mod tests {
         }])
     }
 
-    /// Erato wraps the brief in the configured delegation preamble before it
-    /// becomes the delegate's first user message.
-    fn delegate_first_user_message() -> String {
-        format!(
-            "{DELEGATION_CHILD_BRIEF}\n\n<system-reminder>\nYou are working on a task that another conversation delegated to you. Your final message is returned to the delegating conversation as the result of this task; it is not shown to a person directly.\n</system-reminder>"
-        )
+    /// Erato composes the configured delegation preamble into a user message of
+    /// its own, ahead of the brief — which stays the delegate's last user
+    /// message, and so the one the turn mocks key on.
+    fn delegate_preamble_message() -> String {
+        "<system-reminder>\nYou are working on a task that another conversation delegated to you. Your final message is returned to the delegating conversation as the result of this task; it is not shown to a person directly.\n</system-reminder>".to_string()
     }
 
     fn match_default_mocks(
@@ -1252,7 +1251,8 @@ mod tests {
         let delegate_turn = match_default_mocks(
             json!([
                 {"role": "system", "content": delegate_system},
-                {"role": "user", "content": delegate_first_user_message()},
+                {"role": "user", "content": delegate_preamble_message()},
+                {"role": "user", "content": DELEGATION_CHILD_BRIEF},
             ]),
             None,
         );
@@ -1264,7 +1264,8 @@ mod tests {
         let delegate_after_tool = match_default_mocks(
             json!([
                 {"role": "system", "content": delegate_system},
-                {"role": "user", "content": delegate_first_user_message()},
+                {"role": "user", "content": delegate_preamble_message()},
+                {"role": "user", "content": DELEGATION_CHILD_BRIEF},
                 {"role": "assistant", "content": null},
                 {"role": "tool", "content": "{\"files\":[\"secret.txt\",\"secret2.txt\"]}"},
             ]),

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -1671,6 +1671,8 @@ export type ArchiveChatEndpointVariables = {
 /**
  * This endpoint marks a chat as archived by setting its archived_at timestamp.
  * Archived chats can be filtered out from the recent chats listing by default.
+ * Delegated runs spawned from the chat are archived along with it, except
+ * those whose run has not finished yet.
  */
 export const fetchArchiveChatEndpoint = (
   variables: ArchiveChatEndpointVariables,
@@ -1693,6 +1695,8 @@ export const fetchArchiveChatEndpoint = (
 /**
  * This endpoint marks a chat as archived by setting its archived_at timestamp.
  * Archived chats can be filtered out from the recent chats listing by default.
+ * Delegated runs spawned from the chat are archived along with it, except
+ * those whose run has not finished yet.
  */
 export const useArchiveChatEndpoint = (
   options?: Omit<

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -787,6 +787,9 @@ export type ContentPart =
     }
   | (ContentPartActionFacetMarker & {
       content_type: "action_facet_marker";
+    })
+  | (ContentPartDelegationPreambleMarker & {
+      content_type: "delegation_preamble_marker";
     });
 
 export type ContentPartActionFacetMarker = {
@@ -802,6 +805,16 @@ export type ContentPartActionFacetMarker = {
    * Identifier of the action facet whose template should be rendered.
    */
   facet_id: string;
+};
+
+/**
+ * The structured-brief fields of a delegated run, copied from the chat's
+ * provenance envelope at composition time. The preamble template itself is
+ * not carried: it is read from the config in force when the marker resolves.
+ */
+export type ContentPartDelegationPreambleMarker = {
+  constraints?: null | undefined;
+  expected_output?: null | undefined;
 };
 
 export type ContentPartImage = {


### PR DESCRIPTION
Opening a delegated run showed the child's first user message with the whole delegation preamble inlined — the `<system-reminder>` envelope, the "do not ask clarifying questions / do not address the end user" boilerplate, and the `Expected output:` / `Constraints:` sections. A message written for a model, being read by a person.

Action facets already solved this next door: their directives are markers in the composed snapshot and rendered text only in the request about to be sent. Delegation now uses the same seam.

## What changed

- **The child's user message is the brief and nothing else.** `dispatch` no longer appends the preamble to `args.task`.
- **`expected_output` / `constraints` moved into the provenance envelope** on the chat row, capped at 4000 chars each. They were already durable in the parent's `ToolUse.input`, but that copy lives in a chat the child cannot read and which can be deleted independently.
- **The preamble is composed per turn** from the chat row: `transforms.rs` pushes a `DelegationPreamble` part next to the action-facet directive, `resolve_sequence` emits a `ContentPart::DelegationPreambleMarker`, and the resolver in `file_resolution.rs` renders it against the configured template wrapped in `<system-reminder>`.
- **Adoption switches it off.** Injection is gated on `provenance.adopted_at.is_none()`, and the replay strip (`is_prior_turn_action_facet_message` → `is_prior_turn_directive_message`) drops the marker out of prior turns. Once the owner has written into a run, telling the delegate not to address the end user is wrong, and the first turn's snapshot no longer keeps saying it.
- `resolve_action_facet_markers_in_generation_input` → `resolve_directive_markers_in_generation_input`, now handling both marker kinds.

## Decisions worth knowing

**Every turn, not first turn only.** Riding the message made it first-turn-only; re-deriving from the chat row makes every-turn the natural default. The two only differ once a run has more than one turn, and a run reaches a second turn only by the owner writing into it — which adopts it, which turns the directive off. So the behaviour is unchanged in practice and degrades correctly if a non-adopted child ever gets multiple turns.

**A marker, not rendered text.** The strip on replay has to be a type match; pattern-matching prompt text would be fragile. The new `ContentPart` variant is additive to the OpenAPI schema (regenerated, plus the frontend types) and no frontend code switches on it.

**Runs persisted before this change** keep the preamble inside their message row. No filter can reach that, and pattern-matching stored prompt text to hide it would be the masking this ticket exists to avoid.

## Tests

- Composition unit tests: the marker is built from the envelope; a run with no structured brief still gets the directive; adopted runs, handoff-provenance chats and plain chats compose none; adopting a run drops the directive replayed from its own first turn.
- Delegation unit tests: brief-field capping and blank handling, and that the preamble renders only the sections it was given.
- Integration (happy path): the stored child message is exactly the brief with none of the machinery in it; the composed request carries the directive with both structured fields; and a follow-up the owner writes into the finished run carries neither the directive nor the sentinels, while the brief still replays.

755/755 backend tests pass; clippy, fmt, OpenAPI check, frontend lint/typecheck/prettier all clean.

Unblocks ERMAIN-631, whose header renders these two fields as run parameters.