### PR TITLE
Ask wait-or-background when sending a message with tracked mentions (ERMAIN-640)

### DIFF
--- a/backend/erato/src/frontend_environment.rs
+++ b/backend/erato/src/frontend_environment.rs
@@ -44,6 +44,8 @@ const FRONTEND_ENV_KEY_ASSISTANTS_MAX_SYSTEM_PROMPT_LENGTH: &str =
     "ASSISTANTS_MAX_SYSTEM_PROMPT_LENGTH";
 const FRONTEND_ENV_KEY_ASSISTANTS_MAX_FILES: &str = "ASSISTANTS_MAX_FILES";
 const FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ENABLED: &str = "ASSISTANTS_DELEGATION_ENABLED";
+const FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND: &str =
+    "ASSISTANTS_DELEGATION_ALLOW_BACKGROUND";
 const FRONTEND_ENV_KEY_STARTER_PROMPTS_ENABLED: &str = "STARTER_PROMPTS_ENABLED";
 const FRONTEND_ENV_KEY_PROMPT_OPTIMIZER_ENABLED: &str = "PROMPT_OPTIMIZER_ENABLED";
 const FRONTEND_ENV_KEY_USER_PREFERENCES_ENABLED: &str = "USER_PREFERENCES_ENABLED";
@@ -365,6 +367,10 @@ fn build_frontend_environment(
     env.additional_environment.insert(
         FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ENABLED.to_string(),
         Value::Bool(config.assistants.delegation.enabled),
+    );
+    env.additional_environment.insert(
+        FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND.to_string(),
+        Value::Bool(config.assistants.delegation.allow_background),
     );
     env.additional_environment.insert(
         FRONTEND_ENV_KEY_STARTER_PROMPTS_ENABLED.to_string(),
@@ -1165,6 +1171,7 @@ mod tests {
         let mut config = AppConfig::default();
         config.assistants.enabled = true;
         config.assistants.delegation.enabled = true;
+        config.assistants.delegation.allow_background = true;
 
         for frontend_kind in [FrontendKind::Web, FrontendKind::OfficeAddin] {
             let environment = build_frontend_environment(&config, frontend_kind);
@@ -1172,6 +1179,12 @@ mod tests {
                 environment
                     .additional_environment
                     .get(FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ENABLED),
+                Some(&Value::Bool(true))
+            );
+            assert_eq!(
+                environment
+                    .additional_environment
+                    .get(FRONTEND_ENV_KEY_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND),
                 Some(&Value::Bool(true))
             );
         }

--- a/frontend/src/app/env.ts
+++ b/frontend/src/app/env.ts
@@ -25,6 +25,7 @@ export type Env = {
   disableLogout: boolean;
   assistantsEnabled: boolean;
   assistantsDelegationEnabled: boolean;
+  assistantsDelegationAllowBackground: boolean;
   assistantsEnableEditSharing?: boolean;
   assistantsShowRecentItems: boolean;
   assistantsShowRecentItemsCollapsible: boolean;
@@ -86,6 +87,7 @@ declare global {
     DISABLE_LOGOUT?: boolean;
     ASSISTANTS_ENABLED?: boolean;
     ASSISTANTS_DELEGATION_ENABLED?: boolean;
+    ASSISTANTS_DELEGATION_ALLOW_BACKGROUND?: boolean;
     ASSISTANTS_ENABLE_EDIT_SHARING?: boolean;
     ASSISTANTS_SHOW_RECENT_ITEMS?: boolean;
     ASSISTANTS_SHOW_RECENT_ITEMS_COLLAPSIBLE?: boolean;
@@ -228,6 +230,10 @@ export const env = (): Env => {
     import.meta.env.VITE_ASSISTANTS_DELEGATION_ENABLED === "true"
       ? true
       : (window.ASSISTANTS_DELEGATION_ENABLED ?? false);
+  const assistantsDelegationAllowBackground =
+    import.meta.env.VITE_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND === "true"
+      ? true
+      : (window.ASSISTANTS_DELEGATION_ALLOW_BACKGROUND ?? false);
   const assistantsEnableEditSharing =
     import.meta.env.VITE_ASSISTANTS_ENABLE_EDIT_SHARING === "false"
       ? false
@@ -411,6 +417,7 @@ export const env = (): Env => {
     disableLogout,
     assistantsEnabled,
     assistantsDelegationEnabled,
+    assistantsDelegationAllowBackground,
     assistantsEnableEditSharing,
     assistantsShowRecentItems,
     assistantsShowRecentItemsCollapsible,

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -33,6 +33,7 @@ const createMockEnv = (overrides: Partial<Env> = {}): Env => ({
   disableLogout: false,
   assistantsEnabled: false,
   assistantsDelegationEnabled: false,
+  assistantsDelegationAllowBackground: false,
   assistantsShowRecentItems: false,
   assistantsShowRecentItemsCollapsible: false,
   assistantContextWarningThreshold: 0.5,

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -60,6 +60,7 @@ import type { ChatMessage } from "../MessageList/MessageList";
 import type {
   FileUploadItem,
   ChatModel,
+  DelegationRunMode,
   UserProfile,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { ChatSession } from "@/types/chat";
@@ -356,6 +357,7 @@ export const Chat = ({
       modelId?: string,
       selectedFacetIds?: string[],
       mentionedAssistantIds?: string[],
+      delegationRunMode?: DelegationRunMode,
     ) => {
       logger.log("[CHAT_FLOW] Chat - handleSendMessage called", {
         files: inputFileIds,
@@ -363,6 +365,7 @@ export const Chat = ({
         assistantId,
         selectedFacetIds,
         mentionedAssistantIds,
+        delegationRunMode,
       });
 
       baseHandleSendMessage(
@@ -372,6 +375,7 @@ export const Chat = ({
         assistantId,
         selectedFacetIds,
         mentionedAssistantIds,
+        delegationRunMode,
       ).catch((error) => {
         logger.log("[CHAT_FLOW] Error sending message:", error);
       });

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -4736,4 +4736,503 @@ describe("ChatInput", () => {
       expect(props.toolsDisabled).toBe(true);
     });
   });
+
+  describe("wait-or-background choice", () => {
+    const RESEARCHER = {
+      id: "assistant-research",
+      name: "Researcher",
+      description: "Finds and cites sources",
+      owner_email: "research@example.com",
+    };
+
+    const submitHandlerThatSends =
+      (
+        message: string,
+        attachedFiles: FileUploadItem[],
+        innerOnSendMessage: (message: string, inputFileIds?: string[]) => void,
+        isLoading: boolean,
+        disabled: boolean,
+        resetMessage: () => void,
+      ) =>
+      (event: FormEvent) => {
+        event.preventDefault();
+        if (isLoading || disabled) return;
+        const trimmed = message.trim();
+        const fileIds = attachedFiles.map((file) => file.id);
+        if (trimmed || fileIds.length > 0) {
+          innerOnSendMessage(trimmed, fileIds.length > 0 ? fileIds : undefined);
+          resetMessage();
+        }
+      };
+
+    const enableDelegation = ({ allowBackground = true } = {}) => {
+      mockUseAssistantsFeature.mockReturnValue({
+        enabled: true,
+        delegationEnabled: true,
+        delegationAllowBackground: allowBackground,
+      });
+      mockUseListAssistants.mockReturnValue({ data: [RESEARCHER] });
+      mockUseFrequentAssistants.mockReturnValue({
+        data: { assistants: [RESEARCHER] },
+      });
+      mockUseChatInputHandlers.mockReturnValue({
+        attachedFiles: [],
+        fileError: null,
+        setFileError: vi.fn(),
+        handleFilesUploaded: vi.fn(),
+        handleRemoveFile: vi.fn(),
+        handleRemoveAllFiles: vi.fn(),
+        setAttachedFiles: vi.fn(),
+        createSubmitHandler: submitHandlerThatSends,
+      });
+    };
+
+    const flushFrame = async () => {
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+    };
+
+    const typeWithCaretAtEnd = (textarea: HTMLElement, value: string) => {
+      fireEvent.change(textarea, { target: { value } });
+      (textarea as HTMLTextAreaElement).setSelectionRange(
+        value.length,
+        value.length,
+      );
+      fireEvent.select(textarea);
+    };
+
+    const renderComposer = async (
+      onSendMessage: (...args: unknown[]) => void,
+      { isPendingResponse = false, isMessagingLoading = false } = {},
+    ) => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const { i18n } = await import("@lingui/core");
+      const ui = (pending: boolean) => {
+        mockUseChatContext.mockReturnValue({
+          isPendingResponse: pending,
+          isMessagingLoading,
+          isUploading: false,
+          cancelMessage: vi.fn(),
+          messagingError: null,
+        });
+        return (
+          <QueryClientProvider client={queryClient}>
+            <I18nProvider i18n={i18n}>
+              <ChatInput onSendMessage={onSendMessage} chatId="chat-1" />
+            </I18nProvider>
+          </QueryClientProvider>
+        );
+      };
+      const view = render(ui(isPendingResponse));
+      return {
+        textarea: screen.getByPlaceholderText("Type a message..."),
+        rerenderWithPending: (pending: boolean) => view.rerender(ui(pending)),
+      };
+    };
+
+    const draftWithMention = (textarea: HTMLElement, text: string) => {
+      typeWithCaretAtEnd(textarea, "@Res");
+      fireEvent.click(
+        screen.getByTestId("chat-input-mention-option-assistant-research"),
+      );
+      typeWithCaretAtEnd(textarea, text);
+    };
+
+    const popover = () =>
+      screen.queryByTestId("chat-input-delegation-run-mode");
+
+    beforeEach(() => {
+      useMessageQueueStore.setState({ queuedBySessionId: {} });
+    });
+
+    it("sends a plain draft straight through without asking", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      typeWithCaretAtEnd(textarea, "no delegation here");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "no delegation here",
+        undefined,
+        undefined,
+        [],
+        [],
+      );
+    });
+
+    it("asks before a mentioned send and holds the draft until a choice is made", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).toBeInTheDocument();
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("@Researcher please dig in");
+    });
+
+    it("choosing to wait sends without a run mode", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-wait"),
+      );
+
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please dig in",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+      expect(textarea).toHaveValue("");
+    });
+
+    it("choosing background sends delegation_run_mode background", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-background"),
+      );
+
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please dig in",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+        "background",
+      );
+    });
+
+    it("resolves Enter to wait: the safe option holds focus and a stray Enter never backgrounds", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      await flushFrame();
+
+      // A real browser's Enter activates the focused row, which must be the
+      // wait option.
+      expect(
+        screen.getByTestId("chat-input-delegation-run-mode-wait"),
+      ).toHaveFocus();
+
+      // An Enter landing in the panel outside any row also resolves to wait.
+      fireEvent.keyDown(screen.getByTestId("chat-input-delegation-run-mode"), {
+        key: "Enter",
+      });
+
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please dig in",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("cancels on Escape, keeping the draft", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(popover()).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("@Researcher please dig in");
+    });
+
+    it("does not ask when the server does not allow background", async () => {
+      enableDelegation({ allowBackground: false });
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please dig in",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("does not ask when the delegation feature is off, even for a draft carrying mentions", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea, rerenderWithPending } =
+        await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      // The tracked mention outlives the feature flip (e.g. a restored draft
+      // in a deployment that later turned delegation off).
+      mockUseAssistantsFeature.mockReturnValue({
+        enabled: true,
+        delegationEnabled: false,
+        delegationAllowBackground: true,
+      });
+      rerenderWithPending(false);
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher please dig in",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("asks at queue time and drains the snapshotted background mode", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea, rerenderWithPending } = await renderComposer(
+        onSendMessage,
+        { isPendingResponse: true },
+      );
+
+      draftWithMention(textarea, "@Researcher take over");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-background"),
+      );
+
+      // The choice is snapshotted with the queued draft, not read live later.
+      expect(
+        screen.getByTestId("chat-input-queued-message"),
+      ).toBeInTheDocument();
+      expect(textarea).toHaveValue("");
+      expect(
+        Object.values(useMessageQueueStore.getState().queuedBySessionId).map(
+          (queued) => queued?.delegationRunMode,
+        ),
+      ).toEqual(["background"]);
+
+      rerenderWithPending(false);
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher take over",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+        "background",
+      );
+    });
+
+    it("drains a queued wait choice without the run mode argument", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea, rerenderWithPending } = await renderComposer(
+        onSendMessage,
+        { isPendingResponse: true },
+      );
+
+      draftWithMention(textarea, "@Researcher take over");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-wait"),
+      );
+
+      expect(
+        screen.getByTestId("chat-input-queued-message"),
+      ).toBeInTheDocument();
+
+      rerenderWithPending(false);
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      });
+
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher take over",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+      );
+    });
+
+    it("asks again on the next mentioned send instead of remembering the choice", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage);
+
+      draftWithMention(textarea, "@Researcher first task");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-background"),
+      );
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+
+      draftWithMention(textarea, "@Researcher second task");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      expect(popover()).toBeInTheDocument();
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("carries the background choice through a confirmed queue replace", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage, {
+        isPendingResponse: true,
+      });
+
+      // A plain draft is already queued for the running turn.
+      typeWithCaretAtEnd(textarea, "plain draft first");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(
+        screen.getByTestId("chat-input-queued-message"),
+      ).toBeInTheDocument();
+
+      // The replacing draft answers wait-or-background before the depth-1
+      // overwrite guard asks for confirmation.
+      draftWithMention(textarea, "@Researcher replace with this");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-background"),
+      );
+
+      expect(
+        screen.getByText("Replace the queued message?"),
+      ).toBeInTheDocument();
+      fireEvent.click(screen.getByText("Replace"));
+
+      // The choice rode setQueueReplacePending -> commitQueueReplace into the
+      // queued snapshot; the earlier plain draft is gone.
+      expect(
+        Object.values(useMessageQueueStore.getState().queuedBySessionId),
+      ).toEqual([
+        expect.objectContaining({
+          message: "@Researcher replace with this",
+          delegationRunMode: "background",
+        }),
+      ]);
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("leaves the run mode off the replacing snapshot when the choice was wait", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage, {
+        isPendingResponse: true,
+      });
+
+      typeWithCaretAtEnd(textarea, "plain draft first");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      draftWithMention(textarea, "@Researcher replace with this");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-wait"),
+      );
+      fireEvent.click(screen.getByText("Replace"));
+
+      const queued = Object.values(
+        useMessageQueueStore.getState().queuedBySessionId,
+      );
+      expect(queued).toEqual([
+        expect.objectContaining({ message: "@Researcher replace with this" }),
+      ]);
+      expect(queued[0]).not.toHaveProperty("delegationRunMode");
+    });
+
+    it("sends directly when the turn completed while the popover was open", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea, rerenderWithPending } = await renderComposer(
+        onSendMessage,
+        { isPendingResponse: true },
+      );
+
+      // The popover opened for a queue intent...
+      draftWithMention(textarea, "@Researcher take over");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      expect(popover()).toBeInTheDocument();
+
+      // ...but the turn finishes before the user answers.
+      rerenderWithPending(false);
+      fireEvent.click(
+        screen.getByTestId("chat-input-delegation-run-mode-background"),
+      );
+
+      // Exactly one direct send with the chosen mode; nothing was queued.
+      expect(onSendMessage).toHaveBeenCalledTimes(1);
+      expect(onSendMessage).toHaveBeenCalledWith(
+        "@Researcher take over",
+        undefined,
+        undefined,
+        [],
+        ["assistant-research"],
+        "background",
+      );
+      expect(
+        Object.values(useMessageQueueStore.getState().queuedBySessionId),
+      ).toEqual([]);
+      expect(
+        screen.queryByTestId("chat-input-queued-message"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("neither asks nor sends when the send gate is closed", async () => {
+      enableDelegation();
+      const onSendMessage = vi.fn();
+      const { textarea } = await renderComposer(onSendMessage, {
+        isMessagingLoading: true,
+      });
+
+      draftWithMention(textarea, "@Researcher please dig in");
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      // A submit that would not actually fire must not open the popover
+      // either — it would outlive a send that was never going to happen.
+      expect(popover()).not.toBeInTheDocument();
+      expect(onSendMessage).not.toHaveBeenCalled();
+      expect(textarea).toHaveValue("@Researcher please dig in");
+    });
+  });
 });

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -54,6 +54,7 @@ import {
   useAudioTranscriptionFeature,
   useAudioDictationFeature,
   useAudioConversationalFeature,
+  useAssistantsFeature,
 } from "@/providers/FeatureConfigProvider";
 import {
   applyMentionSelection,
@@ -81,6 +82,7 @@ import { AssistantMentionPopover } from "./AssistantMentionPopover";
 import { ChatInputAddControls } from "./ChatInputAddControls";
 import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
 import { ChatInputTokenUsage } from "./ChatInputTokenUsage";
+import { DelegationRunModePopover } from "./DelegationRunModePopover";
 import { FacetSelector } from "./FacetSelector";
 import { ModelSelector } from "./ModelSelector";
 import { WaveformButton } from "./WaveformButton";
@@ -99,13 +101,18 @@ import type { MentionableAssistant } from "@/hooks/chat/useMentionableAssistants
 import type {
   FileUploadItem,
   ChatModel,
+  DelegationRunMode,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type {
   AssistantMention,
   MentionTrigger,
 } from "@/utils/chat/assistantMentions";
 import type { FileType } from "@/utils/fileTypes";
-import type { ClipboardEvent as ReactClipboardEvent, Ref } from "react";
+import type {
+  ClipboardEvent as ReactClipboardEvent,
+  FormEvent,
+  Ref,
+} from "react";
 
 const logger = createLogger("UI", "ChatInput");
 const AUDIO_TRANSCRIPTION_STATUS_POLL_INTERVAL_MS = 1000;
@@ -225,6 +232,7 @@ interface ChatInputProps {
     modelId?: string,
     selectedFacetIds?: string[],
     mentionedAssistantIds?: string[],
+    delegationRunMode?: DelegationRunMode,
   ) => void;
   onRegenerate?: () => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
@@ -662,6 +670,38 @@ export const ChatInput = ({
     all: mentionableAssistants,
   } = useMentionableAssistants(assistantId);
 
+  // --- Wait-or-background for mentioned sends ------------------------------
+  // Gated on the feature flags rather than `canMentionAssistants`: a restored
+  // draft's tracked mentions outlive the assistant query, and whatever the
+  // draft holds is what submit delegates to. Without the server-side
+  // `allow_background` gate there is no popover at all — offering a choice the
+  // server would downgrade to "wait" is worse than not asking.
+  const {
+    enabled: assistantsFeatureEnabled,
+    delegationEnabled,
+    delegationAllowBackground,
+  } = useAssistantsFeature();
+  const canChooseDelegationRunMode = Boolean(
+    assistantsFeatureEnabled && delegationEnabled && delegationAllowBackground,
+  );
+  // Which pending action the open popover decides for: a direct send or a
+  // queue snapshot. Null = closed.
+  const [delegationRunModeIntent, setDelegationRunModeIntent] = useState<
+    "send" | "queue" | null
+  >(null);
+  // A made choice for the submit that follows it: null = nothing decided,
+  // `{ runMode: undefined }` = the user chose "wait".
+  const pendingRunModeChoiceRef = useRef<{
+    runMode?: DelegationRunMode;
+  } | null>(null);
+
+  const shouldAskDelegationRunMode = useCallback(
+    (candidateMessage: string, tracked: AssistantMention[]) =>
+      canChooseDelegationRunMode &&
+      resolveMentionedAssistantIds(candidateMessage, tracked).length > 0,
+    [canChooseDelegationRunMode],
+  );
+
   // --- Queue-the-next-message (ERMAIN-470) ---------------------------------
   // The queued payload lives in the messageQueueStore keyed by the stable
   // compose session (so it survives the new-chat null->real-id rename and stays
@@ -679,70 +719,55 @@ export const ChatInput = ({
   const [isDrainArmed, setIsDrainArmed] = useState(false);
   // Depth-1 overwrite guard: a message is already queued and the user is trying
   // to queue another. We ask for confirmation (data-loss safety) before
-  // replacing, rather than silently clobbering the earlier draft.
-  const [queueReplacePending, setQueueReplacePending] = useState(false);
+  // replacing, rather than silently clobbering the earlier draft. The pending
+  // record carries the delegation run mode already chosen for the replacing
+  // draft, so confirming snapshots it with the queued message.
+  const [queueReplacePending, setQueueReplacePending] = useState<
+    false | { runMode?: DelegationRunMode }
+  >(false);
   const hasPendingConfirmation = useHasPendingConfirmation(chatId);
 
   // Enter-while-a-turn-is-generating queues the draft instead of sending.
   // Gated on isPendingResponse specifically (a turn is in flight) — not the
   // broader send lock, which also covers the initial history load that produces
   // no completion edge to drain on. Returns true when it consumed the event.
-  const enqueueCurrentMessage = useCallback((): boolean => {
-    if (!isPendingResponse || isAnyTokenLimitExceeded) {
-      return false;
-    }
-    // Leave the audio/dictation auto-send flows untouched.
-    if (
-      isDictating ||
-      isDictationStarting ||
-      isDictationCompleting ||
-      isCapturingAudio
-    ) {
-      return false;
-    }
-    const trimmedMessage = message.trim();
-    if (!trimmedMessage && attachedFiles.length === 0) {
-      return false;
-    }
-    // Depth-1: a message is already queued — confirm before overwriting it
-    // (data-loss safety) rather than silently replacing. Both Enter and the
-    // Send/Queue button reach this choke point, so the guard covers both.
-    if (getQueuedBySessionId(composeSessionId)) {
-      setQueueReplacePending(true);
-      return true;
-    }
-    setQueuedBySessionId(composeSessionId, {
-      message: trimmedMessage,
-      attachedFiles,
-      mentionedAssistants: pruneTrackedMentions(
-        trimmedMessage,
-        mentionedAssistants,
-      ),
-    });
-    setMessage("");
-    handleRemoveAllFiles();
-    return true;
-  }, [
-    isPendingResponse,
-    isAnyTokenLimitExceeded,
-    isDictating,
-    isDictationStarting,
-    isDictationCompleting,
-    isCapturingAudio,
-    message,
-    attachedFiles,
-    mentionedAssistants,
-    getQueuedBySessionId,
-    setQueuedBySessionId,
-    composeSessionId,
-    handleRemoveAllFiles,
-  ]);
-
-  // Confirmed overwrite: replace the queued message with the current composer
-  // draft and clear the composer.
-  const commitQueueReplace = useCallback(() => {
-    const trimmedMessage = message.trim();
-    if (trimmedMessage || attachedFiles.length > 0) {
+  //
+  // A mentioned draft first asks wait-or-background; the resolved choice
+  // re-enters through `decidedDelegation` and is snapshotted with the queued
+  // message — the mode belongs to that draft, not to whatever is selected when
+  // the drain later fires.
+  const enqueueCurrentMessage = useCallback(
+    (decidedDelegation?: { runMode?: DelegationRunMode }): boolean => {
+      if (!isPendingResponse || isAnyTokenLimitExceeded) {
+        return false;
+      }
+      // Leave the audio/dictation auto-send flows untouched.
+      if (
+        isDictating ||
+        isDictationStarting ||
+        isDictationCompleting ||
+        isCapturingAudio
+      ) {
+        return false;
+      }
+      const trimmedMessage = message.trim();
+      if (!trimmedMessage && attachedFiles.length === 0) {
+        return false;
+      }
+      if (
+        !decidedDelegation &&
+        shouldAskDelegationRunMode(trimmedMessage, mentionedAssistants)
+      ) {
+        setDelegationRunModeIntent("queue");
+        return true;
+      }
+      // Depth-1: a message is already queued — confirm before overwriting it
+      // (data-loss safety) rather than silently replacing. Both Enter and the
+      // Send/Queue button reach this choke point, so the guard covers both.
+      if (getQueuedBySessionId(composeSessionId)) {
+        setQueueReplacePending({ runMode: decidedDelegation?.runMode });
+        return true;
+      }
       setQueuedBySessionId(composeSessionId, {
         message: trimmedMessage,
         attachedFiles,
@@ -750,6 +775,48 @@ export const ChatInput = ({
           trimmedMessage,
           mentionedAssistants,
         ),
+        ...(decidedDelegation?.runMode
+          ? { delegationRunMode: decidedDelegation.runMode }
+          : {}),
+      });
+      setMessage("");
+      handleRemoveAllFiles();
+      return true;
+    },
+    [
+      isPendingResponse,
+      isAnyTokenLimitExceeded,
+      isDictating,
+      isDictationStarting,
+      isDictationCompleting,
+      isCapturingAudio,
+      message,
+      attachedFiles,
+      mentionedAssistants,
+      shouldAskDelegationRunMode,
+      getQueuedBySessionId,
+      setQueuedBySessionId,
+      composeSessionId,
+      handleRemoveAllFiles,
+    ],
+  );
+
+  // Confirmed overwrite: replace the queued message with the current composer
+  // draft and clear the composer.
+  const commitQueueReplace = useCallback(() => {
+    const trimmedMessage = message.trim();
+    if (trimmedMessage || attachedFiles.length > 0) {
+      const runMode = queueReplacePending
+        ? queueReplacePending.runMode
+        : undefined;
+      setQueuedBySessionId(composeSessionId, {
+        message: trimmedMessage,
+        attachedFiles,
+        mentionedAssistants: pruneTrackedMentions(
+          trimmedMessage,
+          mentionedAssistants,
+        ),
+        ...(runMode ? { delegationRunMode: runMode } : {}),
       });
       setMessage("");
       handleRemoveAllFiles();
@@ -759,13 +826,16 @@ export const ChatInput = ({
     message,
     attachedFiles,
     mentionedAssistants,
+    queueReplacePending,
     setQueuedBySessionId,
     composeSessionId,
     handleRemoveAllFiles,
   ]);
 
   // Return a queued payload to the composer (chip click-to-edit, abort, error),
-  // merging with whatever the user has typed since so nothing is lost.
+  // merging with whatever the user has typed since so no text or file is lost.
+  // An answered wait-or-background choice is deliberately NOT restored: back
+  // in the composer the draft is editable again, so the next send asks afresh.
   const restoreQueuedToComposer = useCallback(
     (queued: ComposeDraftState) => {
       const merged = mergeComposeDrafts(queued, {
@@ -1325,6 +1395,9 @@ export const ChatInput = ({
         messageContent,
         mentionedAssistants,
       );
+      // Set for the duration of this synchronous submit by the wrapper below;
+      // "wait" stays undefined so the request omits the field.
+      const delegationRunMode = pendingRunModeChoiceRef.current?.runMode;
 
       logger.log("Submit:", {
         messagePreview:
@@ -1334,14 +1407,26 @@ export const ChatInput = ({
         model: selectedModel?.chat_provider_id,
         selectedFacetIds,
         mentionedAssistantIds,
+        delegationRunMode,
       });
-      onSendMessage(
-        messageContent,
-        inputFileIds,
-        selectedModel?.chat_provider_id,
-        selectedFacetIds,
-        mentionedAssistantIds,
-      );
+      if (delegationRunMode) {
+        onSendMessage(
+          messageContent,
+          inputFileIds,
+          selectedModel?.chat_provider_id,
+          selectedFacetIds,
+          mentionedAssistantIds,
+          delegationRunMode,
+        );
+      } else {
+        onSendMessage(
+          messageContent,
+          inputFileIds,
+          selectedModel?.chat_provider_id,
+          selectedFacetIds,
+          mentionedAssistantIds,
+        );
+      }
     },
     isLoading ||
       isPendingResponse ||
@@ -1444,19 +1529,35 @@ export const ChatInput = ({
       setQueueReplacePending(false);
       // Model/facets are read live (not snapshotted at enqueue) so a selection
       // the user changes while the message waits applies to the sent message.
-      // Mentions are the exception: they are part of the queued text.
-      onSendMessage(
-        stillQueued.message,
+      // Mentions are the exception: they are part of the queued text — and the
+      // delegation run mode travels with them, answered for this draft when it
+      // was queued.
+      const queuedInputFileIds =
         stillQueued.attachedFiles.length > 0
           ? stillQueued.attachedFiles.map((file) => file.id)
-          : undefined,
-        selectedModel?.chat_provider_id,
-        selectedFacetIds,
-        resolveMentionedAssistantIds(
-          stillQueued.message,
-          stillQueued.mentionedAssistants,
-        ),
+          : undefined;
+      const queuedMentionedAssistantIds = resolveMentionedAssistantIds(
+        stillQueued.message,
+        stillQueued.mentionedAssistants,
       );
+      if (stillQueued.delegationRunMode) {
+        onSendMessage(
+          stillQueued.message,
+          queuedInputFileIds,
+          selectedModel?.chat_provider_id,
+          selectedFacetIds,
+          queuedMentionedAssistantIds,
+          stillQueued.delegationRunMode,
+        );
+      } else {
+        onSendMessage(
+          stillQueued.message,
+          queuedInputFileIds,
+          selectedModel?.chat_provider_id,
+          selectedFacetIds,
+          queuedMentionedAssistantIds,
+        );
+      }
     }, 0);
     return () => clearTimeout(timer);
   }, [
@@ -1768,6 +1869,62 @@ export const ChatInput = ({
     !isDictating &&
     !isDictationStarting &&
     !isCapturingAudio;
+
+  // Chokepoint in front of handleSubmit (form submit, Enter, and the
+  // post-choice resubmit all pass through): a mentioned send that has not
+  // answered wait-or-background yet opens the popover INSTEAD of submitting,
+  // leaving the draft untouched so a cancel costs nothing. Only a send that
+  // would actually fire is intercepted — the popover must never outlive a
+  // submit that handleSubmit would have dropped. Not memoized for the same
+  // reason as handleSubmit above.
+  const handleComposerSubmit = (e: FormEvent) => {
+    const decided = pendingRunModeChoiceRef.current;
+    if (
+      !decided &&
+      Boolean(canSendMessage) &&
+      !isSendDisabled &&
+      shouldAskDelegationRunMode(message.trim(), mentionedAssistants)
+    ) {
+      e.preventDefault();
+      setDelegationRunModeIntent("send");
+      return;
+    }
+    try {
+      // The submit callback inside handleSubmit reads the choice from the ref
+      // synchronously; clearing in `finally` keeps a submit that never reaches
+      // the callback (guards, empty draft) from leaking the choice into a
+      // later, unrelated send.
+      handleSubmit(e);
+    } finally {
+      pendingRunModeChoiceRef.current = null;
+    }
+  };
+
+  // A popover choice resumes the intercepted action with the chosen mode.
+  const resolveDelegationRunModeChoice = useCallback(
+    (runMode?: DelegationRunMode) => {
+      const intent = delegationRunModeIntent;
+      setDelegationRunModeIntent(null);
+      if (!intent) {
+        return;
+      }
+      focusInput();
+      if (intent === "queue" && enqueueCurrentMessage({ runMode })) {
+        return;
+      }
+      // Direct send — or the turn ended while the queue choice was open, in
+      // which case the draft can simply be sent now.
+      pendingRunModeChoiceRef.current = { runMode };
+      formRef.current?.requestSubmit();
+    },
+    [delegationRunModeIntent, enqueueCurrentMessage, focusInput],
+  );
+
+  // Escape/click-away: the send is abandoned entirely and the draft stays.
+  const cancelDelegationRunModeChoice = useCallback(() => {
+    setDelegationRunModeIntent(null);
+    focusInput();
+  }, [focusInput]);
 
   const shouldShowAudioModeSelector =
     audioConversationalEnabled && audioTranscriptionEnabled;
@@ -2239,7 +2396,7 @@ export const ChatInput = ({
         className={clsx("w-full ", className, {
           "pb-0 sm:pb-0": aiUsageAdvisory,
         })}
-        onSubmit={handleSubmit}
+        onSubmit={handleComposerSubmit}
       >
         {/* Token usage warnings */}
         <ChatInputTokenUsage
@@ -2573,7 +2730,7 @@ export const ChatInput = ({
                     if (enqueueCurrentMessage()) {
                       return;
                     }
-                    handleSubmit(e);
+                    handleComposerSubmit(e);
                   }
                 }}
                 placeholder={
@@ -2703,7 +2860,20 @@ export const ChatInput = ({
               )}
             </div>
 
-            <div className="flex min-w-0 flex-wrap items-center gap-[var(--theme-spacing-control-gap)]">
+            <div className="relative flex min-w-0 flex-wrap items-center gap-[var(--theme-spacing-control-gap)]">
+              {/* Out of flow like the mention popover's anchor: the popover
+                  positions off a measurable element, and the right edge of
+                  this cluster is where the Send/Queue button that triggered
+                  the choice sits. */}
+              {canChooseDelegationRunMode && (
+                <div className="pointer-events-none absolute right-0 top-0 size-0">
+                  <DelegationRunModePopover
+                    isOpen={delegationRunModeIntent !== null}
+                    onChoose={resolveDelegationRunModeChoice}
+                    onCancel={cancelDelegationRunModeChoice}
+                  />
+                </div>
+              )}
               {isAudioMode && (
                 <Button
                   type="button"

--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -169,7 +169,11 @@ export function AddMenuActionRow({
   );
 }
 
-function SectionHeader({
+/**
+ * Non-interactive section label. Exported so popovers outside this menu — the
+ * composer's run-mode choice — carry the same header channel.
+ */
+export function AddMenuSectionHeader({
   id,
   children,
 }: {
@@ -294,7 +298,9 @@ export function ChatInputAddMenu({
         aria-labelledby={section.header != null ? headerId : undefined}
       >
         {section.header != null && (
-          <SectionHeader id={headerId}>{section.header}</SectionHeader>
+          <AddMenuSectionHeader id={headerId}>
+            {section.header}
+          </AddMenuSectionHeader>
         )}
         {section.items.map((item) =>
           renderActionRow(item, `chat-input-add-menu-extra-${item.id}`),
@@ -350,9 +356,9 @@ export function ChatInputAddMenu({
           aria-labelledby={toolsHeaderId}
           className="flex flex-col"
         >
-          <SectionHeader id={toolsHeaderId}>
+          <AddMenuSectionHeader id={toolsHeaderId}>
             {t({ id: "chatInput.addMenu.toolsHeader", message: "Tools" })}
-          </SectionHeader>
+          </AddMenuSectionHeader>
           {tools.map((tool) => {
             const toolDisabled = isBusy || tool.disabled;
             return (

--- a/frontend/src/components/ui/Chat/DelegationRunModePopover.tsx
+++ b/frontend/src/components/ui/Chat/DelegationRunModePopover.tsx
@@ -1,0 +1,166 @@
+import { t } from "@lingui/core/macro";
+import { useEffect, useRef } from "react";
+
+import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
+
+import {
+  ADD_MENU_ITEM_SELECTOR,
+  AddMenuActionRow,
+  AddMenuSectionHeader,
+} from "./ChatInputAddMenu";
+import { AnchoredPopover } from "../Controls/AnchoredPopover";
+
+import type { DelegationRunMode } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+export interface DelegationRunModePopoverProps {
+  isOpen: boolean;
+  /**
+   * `undefined` means "wait for the answer" — the wire default, so the
+   * request omits the field entirely.
+   */
+  onChoose: (runMode?: DelegationRunMode) => void;
+  /** The send (or queue) is abandoned; the draft stays in the composer. */
+  onCancel: () => void;
+}
+
+/**
+ * Asks whether a send that @-mentions assistants should wait for the
+ * delegates' answers or run them in the background, before the request leaves
+ * the browser.
+ *
+ * Keyboard contract: the popover opens from the send gesture, so Enter — the
+ * send muscle memory — resolves to "wait", the safe default: the popover opens
+ * with that option focused, and an Enter that lands anywhere else in the panel
+ * is caught below. Escape (and clicking away) cancels the send entirely and
+ * leaves the draft untouched.
+ *
+ * The choice is deliberately asked on every mentioned send, never remembered:
+ * the error costs are asymmetric. A wrongly backgrounded run produces a
+ * confidently wrong answer built without the delegate's result, while wrongly
+ * waiting merely costs time — so a persisted "background" default must not
+ * fire silently. Revisit as an explicit setting.
+ */
+export function DelegationRunModePopover({
+  isOpen,
+  onChoose,
+  onCancel,
+}: DelegationRunModePopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useRovingMenuFocus({
+    containerRef: panelRef,
+    enabled: isOpen,
+    itemSelector: ADD_MENU_ITEM_SELECTOR,
+  });
+
+  // Focus the "wait" row one frame after opening (the panel is positioned
+  // before paint, but the rows exist only after the portal mounts), so the
+  // Enter still travelling from the send gesture activates the safe default.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      const waitRow = panelRef.current?.querySelector<HTMLElement>(
+        '[data-testid="chat-input-delegation-run-mode-wait"]',
+      );
+      waitRow?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [isOpen]);
+
+  // Belt for an Enter that reaches the panel while no row is focused (e.g.
+  // after clicking the header): resolve to "wait" rather than doing nothing.
+  // Enter on a focused row is native button activation and is not intercepted,
+  // so arrowing to "background" and confirming still works.
+  const handlePanelKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Enter") {
+      return;
+    }
+    if (event.target instanceof HTMLElement && event.target.closest("button")) {
+      return;
+    }
+    event.preventDefault();
+    onChoose(undefined);
+  };
+
+  return (
+    <AnchoredPopover
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onCancel();
+        }
+      }}
+      panelRef={panelRef}
+      role="menu"
+      preferredOrientation={{ vertical: "top", horizontal: "right" }}
+      panelStyle={{
+        maxWidth:
+          "calc(100vw - (var(--theme-layout-dropdown-viewport-margin) * 2))",
+        minWidth: "var(--theme-layout-dropdown-min-width)",
+      }}
+      panelClassName="flex w-80 flex-col"
+      viewportPadding="var(--theme-layout-dropdown-viewport-margin)"
+      dataUi="chat-input-delegation-run-mode-menu"
+      manageFocus={false}
+      ariaLabel={t({
+        id: "chatInput.delegationRunMode.title",
+        message: "How should mentioned assistants run?",
+      })}
+      // The anchor is geometry, not a control: the popover opens from the send
+      // gesture, so the anchor stays out of the a11y tree and the panel is
+      // named directly instead.
+      trigger={(triggerProps) => (
+        <button
+          {...triggerProps}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="sr-only"
+          data-testid="chat-input-delegation-run-mode-anchor"
+        />
+      )}
+    >
+      <div
+        className="dropdown-panel-chrome-geometry flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain"
+        role="none"
+        onKeyDown={handlePanelKeyDown}
+        data-ui="chat-input-delegation-run-mode-content"
+        data-testid="chat-input-delegation-run-mode"
+      >
+        <AddMenuSectionHeader>
+          {t({
+            id: "chatInput.delegationRunMode.title",
+            message: "How should mentioned assistants run?",
+          })}
+        </AddMenuSectionHeader>
+        <AddMenuActionRow
+          label={t({
+            id: "chatInput.delegationRunMode.wait.label",
+            message: "Wait for the answer",
+          })}
+          description={t({
+            id: "chatInput.delegationRunMode.wait.description",
+            message: "The answer arrives in this conversation.",
+          })}
+          testId="chat-input-delegation-run-mode-wait"
+          onActivate={() => onChoose(undefined)}
+        />
+        <AddMenuActionRow
+          label={t({
+            id: "chatInput.delegationRunMode.background.label",
+            message: "Run in the background",
+          })}
+          description={t({
+            id: "chatInput.delegationRunMode.background.description",
+            message:
+              "The answer will not arrive in this conversation; it stays in a separate chat.",
+          })}
+          testId="chat-input-delegation-run-mode-background"
+          onActivate={() => onChoose("background")}
+        />
+      </div>
+    </AnchoredPopover>
+  );
+}

--- a/frontend/src/config/__tests__/themeConfig.test.ts
+++ b/frontend/src/config/__tests__/themeConfig.test.ts
@@ -46,6 +46,7 @@ describe("themeConfig", () => {
     disableLogout: false,
     assistantsEnabled: false,
     assistantsDelegationEnabled: false,
+    assistantsDelegationAllowBackground: false,
     assistantsShowRecentItems: false,
     assistantsShowRecentItemsCollapsible: false,
     assistantContextWarningThreshold: 0.5,

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -2037,4 +2037,68 @@ describe("useChatMessaging", () => {
       );
     });
   });
+
+  describe("delegation run mode", () => {
+    const getSubmitStreamBodies = () =>
+      mockCreateSSEConnection.mock.calls
+        .filter((call: unknown[]) =>
+          (call[0] as string).includes("/submitstream"),
+        )
+        .map((call: unknown[]) =>
+          JSON.parse((call[1] as { body: string }).body),
+        );
+
+    it("threads a chosen background mode into the submitstream body", async () => {
+      mockCreateSSEConnection.mockClear();
+
+      const { result } = renderHook(() => useChatMessaging("chat1"), {
+        wrapper: TestWrapper,
+      });
+
+      await act(async () => {
+        await result.current.sendMessage(
+          "@Researcher take over",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          ["assistant-research"],
+          "background",
+        );
+      });
+
+      const bodies = getSubmitStreamBodies();
+      expect(bodies.length).toBe(1);
+      expect(bodies[0]).toMatchObject({
+        user_message: "@Researcher take over",
+        mentioned_assistant_ids: ["assistant-research"],
+        delegation_run_mode: "background",
+      });
+    });
+
+    it("omits delegation_run_mode when no mode was chosen", async () => {
+      mockCreateSSEConnection.mockClear();
+
+      const { result } = renderHook(() => useChatMessaging("chat1"), {
+        wrapper: TestWrapper,
+      });
+
+      await act(async () => {
+        await result.current.sendMessage(
+          "@Researcher take over",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          ["assistant-research"],
+        );
+      });
+
+      const bodies = getSubmitStreamBodies();
+      expect(bodies.length).toBe(1);
+      expect(bodies[0]).not.toHaveProperty("delegation_run_mode");
+    });
+  });
 });

--- a/frontend/src/hooks/chat/store/messageQueueStore.ts
+++ b/frontend/src/hooks/chat/store/messageQueueStore.ts
@@ -2,6 +2,17 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
 import type { ComposeDraftState } from "@/hooks/chat/useComposeSession";
+import type { DelegationRunMode } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+/**
+ * A queued draft plus the delegation run mode chosen when it was queued.
+ * The mode belongs to the queued message — the user answered wait-or-background
+ * for that draft specifically — so it is snapshotted here rather than read
+ * live at drain time. Absent means the wire default ("wait").
+ */
+export type QueuedMessageState = ComposeDraftState & {
+  delegationRunMode?: DelegationRunMode;
+};
 
 /**
  * The depth-1 "send when the current turn finishes" queue (ERMAIN-470), keyed
@@ -11,16 +22,16 @@ import type { ComposeDraftState } from "@/hooks/chat/useComposeSession";
  * directly — no manual invalidation token.
  */
 interface MessageQueueStore {
-  queuedBySessionId: Partial<Record<string, ComposeDraftState>>;
-  setQueued: (sessionId: string, queued: ComposeDraftState) => void;
+  queuedBySessionId: Partial<Record<string, QueuedMessageState>>;
+  setQueued: (sessionId: string, queued: QueuedMessageState) => void;
   clearQueued: (sessionId: string) => void;
-  getQueued: (sessionId: string) => ComposeDraftState | null;
+  getQueued: (sessionId: string) => QueuedMessageState | null;
 }
 
 const readQueued = (
-  queuedBySessionId: Partial<Record<string, ComposeDraftState>>,
+  queuedBySessionId: Partial<Record<string, QueuedMessageState>>,
   sessionId: string,
-): ComposeDraftState | null => queuedBySessionId[sessionId] ?? null;
+): QueuedMessageState | null => queuedBySessionId[sessionId] ?? null;
 
 export const useMessageQueueStore = create<MessageQueueStore>()(
   devtools(
@@ -61,7 +72,9 @@ export const useMessageQueueStore = create<MessageQueueStore>()(
 );
 
 /** Reactive read of the message queued for `sessionId`, or null. */
-export const useQueuedMessage = (sessionId: string): ComposeDraftState | null =>
+export const useQueuedMessage = (
+  sessionId: string,
+): QueuedMessageState | null =>
   useMessageQueueStore((state) =>
     readQueued(state.queuedBySessionId, sessionId),
   );

--- a/frontend/src/hooks/chat/useChatActions.ts
+++ b/frontend/src/hooks/chat/useChatActions.ts
@@ -2,7 +2,10 @@ import { useCallback } from "react";
 
 import { createLogger } from "@/utils/debugLogger";
 
-import type { ActionFacetRequest } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type {
+  ActionFacetRequest,
+  DelegationRunMode,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { MessageAction } from "@/types/message-controls";
 
 const logger = createLogger("HOOK", "useChatActions");
@@ -17,6 +20,7 @@ interface UseChatActionsProps {
     selectedFacetIds?: string[],
     actionFacet?: ActionFacetRequest,
     mentionedAssistantIds?: string[],
+    delegationRunMode?: DelegationRunMode,
   ) => Promise<string | undefined>;
   onMessageAction?: (action: MessageAction) => Promise<boolean>;
 }
@@ -61,6 +65,7 @@ export function useChatActions({
       assistantId?: string,
       selectedFacetIds?: string[],
       mentionedAssistantIds?: string[],
+      delegationRunMode?: DelegationRunMode,
     ) => {
       if (message.trim() || (inputFileIds && inputFileIds.length > 0)) {
         return sendMessage(
@@ -71,6 +76,7 @@ export function useChatActions({
           selectedFacetIds,
           undefined,
           mentionedAssistantIds,
+          delegationRunMode,
         );
       }
       return Promise.resolve(undefined);

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -63,6 +63,7 @@ import { useExplicitNavigation } from "./useExplicitNavigation";
 import type {
   ActionFacetRequest,
   ContentPart,
+  DelegationRunMode,
   MessageSubmitStreamingResponseMessage,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
@@ -1374,6 +1375,7 @@ export function useChatMessaging(
       selectedFacetIds?: string[],
       actionFacet?: ActionFacetRequest,
       mentionedAssistantIds?: string[],
+      delegationRunMode?: DelegationRunMode,
     ): Promise<string | undefined> => {
       // Prevent duplicate submissions
       if (isSubmittingForKey(streamKey)) {
@@ -1489,6 +1491,7 @@ export function useChatMessaging(
           selectedFacetIds,
           actionFacet,
           mentionedAssistantIds,
+          delegationRunMode,
         );
 
         logger.log("[DEBUG_STREAMING] sendMessage: Sending requestBody:", {

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1922,6 +1922,31 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Dateien und Tools hinzufügen"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.description"
+msgstr "Die Antwort kommt nicht in dieser Unterhaltung an, sondern bleibt in einem separaten Chat."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.label"
+msgstr "Im Hintergrund ausführen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.title"
+msgstr "Wie sollen erwähnte Assistenten ausgeführt werden?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.description"
+msgstr "Die Antwort erscheint in dieser Unterhaltung."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.label"
+msgstr "Auf die Antwort warten"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/AssistantMentionPopover.tsx
 #: src/components/ui/Chat/assistantMentionSection.ts
 msgid "chatInput.mentions.browse"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1922,6 +1922,31 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Add files and tools"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.description"
+msgstr "The answer will not arrive in this conversation; it stays in a separate chat."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.label"
+msgstr "Run in the background"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.title"
+msgstr "How should mentioned assistants run?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.description"
+msgstr "The answer arrives in this conversation."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.label"
+msgstr "Wait for the answer"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/AssistantMentionPopover.tsx
 #: src/components/ui/Chat/assistantMentionSection.ts
 msgid "chatInput.mentions.browse"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1922,6 +1922,31 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Agregar archivos y herramientas"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.description"
+msgstr "La respuesta no llegará a esta conversación; se queda en un chat aparte."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.label"
+msgstr "Ejecutar en segundo plano"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.title"
+msgstr "¿Cómo deben ejecutarse los asistentes mencionados?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.description"
+msgstr "La respuesta llega a esta conversación."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.label"
+msgstr "Esperar la respuesta"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/AssistantMentionPopover.tsx
 #: src/components/ui/Chat/assistantMentionSection.ts
 msgid "chatInput.mentions.browse"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1922,6 +1922,31 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Ajouter des fichiers et des outils"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.description"
+msgstr "La réponse n'arrivera pas dans cette conversation ; elle reste dans un chat séparé."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.label"
+msgstr "Exécuter en arrière-plan"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.title"
+msgstr "Comment exécuter les assistants mentionnés ?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.description"
+msgstr "La réponse arrive dans cette conversation."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.label"
+msgstr "Attendre la réponse"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/AssistantMentionPopover.tsx
 #: src/components/ui/Chat/assistantMentionSection.ts
 msgid "chatInput.mentions.browse"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1922,6 +1922,31 @@ msgid "chatInput.addMenu.trigger"
 msgstr "Dodaj pliki i narzędzia"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.description"
+msgstr "Odpowiedź nie pojawi się w tej rozmowie; pozostanie w osobnym czacie."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.background.label"
+msgstr "Uruchom w tle"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.title"
+msgstr "Jak uruchomić wspomnianych asystentów?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.description"
+msgstr "Odpowiedź pojawi się w tej rozmowie."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegationRunModePopover.tsx
+msgid "chatInput.delegationRunMode.wait.label"
+msgstr "Czekaj na odpowiedź"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/AssistantMentionPopover.tsx
 #: src/components/ui/Chat/assistantMentionSection.ts
 msgid "chatInput.mentions.browse"

--- a/frontend/src/providers/ChatProvider.tsx
+++ b/frontend/src/providers/ChatProvider.tsx
@@ -28,6 +28,7 @@ import type {
   FileUploadItem,
   ChatModel,
   ContentPart,
+  DelegationRunMode,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
 import type { FileType } from "@/utils/fileTypes";
@@ -83,6 +84,7 @@ export interface ChatContextValue {
     selectedFacetIds?: string[],
     actionFacet?: { id: string; args?: Record<string, string> },
     mentionedAssistantIds?: string[],
+    delegationRunMode?: DelegationRunMode,
   ) => Promise<string | undefined>;
   editMessage: (
     messageId: string,

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -86,6 +86,8 @@ interface AssistantsFeatureConfig {
   enabled: boolean;
   /** Whether a message may delegate to other assistants via @-mentions */
   delegationEnabled: boolean;
+  /** Whether the deployment lets a delegated run be sent to the background */
+  delegationAllowBackground: boolean;
   /** Whether assistants may be shared with edit access */
   enableEditSharing: boolean;
   /** Whether recent assistants should be shown in the sidebar */
@@ -270,6 +272,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   assistants: {
     enabled: false,
     delegationEnabled: false,
+    delegationAllowBackground: false,
     enableEditSharing: true,
     showRecentItems: false,
     showRecentItemsCollapsible: false,
@@ -380,6 +383,9 @@ function createFeatureConfig(
     assistants: {
       enabled: environment.assistantsEnabled,
       delegationEnabled: Boolean(environment.assistantsDelegationEnabled),
+      delegationAllowBackground: Boolean(
+        environment.assistantsDelegationAllowBackground,
+      ),
       enableEditSharing: environment.assistantsEnableEditSharing ?? true,
       showRecentItems: environment.assistantsShowRecentItems,
       showRecentItemsCollapsible:

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -158,6 +158,7 @@ describe("FeatureConfigProvider", () => {
         assistants: {
           enabled: false,
           delegationEnabled: false,
+          delegationAllowBackground: false,
           enableEditSharing: true,
           showRecentItems: false,
           showRecentItemsCollapsible: false,
@@ -840,6 +841,7 @@ describe("FeatureConfigProvider", () => {
       expect(result.current).toEqual({
         enabled: false,
         delegationEnabled: false,
+        delegationAllowBackground: false,
         enableEditSharing: true,
         showRecentItems: false,
         showRecentItemsCollapsible: false,
@@ -889,6 +891,7 @@ describe("FeatureConfigProvider", () => {
       expect(result.current).toEqual({
         enabled: true,
         delegationEnabled: false,
+        delegationAllowBackground: false,
         enableEditSharing: true,
         showRecentItems: true,
         showRecentItemsCollapsible: true,

--- a/frontend/src/utils/chat/messageUtils.test.ts
+++ b/frontend/src/utils/chat/messageUtils.test.ts
@@ -102,4 +102,37 @@ describe("constructSubmitStreamRequestBody", () => {
       ),
     ).not.toHaveProperty("mentioned_assistant_ids");
   });
+
+  it("carries the delegation run mode when one was chosen", () => {
+    const body = constructSubmitStreamRequestBody(
+      "ask @Researcher",
+      undefined,
+      undefined,
+      "chat-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ["assistant-1"],
+      "background",
+    );
+
+    expect(body.delegation_run_mode).toBe("background");
+  });
+
+  it("omits delegation_run_mode by default, leaving the wire default (wait)", () => {
+    expect(
+      constructSubmitStreamRequestBody(
+        "ask @Researcher",
+        undefined,
+        undefined,
+        "chat-1",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ["assistant-1"],
+      ),
+    ).not.toHaveProperty("delegation_run_mode");
+  });
 });

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -1,6 +1,9 @@
 import { extractTextFromContent } from "../adapters/contentPartAdapter";
 
-import type { ActionFacetRequest } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type {
+  ActionFacetRequest,
+  DelegationRunMode,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
 
 /**
@@ -115,6 +118,7 @@ export interface SubmitStreamRequestBody {
   selected_facet_ids?: string[];
   action_facet?: ActionFacetRequest;
   mentioned_assistant_ids?: string[];
+  delegation_run_mode?: DelegationRunMode;
 }
 
 /**
@@ -126,6 +130,8 @@ export interface SubmitStreamRequestBody {
  * @param modelId Optional chat provider ID for model selection.
  * @param assistantId Optional assistant ID to associate with the chat.
  * @param mentionedAssistantIds Optional assistants to delegate this turn to.
+ * @param delegationRunMode Optional run mode for delegated mentions; left out
+ *   for the wire default ("wait").
  * @returns The request body object.
  */
 export function constructSubmitStreamRequestBody(
@@ -138,6 +144,7 @@ export function constructSubmitStreamRequestBody(
   selectedFacetIds?: string[],
   actionFacet?: ActionFacetRequest,
   mentionedAssistantIds?: string[],
+  delegationRunMode?: DelegationRunMode,
 ): SubmitStreamRequestBody {
   const body: SubmitStreamRequestBody = {
     user_message: userMessageContent,
@@ -166,6 +173,9 @@ export function constructSubmitStreamRequestBody(
   }
   if (mentionedAssistantIds && mentionedAssistantIds.length > 0) {
     body.mentioned_assistant_ids = mentionedAssistantIds;
+  }
+  if (delegationRunMode) {
+    body.delegation_run_mode = delegationRunMode;
   }
 
   return body;


### PR DESCRIPTION
First frontend layer of the ERMAIN-633 background-delegation stack, based on main (the whole backend chain #1004–#1009 is merged). Frontend stack above this: trace step → runs list → dismissal.

When a send carries at least one tracked mention, a compact popover anchored at the send button asks wait-or-background, and the choice travels as `delegation_run_mode` down the existing chain (`ChatInput` → `Chat.handleSendMessage` → `useChatActions` → `useChatMessaging` → `constructSubmitStreamRequestBody`) exactly the way `mentionedAssistantIds` does.

## The UX decisions the ticket asked to make deliberately

- **Popover, not modal** — reuses the `AnchoredPopover` + menu-row primitives (the `AssistantMentionPopover` pattern), with one hidden geometry-only anchor serving both the send and the queue button.
- **Enter is muscle memory, so Enter means wait.** The wait row is focused on open (plus a panel-level Enter fallback), Escape or click-away cancels the send entirely and keeps the draft, and background is only ever an explicit click. Interception happens in a chokepoint *before* the submit handler that clears the draft, so opening the popover never destroys it.
- **No remembered preference in v1.** The error costs are asymmetric — wrongly waiting costs time, wrongly backgrounding produces a confidently wrong answer built without the data — so a persisted "background" default must never fire silently. Recorded in the component.
- **Wait is expressed by omission at every layer** (it is the wire default), which also keeps every existing exact-arity call assertion valid; only `"background"` is ever transmitted.
- **The queue path asks at queue time and snapshots the choice with the queued draft**; the drain sends the snapshot, the queue-replace confirmation carries it through, and restoring a queued draft to the composer drops the mode so the next send re-asks.
- **Edit and regenerate stay silent** — no field on their requests; the backend replays the persisted mode.

The affordance is gated on `assistants.enabled && delegation.enabled && allow_background`, the last exposed by a minimal backend touch: `ASSISTANTS_DELEGATION_ALLOW_BACKGROUND` joins the existing delegation flag in the frontend-environment window injection (not the OpenAPI spec). A deployment that would downgrade the choice server-side never shows the popover — offering a choice the server overrides is worse than not asking.

New copy carries explicit lingui ids translated in all five locales; the background option's description says the answer will not arrive in this conversation.

## Tests

Fifteen new tests across ChatInput, useChatMessaging and messageUtils: popover only with tracked mentions + both gates on; each choice's wire value; omission by default and on plain sends; Enter resolves to wait (focus + fallback), never background; Escape cancels keeping the draft; queue-time ask with snapshotted background and wait drains; re-ask on every mentioned send. Full frontend suite green at the stack tip (1380 passed), prettier/eslint/both tsc configs/i18n catalogs clean; the backend touch passes fmt/clippy/codegen checks.
