### PR TITLE
Detached delegation dispatch: background runs return at launch (ERMAIN-635)

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -365,12 +365,14 @@ chat_provider_ids = ["test-token-limit"]
 # # Directive composed into every turn of a delegated chat, never stored in its
 # # messages, and dropped once the user writes into the run themselves. The
 # # delegate's own system prompt is untouched; this is additive.
-# # {{expected_output_section}} and {{constraints_section}} are replaced with
-# # formatted blocks when the origin model supplies the corresponding arguments,
-# # and with empty strings otherwise.
+# # {{result_disposition}} is replaced with a sentence matching the run's mode
+# # (awaited: the answer returns to the origin chat; background: the user reads
+# # it in this chat). {{expected_output_section}} and {{constraints_section}}
+# # are replaced with formatted blocks when the origin model supplies the
+# # corresponding arguments, and with empty strings otherwise.
 # # The text below is the built-in default.
 # preamble = """
-# You are working on a task that another conversation delegated to you. Your final message is returned to the delegating conversation as the result of this task; it is not shown to a person directly.
+# You are working on a task that another conversation delegated to you. {{result_disposition}}
 #
 # Complete the task within this conversation: do not ask clarifying questions, do not defer work to a later turn, and do not address the end user. Finish with a final message that stands alone as the task result.
 # {{expected_output_section}}{{constraints_section}}"""

--- a/backend/erato/src/models/chat.rs
+++ b/backend/erato/src/models/chat.rs
@@ -7,7 +7,7 @@ use crate::metrics_constants::{
     POSTGRES_QUERY_FREQUENT_ASSISTANTS, POSTGRES_QUERY_LIST_GENERATING_CHATS,
     POSTGRES_QUERY_LIST_RECENT_CHATS,
 };
-use crate::models::message::GenerationParameters;
+use crate::models::message::{DelegationRunMode, GenerationParameters};
 use crate::models::pagination;
 use crate::policy::prelude::*;
 use crate::query_metrics::named_statement_from_sql_and_values;
@@ -82,6 +82,13 @@ pub struct ChatProvenance {
     /// reasoning as `expected_output`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub constraints: Option<String>,
+    /// Delegation only: `Some(Background)` for a run the origin turn did not
+    /// await — its result never flowed back. Feeds the run's preamble wording
+    /// and, later, the accounting of concurrently running background runs.
+    /// Awaited runs store nothing, so their envelopes stay byte-identical to
+    /// those written before the field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_mode: Option<DelegationRunMode>,
 }
 
 impl ChatProvenanceKind {

--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -365,6 +365,12 @@ pub struct ContentPartDelegationPreambleMarker {
     pub expected_output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub constraints: Option<String>,
+    /// How the run relates to its origin turn; the preamble tells a background
+    /// delegate its answer is read in place rather than returned. Absent means
+    /// awaited, so markers persisted before the field existed keep rendering
+    /// the same text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_mode: Option<DelegationRunMode>,
 }
 
 /// Statistics for a list of messages

--- a/backend/erato/src/server/api/v1beta/file_resolution.rs
+++ b/backend/erato/src/server/api/v1beta/file_resolution.rs
@@ -159,6 +159,7 @@ pub(crate) fn resolve_directive_markers_in_generation_input(
                         &app_state.config.assistants.delegation.preamble,
                         marker.expected_output.as_deref(),
                         marker.constraints.as_deref(),
+                        marker.run_mode.unwrap_or_default(),
                     )
                 }
                 _ => return Some(input_message),

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1214,7 +1214,6 @@ pub struct RegenerateMessageRequest {
     /// and is downgraded to `wait` server-side when the gate is off.
     #[serde(default)]
     #[schema(nullable = false)]
-    #[allow(dead_code)]
     delegation_run_mode: Option<DelegationRunMode>,
 }
 
@@ -1809,6 +1808,9 @@ pub(crate) struct DelegationDispatchContext<'a> {
     pub origin_chat: &'a chats::Model,
     /// The turn's user message; seeding source and provenance anchor.
     pub origin_user_message_id: Uuid,
+    /// Effective run mode for this turn's delegated runs — resolved and
+    /// gate-downgraded at request time, so dispatch executes it as-is.
+    pub run_mode: crate::models::message::DelegationRunMode,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -2566,6 +2568,7 @@ pub(crate) async fn prepare_chat_request_with_adapters(
                 crate::services::delegation::build_delegate_to_assistant_tool(
                     &user_input.delegation_targets,
                     &offered_files,
+                    user_input.delegation_run_mode,
                     effective_model_settings.compat_omit_strict,
                 ),
             );
@@ -3313,12 +3316,14 @@ async fn stream_generate_chat_completion<
             }
 
             // Delegated assistant run: `delegate_to_assistant` executes
-            // server-side as an awaited child chat run and returns a result
-            // envelope. Must stay BEFORE the by-construction client-tool
-            // branch below, which treats every offered non-MCP name as a
-            // client tool. An MCP tool with the same name takes precedence
-            // (the synthetic tool is never offered in that case — see
-            // prepare). Every failure refuses the CALL, never the TURN.
+            // server-side as a child chat run — awaited (result envelope
+            // returns into this turn) or background (the call settles at
+            // launch and the child finishes on its own). Must stay BEFORE
+            // the by-construction client-tool branch below, which treats
+            // every offered non-MCP name as a client tool. An MCP tool with
+            // the same name takes precedence (the synthetic tool is never
+            // offered in that case — see prepare). Every failure refuses the
+            // CALL, never the TURN.
             if unfinished_tool_call.fn_name
                 == crate::services::delegation::DELEGATE_TO_ASSISTANT_TOOL_NAME
                 && !available_mcp_tools_by_name
