### PR TITLE
Generate SBOM and license artifacts before the source copy (ERMAIN-656)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,16 +17,25 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 COPY desktop-sidecar-protocol /app/desktop-sidecar-protocol
 RUN pnpm run build
 
+# The normalize script is copied before the install on purpose: the SBOM and
+# license steps below must share exact cache lineage with the install, because
+# the registry cache restores layers but never `--mount=type=cache` contents.
+# If anything between the install and those steps could invalidate on its own,
+# they would re-execute in a build whose install was a cache hit — reading a
+# pnpm store that is empty in that build.
+COPY scripts/normalize-pnpm-license-json.mjs /app/scripts/normalize-pnpm-license-json.mjs
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml /app/frontend/
 COPY frontend-utils /app/frontend-utils
 WORKDIR /app/frontend
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false
 
-COPY frontend /app/frontend
-COPY scripts/normalize-pnpm-license-json.mjs /app/scripts/normalize-pnpm-license-json.mjs
-RUN pnpm rebuild @swc/core esbuild msw protobufjs unrs-resolver
+# Dependency metadata only — kept ahead of the source copy so application
+# changes can neither invalidate them nor strand them without a store.
 RUN mkdir -p /app/sbom && pnpm sbom --sbom-format cyclonedx --sbom-spec-version 1.7 > /app/sbom/frontend.cdx.json
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm licenses list --prod --json | node ../scripts/normalize-pnpm-license-json.mjs | ./node_modules/.bin/pnpm-licenses generate-disclaimer --json-input --output-file=/app/sbom/frontend.txt
+
+COPY frontend /app/frontend
+RUN pnpm rebuild @swc/core esbuild msw protobufjs unrs-resolver
 RUN NODE_OPTIONS=--max-old-space-size=8192 pnpm run build:lib
 RUN NODE_OPTIONS=--max-old-space-size=8192 pnpm run build
 
@@ -35,11 +44,13 @@ WORKDIR /app/office-addin
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm update @erato/frontend --config.confirmModulesPurge=false
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --config.confirmModulesPurge=false
 
+# Ahead of the source copy for the same store-lineage reason as the frontend's.
+RUN mkdir -p /app/sbom && pnpm sbom --sbom-format cyclonedx --sbom-spec-version 1.7 > /app/sbom/office-addin.cdx.json
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm licenses list --prod --json | node ../scripts/normalize-pnpm-license-json.mjs | ./node_modules/.bin/pnpm-licenses generate-disclaimer --json-input --output-file=/app/sbom/office-addin.txt
+
 RUN cp pnpm-lock.yaml /tmp/office-addin-pnpm-lock.yaml
 COPY office-addin /app/office-addin
 RUN cp /tmp/office-addin-pnpm-lock.yaml pnpm-lock.yaml
-RUN mkdir -p /app/sbom && pnpm sbom --sbom-format cyclonedx --sbom-spec-version 1.7 > /app/sbom/office-addin.cdx.json
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm licenses list --prod --json | node ../scripts/normalize-pnpm-license-json.mjs | ./node_modules/.bin/pnpm-licenses generate-disclaimer --json-input --output-file=/app/sbom/office-addin.txt
 RUN NODE_OPTIONS=--max-old-space-size=8192 pnpm run build
 
 # Final stage - empty image with just the static files for all served frontends


### PR DESCRIPTION
Fixes the deterministic `build-and-push-amd64`/`arm64` failures every frontend-touching PR has hit since #1003 (ERMAIN-648) merged:

```
Error: pnpm returned an invalid license list
SyntaxError: Unexpected end of JSON input
```

## Mechanism

BuildKit's registry cache exports **layers** but never `--mount=type=cache` contents. On a warm build the `pnpm install` layer is a cache hit — a pure blob pull, pnpm never runs — so the job-local `/pnpm/store` mount is empty. `COPY frontend` then invalidates everything after it, so `pnpm licenses list --prod` re-executes against that empty store and emits an error object the normalize script rejects. #1003's own run was green only because it built cold: install actually executed and populated the store. Every warm build since is red the moment `frontend/` differs from main's cached build (observed 10/10 identical failures across the #1004–#1009 merge refs, retries included); main itself would fail on its first frontend commit that leaves the lockfile untouched. The office-addin section had the identical latent bug.

## Fix

The SBOM and licenses steps move up to immediately after their `pnpm install`, ahead of the source copy, and the normalize script is copied **before** the install. That gives the metadata steps exact cache lineage with the install: they can only ever execute in a build where the install also executed — and the install is what populates the store. Application changes can no longer invalidate them (a caching win on top of the fix), and a change to the normalize script now re-runs the install rather than stranding the licenses step storeless.

Inputs are unchanged: the steps depend only on manifest + lockfile + node_modules, and the addin's steps still read the same post-`pnpm update` lockfile they read before (previously via the copy-restore dance, now simply before it).

Merging this heals the stacked PRs' merge-ref builds without touching them. `component-kit-example/Dockerfile` and the backend image were checked — neither reads the store after a source copy, so this is the only affected file.

## Validation

Full cold local build of the `build` stage passes end to end (all 26 steps, both moved SBOM/licenses steps executed); all four artifacts in `/app/sbom` are present and non-empty (0.8–1.2 MB each). The warm-cache path is safe by construction — a cache miss at the licenses step now implies the install missed too.
