### PR TITLE
Drain in-flight generations on shutdown so their fate is recorded (ERMAIN-639)

### DIFF
--- a/backend/erato/Cargo.toml
+++ b/backend/erato/Cargo.toml
@@ -57,7 +57,7 @@ regorus = "0.5.0"
 sha2 = "0.11.0"
 
 # Dependencies: Async runtime
-tokio = { version = "1.52.3", features = ["rt-multi-thread"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "signal"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = { version = "0.7.18", features = ["io"] }
 async-trait = "0.1.89"

--- a/backend/erato/src/main.rs
+++ b/backend/erato/src/main.rs
@@ -16,6 +16,7 @@ use erato::services::sentry::{extend_with_sentry_layers, setup_sentry};
 use erato::startup_log;
 use erato::state::AppState;
 use erato::{ApiDoc, server};
+use std::time::Duration;
 use tower_http::cors::CorsLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
 
@@ -65,6 +66,26 @@ fn configured_tokio_worker_threads() -> usize {
         Err(std::env::VarError::NotUnicode(e)) => {
             panic!("\"{ENV_WORKER_THREADS}\" must be valid unicode, error: {e:?}")
         }
+    }
+}
+
+/// Resolves on the first shutdown request: SIGTERM (how Kubernetes asks a pod
+/// to stop) or Ctrl-C.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        tokio::select! {
+            _ = sigterm.recv() => {}
+            _ = tokio::signal::ctrl_c() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C handler");
     }
 }
 
@@ -159,6 +180,8 @@ async fn async_main(worker_threads: usize) -> Result<(), Report> {
             DeploymentIdentity::from_env().server_header(),
         ));
 
