### PR TITLE
Record MCP servers skipped for missing OAuth authorization in generation metadata (ERMAIN-657)

### DIFF
--- a/backend/erato/src/models/message.rs
+++ b/backend/erato/src/models/message.rs
@@ -179,6 +179,11 @@ pub struct GenerationMetadata {
     /// MCP server IDs that were unavailable while preparing this generation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp_servers_unavailable: Option<Vec<String>>,
+    /// MCP server IDs skipped because the requesting user had not completed
+    /// the server's OAuth authorization. Distinct from unavailable: these
+    /// servers work, the user just needs to connect them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_servers_needing_auth: Option<Vec<String>>,
 }
 
 /// Role of the message author (as defined by the LLM providers)

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1631,6 +1631,9 @@ pub struct PreparedChatRequest {
     generation_request_context: GenerationRequestContext,
     // MCP servers that were unavailable while listing tools for this request.
     mcp_servers_unavailable: Vec<String>,
+    // MCP servers skipped while listing tools because the requesting user has
+    // not completed their OAuth authorization (user-fixable, unlike the above).
+    mcp_servers_needing_auth: Vec<String>,
     // Filtered MCP tools available to this request, including server routing info.
     available_mcp_tools: Vec<crate::services::mcp_session_manager::ManagedTool>,
     // Park budgets of the client tools OFFERED to this request, keyed by the
@@ -1843,6 +1846,7 @@ impl LangfuseTraceEnrichment {
         assistant_id: Option<Uuid>,
         tool_names: &HashSet<String>,
         mcp_servers_unavailable: &[String],
+        mcp_servers_needing_auth: &[String],
         was_aborted: bool,
     ) -> Option<JsonValue> {
         let mut tool_names: Vec<String> = tool_names.iter().cloned().collect();
@@ -1852,6 +1856,7 @@ impl LangfuseTraceEnrichment {
             &tool_names,
             &self.filenames,
             mcp_servers_unavailable,
+            mcp_servers_needing_auth,
             was_aborted,
             Some(&self.platform),
         )
@@ -2629,6 +2634,7 @@ pub(crate) async fn prepare_chat_request_with_adapters(
         generation_parameters,
         generation_request_context,
         mcp_servers_unavailable: tool_discovery.unavailable_server_ids,
+        mcp_servers_needing_auth: tool_discovery.needing_auth_server_ids,
         available_mcp_tools: generation_mcp_tools.clone(),
         offered_client_tool_timeouts,
         chat_request,
@@ -2880,6 +2886,7 @@ async fn stream_generate_chat_completion<
     _user_groups: &[String],
     mcp_auth_context: McpRequestAuthContext<'_>,
     mcp_servers_unavailable: Vec<String>,
+    mcp_servers_needing_auth: Vec<String>,
     allowed_tool_names: HashSet<String>,
     available_mcp_tools: Vec<crate::services::mcp_session_manager::ManagedTool>,
     offered_client_tool_timeouts: HashMap<String, Option<u64>>,
@@ -2937,6 +2944,7 @@ async fn stream_generate_chat_completion<
             assistant_id,
             &initial_tool_names,
             &mcp_servers_unavailable,
+            &mcp_servers_needing_auth,
             false,
         );
         let tags = langfuse_trace_enrichment.all_tags(&model_tags, &initial_tool_names);
@@ -3034,6 +3042,7 @@ async fn stream_generate_chat_completion<
                 || was_aborted
                 || error.is_some()
                 || !mcp_servers_unavailable.is_empty()
+                || !mcp_servers_needing_auth.is_empty()
             {
                 Some(GenerationMetadata {
                     used_prompt_tokens: if total_prompt_tokens > 0 {
@@ -3064,6 +3073,8 @@ async fn stream_generate_chat_completion<
                     error,
                     mcp_servers_unavailable: (!mcp_servers_unavailable.is_empty())
                         .then(|| mcp_servers_unavailable.clone()),
+                    mcp_servers_needing_auth: (!mcp_servers_needing_auth.is_empty())
+                        .then(|| mcp_servers_needing_auth.clone()),
                 })
             } else {
                 None
@@ -4402,6 +4413,8 @@ async fn stream_generate_chat_completion<
                             let trace_model_tags = all_model_tags.clone();
                             let trace_mcp_servers_unavailable =
                                 mcp_servers_unavailable.clone();
+                            let trace_mcp_servers_needing_auth =
+                                mcp_servers_needing_auth.clone();
                             let trace_tags =
                                 trace_enrichment.all_tags(&trace_model_tags, &trace_tool_names);
                             let uses_otel = client.uses_otel();
@@ -4454,6 +4467,7 @@ async fn stream_generate_chat_completion<
                                         assistant_id_for_langfuse,
                                         &trace_tool_names,
                                         &trace_mcp_servers_unavailable,
+                                        &trace_mcp_servers_needing_auth,
                                         true,
                                     ) && let Err(err) =
                                         client.update_trace_metadata(metadata).await
@@ -5011,6 +5025,7 @@ async fn stream_generate_chat_completion<
                         let trace_tool_names = all_tool_names.clone();
                         let trace_model_tags = all_model_tags.clone();
                         let trace_mcp_servers_unavailable = mcp_servers_unavailable.clone();
+                        let trace_mcp_servers_needing_auth = mcp_servers_needing_auth.clone();
                         tokio::spawn(async move {
                             // Update trace output
                             if let Err(e) = client.update_trace_output(output_json).await {
@@ -5031,6 +5046,7 @@ async fn stream_generate_chat_completion<
                                 assistant_id_for_trace,
                                 &trace_tool_names,
                                 &trace_mcp_servers_unavailable,
+                                &trace_mcp_servers_needing_auth,
                                 false,
                             ) {
                                 if let Err(e) = client.update_trace_metadata(metadata).await {
@@ -5094,6 +5110,7 @@ async fn stream_generate_chat_completion<
                         assistant_id,
                         &all_tool_names,
                         &mcp_servers_unavailable,
+                        &mcp_servers_needing_auth,
                         false,
                     );
                     tokio::spawn(async move {
@@ -5524,7 +5541,7 @@ pub async fn generate_chat_summary(
             model_tags.insert(langfuse_model_tag(&model_name));
 
             let trace_metadata =
-                enrichment.trace_metadata(chat.assistant_id, &tool_names, &[], false);
+                enrichment.trace_metadata(chat.assistant_id, &tool_names, &[], &[], false);
             let trace_tags = enrichment.all_tags(&model_tags, &tool_names);
             let assistant_id_for_langfuse = chat.assistant_id;
             let platform = enrichment.platform.clone();
@@ -7282,6 +7299,7 @@ mod reasoning_replay_tests {
             was_aborted: None,
             error: None,
             mcp_servers_unavailable: None,
+            mcp_servers_needing_auth: None,
         }
     }
 
@@ -7933,6 +7951,7 @@ fn generation_metadata_for_error(error: GenerationErrorType) -> GenerationMetada
         was_aborted: None,
         error: Some(error),
         mcp_servers_unavailable: None,
+        mcp_servers_needing_auth: None,
     }
 }
 
@@ -8143,6 +8162,7 @@ pub(crate) async fn run_message_submit_task(
         generation_parameters,
         generation_request_context,
         mcp_servers_unavailable,
+        mcp_servers_needing_auth,
         available_mcp_tools,
         offered_client_tool_timeouts,
         delegation_targets,
@@ -8290,6 +8310,7 @@ pub(crate) async fn run_message_submit_task(
         &me_user.groups,
         mcp_auth_context,
         mcp_servers_unavailable,
+        mcp_servers_needing_auth,
         allowed_tool_names,
         available_mcp_tools,
         offered_client_tool_timeouts,
@@ -8612,6 +8633,7 @@ pub async fn regenerate_message_sse(
                 generation_parameters,
                 generation_request_context,
                 mcp_servers_unavailable,
+                mcp_servers_needing_auth,
                 available_mcp_tools,
                 offered_client_tool_timeouts,
                 delegation_targets,
@@ -8711,6 +8733,7 @@ pub async fn regenerate_message_sse(
                     &me_user.groups,
                     mcp_auth_context,
                     mcp_servers_unavailable,
+                    mcp_servers_needing_auth,
                     allowed_tool_names,
                     available_mcp_tools,
                     offered_client_tool_timeouts,
@@ -9109,6 +9132,7 @@ pub async fn edit_message_sse(
                 generation_parameters,
                 generation_request_context,
                 mcp_servers_unavailable,
+                mcp_servers_needing_auth,
                 available_mcp_tools,
                 offered_client_tool_timeouts,
                 delegation_targets,
@@ -9208,6 +9232,7 @@ pub async fn edit_message_sse(
                     &me_user.groups,
                     mcp_auth_context,
                     mcp_servers_unavailable,
+                    mcp_servers_needing_auth,
                     allowed_tool_names,
                     available_mcp_tools,
                     offered_client_tool_timeouts,
@@ -9673,6 +9698,7 @@ async fn run_continue_message_task(
         .await;
     let available_mcp_tools = mcp_tool_discovery.tools;
     let mcp_servers_unavailable = mcp_tool_discovery.unavailable_server_ids;
+    let mcp_servers_needing_auth = mcp_tool_discovery.needing_auth_server_ids;
     let tool_use = if is_approved {
         let managed_tool = available_mcp_tools
             .iter()
@@ -9812,6 +9838,7 @@ async fn run_continue_message_task(
             &me_user.groups,
             mcp_auth_context,
             mcp_servers_unavailable,
+            mcp_servers_needing_auth,
             allowed_tool_names,
             available_mcp_tools,
             HashMap::new(),

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -1429,6 +1429,11 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     mcp_servers_unavailable: Option<Vec<String>>,
+    /// MCP server IDs skipped for this generation because the requesting user
+    /// has not completed the server's OAuth authorization yet
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    mcp_servers_needing_auth: Option<Vec<String>>,
     /// When the message was created
     created_at: DateTime<FixedOffset>,
     /// When the message was last updated
@@ -2168,6 +2173,9 @@ impl ChatMessage {
         let mcp_servers_unavailable = generation_metadata
             .as_ref()
             .and_then(|metadata| metadata.mcp_servers_unavailable.clone());
+        let mcp_servers_needing_auth = generation_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.mcp_servers_needing_auth.clone());
         Ok(ChatMessage {
             id: msg.id.to_string(),
             chat_id: msg.chat_id.to_string(),
@@ -2176,6 +2184,7 @@ impl ChatMessage {
             error,
             error_report: None,
             mcp_servers_unavailable,
+            mcp_servers_needing_auth,
             created_at: msg.created_at,
             updated_at: msg.updated_at,
             previous_message_id: msg.previous_message_id.map(|id| id.to_string()),

--- a/backend/erato/src/services/genai_langfuse.rs
+++ b/backend/erato/src/services/genai_langfuse.rs
@@ -278,6 +278,7 @@ pub fn create_trace_metadata(
     tool_names: &[String],
     filenames: &[String],
     mcp_servers_unavailable: &[String],
+    mcp_servers_needing_auth: &[String],
     was_aborted: bool,
     platform: Option<&str>,
 ) -> Option<JsonValue> {
@@ -300,6 +301,13 @@ pub fn create_trace_metadata(
         metadata.insert(
             "mcp_servers_unavailable".to_string(),
             json!(mcp_servers_unavailable),
+        );
+    }
+
+    if !mcp_servers_needing_auth.is_empty() {
+        metadata.insert(
+            "mcp_servers_needing_auth".to_string(),
+            json!(mcp_servers_needing_auth),
         );
     }
 
@@ -902,6 +910,7 @@ mod tests {
             &["search".to_string()],
             &["report.pdf".to_string(), "notes.txt".to_string()],
             &["mock_mcp_unavailable_500".to_string()],
+            &["mock_mcp_oauth".to_string()],
             true,
             Some("web"),
         )
@@ -914,7 +923,8 @@ mod tests {
                 "erato_platform": "web",
                 "erato_generation_aborted": true,
                 "filenames": ["report.pdf", "notes.txt"],
-                "mcp_servers_unavailable": ["mock_mcp_unavailable_500"]
+                "mcp_servers_unavailable": ["mock_mcp_unavailable_500"],
+                "mcp_servers_needing_auth": ["mock_mcp_oauth"]
             })
         );
     }

--- a/backend/erato/src/services/mcp_manager.rs
+++ b/backend/erato/src/services/mcp_manager.rs
@@ -38,7 +38,14 @@ pub struct ManagedToolCall {
 #[derive(Debug, Clone, Default)]
 pub struct ToolDiscoveryResult {
     pub tools: Vec<ManagedTool>,
+    /// Servers that could not be reached or errored: broken from the user's
+    /// point of view, nothing they can do about it.
     pub unavailable_server_ids: Vec<String>,
+    /// Servers skipped because the requesting user has not completed the
+    /// server's OAuth authorization: the user can fix these by connecting.
+    /// Kept apart from `unavailable_server_ids` so surfaces can offer the
+    /// connect action instead of reporting an outage.
+    pub needing_auth_server_ids: Vec<String>,
 }
 
 impl Default for McpServers {

--- a/backend/erato/src/services/mcp_session_manager.rs
+++ b/backend/erato/src/services/mcp_session_manager.rs
@@ -457,6 +457,7 @@ impl McpSessionManager {
     ) -> ToolDiscoveryResult {
         let mut all_tools = Vec::new();
         let mut unavailable_server_ids = Vec::new();
+        let mut needing_auth_server_ids = Vec::new();
         let server_ids: Vec<String> = self
             .server_configs
             .keys()
@@ -498,6 +499,12 @@ impl McpSessionManager {
                             error = %e,
                             "Skipping MCP server during tool discovery because OAuth authorization is required"
                         );
+                        // Deliberately non-fatal and NOT `unavailable`: the
+                        // server is fine, this user just has not connected it
+                        // yet. Recording the id (instead of swallowing the
+                        // skip) is what lets a shared assistant tell the user
+                        // why its tools differ for them.
+                        needing_auth_server_ids.push(server_id);
                         continue;
                     }
                     if Self::is_auth_denied_error(&e) {
@@ -536,10 +543,12 @@ impl McpSessionManager {
         );
 
         unavailable_server_ids.sort();
+        needing_auth_server_ids.sort();
 
         ToolDiscoveryResult {
             tools: all_tools,
             unavailable_server_ids,
+            needing_auth_server_ids,
         }
     }
 

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -4590,6 +4590,7 @@ fn answer_metadata(
         was_aborted: was_aborted.then_some(true),
         error,
         mcp_servers_unavailable: None,
+        mcp_servers_needing_auth: None,
     }
 }
 

--- a/backend/erato/tests/integration_tests/api/messages.rs
+++ b/backend/erato/tests/integration_tests/api/messages.rs
@@ -6,7 +6,8 @@ use axum_test::TestServer;
 use chrono::Utc;
 use erato::config::{
     ActionFacetConfig, ExperimentalFacetsConfig, FacetConfig, McpServerAuthenticationConfig,
-    McpServerConfig, ModelSettings, PromptSourceSpecification, SecretConfigString,
+    McpServerConfig, McpServerOauth2AuthenticationConfig, ModelSettings, PromptSourceSpecification,
+    SecretConfigString,
 };
 use erato::db::entity::{chat_file_uploads, chats, file_uploads};
 use erato::models::message::{GenerationInputMessages, GenerationParameters};
@@ -19,10 +20,12 @@ use sqlx::Pool;
 use sqlx::postgres::Postgres;
 use std::collections::HashMap;
 use std::env;
+use std::net::{IpAddr, Ipv4Addr};
 
 use mocktail::MockSet;
 use mocktail::body::BodyAction;
 use mocktail::mock_builder::Then;
+use mocktail::server::{MockServer, MockServerConfig};
 
 use crate::test_app_state;
 use crate::test_utils::{
@@ -3340,6 +3343,189 @@ async fn test_message_submit_tolerates_unavailable_mcp_server_and_records_metada
                 .find(|message| message["id"] == assistant_message_id.to_string())
         })
         .expect("Expected assistant message in chat messages response");
+    assert_eq!(
+        fetched_assistant_message["mcp_servers_unavailable"],
+        json!(["failing-500"])
+    );
+}
+
+/// An OAuth2 MCP server the requesting user has not connected yet is skipped
+/// without failing generation, and the skip is recorded under
+/// `mcp_servers_needing_auth` — never under `mcp_servers_unavailable`, which
+/// stays reserved for genuinely broken servers. A healthy server appears in
+/// neither list.
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_message_submit_records_mcp_server_needing_oauth_authorization(pool: Pool<Postgres>) {
+    let mock_mcp_base_url = mock_mcp_base_url();
+    let (mut app_config, _llm_server) = setup_mock_llm_server(None).await;
+
+    // The OAuth mock only serves authorization-server metadata. That is all
+    // the "configured but not connected" state needs: token resolution finds
+    // the metadata, then fails with AuthorizationRequired because no
+    // credentials are stored for the user — before any MCP request is made.
+    let mut oauth_mocks = MockSet::new();
+    oauth_mocks.mock(|when, then| {
+        when.get()
+            .path("/.well-known/oauth-authorization-server/oauth");
+        then.status(http::StatusCode::OK)
+            .headers([("Content-Type", "application/json")])
+            .json(json!({
+                "authorization_endpoint": "http://127.0.0.1:1/authorize",
+                "token_endpoint": "http://127.0.0.1:1/token",
+            }));
+    });
+    let mockserver_config = MockServerConfig {
+        listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        ..Default::default()
+    };
+    let oauth_server = MockServer::new_http("mcp-oauth-mock")
+        .with_config(mockserver_config)
+        .with_mocks(oauth_mocks);
+    oauth_server
+        .start()
+        .await
+        .expect("Failed to start OAuth metadata mock server");
+    let oauth_server_base_url = oauth_server.url("").to_string();
+    let oauth_server_base_url = oauth_server_base_url.trim_end_matches('/');
+
+    app_config.mcp_servers.insert(
+        "healthy-file".to_string(),
+        mcp_server_config(
+            &mock_mcp_base_url,
+            "/mcp/file",
+            McpServerAuthenticationConfig::None,
+        ),
+    );
+    app_config.mcp_servers.insert(
+        "failing-500".to_string(),
+        mcp_server_config(
+            &mock_mcp_base_url,
+            "/mcp/list-tools-500",
+            McpServerAuthenticationConfig::None,
+        ),
+    );
+    app_config.mcp_servers.insert(
+        "oauth-pending".to_string(),
+        mcp_server_config(
+            oauth_server_base_url,
+            "/oauth",
+            McpServerAuthenticationConfig::Oauth2 {
+                oauth2: McpServerOauth2AuthenticationConfig {
+                    client_id: Some("test-oauth-client".to_string()),
+                    client_secret: None,
+                    scopes: vec![],
+                    client_name: None,
+                },
+            },
+        ),
+    );
+    app_config.mcp_server_permissions.rules.insert(
+        "allow-mcp-servers".to_string(),
+        erato::config::McpServerPermissionRule::AllowAll {
+            mcp_server_ids: vec![
+                "healthy-file".to_string(),
+                "failing-500".to_string(),
+                "oauth-pending".to_string(),
+            ],
+        },
+    );
+
+    let test_token = JwtTokenBuilder::new()
+        .subject("oauth-pending-user")
+        .email("oauth-pending@example.com")
+        .name("oauth-pending-user")
+        .build();
+
+    let app_state = test_app_state(app_config, pool).await;
+    let _user = get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "oauth-pending-user",
+        Some("oauth-pending@example.com"),
+    )
+    .await
+    .expect("Failed to create user");
+
+    let app: Router = router(app_state.clone())
+        .split_for_parts()
+        .0
+        .with_state(app_state.clone());
+    let server = TestServer::new(app.into_make_service()).expect("Failed to create test server");
+
+    let response = server
+        .post("/api/v1beta/me/messages/submitstream")
+        .with_bearer_token(&test_token)
+        .json(&json!({
+            "user_message": "Hello, some of my servers are not connected yet"
+        }))
+        .await;
+    response.assert_status_ok();
+
+    let events = parse_sse_events(&response);
+    let assistant_completed = events
+        .iter()
+        .find_map(|event| {
+            let json: Value = serde_json::from_str(&event.data).ok()?;
+            (json["message_type"] == "assistant_message_completed").then_some(json)
+        })
+        .expect("Expected assistant_message_completed event");
+
+    assert_eq!(
+        assistant_completed["message"]["mcp_servers_needing_auth"],
+        json!(["oauth-pending"])
+    );
+    assert_eq!(
+        assistant_completed["message"]["mcp_servers_unavailable"],
+        json!(["failing-500"])
+    );
+
+    let assistant_message_id = Uuid::parse_str(
+        assistant_completed["message_id"]
+            .as_str()
+            .expect("assistant_message_completed should contain message_id"),
+    )
+    .expect("assistant message id should be a uuid");
+
+    let saved_message = erato::db::entity::messages::Entity::find_by_id(assistant_message_id)
+        .one(&app_state.db)
+        .await
+        .expect("Failed to load saved message")
+        .expect("Expected saved assistant message");
+
+    let generation_metadata = saved_message
+        .generation_metadata
+        .expect("Expected generation metadata on assistant message");
+    assert_eq!(
+        generation_metadata["mcp_servers_needing_auth"],
+        json!(["oauth-pending"])
+    );
+    assert_eq!(
+        generation_metadata["mcp_servers_unavailable"],
+        json!(["failing-500"])
+    );
+
+    let chat_messages_response = server
+        .get(&format!(
+            "/api/v1beta/chats/{}/messages",
+            saved_message.chat_id
+        ))
+        .with_bearer_token(&test_token)
+        .await;
+    chat_messages_response.assert_status_ok();
+
+    let body: Value = chat_messages_response.json();
+    let fetched_assistant_message = body["messages"]
+        .as_array()
+        .and_then(|messages| {
+            messages
+                .iter()
+                .find(|message| message["id"] == assistant_message_id.to_string())
+        })
+        .expect("Expected assistant message in chat messages response");
+    assert_eq!(
+        fetched_assistant_message["mcp_servers_needing_auth"],
+        json!(["oauth-pending"])
+    );
     assert_eq!(
         fetched_assistant_message["mcp_servers_unavailable"],
         json!(["failing-500"])

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -4847,6 +4847,13 @@
             "type": "boolean",
             "description": "Whether this message is in the active thread"
           },
+          "mcp_servers_needing_auth": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "MCP server IDs skipped for this generation because the requesting user\nhas not completed the server's OAuth authorization yet"
+          },
           "mcp_servers_unavailable": {
             "type": "array",
             "items": {

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -713,6 +713,11 @@ export type ChatMessage = {
    */
   is_message_in_active_thread: boolean;
   /**
+   * MCP server IDs skipped for this generation because the requesting user
+   * has not completed the server's OAuth authorization yet
+   */
+  mcp_servers_needing_auth?: string[];
+  /**
    * MCP server IDs that were unavailable while preparing this generation
    */
   mcp_servers_unavailable?: string[];


### PR DESCRIPTION
First layer of the ERMAIN-657 stack (OAuth MCP visibility), based on main. Stack above: assistant server-attachment UI → chat connect hint.

Tool discovery used to swallow the case that matters most for shared assistants: a server the requesting user simply has not OAuth-connected was skipped with a debug log — no entry in `mcp_servers_unavailable`, no metadata, nothing anywhere. A shared assistant therefore silently behaved differently per user, and nobody could tell why.

Discovery now classifies that skip into its own channel, kept strictly apart from genuine failures: **needing auth** = the server works, this user can fix it by connecting; **unavailable** = the server is broken. `mcp_servers_needing_auth` mirrors `mcp_servers_unavailable` at every consumer — persisted generation metadata (including the presence gate, so a generation whose only anomaly is an unconnected server still records it), the `ChatMessage` API type (chat GET, the completion SSE event, share-links route), and Langfuse trace metadata. The skip stays non-fatal; this layer only records — rendering is the third layer.

Deliberately unchanged: the strict tool-approval continue path still tolerates needing-auth servers silently, so a user's unconnected server can never block an approved tool call. The success path is byte-identical for connected users.

OpenAPI and the TS client regenerated.

## Tests

One generation against three configured servers asserts exact-list separation end to end (SSE completion message, persisted metadata JSON, messages GET): an oauth2 server with no stored credentials lands only in `mcp_servers_needing_auth` (exercised via a real metadata-discovery mock, so rmcp fails with AuthorizationRequired exactly as the configured-but-unconnected state does); a genuinely failing server lands only in `mcp_servers_unavailable`; a healthy server in neither. fmt/clippy strict/OpenAPI checks green; full suite green at the stack tip.