@@ -3350,10 +3355,12 @@ async fn stream_generate_chat_completion<
                 };
                 let (status, bg_status, message_status, output_value, response_text) = match outcome
                 {
-                    Ok(outcome) => {
-                        let envelope = outcome.envelope;
+                    Ok(crate::services::delegation::DelegationDispatchOutcome::Completed {
+                        envelope,
+                        trace,
+                    }) => {
                         let response_text = envelope.model_response_text();
-                        let output_value = envelope.output_value(&outcome.trace);
+                        let output_value = envelope.output_value(&trace);
                         if envelope.status
                             == crate::services::delegation::DelegationRunStatus::Completed
                         {
@@ -3374,6 +3381,38 @@ async fn stream_generate_chat_completion<
                             )
                         }
                     }
+                    // A background launch settles the part as a Success — a
+                    // dispatch is not an error — with two deliberately
+                    // different shapes. The UI output carries NO "status":
+                    // the frontend renders any status other than "completed"
+                    // as a failure, and the "background" marker is what its
+                    // background presentation keys off. The model gets an
+                    // explicit "dispatched" status plus the note so its
+                    // final prose reports work that was started, not an
+                    // answer it never received.
+                    Ok(crate::services::delegation::DelegationDispatchOutcome::Dispatched {
+                        assistant_id,
+                        assistant_name,
+                        delegate_chat_id,
+                    }) => (
+                        ToolCallStatus::Success,
+                        BgToolCallStatus::Success,
+                        MessageToolCallStatus::Success,
+                        json!({
+                            "assistant_id": assistant_id,
+                            "assistant_name": assistant_name,
+                            "delegate_chat_id": delegate_chat_id,
+                            "background": true,
+                        }),
+                        json!({
+                            "status": "dispatched",
+                            "delegate_chat_id": delegate_chat_id,
+                            "assistant_id": assistant_id,
+                            "assistant_name": assistant_name,
+                            "note": "the result will not be returned to this conversation",
+                        })
+                        .to_string(),
+                    ),
                     Err(error) => (
                         ToolCallStatus::Error,
                         BgToolCallStatus::Error,
@@ -8070,6 +8109,13 @@ pub(crate) async fn run_message_submit_task(
 
     // Prepare chat request
     let me_profile_input = MeProfileChatRequestInput::from_me_profile(me_user);
+    // No persisted fallback: this request just persisted its own value, so
+    // the request field is the whole story here.
+    let effective_delegation_run_mode = crate::services::delegation::resolve_delegation_run_mode(
+        request.delegation_run_mode,
+        None,
+        &app_state.config.assistants.delegation,
+    );
     let user_input = PromptCompositionUserInput {
         just_submitted_user_message_id: saved_user_message.id,
         requested_chat_provider_id: request.chat_provider_id.clone(),
@@ -8082,6 +8128,7 @@ pub(crate) async fn run_message_submit_task(
             }
         }),
         delegation_targets,
+        delegation_run_mode: effective_delegation_run_mode,
     };
     let PreparedChatRequest {
         chat_request,
@@ -8251,6 +8298,7 @@ pub(crate) async fn run_message_submit_task(
             offered_file_ids: &delegation_offered_file_ids,
             origin_chat: &chat,
             origin_user_message_id: saved_user_message.id,
+            run_mode: effective_delegation_run_mode,
         }),
     );
 
@@ -8436,6 +8484,20 @@ pub async fn regenerate_message_sse(
             .await
         }
     };
+    // Same replay contract as the mentions: an explicit request value wins,
+    // else the mode the turn's user message persisted; the gate downgrade
+    // applies here, at execution time.
+    let effective_delegation_run_mode = crate::services::delegation::resolve_delegation_run_mode(
+        request.delegation_run_mode,
+        crate::models::message::get_input_delegation_run_mode_from_message(
+            &validation_result.previous_message,
+        )
+        .unwrap_or_else(|error| {
+            warn_and_capture_error("read regenerate fallback delegation run mode", &error);
+            None
+        }),
+        &app_state.config.assistants.delegation,
+    );
 
     // Create a channel for sending events
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Report>>(100);
@@ -8534,6 +8596,7 @@ pub async fn regenerate_message_sse(
                         },
                     ),
                 delegation_targets: delegation_targets_for_offer,
+                delegation_run_mode: effective_delegation_run_mode,
             };
             let PreparedChatRequest {
                 chat_request,
@@ -8655,6 +8718,7 @@ pub async fn regenerate_message_sse(
                         offered_file_ids: &delegation_offered_file_ids,
                         origin_chat: &chat,
                         origin_user_message_id: previous_message.id,
+                        run_mode: effective_delegation_run_mode,
                     }),
                 )
                 .await;
@@ -8922,6 +8986,13 @@ pub async fn edit_message_sse(
         }
     }
     .filter(|mode| *mode == DelegationRunMode::Background);
+    // What dispatch executes this turn: the resolved (requested-or-inherited)
+    // value above, gate-downgraded.
+    let effective_delegation_run_mode = crate::services::delegation::resolve_delegation_run_mode(
+        resolved_delegation_run_mode,
+        None,
+        &app_state.config.assistants.delegation,
+    );
     let edit_input_parameters = if resolved_action_facet.is_some()
         || resolved_mentioned_assistant_ids.is_some()
         || resolved_delegation_run_mode.is_some()
@@ -9021,6 +9092,7 @@ pub async fn edit_message_sse(
                     }
                 }),
                 delegation_targets: delegation_targets_for_offer,
+                delegation_run_mode: effective_delegation_run_mode,
             };
             let PreparedChatRequest {
                 chat_request,
@@ -9142,6 +9214,7 @@ pub async fn edit_message_sse(
                         offered_file_ids: &delegation_offered_file_ids,
                         origin_chat: &chat,
                         origin_user_message_id: saved_user_message.id,
+                        run_mode: effective_delegation_run_mode,
                     }),
                 )
                 .await;

--- a/backend/erato/src/server/api/v1beta/token_usage.rs
+++ b/backend/erato/src/server/api/v1beta/token_usage.rs
@@ -583,6 +583,7 @@ pub async fn token_usage_estimate(
                 }
             }),
             delegation_targets: Vec::new(),
+            delegation_run_mode: Default::default(),
         };
         let me_profile_input = MeProfileChatRequestInput::from_me_profile(&me_user);
 

