### PR TITLE
Recent chats: optional origin_chat_id filter (ERMAIN-637)

### DIFF
--- a/backend/erato/src/models/chat.rs
+++ b/backend/erato/src/models/chat.rs
@@ -513,6 +513,10 @@ pub struct RecentChatsFilter<'a> {
     /// Whether delegated runs (provenance kind `delegation`) are included.
     /// They are hidden from listings by default.
     pub include_delegated: bool,
+    /// If set, only chats spawned from this origin chat are returned. This
+    /// composes with `include_delegated` rather than overriding it, so
+    /// listing a chat's delegated runs requires both.
+    pub origin_chat_id: Option<Uuid>,
 }
 
 /// Get the most recent chats for a user.
@@ -575,6 +579,17 @@ pub async fn get_recent_chats(
             String::new()
         }
     };
+    let origin_condition = |param_index: u8| {
+        if filter.origin_chat_id.is_some() {
+            format!("AND \"chats\".\"origin_chat_id\" = ${param_index}")
+        } else {
+            String::new()
+        }
+    };
+    // Optional parameters are bound after each query's fixed ones in the
+    // order search → origin, so origin's index shifts up by one whenever a
+    // search parameter is bound before it.
+    let search_param_count = u8::from(search_query.is_some());
 
     // Query using INNER JOIN LATERAL for better performance
     // This ensures the database does all filtering, sorting, and pagination
