### PR TITLE
Carry a per-request delegation run mode through submit, edit and regenerate (ERMAIN-634)

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -344,6 +344,11 @@ chat_provider_ids = ["test-token-limit"]
 # [assistants.delegation]
 # # Whether in-chat delegation is enabled. Requires assistants.enabled (default: false)
 # enabled = false
+# # Whether users may launch delegated runs in background mode, where the
+# # delegation tool returns at launch and the child run's result never flows
+# # back into the origin turn. When off, a background request is downgraded
+# # to a normally awaited run rather than rejected (default: false)
+# allow_background = false
 # # Maximum wall-clock seconds a delegated child run may take before it is
 # # aborted and reported to the origin chat as timed out (default: 600)
 # run_timeout_seconds = 600

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -36,6 +36,21 @@ pub struct GenerationParameters {
     pub action_facet_args: Option<HashMap<String, String>>,
 }
 
+// Homed here rather than in `services::delegation` because it is a
+// wire+persistence type: requests deserialize it and `InputParameters`
+// stores it.
+/// How a delegated child run relates to the turn that spawned it: `wait`
+/// blocks the turn on the child and feeds the result back into it,
+/// `background` returns at launch and the child result never re-enters the
+/// turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegationRunMode {
+    #[default]
+    Wait,
+    Background,
+}
+
 /// User-provided input context stored on user messages.
 ///
 /// Captures contextual information the user supplied alongside their message,
@@ -54,6 +69,13 @@ pub struct InputParameters {
     /// if any. Persisted so edit and regenerate replay the mentions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mentioned_assistant_ids: Option<Vec<String>>,
+    /// Run mode requested for the delegated runs of this message. Only
+    /// `background` is ever written — absence means wait — and it is the
+    /// requested mode, not the gate-downgraded one: `allow_background` is
+    /// applied at dispatch time, so a replay under a later-enabled gate
+    /// honours the user's original choice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delegation_run_mode: Option<DelegationRunMode>,
 }
 
 /// Request-scoped context captured for a generation request.
@@ -878,6 +900,26 @@ pub fn get_input_mentioned_assistant_ids_from_message(
             })
             .collect()
     }))
+}
+
+/// The delegation run mode stored in a user message's input parameters, if
+/// any. Used by regenerate (and edit fallback) to replay the mode the original
+/// message carried when the request doesn't re-send it.
+pub fn get_input_delegation_run_mode_from_message(
+    message: &messages::Model,
+) -> Result<Option<DelegationRunMode>, Report> {
+    let Some(input_params_json) = &message.input_parameters else {
+        return Ok(None);
+    };
+    let input_params: InputParameters =
+        serde_json::from_value(input_params_json.clone()).map_err(|e| {
+            eyre!(
+                "Failed to parse input parameters for message {}: {}",
+                message.id,
+                e
+            )
+        })?;
+    Ok(input_params.delegation_run_mode)
 }
 
 /// Resolve a provider for a user message branch by checking the assistant response that follows

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -13,10 +13,11 @@ use crate::models::chat::{
 };
 use crate::models::message::{
     ContentPart, ContentPartImage, ContentPartReasoning, ContentPartText, ContentPartToolApproval,
-    ContentPartToolApprovalRequest, ContentPartToolRejection, GenerationErrorType,
-    GenerationInputMessages, GenerationMetadata, GenerationParameters, GenerationRequestContext,
-    MessageRole, MessageSchema, ToolApprovalAnnotations, ToolCallStatus as MessageToolCallStatus,
-    ToolUse, get_generation_chat_provider_id_for_replaced_user_message,
+    ContentPartToolApprovalRequest, ContentPartToolRejection, DelegationRunMode,
+    GenerationErrorType, GenerationInputMessages, GenerationMetadata, GenerationParameters,
+    GenerationRequestContext, MessageRole, MessageSchema, ToolApprovalAnnotations,
+    ToolCallStatus as MessageToolCallStatus, ToolUse,
+    get_generation_chat_provider_id_for_replaced_user_message,
     get_generation_chat_provider_id_from_message, get_message_by_id, submit_message,
     update_message_content, update_message_generation_metadata,
 };