+    let background_tasks = state.background_tasks.clone();
+
     let app = if config.integrations.otel.enabled {
         app
             // include trace context as header into the response
@@ -173,7 +196,74 @@ async fn async_main(worker_threads: usize) -> Result<(), Report> {
     tracing::info!(api_docs_url = %format!("http://{}/scalar", local_addr), "API docs available");
     tracing::info!(frontend_url = %format!("http://{}", local_addr), "Frontend available");
     tracing::info!(listen_addr = %local_addr, worker_threads, "Server listening");
-    axum::serve(listener, app.into_make_service()).await?;
+
+    // Everything after the signal shares one deadline: the connection drain
+    // and the generation drain draw from the same budget, so the total
+    // post-signal time stays within the deployment's termination grace
+    // period no matter which phase consumes it.
+    let drain_window = Duration::from_secs(config.generation_status.shutdown_drain_secs);
+    let (drain_deadline_tx, drain_deadline_rx) =
+        tokio::sync::watch::channel(None::<tokio::time::Instant>);
+    let shutdown = {
+        let background_tasks = background_tasks.clone();
+        async move {
+            shutdown_signal().await;
+            tracing::info!("Shutdown signal received; draining in-flight generations");
+            let _ = drain_deadline_tx.send(Some(tokio::time::Instant::now() + drain_window));
+            // Aborting before the connection drain matters: the graceful
+            // shutdown below waits for open responses, and a live SSE stream
+            // only ends once its generation stops — without the abort, the
+            // server would sit on streaming connections until killed.
+            background_tasks.request_abort_all().await;
+        }
+    };
+    // The graceful shutdown awaits every open response without a timeout of
+    // its own, so a wedged handler or a stalled SSE tail could hold the serve
+    // future open past the grace period — and everything below it, abort
+    // sweep, generation drain and logging, would never run. Once the deadline
+    // passes, dropping the serve future closes the remaining connections,
+    // which is the correct outcome at that point.
+    let deadline_elapsed = {
+        let mut deadline_rx = drain_deadline_rx.clone();
+        async move {
+            // An error means the serve future resolved without a signal ever
+            // arriving; this branch then simply never fires.
+            if deadline_rx
+                .wait_for(|deadline| deadline.is_some())
+                .await
+                .is_err()
+            {
+                std::future::pending::<()>().await;
+            }
+            let deadline = (*deadline_rx.borrow()).expect("set before the sender is dropped");
+            tokio::time::sleep_until(deadline).await;
+        }
+    };
+    tokio::select! {
+        result = axum::serve(listener, app.into_make_service()).with_graceful_shutdown(shutdown) => result?,
+        () = deadline_elapsed => {
+            tracing::warn!("Shutdown deadline elapsed with connections still open; dropping them");
+        }
+    }
+
+    // A second sweep for generations spawned by requests that were already
+    // past the listener when the signal fired.
+    background_tasks.request_abort_all().await;
+    if !drain_window.is_zero() {
+        // The generation drain gets whatever the connection drain left of
+        // the shared deadline, never a fresh window.
+        let remaining = (*drain_deadline_rx.borrow())
+            .map(|deadline| deadline.saturating_duration_since(tokio::time::Instant::now()))
+            .unwrap_or(drain_window);
+        if background_tasks.drain(remaining).await {
+            tracing::info!("All in-flight generations recorded their outcome");
+        } else {
+            tracing::warn!(
+                drain_secs = config.generation_status.shutdown_drain_secs,
+                "Exiting with generations still in flight; the stale-lease reaper will mark them errored"
+            );
+        }
+    }
 
     Ok(())
 }
@@ -181,6 +271,15 @@ async fn async_main(worker_threads: usize) -> Result<(), Report> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn shutdown_signal_stays_pending_until_a_signal_arrives() {
+        let result = tokio::time::timeout(Duration::from_millis(20), shutdown_signal()).await;
+        assert!(
+            result.is_err(),
+            "the shutdown future must not resolve on its own"
+        );
+    }
 
     #[test]
     fn configured_tokio_worker_threads_has_minimum() {

--- a/backend/erato/src/services/background_tasks.rs
+++ b/backend/erato/src/services/background_tasks.rs
@@ -32,6 +32,7 @@ use crate::services::client_tools::{ClientToolDelivery, ClientToolOutcome};
 /// Maximum number of events to store in history per task
 const MAX_EVENT_HISTORY: usize = 10_000;
 const SHARED_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 fn owner_pod() -> String {
     std::env::var("POD_NAME")
@@ -261,6 +262,50 @@ impl BackgroundTaskManager {
                     "Failed to persist generation outcome"
                 );
             }
+        }
+    }
+
+    /// Request a cooperative abort on every in-flight generation. Each task's
+    /// run observes the request at its next abort checkpoint (stream chunk or
+    /// tool boundary) and winds down through its normal cleanup tail, which
+    /// persists the outcome and removes the map entry.
+    pub async fn request_abort_all(&self) {
+        let tasks: Vec<Arc<StreamingTask>> = {
+            let tasks = self.tasks.read().await;
+            tasks.values().map(Arc::clone).collect()
+        };
+        for task in tasks {
+            task.request_abort();
+        }
+    }
+
+    /// Wait until every in-flight generation has cleaned itself up (the task
+    /// map is empty) or the window elapses, whichever comes first. Every poll
+    /// re-issues the abort sweep: an already-aborted parent can still finish
+    /// an in-flight tool call and register a background child after the
+    /// entry sweeps ran, and without a fresh abort that late arrival would
+    /// burn the whole window and die unrecorded. Returns whether the map
+    /// fully drained; on giving up, the chats still in flight are logged.
+    pub async fn drain(&self, window: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + window;
+        loop {
+            self.request_abort_all().await;
+            let remaining: Vec<Uuid> = {
+                let tasks = self.tasks.read().await;
+                tasks.keys().copied().collect()
+            };
+            if remaining.is_empty() {
+                return true;
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                tracing::warn!(
+                    chat_ids = ?remaining,
+                    "Drain window elapsed with generations still in flight"
+                );
+                return false;
+            }
+            tokio::time::sleep(DRAIN_POLL_INTERVAL.min(deadline - now)).await;
         }
     }
 
