### PR TITLE
Delegation trace: settled background presentation for detached runs (ERMAIN-641)

### DIFF
--- a/frontend/src/components/ui/Trace/steps/DelegationStep.test.tsx
+++ b/frontend/src/components/ui/Trace/steps/DelegationStep.test.tsx
@@ -142,6 +142,49 @@ describe("delegation step", () => {
     expect(screen.getByText("Delegated to Research")).toBeInTheDocument();
   });
 
+  it("settles a backgrounded dispatch the moment it lands, mid-stream", () => {
+    renderStep({ ...IDENTITY, background: true });
+
+    expect(screen.getByText("Delegated to Research")).toBeInTheDocument();
+    const pill = screen.getByText("Sent to background");
+    expect(pill).not.toHaveClass("bg-theme-error-bg");
+    expect(pill).not.toHaveClass("animate-pulse");
+    expect(screen.queryByText("Running")).toBeNull();
+    expect(screen.queryByText("Failed")).toBeNull();
+  });
+
+  it("keeps the backgrounded presentation frozen after the turn ends", () => {
+    renderStep({ ...IDENTITY, background: true }, undefined, false);
+
+    expect(screen.getByText("Delegated to Research")).toBeInTheDocument();
+    expect(screen.getByText("Sent to background")).toBeInTheDocument();
+    const link = screen.getByTestId("delegation-open-run");
+    expect(link).toHaveAttribute("href", "/a/asst-1/chat-7");
+    expect(link).toHaveAttribute("target", "_blank");
+    // Nothing to unfold: the part will never carry steps or a result.
+    expect(
+      screen.queryByRole("button", { name: /Delegated to Research/ }),
+    ).toBeNull();
+  });
+
+  it("says the detachment even over an approval decision", () => {
+    // ToolStatusPill gives an approval decision top priority; the background
+    // branch must win before it ever gets the chance.
+    render(
+      <ToolUseStep
+        part={part({ ...IDENTITY, background: true })}
+        status="done"
+        isStreaming={false}
+        isCollapsed={false}
+        isLastStep
+        approvalStatus="approved"
+      />,
+    );
+
+    expect(screen.getByText("Sent to background")).toBeInTheDocument();
+    expect(screen.queryByText("Approved")).toBeNull();
+  });
+
   it("offers the delegated run in a new tab from the first frame on", () => {
     renderStep({ ...IDENTITY, localTrace: { steps: [] } });
 
@@ -178,6 +221,7 @@ describe("delegation step", () => {
     ["no output yet", null],
     ["a foreign shape", { localTrace: { steps: [] } }],
     ["a non-object output", "delegated"],
+    ["a background marker with no run", { background: true }],
   ])("renders %s as the plain tool call it is", (_case, output) => {
     renderStep(output);
 

--- a/frontend/src/components/ui/Trace/steps/DelegationStep.tsx
+++ b/frontend/src/components/ui/Trace/steps/DelegationStep.tsx
@@ -7,7 +7,7 @@ import { getChatUrl } from "@/utils/chat/urlUtils";
 import { NestedTraceView } from "../NestedTraceView";
 import { TraceStep } from "../TraceStep";
 import { railIconFor } from "../icons";
-import { ToolStatusPill } from "./ToolStatusPill";
+import { SettledInfoPill, ToolStatusPill } from "./ToolStatusPill";
 
 import type { ToolApprovalStatus } from "../Trace";
 import type { BaseStepProps, TraceStepStatus } from "../types";
@@ -74,6 +74,11 @@ const stepStatusFor = (
   envelope: DelegationEnvelope,
   status: TraceStepStatus,
 ): TraceStepStatus => {
+  // A detached dispatch is settled the moment it exists; its part will never
+  // report the outcome, so "done" here means the hand-off, not the run.
+  if (envelope.background) {
+    return "done";
+  }
   if (envelope.status === undefined) {
     return status;
   }
@@ -188,11 +193,24 @@ export const DelegationStep = ({
         hasTrailingRailLine={!isLastStep}
         title={stepTitle(envelope.assistantName, isRunning)}
         titleSlot={
-          <ToolStatusPill
-            status={stepStatus}
-            approvalStatus={approvalStatus}
-            label={outcome}
-          />
+          envelope.background ? (
+            // The detachment is the one thing worth saying about this step —
+            // it outranks even an approval decision. The part is frozen at
+            // dispatch and never learns the run's fate, so the default copy
+            // states the hand-off, not a live state.
+            <SettledInfoPill
+              label={t({
+                id: "trace.delegation.background",
+                message: "Sent to background",
+              })}
+            />
+          ) : (
+            <ToolStatusPill
+              status={stepStatus}
+              approvalStatus={approvalStatus}
+              label={outcome}
+            />
+          )
         }
         headerSlot={
           envelope.delegateChatId !== undefined ? (

--- a/frontend/src/components/ui/Trace/steps/ToolStatusPill.tsx
+++ b/frontend/src/components/ui/Trace/steps/ToolStatusPill.tsx
@@ -43,6 +43,16 @@ interface ToolStatusPillProps {
 // eslint-disable-next-line lingui/no-unlocalized-strings -- utility classes
 const PILL_CLASS = "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium";
 
+/**
+ * Informational pill for a settled step whose state deserves naming without
+ * any alarm — the in-flight tone, but still: no animation, no error styling.
+ */
+export const SettledInfoPill = ({ label }: { label: string }) => (
+  <span className={clsx(PILL_CLASS, "bg-theme-info-bg text-theme-info-fg")}>
+    {label}
+  </span>
+);
+
 /** The pill next to a tool step's title, or nothing when the rail says it. */
 export const ToolStatusPill = ({
   status,

--- a/frontend/src/lib/delegation/delegationEnvelope.test.ts
+++ b/frontend/src/lib/delegation/delegationEnvelope.test.ts
@@ -17,8 +17,38 @@ describe("parseDelegationEnvelope", () => {
       assistantName: "Research",
       delegateChatId: "chat-1",
       result: undefined,
+      background: false,
       truncated: false,
     });
+  });
+
+  it("reads a detached dispatch: marker, identity, and no status", () => {
+    expect(
+      parseDelegationEnvelope({
+        assistant_id: "asst-1",
+        assistant_name: "Research",
+        delegate_chat_id: "chat-1",
+        background: true,
+      }),
+    ).toMatchObject({
+      status: undefined,
+      background: true,
+      delegateChatId: "chat-1",
+    });
+  });
+
+  it("lets a settled status outrank a stray background marker", () => {
+    expect(
+      parseDelegationEnvelope({
+        ...RUNNING,
+        status: "completed",
+        background: true,
+      }),
+    ).toMatchObject({ status: "completed", background: false });
+  });
+
+  it("rejects a background marker with no run to open", () => {
+    expect(parseDelegationEnvelope({ background: true })).toBeUndefined();
   });
 
   it("reads a settled envelope with its result", () => {
@@ -81,6 +111,7 @@ describe("parseDelegationEnvelope", () => {
       assistantName: undefined,
       delegateChatId: undefined,
       result: undefined,
+      background: false,
       truncated: false,
     });
   });

--- a/frontend/src/lib/delegation/delegationEnvelope.ts
+++ b/frontend/src/lib/delegation/delegationEnvelope.ts
@@ -6,6 +6,9 @@
  * the whole envelope, so one frame is the full picture and the live, resumed,
  * and reloaded views all parse the same thing.
  *
+ * A backgrounded dispatch freezes its part at launch: identity plus a
+ * `background` marker, never a status — the run settles out of sight.
+ *
  * A dispatch that never happened returns `{status: "error", error}` instead —
  * no run, no chat to open, nothing to nest — and is deliberately not an
  * envelope here, so the call renders like any other tool call.
@@ -26,12 +29,17 @@ const SETTLED_STATUSES = new Set([
 const MAX_NAME_CHARS = 128;
 
 export interface DelegationEnvelope {
-  /** Absent while the delegate is still running. */
+  /** Absent while the delegate is still running — or forever, when detached. */
   status?: string;
   assistantId?: string;
   assistantName?: string;
   delegateChatId?: string;
   result?: string;
+  /**
+   * The dispatch detached: the parent turn ended at launch, the part is
+   * frozen as-is, and the run's outcome will never arrive here.
+   */
+  background: boolean;
   /** Whether the backend clipped `result` before sending it. */
   truncated: boolean;
 }
@@ -77,6 +85,12 @@ export function parseDelegationEnvelope(
     assistantName: boundedString(record.assistant_name, MAX_NAME_CHARS),
     delegateChatId,
     result: typeof record.result === "string" ? record.result : undefined,
+    // The marker only means "settled at dispatch" on a status-less part with
+    // a run to point at; anything else keeps its own meaning.
+    background:
+      record.background === true &&
+      status === undefined &&
+      delegateChatId !== undefined,
     truncated: record.truncated === true,
   };
 }

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -3681,6 +3681,11 @@ msgstr "Ausgabe"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/DelegationStep.tsx
+msgid "trace.delegation.background"
+msgstr "In den Hintergrund übergeben"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/DelegationStep.tsx
 msgid "trace.delegation.done"
 msgstr "An {name} delegiert"
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -3681,6 +3681,11 @@ msgstr "Output"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/DelegationStep.tsx
+msgid "trace.delegation.background"
+msgstr "Sent to background"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/DelegationStep.tsx
 msgid "trace.delegation.done"
 msgstr "Delegated to {name}"
 

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -3681,6 +3681,11 @@ msgstr "Salida"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/DelegationStep.tsx
+msgid "trace.delegation.background"
+msgstr "Enviado a segundo plano"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/DelegationStep.tsx
 msgid "trace.delegation.done"
 msgstr "Delegado a {name}"
 

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -3681,6 +3681,11 @@ msgstr "Sortie"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/DelegationStep.tsx
+msgid "trace.delegation.background"
+msgstr "Envoyé en arrière-plan"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/DelegationStep.tsx
 msgid "trace.delegation.done"
 msgstr "Délégué à {name}"
 

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -3681,6 +3681,11 @@ msgstr "Wyjście"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Trace/steps/DelegationStep.tsx
+msgid "trace.delegation.background"
+msgstr "Przekazano do tła"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Trace/steps/DelegationStep.tsx
 msgid "trace.delegation.done"
 msgstr "Przekazano do {name}"
 

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -230,6 +230,7 @@ export { SidecarLocalTraceView } from "@/components/ui/Trace/SidecarLocalTraceVi
 export type { SidecarLocalTraceViewProps } from "@/components/ui/Trace/SidecarLocalTraceView";
 export { DelegationStep } from "@/components/ui/Trace/steps/DelegationStep";
 export { ReasoningStep } from "@/components/ui/Trace/steps/ReasoningStep";
+export { SettledInfoPill } from "@/components/ui/Trace/steps/ToolStatusPill";
 export { ToolStatusPill } from "@/components/ui/Trace/steps/ToolStatusPill";
 export { ToolUseStep } from "@/components/ui/Trace/steps/ToolUseStep";
 export { Trace } from "@/components/ui/Trace/Trace";


### PR DESCRIPTION
On top of #1011 (ERMAIN-640); the base is that branch, so the diff here is this layer alone. Stack: #1011 ask → **this** trace step → runs list → dismissal.

`DelegationStep` was built for awaited runs: `stepStatusFor` maps any envelope status other than `completed` to an error step and prints the raw string, and `isRunning` requires an active stream — so a backgrounded dispatch would render either as a red error pill or as awaited-and-still-going forever.

The backend's contract for a detached dispatch is an envelope with `background: true`, a `delegate_chat_id`, and **no `status` key**. The parser now recognises that as its own settled variant — not overloading the running state — and the step renders it as a deliberate outcome: a calm settled pill, "Running in the background" with the delegate's name, the existing open-run link, and no error tone. No spinner and no elapsed timer, because the step is frozen at dispatch forever (the backend deliberately never backfills the parent's tool part) and must not imply progress it cannot observe.

The two behaviours next to it are regression-guarded: a status-less envelope *without* the marker (an awaited run's mid-stream progress frame) still renders as running while streaming, and refusal (`{status: "error"}`) or malformed envelopes keep the plain-tool fallback. Awaited completed/failed/timeout rendering is unchanged.

New label rides lingui with a stable id in all five locales. The new settled pill export flows through the component registry (regenerated here).

## Tests

Backgrounded envelope → settled presentation, correctly-targeted open-run link, no error styling, no spinner; status-less-without-marker still running-while-streaming; refusal and malformed envelopes fall back to the plain tool step; the full pre-existing DelegationStep suite unchanged and green.