@@ -661,6 +662,12 @@ pub struct MessageSubmitRequest {
     #[serde(default)]
     #[schema(nullable = false)]
     mentioned_assistant_ids: Option<Vec<Uuid>>,
+    /// How delegated runs spawned by this message are awaited. Defaults to
+    /// `wait`; `background` requires `assistants.delegation.allow_background`
+    /// and is downgraded to `wait` server-side when the gate is off.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    delegation_run_mode: Option<DelegationRunMode>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1202,6 +1209,13 @@ pub struct RegenerateMessageRequest {
     #[serde(default)]
     #[schema(nullable = false)]
     mentioned_assistant_ids: Option<Vec<Uuid>>,
+    /// How delegated runs spawned by this message are awaited. Defaults to
+    /// `wait`; `background` requires `assistants.delegation.allow_background`
+    /// and is downgraded to `wait` server-side when the gate is off.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    #[allow(dead_code)]
+    delegation_run_mode: Option<DelegationRunMode>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -1343,6 +1357,12 @@ pub struct EditMessageRequest {
     #[serde(default)]
     #[schema(nullable = false)]
     mentioned_assistant_ids: Option<Vec<Uuid>>,
+    /// How delegated runs spawned by this message are awaited. Defaults to
+    /// `wait`; `background` requires `assistants.delegation.allow_background`
+    /// and is downgraded to `wait` server-side when the gate is off.
+    #[serde(default)]
+    #[schema(nullable = false)]
+    delegation_run_mode: Option<DelegationRunMode>,
 }
 
 #[derive(serde::Deserialize, ToSchema)]
@@ -1771,6 +1791,7 @@ impl MessageSubmitRequest {
             selected_facet_ids: Vec::new(),
             action_facet: None,
             mentioned_assistant_ids: None,
+            delegation_run_mode: None,
         }
     }
 }
@@ -8012,16 +8033,25 @@ pub(crate) async fn run_message_submit_task(
                 .map(|id| id.to_string())
                 .collect::<Vec<_>>()
         });
-    let user_input_parameters =
-        if request.action_facet.is_some() || mentioned_assistant_ids_for_persistence.is_some() {
-            Some(crate::models::message::InputParameters {
-                action_facet_id: request.action_facet.as_ref().map(|af| af.id.clone()),
-                action_facet_args: request.action_facet.as_ref().map(|af| af.args.clone()),
-                mentioned_assistant_ids: mentioned_assistant_ids_for_persistence,
-            })
-        } else {
-            None
-        };
+    // Only `background` is persisted (absence means wait), and as requested,
+    // not gate-downgraded: the gate applies at dispatch time, so a replay
+    // under a later-enabled gate honours the user's original choice.
+    let delegation_run_mode_for_persistence = request
+        .delegation_run_mode
+        .filter(|mode| *mode == DelegationRunMode::Background);
+    let user_input_parameters = if request.action_facet.is_some()
+        || mentioned_assistant_ids_for_persistence.is_some()
+        || delegation_run_mode_for_persistence.is_some()
+    {
+        Some(crate::models::message::InputParameters {
+            action_facet_id: request.action_facet.as_ref().map(|af| af.id.clone()),
+            action_facet_args: request.action_facet.as_ref().map(|af| af.args.clone()),
+            mentioned_assistant_ids: mentioned_assistant_ids_for_persistence,
+            delegation_run_mode: delegation_run_mode_for_persistence,
+        })
+    } else {
+        None
+    };
     let saved_user_message = bg_stream_save_user_message(
         task,
         app_state,
@@ -8874,19 +8904,40 @@ pub async fn edit_message_sse(
             },
         ),
     };