@@ -1235,6 +1280,95 @@ mod tests {
         task.request_abort();
 
         assert!(task.is_abort_requested());
+    }
+
+    #[tokio::test]
+    async fn request_abort_all_reaches_every_registered_task() {
+        let manager = BackgroundTaskManager::new(None, GenerationStatusConfig::default(), None);
+        let (_receiver1, task1) = manager.start_task(Uuid::new_v4(), Uuid::new_v4()).await;
+        let (_receiver2, task2) = manager.start_task(Uuid::new_v4(), Uuid::new_v4()).await;
+
+        let waiter1 = tokio::spawn({
+            let task = Arc::clone(&task1);
+            async move { task.wait_for_abort().await }
+        });
+        let waiter2 = tokio::spawn({
+            let task = Arc::clone(&task2);
+            async move { task.wait_for_abort().await }
+        });
+
+        manager.request_abort_all().await;
+
+        tokio::time::timeout(Duration::from_secs(1), waiter1)
+            .await
+            .expect("first waiter should observe the abort")
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), waiter2)
+            .await
+            .expect("second waiter should observe the abort")
+            .unwrap();
+        assert!(task1.is_abort_requested());
+        assert!(task2.is_abort_requested());
+    }
+
+    #[tokio::test]
+    async fn drain_completes_once_tasks_clean_up_on_abort() {
+        let manager = BackgroundTaskManager::new(None, GenerationStatusConfig::default(), None);
+        assert!(manager.drain(Duration::ZERO).await);
+
+        let chat_id = Uuid::new_v4();
+        let (_receiver, task) = manager.start_task(chat_id, Uuid::new_v4()).await;
+        let worker = tokio::spawn({
+            let manager = manager.clone();
+            let task = Arc::clone(&task);
+            async move {
+                task.wait_for_abort().await;
+                manager
+                    .remove_task(&chat_id, task.generation_id, TaskOutcome::Completed)
+                    .await;
+            }
+        });
+
+        manager.request_abort_all().await;
+        assert!(manager.drain(Duration::from_secs(5)).await);
+        worker.await.unwrap();
+        assert!(manager.get_task(&chat_id).await.is_none());
+    }
+
+    /// A task that shows up after the entry sweeps — a background child
+    /// dispatched by a parent finishing its tool call mid-shutdown — must be
+    /// aborted by the drain itself rather than burn the whole window.
+    #[tokio::test]
+    async fn drain_aborts_tasks_registered_after_the_sweep() {
+        let manager = BackgroundTaskManager::new(None, GenerationStatusConfig::default(), None);
+        manager.request_abort_all().await;
+        let chat_id = Uuid::new_v4();
+        let (_receiver, task) = manager.start_task(chat_id, Uuid::new_v4()).await;
+        let worker = tokio::spawn({
+            let manager = manager.clone();
+            let task = Arc::clone(&task);
+            async move {
+                task.wait_for_abort().await;
+                manager
+                    .remove_task(&chat_id, task.generation_id, TaskOutcome::Completed)
+                    .await;
+            }
+        });
+
+        assert!(manager.drain(Duration::from_secs(5)).await);
+        worker.await.unwrap();
+        assert!(manager.get_task(&chat_id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn drain_gives_up_when_a_task_never_finishes() {
+        let manager = BackgroundTaskManager::new(None, GenerationStatusConfig::default(), None);
+        let chat_id = Uuid::new_v4();
+        let (_receiver, _task) = manager.start_task(chat_id, Uuid::new_v4()).await;
+
+        manager.request_abort_all().await;
+        assert!(!manager.drain(Duration::from_millis(50)).await);
+        assert!(manager.get_task(&chat_id).await.is_some());
     }
 
     #[tokio::test]

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -3533,6 +3533,15 @@ pub struct GenerationStatusConfig {
     // Defaults to 60.
     #[serde(default = "default_generation_status_terminal_retention_secs")]
     pub terminal_retention_secs: u64,
+
+    // Upper bound in seconds on how long the process keeps running after a
+    // shutdown signal: one deadline shared by the connection drain and the
+    // generation drain, within which aborted in-flight generations persist
+    // their terminal outcome before exiting. 0 skips the wait entirely.
+    // Defaults to 25, leaving headroom inside Kubernetes' default 30-second
+    // termination grace period.
+    #[serde(default = "default_generation_status_shutdown_drain_secs")]
+    pub shutdown_drain_secs: u64,
 }
 
 fn default_generation_status_heartbeat_interval_secs() -> u64 {
@@ -3547,12 +3556,17 @@ fn default_generation_status_terminal_retention_secs() -> u64 {
     60
 }
 
+fn default_generation_status_shutdown_drain_secs() -> u64 {
+    25
+}
+
 impl Default for GenerationStatusConfig {
     fn default() -> Self {
         Self {
             heartbeat_interval_secs: default_generation_status_heartbeat_interval_secs(),
             stale_after_secs: default_generation_status_stale_after_secs(),
             terminal_retention_secs: default_generation_status_terminal_retention_secs(),
+            shutdown_drain_secs: default_generation_status_shutdown_drain_secs(),
         }
     }
 }

--- a/backend/generated/config_reference.json
+++ b/backend/generated/config_reference.json
@@ -370,6 +370,7 @@
   },
   "generation.max_tool_calls_per_message": {},
   "generation_status.heartbeat_interval_secs": {},
+  "generation_status.shutdown_drain_secs": {},
   "generation_status.stale_after_secs": {},
   "generation_status.terminal_retention_secs": {},
   "guardrails.prompt_patterns.<pattern-id>.language": {},

--- a/site/content/docs/configuration.mdx
+++ b/site/content/docs/configuration.mdx
@@ -4226,7 +4226,7 @@ Configuration for the persisted per-chat generation status that powers the chat 
 
 **Type:** `object`
 
-**Default behavior:** `heartbeat_interval_secs` defaults to `10`, `stale_after_secs` to `30`, and `terminal_retention_secs` to `60`.
+**Default behavior:** `heartbeat_interval_secs` defaults to `10`, `stale_after_secs` to `30`, `terminal_retention_secs` to `60`, and `shutdown_drain_secs` to `25`.
 
 **Example:**
 
@@ -4235,6 +4235,7 @@ Configuration for the persisted per-chat generation status that powers the chat 
 heartbeat_interval_secs = 10
 stale_after_secs = 30
 terminal_retention_secs = 60
+shutdown_drain_secs = 25
 ```
 
 #### `generation_status.heartbeat_interval_secs`
@@ -4266,3 +4267,15 @@ Seconds a completed or errored generation remains visible in the generating-chat
 **Type:** `number`
 
 **Default value:** `60`
+
+#### `generation_status.shutdown_drain_secs`
+
+{/* erato_toml_config_key: generation_status.shutdown_drain_secs */}
+
+Upper bound in seconds on how long the process keeps running after a shutdown signal (SIGTERM or Ctrl-C): one deadline shared by the connection drain and the generation drain, within which aborted in-flight generations persist their terminal outcome before exiting. Without this window, a deploy would kill generations mid-stream and their chats would only be marked as errored once the stale-heartbeat reaper notices. Set to `0` to skip the wait entirely.
+
+The value should stay below the deployment's termination grace period (Kubernetes defaults to 30 seconds), or the process gets killed before the drain finishes.
+
+**Type:** `number`
+
+**Default value:** `25`


### PR DESCRIPTION
On top of #1008 (ERMAIN-638), the top of the ERMAIN-633 backend stack; diff is this layer alone. Stack: #1000 → #1004 wire → #1005 detach → #1006 bounds → #1007 origin filter → #1008 durable outcome → **this**.

`main.rs` served with no `with_graceful_shutdown`: on SIGTERM the runtime dropped and every in-flight generation died mid-stream. For an ordinary chat the user is watching and retries; for a background delegation it is silent data loss — the parent turn already reported the work dispatched. Not delegation-specific (this improves every generation); background mode is what made it consequential.

The ticket's open question is decided the simple way: the drain **aborts in-flight work cleanly and records its fate** — it does not try to finish it. Restart-durable runs remain separate future work.

## The shape, and why the ordering matters

- **Aborts fire *inside* the shutdown-signal future**, not after serve returns. A live SSE stream only ends once its generation stops, so aborting post-serve would deadlock hyper's connection drain until SIGKILL — reproducing the exact bug. A second sweep after serve returns catches generations that slipped past the listener.
- **One post-signal deadline** — `generation_status.shutdown_drain_secs` (new key, default 25, inside Kubernetes' default 30s termination grace; `0` = no wait, aborts still fire) — bounds *both* phases: the serve await is raced against it (a wedged handler or stalled SSE tail can no longer block the tail of main forever), and the generation drain then gets only the remaining time.
- **The drain re-aborts on every poll:** a winding-down parent can still complete an in-flight tool call and dispatch a background child that registers *after* the sweeps; re-running the idempotent abort each iteration catches it, and the per-task cleanup tails persist the outcomes as usual.

tokio's `signal` feature is now explicit in Cargo.toml rather than relied on through feature unification.

## Tests

Unit tests on the manager: abort-all reaches every registered task; drain completes promptly once tasks clean themselves up on abort; drain gives up at the window when a task never finishes; a task registered mid-drain still gets aborted. Plus a smoke test that the signal future stays pending without a signal. Full gates at this stack tip: 785/785 nextest, fmt, clippy `-D warnings` + no-default-features, both codegen `--check`s, config-docs coverage, prettier on the generated client.