--- a/backend/erato/src/services/delegation.rs
+++ b/backend/erato/src/services/delegation.rs
@@ -90,10 +90,14 @@ fn bounded_untrusted(value: &str, max_chars: usize, fallback: &str) -> String {
 /// Build the `delegate_to_assistant` tool for the validated targets of this
 /// turn. The `assistant_id` (and any `file_ids`) are enum-constrained to what
 /// was validated/offered, and the description enumerates targets and
-/// attachments so the model selects them informed.
+/// attachments so the model selects them informed. The run mode changes what
+/// the description promises: a background dispatch never brings the answer
+/// back, and a model that expects a result would write a task brief that
+/// leans on a follow-up which cannot happen.
 pub fn build_delegate_to_assistant_tool(
     targets: &[DelegationTarget],
     offered_files: &[DelegationOfferedFile],
+    run_mode: DelegationRunMode,
     omit_tool_strict: bool,
 ) -> GenaiTool {
     let target_ids: Vec<String> = targets.iter().map(|target| target.id.to_string()).collect();
@@ -114,11 +118,22 @@ pub fn build_delegate_to_assistant_tool(
         .collect::<Vec<_>>()
         .join("\n");
 
+    let run_sentence = match run_mode {
+        DelegationRunMode::Wait => {
+            "The delegate works on the task in its own chat run and this tool returns its final \
+             answer as the result; the run may take a while."
+        }
+        DelegationRunMode::Background => {
+            "The delegate works on the task in its own chat run in the background: this tool \
+             returns as soon as the run is launched and the delegate's answer will NOT come back \
+             to this conversation, so the task brief must be fully self-contained — no follow-up \
+             is possible."
+        }
+    };
     let guidance = untrusted_guidance();
     let mut description = format!(
         "Delegate a task to one of the assistants the user mentioned in their message. \
-         The delegate works on the task in its own chat run and this tool returns its final \
-         answer as the result; the run may take a while. Give a self-contained task brief — \
+         {run_sentence} Give a self-contained task brief — \
          the delegate does not see this conversation unless you set \
          include_conversation_context. {guidance}\nAvailable assistants:\n\
          <{UNTRUSTED_TAG}>\n{target_lines}\n</{UNTRUSTED_TAG}>"
@@ -400,11 +415,20 @@ impl DelegationResultEnvelope {
     }
 }
 
-/// What a dispatched call produced: the model-facing envelope, and the
-/// UI-facing trace of the child run that ran alongside it.
-pub(crate) struct DelegationDispatchOutcome {
-    pub envelope: DelegationResultEnvelope,
-    pub trace: DelegationTrace,
+/// What a dispatched call produced. An awaited run hands back the result
+/// envelope plus the UI-facing trace of the child run; a background run is
+/// over from the parent's point of view the moment it launches, so all it
+/// carries is the identity of what was launched.
+pub(crate) enum DelegationDispatchOutcome {
+    Completed {
+        envelope: DelegationResultEnvelope,
+        trace: DelegationTrace,
+    },
+    Dispatched {
+        assistant_id: Uuid,
+        assistant_name: String,
+        delegate_chat_id: Uuid,
+    },
 }
 
 /// The parent generation's stream, and where on it the delegation tool part
@@ -513,14 +537,31 @@ async fn parent_abort_signal(
 }
 
 /// Renders the configured delegation preamble, filling the optional
-/// structured-brief sections. Called once per turn of a delegated run from the
-/// directive resolver, against the fields stored in the run's provenance.
+/// structured-brief sections and the run-mode-dependent result disposition.
+/// Called once per turn of a delegated run from the directive resolver,
+/// against the fields stored in the run's provenance.
 pub(crate) fn render_delegation_preamble(
     preamble_template: &str,
     expected_output: Option<&str>,
     constraints: Option<&str>,
+    run_mode: DelegationRunMode,
 ) -> String {
     let mut args = std::collections::HashMap::new();
+    args.insert(
+        "result_disposition".to_string(),
+        match run_mode {
+            DelegationRunMode::Wait => {
+                "Your final message is returned to the delegating conversation as the result of \
+                 this task; it is not shown to a person directly."
+            }
+            DelegationRunMode::Background => {
+                "You are working in the background: the delegating conversation will not receive \
+                 your final message automatically; the user opens this conversation to read it. \
+                 Your final message must stand alone as the complete task result."
+            }
+        }
+        .to_string(),
+    );
     args.insert(
         "expected_output_section".to_string(),
         expected_output
@@ -810,10 +851,11 @@ async fn discard_unstarted_delegated_chat(
 
 /// Dispatches a `delegate_to_assistant` call: validates the arguments against
 /// what this turn offered, creates the delegated child chat (owned by the
-/// origin user, full provenance envelope), runs the delegate as an awaited
-/// child run streaming its progress onto the parent's tool part, and returns
-/// the result. `Err` is a refusal message for the model — the caller refuses
-/// the call, never the turn.
+/// origin user, full provenance envelope) and starts the delegate's run. An
+/// awaited run streams its progress onto the parent's tool part and returns
+/// the result envelope; a background run returns at launch and the child
+/// finishes on its own. `Err` is a refusal message for the model — the caller
+/// refuses the call, never the turn.
 pub(crate) async fn dispatch_delegate_tool_call(
     app_state: &AppState,
     policy: &PolicyEngine,
@@ -907,6 +949,8 @@ pub(crate) async fn dispatch_delegate_tool_call(
         adopted_at: None,
         expected_output: bounded_brief_field(args.expected_output.as_deref()),
         constraints: bounded_brief_field(args.constraints.as_deref()),
+        run_mode: (context.run_mode == DelegationRunMode::Background)
+            .then_some(DelegationRunMode::Background),
     };
     let child_chat = crate::models::chat::create_delegated_chat(
         &app_state.db,
@@ -961,7 +1005,7 @@ pub(crate) async fn dispatch_delegate_tool_call(
             file_ids,
             previous_message_id,
         );
-    let mut handle = tokio::spawn(run_delegated_child(
+    let handle = tokio::spawn(run_delegated_child(
         app_state.clone(),
         policy.clone(),
         context.me_user.clone(),
@@ -969,6 +1013,26 @@ pub(crate) async fn dispatch_delegate_tool_call(
         child_request,
         child_chat.id,
     ));
+
+    // A background dispatch is over here: dropping the handle detaches the
+    // child (its own lifecycle guard persists and cleans up), no trace is
+    // tapped, and a parent abort is not forwarded — the run outlives the
+    // turn and stays stoppable through its own chat's abort. Nothing ever
+    // backfills the parent's tool part either: the parent's assistant
+    // message is written once at turn end, so the part stays frozen at the
+    // launch shape and that is also the model's permanent memory of the
+    // call when the turn is replayed. How the run went is read off the run
+    // itself, not off the parent turn.
+    if context.run_mode == DelegationRunMode::Background {
+        drop(child_rx);
+        drop(handle);
+        return Ok(DelegationDispatchOutcome::Dispatched {
+            assistant_id,
+            assistant_name: assistant.name,
+            delegate_chat_id: child_chat.id,
+        });
+    }
+    let mut handle = handle;
 
     let mut trace = DelegationTraceCollector::new(dispatch_started);
     let mut progress = DelegationProgressEmitter {
@@ -1057,7 +1121,7 @@ pub(crate) async fn dispatch_delegate_tool_call(
     trace.finish();
     progress.flush(&trace).await;
 
-    Ok(DelegationDispatchOutcome {
+    Ok(DelegationDispatchOutcome::Completed {
         envelope: build_result_envelope(
             app_state,
             child_chat.id,
@@ -1106,7 +1170,7 @@ mod tests {
         targets: &[DelegationTarget],
         offered_files: &[DelegationOfferedFile],
     ) -> String {
-        build_delegate_to_assistant_tool(targets, offered_files, false)
+        build_delegate_to_assistant_tool(targets, offered_files, DelegationRunMode::Wait, false)
             .description
             .expect("tool description")
     }
@@ -1308,6 +1372,7 @@ mod tests {
                 id: file_id,
                 filename: format!("{}.pdf", close_tag()),
             }],
+            DelegationRunMode::Wait,
             false,
         );
 
@@ -1348,12 +1413,60 @@ mod tests {
     fn the_preamble_renders_only_the_sections_it_was_given() {
         let template = "Directive.{{expected_output_section}}{{constraints_section}}";
 
-        let bare = render_delegation_preamble(template, None, Some(" "));
+        let bare = render_delegation_preamble(template, None, Some(" "), DelegationRunMode::Wait);
         assert_eq!(bare, "Directive.");
 
-        let full = render_delegation_preamble(template, Some("A list."), Some("Attachments only."));
+        let full = render_delegation_preamble(
+            template,
+            Some("A list."),
+            Some("Attachments only."),
+            DelegationRunMode::Wait,
+        );
         assert!(full.contains("Expected output:\nA list."));
         assert!(full.contains("Constraints:\nAttachments only."));
+    }
+
+    #[test]
+    fn the_preamble_tells_the_delegate_where_its_answer_goes() {
+        let template = "{{result_disposition}}";
+
+        let awaited = render_delegation_preamble(template, None, None, DelegationRunMode::Wait);
+        assert!(awaited.contains("returned to the delegating conversation"));
+
+        let background =
+            render_delegation_preamble(template, None, None, DelegationRunMode::Background);
+        assert!(background.contains("working in the background"));
+        assert!(background.contains("will not receive your final message automatically"));
+        assert!(!background.contains("returned to the delegating conversation"));
+    }
+
+    #[test]
+    fn a_template_without_the_disposition_placeholder_renders_without_it() {
+        let rendered = render_delegation_preamble(
+            "Custom operator directive.",
+            None,
+            None,
+            DelegationRunMode::Background,
+        );
+        assert_eq!(rendered, "Custom operator directive.");
+    }
+
+    #[test]
+    fn the_background_offer_says_the_answer_never_comes_back() {
+        let targets = [target("Helper", None)];
+        let wait_description =
+            build_delegate_to_assistant_tool(&targets, &[], DelegationRunMode::Wait, false)
+                .description
+                .expect("tool description");
+        let background_description =
+            build_delegate_to_assistant_tool(&targets, &[], DelegationRunMode::Background, false)
+                .description
+                .expect("tool description");
+
+        assert!(wait_description.contains("returns its final answer as the result"));
+        assert!(background_description.contains("will NOT come back to this conversation"));
+        assert!(background_description.contains("no follow-up is possible"));
+        assert!(!background_description.contains("returns its final answer as the result"));
     }
 
     fn delegation_config(enabled: bool, allow_background: bool) -> AssistantsDelegationConfig {

--- a/backend/erato/src/services/genai_langfuse.rs
+++ b/backend/erato/src/services/genai_langfuse.rs
@@ -177,6 +177,7 @@ pub fn convert_content_parts_to_json(content_parts: &[ContentPart]) -> Result<Js
                     "type": "delegation_preamble_marker",
                     "expected_output": marker.expected_output,
                     "constraints": marker.constraints,
+                    "run_mode": marker.run_mode,
                 }));
             }
             ContentPart::ToolApprovalRequest(request) => {

--- a/backend/erato/src/services/prompt_composition/tests.rs
+++ b/backend/erato/src/services/prompt_composition/tests.rs
@@ -2898,6 +2898,7 @@ mod test_cases {
                 adopted_at: adopted.then(|| chrono::Utc::now().into()),
                 expected_output: expected_output.map(str::to_string),
                 constraints: constraints.map(str::to_string),
+                run_mode: None,
             }),
         };
         let mut chat = create_test_chat();

--- a/backend/erato/src/services/prompt_composition/transforms.rs
+++ b/backend/erato/src/services/prompt_composition/transforms.rs
@@ -315,6 +315,7 @@ pub async fn build_abstract_sequence_with_facet_tool_expansions(
         sequence.push(AbstractChatSequencePart::DelegationPreamble {
             expected_output: provenance.expected_output.clone(),
             constraints: provenance.constraints.clone(),
+            run_mode: provenance.run_mode,
         });
     }
 
@@ -559,6 +560,7 @@ pub async fn resolve_sequence(
             AbstractChatSequencePart::DelegationPreamble {
                 expected_output,
                 constraints,
+                run_mode,
             } => {
                 // Same shape as the action-facet directive: a marker in the
                 // user turn, never setting `has_system_message` — the preamble
@@ -570,6 +572,7 @@ pub async fn resolve_sequence(
                         ContentPartDelegationPreambleMarker {
                             expected_output,
                             constraints,
+                            run_mode,
                         },
                     ),
                 });

--- a/backend/erato/src/services/prompt_composition/types.rs
+++ b/backend/erato/src/services/prompt_composition/types.rs
@@ -34,6 +34,12 @@ pub struct PromptCompositionUserInput {
     /// Non-empty only on mention-carrying turns; drives the request-scoped
     /// `delegate_to_assistant` tool offer.
     pub delegation_targets: Vec<crate::services::delegation::DelegationTarget>,
+
+    /// Effective run mode of any delegated runs this turn dispatches — the
+    /// gate-downgraded value, i.e. what dispatch will actually do. Varies the
+    /// tool offer's wording so the model briefs a background delegate whose
+    /// answer never comes back accordingly.
+    pub delegation_run_mode: crate::models::message::DelegationRunMode,
 }
 
 /// Action facet input for prompt composition.
@@ -88,11 +94,13 @@ pub enum AbstractChatSequencePart {
     },
 
     /// Run directive of a delegated chat, carrying the structured-brief fields
-    /// off the chat's provenance envelope. Rendered in the resolver step from
-    /// the configured template, for the same reason as `ActionFacetPrompt`.
+    /// and the run mode off the chat's provenance envelope. Rendered in the
+    /// resolver step from the configured template, for the same reason as
+    /// `ActionFacetPrompt`.
     DelegationPreamble {
         expected_output: Option<String>,
         constraints: Option<String>,
+        run_mode: Option<crate::models::message::DelegationRunMode>,
     },
 
     /// File attached to the current user input

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -160,6 +160,7 @@ async fn write_delegation_provenance(
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         }),
     };
     let chat = erato::db::entity::chats::Entity::find_by_id(chat_id)
@@ -2684,6 +2685,758 @@ async fn test_delegation_abort_forwarding_cancels_child(pool: Pool<Postgres>) {
     );
 }
 
+async fn submit_with_mentions_and_run_mode(
+    server: &TestServer,
+    chat_id: Option<&str>,
+    text: &str,
+    mentioned_assistant_ids: &[&str],
+    run_mode: &str,
+) -> axum_test::TestResponse {
+    let mut body = json!({
+        "user_message": text,
+        "mentioned_assistant_ids": mentioned_assistant_ids,
+        "delegation_run_mode": run_mode,
+    });
+    if let Some(chat_id) = chat_id {
+        body["existing_chat_id"] = json!(chat_id);
+    }
+    server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&body)
+        .await
+}
+
+/// Waits until the delegated child persisted an assistant answer containing
+/// `needle` and its generation reached a terminal `completed` state.
+async fn wait_for_child_completion(
+    db: &sea_orm::DatabaseConnection,
+    child_chat_id: Uuid,
+    needle: &str,
+) {
+    for _ in 0..100 {
+        let answered = chat_messages_by_created_at(db, child_chat_id)
+            .await
+            .iter()
+            .any(|row| {
+                row.raw_message["role"] == "assistant"
+                    && row.raw_message["content"]
+                        .as_array()
+                        .into_iter()
+                        .flatten()
+                        .any(|part| {
+                            part["text"]
+                                .as_str()
+                                .is_some_and(|text| text.contains(needle))
+                        })
+            });
+        let state = erato::db::entity::chats::Entity::find_by_id(child_chat_id)
+            .one(db)
+            .await
+            .unwrap()
+            .unwrap()
+            .generation_state;
+        if answered && state.as_deref() == Some("completed") {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    panic!("delegated child chat {child_chat_id} never completed with its answer");
+}
+
+fn provenance_of(chat: &erato::db::entity::chats::Model) -> ChatProvenance {
+    erato::models::chat::AssistantConfiguration::from_json(
+        chat.assistant_configuration.as_ref().unwrap(),
+    )
+    .unwrap()
+    .provenance
+    .unwrap()
+}
+
+/// Background dispatch settles the tool at launch: the parent turn completes
+/// while the child still runs, the model hears `dispatched` plus the
+/// no-result note, and the UI part is a status-less Success carrying the
+/// `background` marker instead of a result or trace. The child gets the
+/// background preamble and lands its answer in its own chat afterwards.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_background_dispatch_returns_at_launch(pool: Pool<Postgres>) {
+    let parent_first_recorder = RequestBodyRecorder::new();
+    let parent_final_recorder = RequestBodyRecorder::new();
+    let child_recorder = RequestBodyRecorder::new();
+
+    let mut mocks = MockSet::new();
+    // Child: slow enough that the parent demonstrably finishes first.
+    {
+        let recorder = child_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["CHILD-BG-TASK"],
+                    &["dispatched"],
+                ))
+                .matcher(recorder);
+            let mut actions =
+                crate::test_utils::build_openai_text_streaming_response(&["CHILD-BG-ANSWER done"]);
+            actions.insert(0, BodyAction::Delay(std::time::Duration::from_secs(3)));
+            mock_llm_sse_response(then, actions);
+        });
+    }
+    // Parent turn 2: the dispatched tool response arrived.
+    {
+        let recorder = parent_final_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(&["dispatched"], &[]))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_text_streaming_response(&[
+                    "PARENT-BG-FINAL the delegate was started",
+                ]),
+            );
+        });
+    }
+    // Parent turn 1: delegate.
+    {
+        let recorder = parent_first_recorder.clone();
+        mocks.mock(move |when, then| {
+            when.post()
+                .path("/v1/chat/completions")
+                .matcher(BodyContainsMatcher::new(
+                    &["bg parent question"],
+                    &["CHILD-BG-TASK", "dispatched"],
+                ))
+                .matcher(recorder);
+            mock_llm_sse_response(
+                then,
+                crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                    "call_delegate_bg",
+                    "delegate_to_assistant",
+                    json!({
+                        "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                        "task": "CHILD-BG-TASK take your time",
+                    }),
+                )]),
+            );
+        });
+    }
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.allow_background = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, &delegate_prompt(), None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions_and_run_mode(
+        &server,
+        None,
+        "bg parent question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+        "background",
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    // The two output shapes diverge: the UI part is a status-less Success
+    // with the background marker and no result or trace.
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert!(output.get("status").is_none(), "no status on the UI output");
+    assert_eq!(output["background"], true);
+    assert_eq!(output["assistant_name"], "Fixed Delegate");
+    assert!(output.get("result").is_none());
+    assert!(output.get("localTrace").is_none());
+    let delegate_chat_id = Uuid::parse_str(output["delegate_chat_id"].as_str().unwrap()).unwrap();
+    assert!(
+        delegation_progress_frames(&events).is_empty(),
+        "a background run streams no progress onto the parent"
+    );
+    assert!(extract_full_text_answer(&events).contains("PARENT-BG-FINAL"));
+
+    // The parent completed while the child is still running.
+    let child_chat = erato::db::entity::chats::Entity::find_by_id(delegate_chat_id)
+        .one(&app_state.db)
+        .await
+        .unwrap()
+        .expect("delegated child chat");
+    assert_eq!(child_chat.generation_state.as_deref(), Some("running"));
+    assert_eq!(
+        provenance_of(&child_chat).run_mode,
+        Some(erato::models::message::DelegationRunMode::Background)
+    );
+
+    // The model heard a launch, never the answer.
+    let parent_final_bodies = parent_final_recorder.bodies();
+    let dispatch_body = parent_final_bodies
+        .iter()
+        .find(|body| body.contains("dispatched"))
+        .expect("parent turn with the dispatched tool response");
+    assert!(dispatch_body.contains("the result will not be returned to this conversation"));
+    assert!(!dispatch_body.contains("CHILD-BG-ANSWER"));
+
+    // The offer promised no returning answer…
+    let parent_first_bodies = parent_first_recorder.bodies();
+    let offer_body = parent_first_bodies
+        .iter()
+        .find(|body| body.contains("delegate_to_assistant"))
+        .expect("parent completion request with the delegation tool offer");
+    assert!(offer_body.contains("will NOT come back to this conversation"));
+
+    // …and the child's preamble matches: it works in the background.
+    let mut child_bodies = child_recorder.bodies();
+    for _ in 0..100 {
+        if !child_bodies.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        child_bodies = child_recorder.bodies();
+    }
+    let child_body = child_bodies.first().expect("child completion request");
+    assert!(child_body.contains("working in the background"));
+    assert!(!child_body.contains("returned to the delegating conversation"));
+
+    // The persisted parent tool part froze at the launch shape.
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let messages_response = server
+        .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    messages_response.assert_status_ok();
+    let tool_use = messages_response.json::<Value>()["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["id"] == assistant_message_id.as_str())
+        .expect("parent assistant message")["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|part| part["content_type"] == "tool_use")
+        .expect("tool_use part")
+        .clone();
+    assert_eq!(tool_use["status"], "success");
+    assert!(tool_use["output"].get("status").is_none());
+    assert_eq!(tool_use["output"]["background"], true);
+    assert_eq!(
+        tool_use["output"]["delegate_chat_id"],
+        delegate_chat_id.to_string()
+    );
+    assert!(tool_use["output"].get("localTrace").is_none());
+
+    // The child still finishes on its own and its answer lives in its chat.
+    wait_for_child_completion(&app_state.db, delegate_chat_id, "CHILD-BG-ANSWER").await;
+}
+
+/// Stopping the parent generation does not stop a background child: the abort
+/// is not forwarded, and the child runs to completion on its own.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_parent_abort_leaves_background_child_running(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    // Child: slow, but well within what the test waits for.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-BG-ABORT-TASK"],
+                &["dispatched"],
+            ));
+        let mut actions = crate::test_utils::build_openai_text_streaming_response(&[
+            "CHILD-BG-ABORT-ANSWER intact",
+        ]);
+        actions.insert(0, BodyAction::Delay(std::time::Duration::from_secs(4)));
+        mock_llm_sse_response(then, actions);
+    });
+    // Parent turn 2: stall long enough for the abort to land mid-turn.
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["dispatched"], &[]));
+        mock_llm_sse_response(
+            then,
+            vec![
+                BodyAction::Delay(std::time::Duration::from_secs(30)),
+                BodyAction::Bytes("data: [DONE]\n\n".into()),
+            ],
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["bg abort question"],
+                &["CHILD-BG-ABORT-TASK", "dispatched"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_bg_abort",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-BG-ABORT-TASK keep going",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.allow_background = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "background delegate", None).await;
+
+    // Real TCP server so the abort can run concurrently with the stream.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let app: Router = erato::server::router::router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state.clone());
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://{server_addr}");
+
+    let create_response = client
+        .post(format!("{base_url}/api/v1beta/me/chats"))
+        .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+        .json(&json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(create_response.status().is_success());
+    let parent_chat = create_response.json::<Value>().await.unwrap()["chat_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let parent_chat_id = Uuid::parse_str(&parent_chat).unwrap();
+
+    let submit_client = client.clone();
+    let submit_base = base_url.clone();
+    let submit_chat = parent_chat.clone();
+    let submit_handle = tokio::spawn(async move {
+        let response = submit_client
+            .post(format!("{submit_base}/api/v1beta/me/messages/submitstream"))
+            .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+            .json(&json!({
+                "existing_chat_id": submit_chat,
+                "user_message": "bg abort question",
+                "mentioned_assistant_ids": [DELEGATE_ASSISTANT_FIXED_ID],
+                "delegation_run_mode": "background",
+            }))
+            .send()
+            .await
+            .expect("submit request");
+        assert!(response.status().is_success());
+        response.text().await.expect("submit body")
+    });
+
+    // Wait until the delegated child chat exists (the child run is in flight).
+    let mut child_chat_id = None;
+    for _ in 0..100 {
+        let children = erato::db::entity::chats::Entity::find()
+            .filter(erato::db::entity::chats::Column::OriginChatId.eq(parent_chat_id))
+            .all(&app_state.db)
+            .await
+            .unwrap();
+        if let Some(child) = children.first() {
+            child_chat_id = Some(child.id);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let child_chat_id = child_chat_id.expect("delegated child chat never appeared");
+
+    let abort_response = client
+        .post(format!("{base_url}/api/v1beta/me/messages/abortstream"))
+        .header("Authorization", format!("Bearer {TEST_JWT_TOKEN}"))
+        .json(&json!({ "chat_id": parent_chat }))
+        .send()
+        .await
+        .unwrap();
+    assert!(abort_response.status().is_success());
+
+    tokio::time::timeout(std::time::Duration::from_secs(20), submit_handle)
+        .await
+        .expect("parent stream should close after abort")
+        .unwrap();
+
+    // The child was not aborted with the parent: its full answer arrives.
+    wait_for_child_completion(&app_state.db, child_chat_id, "CHILD-BG-ABORT-ANSWER").await;
+}
+
+/// With `allow_background` off, a background request downgrades to the awaited
+/// path: full result envelope, `completed` status, result text present.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_background_request_downgrades_to_awaited_when_gate_off(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-GATE-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["CHILD-GATE-ANSWER now"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["delegate_chat_id"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-GATE-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["gate off question"],
+                &["CHILD-GATE-TASK", "delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_gate",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-GATE-TASK answer now",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "gated delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions_and_run_mode(
+        &server,
+        None,
+        "gate off question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+        "background",
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+
+    let output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(output["status"], "completed");
+    assert!(output.get("background").is_none());
+    assert!(
+        output["result"]
+            .as_str()
+            .unwrap()
+            .contains("CHILD-GATE-ANSWER")
+    );
+    assert!(extract_full_text_answer(&events).contains("PARENT-GATE-FINAL"));
+
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+    let child_chat = delegated_child_chat(&app_state.db, Uuid::parse_str(&chat_id).unwrap()).await;
+    assert!(provenance_of(&child_chat).run_mode.is_none());
+}
+
+/// Regenerating the backgrounded turn without re-sending the field replays the
+/// persisted mode end-to-end: the new dispatch is background again.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_replays_background_dispatch(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-BG-REGEN-TASK"],
+                &["dispatched"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["CHILD-BG-REGEN-ANSWER"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["dispatched"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-BG-REGEN-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["bg regen question"],
+                &["CHILD-BG-REGEN-TASK", "dispatched"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_bg_regen",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-BG-REGEN-TASK run again",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.allow_background = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "regen delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions_and_run_mode(
+        &server,
+        None,
+        "bg regen question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+        "background",
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let first_output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(first_output["background"], true);
+    let first_child_id =
+        Uuid::parse_str(first_output["delegate_chat_id"].as_str().unwrap()).unwrap();
+    wait_for_child_completion(&app_state.db, first_child_id, "CHILD-BG-REGEN-ANSWER").await;
+
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({ "current_message_id": assistant_message_id }))
+        .await;
+    regenerate_response.assert_status_ok();
+    let regen_events = parse_sse_events(&regenerate_response);
+
+    let regen_output = find_tool_call_update_output(&regen_events, "delegate_to_assistant");
+    assert!(regen_output.get("status").is_none());
+    assert_eq!(regen_output["background"], true);
+    let second_child_id =
+        Uuid::parse_str(regen_output["delegate_chat_id"].as_str().unwrap()).unwrap();
+    assert_ne!(second_child_id, first_child_id);
+
+    let second_child = erato::db::entity::chats::Entity::find_by_id(second_child_id)
+        .one(&app_state.db)
+        .await
+        .unwrap()
+        .expect("second delegated child chat");
+    assert_eq!(
+        provenance_of(&second_child).run_mode,
+        Some(erato::models::message::DelegationRunMode::Background)
+    );
+    wait_for_child_completion(&app_state.db, second_child_id, "CHILD-BG-REGEN-ANSWER").await;
+}
+
+/// Regenerating a backgrounded turn with an explicit `wait` in the request
+/// overrides the persisted mode end-to-end: the new dispatch is awaited, so
+/// the full result envelope lands on the tool part instead of a frozen
+/// background offer.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_regenerate_request_wait_overrides_persisted_background(pool: Pool<Postgres>) {
+    let mut mocks = MockSet::new();
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-WAIT-REGEN-TASK"],
+                &["delegate_chat_id"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["CHILD-WAIT-REGEN-ANSWER"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(&["dispatched"], &[]));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&[
+                "PARENT-WAIT-REGEN-BG-FINAL",
+            ]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["CHILD-WAIT-REGEN-ANSWER"],
+                &["dispatched"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_text_streaming_response(&["PARENT-WAIT-REGEN-FINAL"]),
+        );
+    });
+    mocks.mock(|when, then| {
+        when.post()
+            .path("/v1/chat/completions")
+            .matcher(BodyContainsMatcher::new(
+                &["wait regen question"],
+                &["CHILD-WAIT-REGEN-TASK", "dispatched"],
+            ));
+        mock_llm_sse_response(
+            then,
+            crate::test_utils::build_openai_tool_calls_streaming_response(&[(
+                "call_delegate_wait_regen",
+                "delegate_to_assistant",
+                json!({
+                    "assistant_id": DELEGATE_ASSISTANT_FIXED_ID,
+                    "task": "CHILD-WAIT-REGEN-TASK answer now",
+                }),
+            )]),
+        );
+    });
+
+    let (mut app_config, _llm) = setup_mock_llm_server_with_mocks(mocks).await;
+    app_config.assistants.delegation.enabled = true;
+    app_config.assistants.delegation.allow_background = true;
+    let app_state = test_app_state(app_config, pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    insert_fixed_delegate_assistant(&app_state.db, me.id, "wait regen delegate", None).await;
+    let server = app_server(app_state.clone());
+
+    let response = submit_with_mentions_and_run_mode(
+        &server,
+        None,
+        "wait regen question",
+        &[DELEGATE_ASSISTANT_FIXED_ID],
+        "background",
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let first_output = find_tool_call_update_output(&events, "delegate_to_assistant");
+    assert_eq!(first_output["background"], true);
+    let first_child_id =
+        Uuid::parse_str(first_output["delegate_chat_id"].as_str().unwrap()).unwrap();
+    wait_for_child_completion(&app_state.db, first_child_id, "CHILD-WAIT-REGEN-ANSWER").await;
+
+    let assistant_message_id = assistant_message_id_from_events(&events);
+    let regenerate_response = server
+        .post("/api/v1beta/me/messages/regeneratestream")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .json(&json!({
+            "current_message_id": assistant_message_id,
+            "delegation_run_mode": "wait",
+        }))
+        .await;
+    regenerate_response.assert_status_ok();
+    let regen_events = parse_sse_events(&regenerate_response);
+
+    let regen_output = find_tool_call_update_output(&regen_events, "delegate_to_assistant");
+    assert_eq!(regen_output["status"], "completed");
+    assert!(regen_output.get("background").is_none());
+    assert!(
+        regen_output["result"]
+            .as_str()
+            .unwrap()
+            .contains("CHILD-WAIT-REGEN-ANSWER")
+    );
+    assert!(extract_full_text_answer(&regen_events).contains("PARENT-WAIT-REGEN-FINAL"));
+
+    let second_child_id =
+        Uuid::parse_str(regen_output["delegate_chat_id"].as_str().unwrap()).unwrap();
+    assert_ne!(second_child_id, first_child_id);
+    let second_child = erato::db::entity::chats::Entity::find_by_id(second_child_id)
+        .one(&app_state.db)
+        .await
+        .unwrap()
+        .expect("second delegated child chat");
+    assert!(provenance_of(&second_child).run_mode.is_none());
+}
+
 async fn rebuilt_policy(app_state: &erato::state::AppState) -> erato::policy::engine::PolicyEngine {
     let policy = erato::policy::engine::PolicyEngine::new();
     policy
@@ -2760,6 +3513,7 @@ async fn test_listing_hides_delegated_runs_and_exposes_provenance(pool: Pool<Pos
                 adopted_at: None,
                 expected_output: None,
                 constraints: None,
+                run_mode: None,
             },
             format!("Delegated run {index}"),
         )
@@ -2935,6 +3689,7 @@ async fn test_parked_delegated_chat_stays_reachable(pool: Pool<Postgres>) {
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         },
         "Parked delegated run".to_string(),
     )
@@ -3506,6 +4261,7 @@ async fn spawn_delegated_run(
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         },
         title.to_string(),
     )
@@ -3538,6 +4294,7 @@ async fn spawn_handoff_branch(
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         },
         "Handoff branch".to_string(),
     )
@@ -3927,6 +4684,7 @@ async fn test_submit_into_live_delegated_run_conflicts(pool: Pool<Postgres>) {
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         },
         "Continuable run".to_string(),
     )
@@ -4273,6 +5031,7 @@ async fn test_chat_detail_carries_provenance_and_run_parameters(pool: Pool<Postg
             adopted_at: None,
             expected_output: Some("One number per line.".to_string()),
             constraints: Some("Only the attached figures.".to_string()),
+            run_mode: None,
         },
         "Summarize the numbers".to_string(),
     )
@@ -4356,6 +5115,7 @@ async fn test_chat_detail_reports_adopted_and_archived_runs(pool: Pool<Postgres>
             adopted_at: None,
             expected_output: None,
             constraints: None,
+            run_mode: None,
         },
         "Adoptable run".to_string(),
     )

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -2799,13 +2799,15 @@ pub struct AssistantsDelegationConfig {
     pub auto_archive_after_days: u32,
 
     // Directive composed into every turn of a delegated chat, telling the
-    // delegate it runs as a delegated worker and that its final message is
-    // returned to the origin chat as the task result. It is never stored in the
-    // chat's messages, and it stops once the user writes into the run
-    // themselves — from then on the delegate is talking to them.
-    // `{{expected_output_section}}` and `{{constraints_section}}` are replaced
-    // with formatted blocks when the origin model supplies the corresponding
-    // tool arguments, and with empty strings otherwise.
+    // delegate it runs as a delegated worker and where its final message ends
+    // up. It is never stored in the chat's messages, and it stops once the user
+    // writes into the run themselves — from then on the delegate is talking to
+    // them. `{{result_disposition}}` is replaced with a sentence matching the
+    // run's mode (awaited: the answer returns to the origin chat; background:
+    // the user reads it in this chat); `{{expected_output_section}}` and
+    // `{{constraints_section}}` are replaced with formatted blocks when the
+    // origin model supplies the corresponding tool arguments, and with empty
+    // strings otherwise.
     #[serde(default = "default_delegation_preamble")]
     pub preamble: String,
 }
@@ -2841,7 +2843,7 @@ fn default_delegation_auto_archive_after_days() -> u32 {
 }
 
 fn default_delegation_preamble() -> String {
-    r#"You are working on a task that another conversation delegated to you. Your final message is returned to the delegating conversation as the result of this task; it is not shown to a person directly.
+    r#"You are working on a task that another conversation delegated to you. {{result_disposition}}
 
 Complete the task within this conversation: do not ask clarifying questions, do not defer work to a later turn, and do not address the end user. Finish with a final message that stands alone as the task result.
 {{expected_output_section}}{{constraints_section}}"#

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -5279,6 +5279,17 @@
               "string",
               "null"
             ]
+          },
+          "run_mode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DelegationRunMode",
+                "description": "How the run relates to its origin turn; the preamble tells a background\ndelegate its answer is read in place rather than returned. Absent means\nawaited, so markers persisted before the field existed keep rendering\nthe same text."
+              }
+            ]
           }
         }
       },

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -898,6 +898,7 @@ export type ContentPartActionFacetMarker = {
 export type ContentPartDelegationPreambleMarker = {
   constraints?: null | undefined;
   expected_output?: null | undefined;
+  run_mode?: null | DelegationRunMode;
 };
 
 export type ContentPartImage = {

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -3504,7 +3504,7 @@ auto_archive_after_days = 14
 
 {/* erato_toml_config_key: assistants.delegation.preamble */}
 
-Directive rendered into the delegated chat's first turn, telling the delegate it runs as a delegated worker and that its final message is returned to the origin chat as the task result. The delegate's own system prompt is untouched; the directive is additive. The placeholders `{{expected_output_section}}` and `{{constraints_section}}` are replaced with formatted blocks when the origin model supplies the corresponding tool arguments, and with empty strings otherwise.
+Directive rendered into the delegated chat's first turn, telling the delegate it runs as a delegated worker and where its final message ends up. The delegate's own system prompt is untouched; the directive is additive. The placeholder `{{result_disposition}}` is replaced with a sentence matching the run's mode — for an awaited run, that the final message is returned to the origin chat as the task result; for a background run, that the origin chat does not receive it and the user reads it in the run itself. The placeholders `{{expected_output_section}}` and `{{constraints_section}}` are replaced with formatted blocks when the origin model supplies the corresponding tool arguments, and with empty strings otherwise. A template that omits a placeholder simply renders without that part.
 
 **Default value:** the built-in directive shown in the `erato.template.toml` reference block
 


### PR DESCRIPTION
On top of #1004 (ERMAIN-634); the base is that branch, so the diff here is this layer alone. Stack: #1000 header → #1004 run-mode wire → **this** detached dispatch → bounds → origin filter → durable outcome → graceful shutdown.

When the effective mode is `background`, `dispatch_delegate_tool_call` short-circuits right after spawning the child: the trace tap and the join handle are dropped, no progress frames, no result envelope — the parent turn settles the tool part terminally at dispatch and completes. `DelegationDispatchOutcome` became an enum (`Completed { envelope, trace }` / `Dispatched { … }`).

## Two output shapes that must differ

- **To the model:** `{"status":"dispatched", …, "note":"the result will not be returned to this conversation"}` — it writes a final message saying it *started* the work, not pretending to have the answer.
- **To the UI:** `{assistant_id, assistant_name, delegate_chat_id, background: true}` with **no `status` key**. The current trace step renders any non-`completed` status as a red error pill printing the raw string; a status-less envelope reads as running today, and `background: true` is the hook the trace-step follow-up (ERMAIN-641) keys its own presentation on. The tool part settles `Success`.

**No backfill** — the parent's assistant message is written once at turn end, so the tool part is frozen at dispatch forever, and that is also the model's durable memory of the call. Completion surfaces through the origin-chat run list (later layers). Reasoning recorded at the dispatch branch.

Parent abort no longer reaches a background child; the run stays stoppable through its own chat id via the existing cross-replica command listener. The effective (gate-downgraded) mode is resolved at all three dispatch sites mirroring the mentions request-else-persisted pattern, and `ChatProvenance` records `run_mode` (only for background — old envelopes byte-identical).

Wording: the background tool offer says the answer will NOT come back and the brief must be fully self-contained; the preamble's result-disposition sentence became a `{{result_disposition}}` placeholder filled per mode (a custom template without it simply renders without that part — noted in the docs).

A detached child is **not yet bounded** — that is the next layer; `allow_background` defaulting to false is the interim guard.

## Tests

Background dispatch returns at launch (frozen part shape, model-facing text, offer wording, background preamble, provenance, child completing later in its own chat); aborting the parent leaves the child running; gate-off downgrades to the awaited path; regenerate replays a persisted `background`; an explicit `wait` on regenerate overrides it. Awaited-path tests unchanged.