-    let edit_input_parameters =
-        if resolved_action_facet.is_some() || resolved_mentioned_assistant_ids.is_some() {
-            Some(crate::models::message::InputParameters {
-                action_facet_id: resolved_action_facet.as_ref().map(|af| af.id.clone()),
-                action_facet_args: resolved_action_facet.as_ref().map(|af| af.args.clone()),
-                mentioned_assistant_ids: resolved_mentioned_assistant_ids
-                    .as_ref()
-                    .filter(|ids| !ids.is_empty())
-                    .map(|ids| ids.iter().map(|id| id.to_string()).collect()),
-            })
-        } else {
-            None
-        };
+    // The run mode follows the same edit contract as the mentions: an explicit
+    // request value wins (including an explicit `wait`, which clears an
+    // inherited `background`), an absent one inherits the mode the original
+    // user message stored. Only `background` is persisted (absence means
+    // wait), and as requested, not gate-downgraded: the gate applies at
+    // dispatch time, so a replay under a later-enabled gate honours the
+    // user's original choice.
+    let resolved_delegation_run_mode = match request.delegation_run_mode {
+        Some(mode) => Some(mode),
+        None => {
+            crate::models::message::get_input_delegation_run_mode_from_message(&message_to_edit)
+                .unwrap_or_else(|error| {
+                    warn_and_capture_error("read edit fallback delegation run mode", &error);
+                    None
+                })
+        }
+    }
+    .filter(|mode| *mode == DelegationRunMode::Background);
+    let edit_input_parameters = if resolved_action_facet.is_some()
+        || resolved_mentioned_assistant_ids.is_some()
+        || resolved_delegation_run_mode.is_some()
+    {
+        Some(crate::models::message::InputParameters {
+            action_facet_id: resolved_action_facet.as_ref().map(|af| af.id.clone()),
+            action_facet_args: resolved_action_facet.as_ref().map(|af| af.args.clone()),
+            mentioned_assistant_ids: resolved_mentioned_assistant_ids
+                .as_ref()
+                .filter(|ids| !ids.is_empty())
+                .map(|ids| ids.iter().map(|id| id.to_string()).collect()),
+            delegation_run_mode: resolved_delegation_run_mode,
+        })
+    } else {
+        None
+    };
     let task_for_stream = task.clone();
     let app_state_for_cleanup = app_state.clone();
     let chat_id_for_cleanup = chat.id;

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -1,10 +1,12 @@
 //! In-chat delegation to @-mentioned assistants.
 
+use crate::models::message::DelegationRunMode;
 use crate::policy::prelude::*;
 use crate::services::background_tasks::StreamingEvent;
 use crate::services::delegation_trace::{DelegationTrace, DelegationTraceCollector, TraceChange};
 use crate::state::AppState;
 use axum::http::StatusCode;
+use erato_config::config::AssistantsDelegationConfig;
 use genai::chat::Tool as GenaiTool;
 use genai::chat::ToolName as GenaiToolName;
 use sea_orm::prelude::Uuid;
@@ -322,6 +324,25 @@ pub async fn resolve_persisted_mentions(
             Vec::new()
         }
     }
+}
+
+/// Effective run mode for the delegated runs of a turn: an explicit request
+/// value wins over the mode persisted on the replayed user message, and absent
+/// both, the run is awaited. `Background` needs the deployment to opt in via
+/// `assistants.delegation.allow_background`; without it the request is
+/// downgraded to `Wait` rather than rejected — the client-side gate is UX,
+/// the server decides.
+pub fn resolve_delegation_run_mode(
+    requested: Option<DelegationRunMode>,
+    persisted: Option<DelegationRunMode>,
+    config: &AssistantsDelegationConfig,
+) -> DelegationRunMode {
+    let mode = requested.or(persisted).unwrap_or_default();
+    if mode == DelegationRunMode::Background && !(config.enabled && config.allow_background) {
+        tracing::debug!("Downgrading a background delegation request to wait: gate is off");
+        return DelegationRunMode::Wait;
+    }
+    mode
 }
 
 /// Terminal status of a delegated child run, as reported to the origin model.