@@ -615,12 +630,14 @@ pub async fn get_recent_chats(
             {}
             {}
             {}
+            {}
         ORDER BY latest_msg.created_at DESC
         LIMIT $2
         OFFSET $3
         "#,
         archived_condition,
         search_condition(4),
+        origin_condition(4 + search_param_count),
         pinned_condition,
         chat_type_condition,
         delegated_condition
@@ -633,6 +650,9 @@ pub async fn get_recent_chats(
     ];
     if let Some(search_query) = search_query {
         query_values.push(search_query.into());
+    }
+    if let Some(origin_chat_id) = filter.origin_chat_id {
+        query_values.push(origin_chat_id.into());
     }
 
     let chats_with_messages: Vec<ChatWithLatestMessage> =
@@ -670,10 +690,12 @@ pub async fn get_recent_chats(
                         {}
                         {}
                         {}
+                        {}
                 ) AS sub_query
                 "#,
                 archived_condition,
                 search_condition(2),
+                origin_condition(2 + search_param_count),
                 pinned_condition,
                 chat_type_condition,
                 delegated_condition
@@ -687,6 +709,9 @@ pub async fn get_recent_chats(
             let mut count_values = vec![owner_user_id.into()];
             if let Some(search_query) = search_query {
                 count_values.push(search_query.into());
+            }
+            if let Some(origin_chat_id) = filter.origin_chat_id {
+                count_values.push(origin_chat_id.into());
             }
 
             let count_result: CountResult =

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -2642,10 +2642,12 @@ async fn assemble_chat_messages_response(
         ("q" = Option<String>, Query, description = "Optional full-text search query for chat titles. User-provided titles take precedence over generated summary titles. Empty values are treated like an unfiltered recent chats list."),
         ("pinned" = Option<bool>, Query, description = "If provided, filter chats by their pinned state."),
         ("type" = Option<RecentChatTypeFilter>, Query, description = "If provided, only return chats of the given kind: `chat` for chats without an assistant, `assistant` for assistant-based chats."),
-        ("include_delegated" = Option<bool>, Query, description = "Whether to include delegated runs (chats spawned by in-chat delegation). Defaults to false; delegated runs are hidden from listings unless requested.")
+        ("include_delegated" = Option<bool>, Query, description = "Whether to include delegated runs (chats spawned by in-chat delegation). Defaults to false; delegated runs are hidden from listings unless requested."),
+        ("origin_chat_id" = Option<Uuid>, Query, description = "If provided, only return chats spawned from this origin chat. Composes with `include_delegated` rather than overriding it, so listing a chat's delegated runs requires passing both.")
     ),
     responses(
         (status = OK, body = RecentChatsResponse, description = "Successfully retrieved chats with pagination metadata"),
+        (status = BAD_REQUEST, description = "Invalid origin_chat_id format"),
         (status = INTERNAL_SERVER_ERROR, description = "Server error while retrieving chats")
     ),
     security(
@@ -2682,6 +2684,14 @@ pub async fn recent_chats(
         .get("include_delegated")
         .and_then(|value| value.parse::<bool>().ok())
         .unwrap_or(false);
+    let origin_chat_id = if let Some(value) = params.get("origin_chat_id") {
+        Some(Uuid::parse_str(value).map_err(|e| {
+            tracing::error!("Invalid origin_chat_id format: {}", e);
+            StatusCode::BAD_REQUEST
+        })?)
+    } else {
+        None
+    };
 
     policy
         .rebuild_data_if_needed(&app_state.db, &app_state.config)
@@ -2708,6 +2718,7 @@ pub async fn recent_chats(
             chat_type,
             search_query,
             include_delegated,
+            origin_chat_id,
         },
         app_state.config.generation_status.stale_after_secs,
     )

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -3,8 +3,8 @@
 
 use crate::test_app_state;
 use crate::test_utils::{
-    Event, RequestBodyRecorder, TEST_JWT_TOKEN, TEST_USER_ISSUER, TEST_USER_SUBJECT,
-    TestRequestAuthExt, parse_sse_events, setup_mock_llm_server_with_mocks,
+    Event, JwtTokenBuilder, RequestBodyRecorder, TEST_JWT_TOKEN, TEST_USER_ISSUER,
+    TEST_USER_SUBJECT, TestRequestAuthExt, parse_sse_events, setup_mock_llm_server_with_mocks,
 };
 use axum::Router;
 use axum::http;
@@ -4110,6 +4110,60 @@ fn listed_chat_ids(listing: &Value) -> Vec<String> {
         .collect()
 }
 
+/// Spawns a delegated run from `origin_chat_id` via the model layer and gives
+/// it one message, since listings join each chat's latest message.
+async fn spawn_listed_delegated_run(
+    app_state: &erato::state::AppState,
+    me_user_id: &str,
+    assistant_id: Uuid,
+    origin_chat_id: Uuid,
+    title: &str,
+) -> String {
+    let child = erato::models::chat::create_delegated_chat(
+        &app_state.db,
+        &rebuilt_policy(app_state).await,
+        &erato::policy::types::Subject::User(me_user_id.to_string()),
+        me_user_id,
+        assistant_id,
+        ChatProvenance {
+            kind: ChatProvenanceKind::Delegation,
+            origin_chat_id: Some(origin_chat_id),
+            origin_message_id: None,
+            origin_assistant_id: Some(assistant_id),
+            rebase_cutoff: Some(sqlx::types::chrono::Utc::now().into()),
+            depth: 1,
+            adopted_at: None,
+            expected_output: None,
+            constraints: None,
+            run_mode: None,
+        },
+        title.to_string(),
+    )
+    .await
+    .unwrap();
+    erato::models::message::submit_message(
+        &app_state.db,
+        &rebuilt_policy(app_state).await,
+        &erato::policy::types::Subject::User(me_user_id.to_string()),
+        &child.id,
+        json!({
+            "role": "user",
+            "content": [{"content_type": "text", "text": "delegated task"}],
+            "name": me_user_id,
+        }),
+        None,
+        None,
+        None,
+        &[],
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    child.id.to_string()
+}
+
 /// Listing matrix: delegated runs are hidden everywhere by default, visible
 /// with `include_delegated=true` (carrying provenance fields), tolerate a
 /// deleted origin, and compose with the type filter. Delegated runs do not
@@ -4295,6 +4349,190 @@ async fn test_listing_hides_delegated_runs_and_exposes_provenance(pool: Pool<Pos
         .find(|item| item["id"] == assistant.as_str())
         .and_then(|item| item["usage_count"].as_i64());
     assert_eq!(usage, None, "delegated runs must not feed the ranking");
+}
+
+/// The `origin_chat_id` filter narrows a listing to the runs spawned from one
+/// chat. It composes with `include_delegated` rather than overriding it (the
+/// filter alone matches nothing for delegated children), with the type
+/// filter, with search, and with pagination — where `total_count` must
+/// reflect the filtered set. An origin without children and another user
+/// asking for the same origin both see an empty page; malformed ids are
+/// rejected.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_listing_filters_by_origin_chat(pool: Pool<Postgres>) {
+    let app_state = test_app_state(delegation_enabled_config(), pool).await;
+    let me = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        TEST_USER_SUBJECT,
+        None,
+    )
+    .await
+    .unwrap();
+    let me_user_id = me.id.to_string();
+    let server = app_server(app_state.clone());
+
+    let assistant = create_assistant(&server, "Origin Filter Assistant", "prompt").await;
+    let assistant_id = Uuid::parse_str(&assistant).unwrap();
+
+    let origin_a = create_chat(&server, Some(&assistant)).await;
+    let origin_a_id = Uuid::parse_str(&origin_a).unwrap();
+    let origin_b = create_chat(&server, Some(&assistant)).await;
+    let origin_b_id = Uuid::parse_str(&origin_b).unwrap();
+    let childless = create_chat(&server, Some(&assistant)).await;
+
+    let child_a1 = spawn_listed_delegated_run(
+        &app_state,
+        &me_user_id,
+        assistant_id,
+        origin_a_id,
+        "Alpha one",
+    )
+    .await;
+    let child_a2 = spawn_listed_delegated_run(
+        &app_state,
+        &me_user_id,
+        assistant_id,
+        origin_a_id,
+        "Alpha two",
+    )
+    .await;
+    let child_b = spawn_listed_delegated_run(
+        &app_state,
+        &me_user_id,
+        assistant_id,
+        origin_b_id,
+        "Bravo run",
+    )
+    .await;
+    app_state.global_policy_engine.invalidate_data().await;
+
+    let mut a_children = vec![child_a1.clone(), child_a2.clone()];
+    a_children.sort();
+
+    // Exactly origin A's children; B's child is excluded.
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true"),
+    )
+    .await;
+    let mut ids = listed_chat_ids(&listing);
+    ids.sort();
+    assert_eq!(ids, a_children);
+    assert_eq!(listing["stats"]["total_count"], 2);
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_b}&include_delegated=true"),
+    )
+    .await;
+    assert_eq!(listed_chat_ids(&listing), vec![child_b]);
+
+    // Without include_delegated the delegated-run condition still applies,
+    // so the origin filter alone matches nothing.
+    let listing = recent_chats(&server, &format!("?origin_chat_id={origin_a}")).await;
+    assert!(listed_chat_ids(&listing).is_empty());
+    assert_eq!(listing["stats"]["total_count"], 0);
+
+    // Composes with the type filter.
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&type=assistant"),
+    )
+    .await;
+    assert_eq!(listed_chat_ids(&listing).len(), 2);
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&type=chat"),
+    )
+    .await;
+    assert!(listed_chat_ids(&listing).is_empty());
+
+    // Composes with search; the full page forces the count query with both
+    // the search and origin parameters bound.
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&q=Alpha"),
+    )
+    .await;
+    assert_eq!(listed_chat_ids(&listing).len(), 2);
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&q=Alpha&limit=1"),
+    )
+    .await;
+    assert_eq!(listed_chat_ids(&listing).len(), 1);
+    assert_eq!(listing["stats"]["total_count"], 2);
+    assert_eq!(listing["stats"]["has_more"], true);
+
+    // Pagination: pages are disjoint and total_count reflects the filtered
+    // set, not the whole history.
+    let first = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&limit=1&offset=0"),
+    )
+    .await;
+    let second = recent_chats(
+        &server,
+        &format!("?origin_chat_id={origin_a}&include_delegated=true&limit=1&offset=1"),
+    )
+    .await;
+    assert_eq!(first["stats"]["total_count"], 2);
+    assert_eq!(first["stats"]["has_more"], true);
+    assert_eq!(second["stats"]["total_count"], 2);
+    assert_eq!(second["stats"]["has_more"], false);
+    let mut paged: Vec<String> = [&first, &second]
+        .into_iter()
+        .flat_map(listed_chat_ids)
+        .collect();
+    paged.sort();
+    assert_eq!(paged, a_children);
+
+    // An origin without children yields an empty page with clean stats.
+    let listing = recent_chats(
+        &server,
+        &format!("?origin_chat_id={childless}&include_delegated=true"),
+    )
+    .await;
+    assert!(listed_chat_ids(&listing).is_empty());
+    assert_eq!(listing["stats"]["total_count"], 0);
+    assert_eq!(listing["stats"]["has_more"], false);
+
+    // Listings are owner-scoped: another user asking for this origin id
+    // sees nothing.
+    let other_subject = "origin-filter-other-user";
+    let other_token = JwtTokenBuilder::new()
+        .subject(other_subject)
+        .email("origin-filter-other@example.com")
+        .build();
+    erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        other_subject,
+        Some("origin-filter-other@example.com"),
+    )
+    .await
+    .unwrap();
+    let response = server
+        .get(&format!(
+            "/api/v1beta/me/recent_chats?origin_chat_id={origin_a}&include_delegated=true"
+        ))
+        .with_bearer_token(&other_token)
+        .await;
+    response.assert_status_ok();
+    let listing = response.json::<Value>();
+    assert!(listed_chat_ids(&listing).is_empty());
+    assert_eq!(listing["stats"]["total_count"], 0);
+
+    // Malformed ids are rejected up front.
+    let response = server
+        .get("/api/v1beta/me/recent_chats?origin_chat_id=not-a-uuid")
+        .with_bearer_token(TEST_JWT_TOKEN)
+        .await;
+    response.assert_status(axum::http::StatusCode::BAD_REQUEST);
 }
 
 /// A delegated chat parked in `awaiting_approval` still surfaces through

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2852,6 +2852,16 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "origin_chat_id",
+            "in": "query",
+            "description": "If provided, only return chats spawned from this origin chat. Composes with `include_delegated` rather than overriding it, so listing a chat's delegated runs requires passing both.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2864,6 +2874,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid origin_chat_id format"
           },
           "500": {
             "description": "Server error while retrieving chats"

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -5383,6 +5383,12 @@ export type RecentChatsQueryParams = {
    * Whether to include delegated runs (chats spawned by in-chat delegation). Defaults to false; delegated runs are hidden from listings unless requested.
    */
   include_delegated?: boolean;
+  /**
+   * If provided, only return chats spawned from this origin chat. Composes with `include_delegated` rather than overriding it, so listing a chat's delegated runs requires passing both.
+   *
+   * @format uuid
+   */
+  origin_chat_id?: string;
 };
 
 export type RecentChatsError = Fetcher.ErrorWrapper<undefined>;


### PR DESCRIPTION
On top of #1006 (ERMAIN-636); diff is this layer alone. Stack: #1000 → #1004 wire → #1005 detach → #1006 bounds → **this** origin filter → durable outcome → graceful shutdown.

`GET /me/recent_chats` gains an optional `origin_chat_id` filter, so a client can ask "the runs launched from this chat" without paging the whole history — the query the background-runs sidebar section (ERMAIN-642) makes. The heavy lifting existed already (stored generated column, `idx_chats_origin_chat_id`, surfaced on `RecentChat`); this is one condition.

The one fiddly bit the ticket named: both listing queries build positional parameters by hand with hardcoded indices. A single `search_param_count` local now drives both numberings — the list binds origin at `4 + search_param_count` (after `$1` owner / `$2` limit / `$3` offset, optionals appended search → origin), the count at `2 + search_param_count` — and the values are pushed in exactly that order, with one rationale comment proving the alignment.

It composes with `include_delegated` rather than overriding it: the delegated-condition is untouched, so the origin filter alone returns nothing for delegated children — stated in the param docs and asserted. An unparseable `origin_chat_id` is a 400, now also documented in the endpoint's responses. OpenAPI and the TS client regenerated.

## Tests

One comprehensive integration test: exact-children filtering across two origins; composition with the type filter, with `include_delegated=false`, and with `q=` search — including a full-page query that forces the **count** query with both optional parameters bound, which is precisely the numbering trap; pagination totals over the filtered set; a childless origin; cross-user isolation (another user's origin id returns nothing — authorization is by owner); and the 400.
