### PR TITLE
Delegated runs list: dismiss finished background runs (ERMAIN-643)

### DIFF
--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
@@ -1,11 +1,12 @@
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { skipToken } from "@tanstack/react-query";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import {
+  selectAttentionCount,
   selectPollDriverCount,
   useGenerationStatusStore,
 } from "@/hooks/chat/store/generationStatusStore";
@@ -22,6 +23,15 @@ import type { Messages } from "@lingui/core";
 vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
   useRecentChats: vi.fn(() => ({ data: undefined, isLoading: false })),
 }));
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 const recentChat = (overrides: Partial<RecentChat> & { id: string }) =>
   ({
@@ -311,6 +321,153 @@ describe("DelegatedRunsSection", () => {
   });
 });
 
+describe("DelegatedRunsSection check-off", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useGenerationStatusStore.getState().reset();
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+  });
+
+  const settledRuns = () =>
+    mockRuns([
+      recentChat({ id: "run-1", delegated_run_outcome: "completed" }),
+      recentChat({ id: "run-2", delegated_run_outcome: "failed" }),
+    ]);
+
+  it("offers the dismiss action on settled rows only", () => {
+    mockRuns([
+      recentChat({
+        id: "run-1",
+        active_generation_started_at: "2026-08-19T12:00:00.000Z",
+      }),
+      recentChat({ id: "run-2", delegated_run_outcome: "completed" }),
+      recentChat({
+        id: "run-3",
+        pending_tool_approval_at: "2026-08-19T12:01:00.000Z",
+      }),
+    ]);
+
+    renderSection("origin-1");
+    expandRuns();
+
+    const dismissButtons = screen.getAllByTestId("delegated-run-dismiss");
+    expect(dismissButtons).toHaveLength(1);
+    expect(dismissButtons[0].closest('[data-chat-id="run-2"]')).not.toBeNull();
+    expect(dismissButtons[0]).toHaveAccessibleName("Dismiss run");
+  });
+
+  it("removes the checked-off row, keeps the others, and survives a reload", () => {
+    settledRuns();
+    const { unmount } = renderSection("origin-1");
+    expandRuns();
+
+    let rows = screen.getAllByTestId("delegated-run-item");
+    fireEvent.click(within(rows[0]).getByTestId("delegated-run-dismiss"));
+
+    rows = screen.getAllByTestId("delegated-run-item");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("href", "/a/assistant-1/run-2");
+    expect(localStorage.getItem("erato.chat.dismissedDelegatedRuns")).toEqual(
+      JSON.stringify(["run-1"]),
+    );
+
+    // Fresh mount with the listing unchanged (it still returns the run):
+    // the persisted dismissal keeps the row out.
+    unmount();
+    renderSection("origin-1");
+    expandRuns();
+    rows = screen.getAllByTestId("delegated-run-item");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("href", "/a/assistant-1/run-2");
+  });
+
+  it("hides the section entirely once every run is checked off", () => {
+    mockRuns([recentChat({ id: "run-1", delegated_run_outcome: "completed" })]);
+    const { container } = renderSection("origin-1");
+    expandRuns();
+
+    fireEvent.click(screen.getByTestId("delegated-run-dismiss"));
+
+    expect(
+      container.querySelector('[data-ui="delegated-runs-section"]'),
+    ).toBeNull();
+  });
+
+  it("consumes a locally observed outcome so the attention badge drops", () => {
+    mockRuns([recentChat({ id: "run-1" })]);
+    act(() => {
+      const store = useGenerationStatusStore.getState();
+      store.seedRunning("run-1", "2026-08-19T12:00:00.000Z");
+      store.markTerminalLocal("run-1", "finished");
+    });
+
+    renderSection("origin-1");
+    expandRuns();
+    expect(selectAttentionCount(useGenerationStatusStore.getState())).toBe(1);
+
+    fireEvent.click(screen.getByTestId("delegated-run-dismiss"));
+
+    expect(
+      useGenerationStatusStore.getState().statusByChatId["run-1"],
+    ).toMatchObject({ kind: "cleared" });
+    expect(selectAttentionCount(useGenerationStatusStore.getState())).toBe(0);
+  });
+
+  it("keeps a visited run's settled state and check-off across a reload", () => {
+    // The cached listing is stale — fetched while the run still ran — and
+    // this client then watched the run finish before the user opened it.
+    mockRuns([recentChat({ id: "run-1" })]);
+    act(() => {
+      const store = useGenerationStatusStore.getState();
+      store.seedRunning("run-1", "2026-08-19T12:00:00.000Z");
+      store.markTerminalLocal("run-1", "finished");
+      store.setCurrentChatId("run-1");
+    });
+
+    const { unmount } = renderSection("origin-1");
+    expandRuns();
+
+    // Visiting consumed the notification, not the status: the row still
+    // says finished and can still be checked off. (Regression: the volatile
+    // tombstone used to blank both, and a reload — durable outcome, empty
+    // store — brought them back, reading as dismissed runs reappearing.)
+    const row = screen.getByTestId("delegated-run-item");
+    expect(within(row).getByTestId("chat-generation-status")).toHaveAttribute(
+      "data-status",
+      "finished",
+    );
+    fireEvent.click(within(row).getByTestId("delegated-run-dismiss"));
+    expect(screen.queryByTestId("delegated-run-item")).toBeNull();
+
+    // Reload: memory gone, listing fresh with the durable outcome. The
+    // persisted check-off keeps the row out.
+    unmount();
+    act(() => useGenerationStatusStore.getState().reset());
+    mockRuns([recentChat({ id: "run-1", delegated_run_outcome: "completed" })]);
+    const { container } = renderSection("origin-1");
+    expect(
+      container.querySelector('[data-ui="delegated-runs-section"]'),
+    ).toBeNull();
+  });
+
+  it("opening a run still navigates while checking one off does not", () => {
+    settledRuns();
+    renderSection("origin-1");
+    expandRuns();
+
+    const rows = screen.getAllByTestId("delegated-run-item");
+    fireEvent.click(rows[1]);
+    expect(navigateMock).toHaveBeenCalledWith("/a/assistant-1/run-2");
+
+    navigateMock.mockClear();
+    fireEvent.click(within(rows[0]).getByTestId("delegated-run-dismiss"));
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId("delegated-run-item")).toHaveLength(1);
+  });
+});
+
 describe("resolveDelegatedRunStatus", () => {
   const runningStore = {
     kind: "running",
@@ -331,13 +488,22 @@ describe("resolveDelegatedRunStatus", () => {
     ).toBe("running");
   });
 
-  it("shows no indicator for a consumed outcome despite stale row markers", () => {
+  it("shows no indicator for a tombstone that consumed no outcome, despite stale row markers", () => {
     expect(
       resolveDelegatedRunStatus(
         { active_generation_started_at: "2026-08-19T12:00:00.000Z" },
         { kind: "cleared", startedAt: null },
       ),
     ).toBeNull();
+  });
+
+  it("keeps stating the outcome a tombstone consumed, blocking stale live markers", () => {
+    expect(
+      resolveDelegatedRunStatus(
+        { active_generation_started_at: "2026-08-19T12:00:00.000Z" },
+        { kind: "cleared", startedAt: null, consumed: "finished" },
+      ),
+    ).toBe("finished");
   });
 
   it("maps a pending-approval marker to action required before seeding", () => {

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
@@ -1,13 +1,14 @@
 import { t } from "@lingui/core/macro";
 import { skipToken } from "@tanstack/react-query";
 import clsx from "clsx";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import {
   seedGenerationStatusFromListing,
   useGenerationStatusStore,
 } from "@/hooks/chat/store/generationStatusStore";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { useRecentChats } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useAssistantsFeature } from "@/providers/FeatureConfigProvider";
 import {
@@ -23,13 +24,45 @@ import {
 
 import { ChatAttentionStatusDot } from "./ChatAttentionStatusDot";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
+import { Button } from "../Controls/Button";
 import { Collapse } from "../Controls/Collapse";
 import { MessageTimestamp } from "../Message/MessageTimestamp";
-import { OpenNewWindowIcon, ChevronRightIcon } from "../icons";
+import { OpenNewWindowIcon, CheckIcon, ChevronRightIcon } from "../icons";
 
 import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
-const DelegatedRunRow = memo<{ chat: RecentChat }>(({ chat }) => {
+/**
+ * Checked-off runs, deliberately per-device: a run's outcome is a property
+ * of the chat and no per-user seen-state exists server-side, so a dismissal
+ * recorded here does not follow the user to their other devices.
+ */
+const DISMISSED_DELEGATED_RUNS_STORAGE_KEY =
+  "erato.chat.dismissedDelegatedRuns";
+
+/**
+ * Delegated runs stay listable forever, so the set only grows. The cap
+ * bounds it by shedding the oldest dismissals — worst case a long-forgotten
+ * run reappears in its origin chat's section and can be checked off again.
+ */
+const DISMISSED_RUNS_LIMIT = 500;
+
+/** Stable fallback: `useSyncExternalStore` needs a referentially constant
+ * snapshot for the unset case. */
+const NO_DISMISSED_RUN_IDS: readonly string[] = [];
+
+const parseDismissedRunIds = (value: unknown): readonly string[] | null =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? value
+    : null;
+
+// Hoisted so the setter (and with it each row's dismiss callback) keeps a
+// stable identity across renders.
+const DISMISSED_RUN_IDS_OPTIONS = { parse: parseDismissedRunIds };
+
+const DelegatedRunRow = memo<{
+  chat: RecentChat;
+  onDismiss: (chatId: string) => void;
+}>(({ chat, onDismiss }) => {
   const navigate = useNavigate();
   const storeStatus = useGenerationStatusStore(
     (state) => state.statusByChatId[chat.id],
@@ -43,6 +76,7 @@ const DelegatedRunRow = memo<{ chat: RecentChat }>(({ chat }) => {
   const href = getChatUrl(chat.id, chat.assistant_id);
 
   const isLive = status === "running" || status === "action_required";
+  const isSettled = status === "finished" || status === "error";
   // Elapsed anchors to the live generation's start when one is known; a
   // settled run shows when it last wrote instead.
   const liveStartedAt =
@@ -93,6 +127,27 @@ const DelegatedRunRow = memo<{ chat: RecentChat }>(({ chat }) => {
           className="size-3.5 shrink-0 text-theme-fg-muted opacity-0 group-hover/run:opacity-100 group-focus-visible/run:opacity-100"
           aria-hidden="true"
         />
+        {isSettled && (
+          /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- div exists to prevent bubbling */
+          <div
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <Button
+              variant="icon-only"
+              size="sm"
+              icon={<CheckIcon className="size-4" />}
+              aria-label={t({
+                id: "chat.history.delegatedRuns.dismiss",
+                message: "Dismiss run",
+              })}
+              onClick={() => onDismiss(chat.id)}
+              data-testid="delegated-run-dismiss"
+            />
+          </div>
+        )}
       </InteractiveContainer>
     </a>
   );
@@ -135,12 +190,37 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
           }
         : skipToken,
     );
+    const [dismissedRunIds, setDismissedRunIds] = usePersistedState(
+      DISMISSED_DELEGATED_RUNS_STORAGE_KEY,
+      NO_DISMISSED_RUN_IDS,
+      DISMISSED_RUN_IDS_OPTIONS,
+    );
     // Awaited delegations already delivered their answer inline to the
     // origin turn; only detached (background) runs have a life of their own
-    // worth listing here.
+    // worth listing here. A row leaves this list through the persisted
+    // check-off and nothing else: opening a run keeps both the row and its
+    // settled status — the dot is a status column, not an unread marker —
+    // so what the list shows never rides in-memory state a reload drops.
     const runs = useMemo(
-      () => (data?.chats ?? []).filter(isBackgroundRun),
-      [data?.chats],
+      () =>
+        (data?.chats ?? [])
+          .filter(isBackgroundRun)
+          .filter((chat) => !dismissedRunIds.includes(chat.id)),
+      [data?.chats, dismissedRunIds],
+    );
+
+    const dismissRun = useCallback(
+      (chatId: string) => {
+        // Also consume a locally observed outcome so the attention badge
+        // stops counting the checked-off run.
+        useGenerationStatusStore.getState().consumeTerminalOutcome(chatId);
+        setDismissedRunIds((previous) =>
+          previous.includes(chatId)
+            ? previous
+            : [...previous, chatId].slice(-DISMISSED_RUNS_LIMIT),
+        );
+      },
+      [setDismissedRunIds],
     );
 
     // Seed the status store from the listing's running and pending-approval
@@ -215,7 +295,11 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
                 data-ui="delegated-runs-list"
               >
                 {runs.map((chat) => (
-                  <DelegatedRunRow key={chat.id} chat={chat} />
+                  <DelegatedRunRow
+                    key={chat.id}
+                    chat={chat}
+                    onDismiss={dismissRun}
+                  />
                 ))}
               </div>
             )}

--- a/frontend/src/hooks/chat/store/__tests__/generationStatusStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/generationStatusStore.test.ts
@@ -305,6 +305,39 @@ describe("generationStatusStore", () => {
     });
   });
 
+  describe("consumeTerminalOutcome", () => {
+    it("tombstones a finished outcome and blocks stale re-seeding", () => {
+      store().seedRunning("chat-1", iso(0));
+      store().markTerminalLocal("chat-1", "finished");
+      store().consumeTerminalOutcome("chat-1");
+      // The consumed kind survives on the tombstone, so status surfaces can
+      // keep stating the outcome a reload would restore from the listing.
+      expect(statusOf("chat-1")).toMatchObject({
+        kind: "cleared",
+        startedAt: iso(0),
+        consumed: "finished",
+      });
+
+      // Stale list row still carrying the consumed generation's marker.
+      store().seedRunning("chat-1", iso(0));
+      expect(statusOf("chat-1")).toMatchObject({ kind: "cleared" });
+      expect(selectAttentionCount(store())).toBe(0);
+    });
+
+    it("leaves live entries and unknown chats untouched", () => {
+      store().seedRunning("chat-1", iso(0));
+      store().consumeTerminalOutcome("chat-1");
+      expect(statusOf("chat-1")).toMatchObject({ kind: "running" });
+
+      store().seedActionRequired("chat-2", iso(0));
+      store().consumeTerminalOutcome("chat-2");
+      expect(statusOf("chat-2")).toMatchObject({ kind: "action_required" });
+
+      store().consumeTerminalOutcome("chat-3");
+      expect(statusOf("chat-3")).toBeUndefined();
+    });
+  });
+
   describe("setCurrentChatId", () => {
     it("clears a terminal status on the chat being navigated to", () => {
       store().seedRunning("chat-1", iso(0));
@@ -313,6 +346,7 @@ describe("generationStatusStore", () => {
       expect(statusOf("chat-1")).toMatchObject({
         kind: "cleared",
         startedAt: iso(0),
+        consumed: "finished",
       });
       expect(store().currentChatId).toBe("chat-1");
     });

--- a/frontend/src/hooks/chat/store/generationStatusStore.ts
+++ b/frontend/src/hooks/chat/store/generationStatusStore.ts
@@ -12,8 +12,13 @@ import type {
  * "finished"/"error" exist only when this client observed a chat leave the
  * running set, so a page refresh clears them by design. "cleared" is a
  * tombstone left when an outcome is consumed (or a running entry goes
- * unknown): it renders nothing but remembers which generation it refers to,
- * so stale list rows and in-flight poll responses cannot resurrect it.
+ * unknown): it remembers which generation it refers to, so stale list rows
+ * and in-flight poll responses cannot resurrect it. Notification surfaces
+ * (badges, sidebar dots) render nothing for it; when the outcome kind was
+ * known at consumption it survives in `consumed`, so status surfaces (the
+ * delegated-runs checklist, the trace pill) can keep stating the truth — a
+ * reload replaces them with the durable listing outcome, and the two must
+ * agree or visited runs appear to change state across reloads.
  *
  * `startedAt` carries the server-side start time when seeded from list rows
  * or the poll, and the client clock when seeded by this tab's own sends —
@@ -31,7 +36,12 @@ export type ChatGenerationStatus =
   | { kind: "action_required"; startedAt: string; localSeenAt: number }
   | { kind: "finished"; startedAt: string | null }
   | { kind: "error"; startedAt: string | null }
-  | { kind: "cleared"; startedAt: string | null };
+  | {
+      kind: "cleared";
+      startedAt: string | null;
+      /** Outcome kind this tombstone consumed, when one was known. */
+      consumed?: "finished" | "error";
+    };
 
 /**
  * A freshly seeded running entry is not cleared by a poll snapshot that does
@@ -57,6 +67,10 @@ interface GenerationStatusStore {
   markApprovalDecided: (chatId: string) => void;
   applyPollSnapshot: (entries: GeneratingChat[]) => void;
   markTerminalLocal: (chatId: string, kind: "finished" | "error") => void;
+  /** The user acknowledged a finished/error outcome without opening the chat
+   * (e.g. checked its run off a list); tombstone it so badges stop counting
+   * it while stale rows still cannot resurrect it. */
+  consumeTerminalOutcome: (chatId: string) => void;
   setCurrentChatId: (chatId: string | null) => void;
   clearStatus: (chatId: string) => void;
   reset: () => void;
@@ -241,6 +255,7 @@ export const useGenerationStatusStore = create<GenerationStatusStore>()(
                 next[entry.chat_id] = {
                   kind: "cleared",
                   startedAt: entry.started_at,
+                  consumed: entry.state === "completed" ? "finished" : "error",
                 };
               } else {
                 next[entry.chat_id] =
@@ -287,7 +302,7 @@ export const useGenerationStatusStore = create<GenerationStatusStore>()(
               return {
                 statusByChatId: {
                   ...prev.statusByChatId,
-                  [chatId]: { kind: "cleared", startedAt },
+                  [chatId]: { kind: "cleared", startedAt, consumed: kind },
                 },
               };
             }
@@ -300,6 +315,30 @@ export const useGenerationStatusStore = create<GenerationStatusStore>()(
           },
           false,
           "generationStatus/markTerminalLocal",
+        ),
+
+      consumeTerminalOutcome: (chatId) =>
+        set(
+          (prev) => {
+            const existing = prev.statusByChatId[chatId];
+            // A live entry stays: the acknowledgement targets an outcome, and
+            // a run that is generating (again) has none to consume yet.
+            if (existing?.kind !== "finished" && existing?.kind !== "error") {
+              return prev;
+            }
+            return {
+              statusByChatId: {
+                ...prev.statusByChatId,
+                [chatId]: {
+                  kind: "cleared",
+                  startedAt: existing.startedAt,
+                  consumed: existing.kind,
+                },
+              },
+            };
+          },
+          false,
+          "generationStatus/consumeTerminalOutcome",
         ),
 
       setCurrentChatId: (chatId) =>
@@ -322,6 +361,7 @@ export const useGenerationStatusStore = create<GenerationStatusStore>()(
                   [chatId as string]: {
                     kind: "cleared",
                     startedAt: status.startedAt,
+                    consumed: status.kind,
                   },
                 },
               };

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1368,6 +1368,11 @@ msgid "chat.history.delegatedRuns"
 msgstr "Delegierte Läufe"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.dismiss"
+msgstr "Lauf ausblenden"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Gruppieren nach"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1368,6 +1368,11 @@ msgid "chat.history.delegatedRuns"
 msgstr "Delegated runs"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.dismiss"
+msgstr "Dismiss run"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Group by"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1368,6 +1368,11 @@ msgid "chat.history.delegatedRuns"
 msgstr "Ejecuciones delegadas"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.dismiss"
+msgstr "Descartar ejecución"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Agrupar por"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1368,6 +1368,11 @@ msgid "chat.history.delegatedRuns"
 msgstr "Exécutions déléguées"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.dismiss"
+msgstr "Ignorer l'exécution"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Regrouper par"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1368,6 +1368,11 @@ msgid "chat.history.delegatedRuns"
 msgstr "Delegowane uruchomienia"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.dismiss"
+msgstr "Odrzuć uruchomienie"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Grupuj według"

--- a/frontend/src/utils/chatHistoryGrouping.ts
+++ b/frontend/src/utils/chatHistoryGrouping.ts
@@ -63,11 +63,14 @@ const RUN_OUTCOME_FAILED = "failed";
  * authority (seeded from the listing and kept fresh by the poll), so a
  * running or parked entry outranks the listing's terminal outcome — a chat
  * can be generating again after adoption while its outcome already exists.
- * A "cleared" tombstone means an observed outcome was consumed, so neither
- * the stale listing markers nor a pending fallback may resurrect it; the row
- * shows no indicator until the refetched listing carries the durable
- * outcome. A row with no signal at all is a run between dispatch and its
- * generation lease, which is live, not broken.
+ * This is a status column, not an unread marker: a "cleared" tombstone
+ * (outcome consumed, e.g. by opening the run) keeps saying the consumed
+ * outcome here, exactly what the refetched listing's durable outcome will
+ * say after a reload — while still blocking the stale listing markers and
+ * the pending fallback from resurrecting a live state. A tombstone that
+ * consumed no outcome (a decided approval, an entry that went unknown)
+ * shows nothing. A row with no signal at all is a run between dispatch and
+ * its generation lease, which is live, not broken.
  */
 export function resolveDelegatedRunStatus(
   chat: Pick<
@@ -89,7 +92,7 @@ export function resolveDelegatedRunStatus(
   if (storeStatus?.kind === "finished" || storeStatus?.kind === "error") {
     return storeStatus.kind;
   }
-  if (storeStatus?.kind === "cleared") return null;
+  if (storeStatus?.kind === "cleared") return storeStatus.consumed ?? null;
   if (chat.pending_tool_approval_at) return "action_required";
   return "running";
 }


### PR DESCRIPTION
Top of the ERMAIN-633 frontend stack, on #1013 (ERMAIN-642); diff is this layer alone. Stack: #1011 ask → #1012 trace → #1013 runs list → **this**.

A finished background run should be dismissible so the list drains rather than accumulating. The semantics existed already — the generation-status store's `"cleared"` variant is precisely a dismissal tombstone — but they were in-memory by design and vanished on refresh.

**Deliberate v1 shape: local, per-device persistence.** The durable-completion work made a run's outcome a property of the chat itself, and there is no per-user seen/dismissed seat in the backend schema — so dismissal persists client-side (the same storage mechanism the repo's persisted state uses, keyed per run chat id). "Dismissed on my laptop doesn't follow to my phone" is the accepted trade-off until a real user-preference store exists; recorded in code.

Behaviour: terminal rows (completed or failed) gain an unobtrusive check-off action with an accessible label — never offered on running or parked rows. Dismissing removes the row, survives reload, and doesn't resurface when the listing refetches; the section count/badge covers only undismissed runs; other runs are unaffected. No success toast — the row disappearing is the feedback, per the repo's convention. Opening the run itself is untouched and remains the way to actually read the result.

## Tests

Dismiss removes the row and survives a simulated remount/reload; the action exists only on terminal rows; refetch does not resurrect a dismissed run; a different run is unaffected; the count excludes dismissed; the open-run flow still works. Full frontend suite at this tip: 1380 passed, prettier/eslint/both tsc configs/i18n catalogs/component registry all clean.

## Refined after manual testing

The reported "dismissed runs reappear after reload" was not the persisted check-off failing — it was **visited** runs: opening a run consumed its outcome into the volatile in-memory tombstone, which masked the row's settled state (dot *and* dismiss affordance), so it merely looked dealt-with; a reload dropped the tombstone and the durable outcome resurrected it. Fixed semantically: cleared tombstones now record which outcome they consumed and the checklist resolver keeps stating it — the dot is a status column, not an unread marker — so a visited run keeps its truthful settled state and stays dismissible, identical before and after reload. A row leaves this list through the persisted check-off and nothing else. Notification surfaces (sidebar badges) keep their consumption semantics unchanged. Regression test simulates stale listing → observed finish → visit → dismiss → reload with real storage.

Known follow-up (not a bug here): the dismissal storage key is per-device and per-browser-profile, not per-user — worth revisiting if shared-device deployments matter.