@@ -1333,5 +1354,78 @@ mod tests {
         let full = render_delegation_preamble(template, Some("A list."), Some("Attachments only."));
         assert!(full.contains("Expected output:\nA list."));
         assert!(full.contains("Constraints:\nAttachments only."));
+    }
+
+    fn delegation_config(enabled: bool, allow_background: bool) -> AssistantsDelegationConfig {
+        AssistantsDelegationConfig {
+            enabled,
+            allow_background,
+            ..AssistantsDelegationConfig::default()
+        }
+    }
+
+    #[test]
+    fn the_run_mode_defaults_to_wait_when_nothing_requested_or_persisted() {
+        assert_eq!(
+            resolve_delegation_run_mode(None, None, &delegation_config(true, true)),
+            DelegationRunMode::Wait
+        );
+    }
+
+    #[test]
+    fn a_requested_run_mode_beats_the_persisted_one() {
+        let config = delegation_config(true, true);
+        assert_eq!(
+            resolve_delegation_run_mode(
+                Some(DelegationRunMode::Wait),
+                Some(DelegationRunMode::Background),
+                &config
+            ),
+            DelegationRunMode::Wait
+        );
+        assert_eq!(
+            resolve_delegation_run_mode(
+                Some(DelegationRunMode::Background),
+                Some(DelegationRunMode::Wait),
+                &config
+            ),
+            DelegationRunMode::Background
+        );
+        assert_eq!(
+            resolve_delegation_run_mode(None, Some(DelegationRunMode::Background), &config),
+            DelegationRunMode::Background
+        );
+    }
+
+    #[test]
+    fn a_background_request_is_downgraded_when_the_gate_is_off() {
+        assert_eq!(
+            resolve_delegation_run_mode(
+                Some(DelegationRunMode::Background),
+                None,
+                &delegation_config(true, false)
+            ),
+            DelegationRunMode::Wait
+        );
+        assert_eq!(
+            resolve_delegation_run_mode(
+                None,
+                Some(DelegationRunMode::Background),
+                &delegation_config(false, true)
+            ),
+            DelegationRunMode::Wait
+        );
+    }
+
+    #[test]
+    fn a_background_request_passes_through_when_the_gate_is_on() {
+        assert_eq!(
+            resolve_delegation_run_mode(
+                Some(DelegationRunMode::Background),
+                None,
+                &delegation_config(true, true)
+            ),
+            DelegationRunMode::Background
+        );
     }
 }

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -952,6 +952,215 @@ async fn test_regenerate_and_edit_replay_persisted_mentions(pool: Pool<Postgres>
     bad_edit.assert_status(axum::http::StatusCode::BAD_REQUEST);
 }
 
+/// The requested run mode round-trips into the user message's
+/// `input_parameters`: `background` is persisted verbatim even though
+/// `allow_background` is off — the gate applies at dispatch, not at
+/// persistence — while an absent or explicit `wait` leaves no key behind.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_submit_persists_requested_background_run_mode(pool: Pool<Postgres>) {
+    async fn user_row_of(
+        server: &TestServer,
+        db: &sea_orm::DatabaseConnection,
+        body: Value,
+    ) -> erato::db::entity::messages::Model {
+        let response = server
+            .post("/api/v1beta/me/messages/submitstream")
+            .with_bearer_token(TEST_JWT_TOKEN)
+            .json(&body)
+            .await;
+        response.assert_status_ok();
+        let events = parse_sse_events(&response);
+        let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+        chat_messages_by_created_at(db, Uuid::parse_str(&chat_id).unwrap())
+            .await
+            .into_iter()
+            .find(|row| row.raw_message["role"] == "user")
+            .expect("user message row")
+    }
+
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+    let target = create_assistant(&server, "Run Mode Target", "prompt").await;
+
+    // Background with a mention: both persist.
+    let row = user_row_of(
+        &server,
+        &app_state.db,
+        json!({
+            "user_message": "background with mention",
+            "mentioned_assistant_ids": [target],
+            "delegation_run_mode": "background",
+        }),
+    )
+    .await;
+    let input_params = row.input_parameters.as_ref().expect("input parameters");
+    assert_eq!(input_params["delegation_run_mode"], "background");
+    assert_eq!(
+        erato::models::message::get_input_delegation_run_mode_from_message(&row).unwrap(),
+        Some(erato::models::message::DelegationRunMode::Background)
+    );
+
+    // Background without a mention: the mode persists on its own.
+    let row = user_row_of(
+        &server,
+        &app_state.db,
+        json!({
+            "user_message": "background without mention",
+            "delegation_run_mode": "background",
+        }),
+    )
+    .await;
+    let input_params = row.input_parameters.as_ref().expect("input parameters");
+    assert_eq!(input_params["delegation_run_mode"], "background");
+    assert!(input_params.get("mentioned_assistant_ids").is_none());
+
+    // Field absent: no run mode key next to the persisted mentions.
+    let row = user_row_of(
+        &server,
+        &app_state.db,
+        json!({
+            "user_message": "absent field",
+            "mentioned_assistant_ids": [target],
+        }),
+    )
+    .await;
+    let input_params = row.input_parameters.as_ref().expect("input parameters");
+    assert!(input_params.get("delegation_run_mode").is_none());
+
+    // Explicit wait: persisted as absent, same as the default.
+    let row = user_row_of(
+        &server,
+        &app_state.db,
+        json!({
+            "user_message": "explicit wait",
+            "mentioned_assistant_ids": [target],
+            "delegation_run_mode": "wait",
+        }),
+    )
+    .await;
+    let input_params = row.input_parameters.as_ref().expect("input parameters");
+    assert!(input_params.get("delegation_run_mode").is_none());
+}
+
+/// Edit replays the persisted run mode onto the new sibling row when the
+/// request doesn't re-send it, and an explicit `wait` on the edit clears the
+/// inherited `background` instead of falling back to it.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_edit_inherits_and_explicit_wait_clears_run_mode(pool: Pool<Postgres>) {
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+    let target = create_assistant(&server, "Run Mode Edit Target", "prompt").await;
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "user_message": "background origin",
+            "mentioned_assistant_ids": [target],
+            "delegation_run_mode": "background",
+        }))
+        .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let chat_id = Uuid::parse_str(&crate::test_utils::extract_chat_id(&events).unwrap()).unwrap();
+    let rows = chat_messages_by_created_at(&app_state.db, chat_id).await;
+    let original_user_row = rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "user")
+        .expect("user message row");
+
+    // Edit without the field: background carries onto the new sibling row.
+    let edit_response = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_row.id,
+            "replace_user_message": "edited, mode inherited",
+        }))
+        .await;
+    edit_response.assert_status_ok();
+    let rows = chat_messages_by_created_at(&app_state.db, chat_id).await;
+    let edited_row = rows
+        .iter()
+        .find(|row| row.raw_message["content"][0]["text"] == "edited, mode inherited")
+        .expect("edited sibling row");
+    assert_eq!(
+        erato::models::message::get_input_delegation_run_mode_from_message(edited_row).unwrap(),
+        Some(erato::models::message::DelegationRunMode::Background)
+    );
+
+    // Edit with an explicit wait: the inherited background is cleared while
+    // the mentions still replay.
+    let edit_response = server
+        .post("/api/v1beta/me/messages/editstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "message_id": original_user_row.id,
+            "replace_user_message": "edited, mode cleared",
+            "delegation_run_mode": "wait",
+        }))
+        .await;
+    edit_response.assert_status_ok();
+    let rows = chat_messages_by_created_at(&app_state.db, chat_id).await;
+    let cleared_row = rows
+        .iter()
+        .find(|row| row.raw_message["content"][0]["text"] == "edited, mode cleared")
+        .expect("cleared sibling row");
+    let input_params = cleared_row
+        .input_parameters
+        .as_ref()
+        .expect("input parameters");
+    assert!(input_params.get("delegation_run_mode").is_none());
+    assert_eq!(
+        erato::models::message::get_input_mentioned_assistant_ids_from_message(cleared_row)
+            .unwrap()
+            .expect("mentions carried onto the cleared row"),
+        vec![Uuid::parse_str(&target).unwrap()]
+    );
+}
+
+/// Regenerate accepts the run mode field on the wire: a request carrying
+/// `delegation_run_mode` round-trips with a 200.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_accepts_run_mode_field(pool: Pool<Postgres>) {
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+
+    let target = create_assistant(&server, "Run Mode Regen Target", "prompt").await;
+    let response = submit_with_mentions(&server, None, "regen origin", &[&target]).await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let assistant_message_id = assistant_message_id_from_events(&events);
+
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "current_message_id": assistant_message_id,
+            "delegation_run_mode": "background",
+        }))
+        .await;
+    regenerate_response.assert_status_ok();
+}
+
 const DELEGATE_ASSISTANT_FIXED_ID: &str = "00000000-0000-4000-8000-00000000d001";
 
 async fn insert_fixed_delegate_assistant(

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -2763,6 +2763,14 @@ pub struct AssistantsDelegationConfig {
     #[serde(default)]
     pub enabled: bool,
 
+    // Whether users may launch delegated runs in background mode, where the
+    // delegation tool returns at launch and the child result never flows back
+    // into the origin turn. A `background` request under a deployment with
+    // this off is downgraded to `wait`, not rejected — the client-side gate is
+    // UX, the server decides. Defaults to `false`.
+    #[serde(default)]
+    pub allow_background: bool,
+
     // Maximum wall-clock duration in seconds a delegated child run may take
     // before it is aborted and reported to the origin chat as timed out.
     // Defaults to `600`.
@@ -2806,6 +2814,7 @@ impl Default for AssistantsDelegationConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            allow_background: false,
             run_timeout_seconds: default_delegation_run_timeout_seconds(),
             max_mentions_per_message: default_delegation_max_mentions_per_message(),
             result_max_chars: default_delegation_result_max_chars(),

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -25,6 +25,7 @@
   "assistant_hub.reviewers.rules.<rule-name>.rule_type": {},
   "assistants.context_file_contributor_threshold": {},
   "assistants.context_warning_threshold": {},
+  "assistants.delegation.allow_background": {},
   "assistants.delegation.auto_archive_after_days": {},
   "assistants.delegation.enabled": {},
   "assistants.delegation.max_mentions_per_message": {},

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -5642,6 +5642,14 @@
           }
         }
       },
+      "DelegationRunMode": {
+        "type": "string",
+        "description": "How a delegated child run relates to the turn that spawned it: `wait`\nblocks the turn on the child and feeds the result back into it,\n`background` returns at launch and the child result never re-enters the\nturn.",
+        "enum": [
+          "wait",
+          "background"
+        ]
+      },
       "DesktopSidecarDistributionFileResponse": {
         "type": "object",
         "required": [
@@ -5897,6 +5905,10 @@
             "type": "string",
             "description": "The ID of the chat provider to use for generation. If not provided, will use the highest priority model for the user.",
             "example": "primary"
+          },
+          "delegation_run_mode": {
+            "$ref": "#/components/schemas/DelegationRunMode",
+            "description": "How delegated runs spawned by this message are awaited. Defaults to\n`wait`; `background` requires `assistants.delegation.allow_background`\nand is downgraded to `wait` server-side when the gate is off."
           },
           "mentioned_assistant_ids": {
             "type": "array",
@@ -6792,6 +6804,10 @@
             "description": "The ID of the chat provider to use for generation. If not provided, will use the highest priority model for the user.",
             "example": "primary"
           },
+          "delegation_run_mode": {
+            "$ref": "#/components/schemas/DelegationRunMode",
+            "description": "How delegated runs spawned by this message are awaited. Defaults to\n`wait`; `background` requires `assistants.delegation.allow_background`\nand is downgraded to `wait` server-side when the gate is off."
+          },
           "existing_chat_id": {
             "type": [
               "string",
@@ -7659,6 +7675,10 @@
             "format": "uuid",
             "description": "The ID of the message that should have a replacement response generated.",
             "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "delegation_run_mode": {
+            "$ref": "#/components/schemas/DelegationRunMode",
+            "description": "How delegated runs spawned by this message are awaited. Defaults to\n`wait`; `background` requires `assistants.delegation.allow_background`\nand is downgraded to `wait` server-side when the gate is off."
           },
           "mentioned_assistant_ids": {
             "type": "array",

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -1104,6 +1104,14 @@ export type CreateUserToolApprovalSettingRequest = {
   tool_name: string;
 };
 
+/**
+ * How a delegated child run relates to the turn that spawned it: `wait`
+ * blocks the turn on the child and feeds the result back into it,
+ * `background` returns at launch and the child result never re-enters the
+ * turn.
+ */
+export type DelegationRunMode = "wait" | "background";
+
 export type DesktopSidecarDistributionFileResponse = {
   download_filename: string;
   id: string;
@@ -1250,6 +1258,7 @@ export type EditMessageRequest = {
    * @example primary
    */
   chat_provider_id?: string;
+  delegation_run_mode?: DelegationRunMode;
   /**
    * Assistants the user @-mentioned in this message as delegation targets.
    * Validated server-side; requires `assistants.delegation.enabled`.
@@ -1656,6 +1665,7 @@ export type MessageSubmitRequest = {
    * @example primary
    */
   chat_provider_id?: string;
+  delegation_run_mode?: DelegationRunMode;
   /**
    * The ID of an existing chat to use. If provided, the chat with this ID will be used instead of creating a new one.
    * This is useful for scenarios where you have created a chat first (e.g. for file uploads) before sending the first message.
@@ -2096,6 +2106,7 @@ export type RegenerateMessageRequest = {
    * @example 00000000-0000-0000-0000-000000000000
    */
   current_message_id: string;
+  delegation_run_mode?: DelegationRunMode;
   /**
    * Assistants the user @-mentioned in this message as delegation targets.
    * Validated server-side; requires `assistants.delegation.enabled`.

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -3413,6 +3413,23 @@ Whether in-chat delegation to @-mentioned assistants is enabled. When enabled, u
 enabled = true
 ```
 
+#### `assistants.delegation.allow_background`
+
+{/* erato_toml_config_key: assistants.delegation.allow_background */}
+
+Whether users may launch delegated runs in background mode, where the delegation tool returns at launch and the child run's result never flows back into the origin turn. When disabled, a request asking for background mode is downgraded to a normally awaited run rather than rejected. Requires `assistants.delegation.enabled`.
+
+**Default value:** `false`
+
+**Type:** `boolean`
+
+**Example:**
+
+```toml
+[assistants.delegation]
+allow_background = true
+```
+
 #### `assistants.delegation.run_timeout_seconds`
 
 {/* erato_toml_config_key: assistants.delegation.run_timeout_seconds */}


### PR DESCRIPTION
Stacked on #1000 (ERMAIN-631), first layer of the ERMAIN-633 background-delegation stack; the base is that branch, so the diff here is this layer alone.

The wire only — nothing behavioural. `delegation_run_mode: "wait" | "background"` (default `wait`) on `MessageSubmitRequest`, `EditMessageRequest` and `RegenerateMessageRequest`, carried exactly the way `mentioned_assistant_ids` is.

## Persistence and the gate

The mode is persisted into `InputParameters` so edit and regenerate replay it instead of silently reverting to `wait` — the detail the ticket flagged as most likely to be missed. Two deliberate choices there:

- **Only `background` is persisted.** `wait` is the default, so absence means wait and every pre-existing envelope stays byte-identical.
- **The requested mode is persisted, not the gate-downgraded one.** `assistants.delegation.allow_background` (new key, default `false`) downgrades `background` to `wait` at execution time, never rejects — the client gate is UX, the server decides. Persisting the requested value means a replay under a later-enabled gate honours the user's original choice.

Edit resolves explicit-request-wins-else-inherit-from-the-edited-message, and an explicit `wait` clears an inherited `background`. `resolve_delegation_run_mode` (requested > persisted > wait, downgrade unless `enabled && allow_background`) is introduced here with unit tests; the next layer wires it into dispatch.

OpenAPI, config reference, the TS client, the site config docs and the `erato.template.toml` reference block (a config test parses that block against the Rust defaults) are all regenerated.

## Tests

Submit persists `background` (with and without mentions) and omits the key otherwise; edit inherits and explicit `wait` clears; regenerate accepts the field; resolver unit tests cover default, precedence and both gate directions. Full suite green at the stack tip (785 passed), fmt/clippy `-D warnings`/no-default-features, both codegen `--check`s, config-docs coverage, prettier on the generated client.
