### PR TITLE
Chat: point at unconnected MCP servers instead of silently dropping their tools (ERMAIN-657)

### DIFF
--- a/frontend/src/components/ui/Assistant/McpServerSelector.tsx
+++ b/frontend/src/components/ui/Assistant/McpServerSelector.tsx
@@ -1,9 +1,9 @@
 import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { useCallback, useMemo } from "react";
-import { useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/Controls/Button";
+import { useOpenMcpServersSettings } from "@/hooks/ui/useOpenMcpServersSettings";
 
 import { CheckCircleIcon, ErrorIcon, WarningCircleIcon } from "../icons";
 
@@ -37,21 +37,12 @@ export const McpServerSelector = ({
   onSelectionChange,
   disabled = false,
 }: McpServerSelectorProps) => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
   const selectedServerIdsSet = useMemo(
     () => new Set(selectedServerIds),
     [selectedServerIds],
   );
 
-  const openServerSettings = useCallback(() => {
-    /* eslint-disable lingui/no-unlocalized-strings -- URL query parameter keys */
-    const nextParams = new URLSearchParams(searchParams);
-    nextParams.set("preferencesDialog", "open");
-    nextParams.set("preferencesTab", "serversTools");
-    /* eslint-enable lingui/no-unlocalized-strings */
-    setSearchParams(nextParams);
-  }, [searchParams, setSearchParams]);
+  const openServerSettings = useOpenMcpServersSettings();
 
   const toggleServerSelection = useCallback(
     (serverId: string) => {
@@ -163,19 +154,24 @@ export const McpServerSelector = ({
                         message: "Requires connection",
                       })}
                     </span>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="sm"
-                      disabled={disabled}
-                      onClick={openServerSettings}
-                      data-testid={`mcp-server-connect-${server.id}`}
-                    >
-                      {t({
-                        id: "assistant.form.mcpServers.connectAction",
-                        message: "Connect in Settings",
-                      })}
-                    </Button>
+                    {/* A null callback means no Router-mounted settings
+                        chrome exists on this host, so the shortcut would be
+                        a dead button — the status label alone stands. */}
+                    {openServerSettings && (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        disabled={disabled}
+                        onClick={openServerSettings}
+                        data-testid={`mcp-server-connect-${server.id}`}
+                      >
+                        {t({
+                          id: "assistant.form.mcpServers.connectAction",
+                          message: "Connect in Settings",
+                        })}
+                      </Button>
+                    )}
                   </>
                 )}
                 {isUnavailable && (

--- a/frontend/src/components/ui/Chat/ChatMessage.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.test.tsx
@@ -1,5 +1,6 @@
 import { I18nProvider } from "@lingui/react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { messages as enMessages } from "@/locales/en/messages.json";
@@ -292,6 +293,132 @@ describe("ChatMessage", () => {
       expect(
         screen.getByRole("button", { name: "Copy error report" }),
       ).toHaveTextContent("Copied");
+    });
+  });
+
+  describe("MCP needing-auth notice", () => {
+    const LocationProbe = () => {
+      const location = useLocation();
+      return <div data-testid="location-search">{location.search}</div>;
+    };
+
+    const renderAssistantMessage = async (
+      overrides: Partial<UiChatMessage>,
+      {
+        isSharedDialog = false,
+        withRouter = true,
+      }: { isSharedDialog?: boolean; withRouter?: boolean } = {},
+    ) => {
+      const message: UiChatMessage = {
+        id: "msg_mcp_auth",
+        content: [{ content_type: "text", text: "Answered without tools" }],
+        role: "assistant",
+        sender: "assistant",
+        authorId: "assistant_1",
+        createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+        status: "complete",
+        ...overrides,
+      };
+
+      const Controls = () => <div data-testid="message-controls-probe" />;
+
+      const { i18n } = await import("@lingui/core");
+      i18n.load("en", enMessages as unknown as Messages);
+      i18n.activate("en");
+
+      const tree = (
+        <I18nProvider i18n={i18n}>
+          <ChatMessage
+            message={message}
+            controls={Controls}
+            controlsContext={{
+              currentUserId: "user_1",
+              dialogOwnerId: "user_1",
+              isSharedDialog,
+            }}
+            onMessageAction={async () => true}
+          />
+          {withRouter && <LocationProbe />}
+        </I18nProvider>
+      );
+
+      render(withRouter ? <MemoryRouter>{tree}</MemoryRouter> : tree);
+    };
+
+    it("renders the notice with the server name and a working settings link", async () => {
+      await renderAssistantMessage({
+        mcp_servers_needing_auth: ["github-server"],
+      });
+
+      expect(screen.getByTestId("mcp-needs-auth-notice")).toHaveTextContent(
+        "github-server is available in this chat but not connected, so its tools were not used.",
+      );
+
+      fireEvent.click(screen.getByTestId("mcp-needs-auth-connect"));
+
+      expect(screen.getByTestId("location-search")).toHaveTextContent(
+        "?preferencesDialog=open&preferencesTab=serversTools",
+      );
+    });
+
+    it("enumerates multiple servers in a single notice", async () => {
+      await renderAssistantMessage({
+        mcp_servers_needing_auth: ["github-server", "jira-server"],
+      });
+
+      const notices = screen.getAllByTestId("mcp-needs-auth-notice");
+      expect(notices).toHaveLength(1);
+      expect(notices[0]).toHaveTextContent(
+        "github-server, jira-server are available in this chat but not connected, so their tools were not used.",
+      );
+    });
+
+    it("renders nothing without the metadata", async () => {
+      await renderAssistantMessage({});
+
+      expect(
+        screen.queryByTestId("mcp-needs-auth-notice"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not treat genuinely unavailable servers as needing auth", async () => {
+      await renderAssistantMessage({
+        mcp_servers_unavailable: ["broken-server"],
+      });
+
+      expect(
+        screen.queryByTestId("mcp-needs-auth-notice"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the notice but suppresses Connect on the shared-dialog surface", async () => {
+      await renderAssistantMessage(
+        { mcp_servers_needing_auth: ["github-server"] },
+        { isSharedDialog: true },
+      );
+
+      expect(screen.getByTestId("mcp-needs-auth-notice")).toHaveTextContent(
+        "github-server is available in this chat but not connected, so its tools were not used.",
+      );
+      // Share-link viewers have no settings dialog to land in.
+      expect(
+        screen.queryByTestId("mcp-needs-auth-connect"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the notice but suppresses Connect where no Router is mounted", async () => {
+      await renderAssistantMessage(
+        { mcp_servers_needing_auth: ["github-server"] },
+        { withRouter: false },
+      );
+
+      expect(screen.getByTestId("mcp-needs-auth-notice")).toHaveTextContent(
+        "github-server is available in this chat but not connected, so its tools were not used.",
+      );
+      // Kit/add-in hosts mount no settings-dialog chrome to answer the click.
+      expect(
+        screen.queryByTestId("mcp-needs-auth-connect"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -19,6 +19,7 @@ import { hasToolCalls as messageHasToolCalls } from "@/utils/adapters/toolCallAd
 import { isImageFile } from "@/utils/file/fileTypeUtils";
 import { teamsUploadDisplayName } from "@/utils/teams/teamsUploadName";
 
+import { McpNeedsAuthNotice } from "./McpNeedsAuthNotice";
 import { Alert } from "../Feedback/Alert";
 import { Avatar } from "../Feedback/Avatar";
 import { CopyErrorButton } from "../Feedback/CopyErrorButton";
@@ -247,6 +248,26 @@ export const ChatMessage = memo(function ChatMessage({
             hasError={!!message.error}
             outlookArtifact={message.outlookArtifact}
           />
+
+          {/* Only the assistant message of the affected generation carries
+              this metadata, so absence costs nothing here. Deliberately keyed
+              off needing-auth alone: unavailable servers have no user-side
+              remedy, so they must not raise a connect affordance.
+
+              The text renders on every surface — like the error alert above,
+              it is part of the record of the response — but the Connect button
+              needs the settings-dialog chrome that watches the preferences
+              query params, which share-link pages do not mount, hence this
+              flag. Routerless hosts (component-kit / add-in) are handled by
+              the notice itself, which drops the button when its settings
+              hook reports no Router. */}
+          {message.mcp_servers_needing_auth &&
+            message.mcp_servers_needing_auth.length > 0 && (
+              <McpNeedsAuthNotice
+                serverIds={message.mcp_servers_needing_auth}
+                showConnect={!controlsContext.isSharedDialog}
+              />
+            )}
 
           {/* Display attached files if any */}
           {message.input_files_ids && message.input_files_ids.length > 0 && (

--- a/frontend/src/components/ui/Chat/McpNeedsAuthNotice.tsx
+++ b/frontend/src/components/ui/Chat/McpNeedsAuthNotice.tsx
@@ -1,0 +1,84 @@
+import { plural, t } from "@lingui/core/macro";
+
+import { Button } from "@/components/ui/Controls/Button";
+import { useOpenMcpServersSettings } from "@/hooks/ui/useOpenMcpServersSettings";
+
+import { InfoIcon } from "../icons";
+
+interface McpNeedsAuthNoticeProps {
+  /**
+   * MCP server ids the generation skipped because THIS user has not completed
+   * their OAuth connection. Genuinely broken servers travel in a separate
+   * field and must never be routed here — their fix is not "connect".
+   */
+  serverIds: string[];
+  /**
+   * Whether to offer the "Connect" affordance. The informational text renders
+   * regardless — it is part of the record of how the response was produced —
+   * but the button only helps where the settings-dialog chrome watching the
+   * preferences query params is mounted.
+   */
+  showConnect?: boolean;
+}
+
+/**
+ * Quiet footnote on an assistant message whose generation skipped one or more
+ * MCP servers awaiting the user's OAuth connection. Deliberately not an
+ * error/alert: the response itself succeeded, the servers are healthy, and
+ * connecting is optional — so this renders as muted metadata with one inline
+ * affordance into the settings dialog, costing nothing to ignore.
+ *
+ * A server's id doubles as its display name everywhere (settings pane,
+ * assistant editor) — the listing API exposes no separate label to resolve.
+ */
+export const McpNeedsAuthNotice = ({
+  serverIds,
+  showConnect = true,
+}: McpNeedsAuthNoticeProps) => {
+  const openMcpServersSettings = useOpenMcpServersSettings();
+
+  if (serverIds.length === 0) {
+    return null;
+  }
+
+  const serverCount = serverIds.length;
+  const serverList = serverIds.join(", ");
+
+  return (
+    <div
+      role="note"
+      data-testid="mcp-needs-auth-notice"
+      className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-theme-fg-muted"
+    >
+      <InfoIcon className="size-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        {t({
+          id: "chat.message.mcpNeedsAuth.text",
+          message: plural(serverCount, {
+            one: `${serverList} is available in this chat but not connected, so its tools were not used.`,
+            other: `${serverList} are available in this chat but not connected, so their tools were not used.`,
+          }),
+        })}
+      </span>
+      {/* Same decision twice: the text stays — it is part of the record of
+          the response — but the button goes wherever nothing would answer it.
+          `showConnect` covers surfaces that opted out (share-link dialogs);
+          the null callback covers hosts with no Router and therefore no
+          settings-dialog chrome (component-kit / add-in). */}
+      {showConnect && openMcpServersSettings && (
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          onClick={openMcpServersSettings}
+          data-testid="mcp-needs-auth-connect"
+        >
+          {t({
+            id: "chat.message.mcpNeedsAuth.connect",
+            message: "Connect",
+          })}
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/ui/index.ts
+++ b/frontend/src/hooks/ui/index.ts
@@ -13,3 +13,4 @@ export * from "./useFilePreviewModal";
 export * from "./useThemedIcon";
 export * from "./usePageAlignment";
 export * from "./useRovingMenuFocus";
+export * from "./useOpenMcpServersSettings";

--- a/frontend/src/hooks/ui/useOpenMcpServersSettings.ts
+++ b/frontend/src/hooks/ui/useOpenMcpServersSettings.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useInRouterContext, useSearchParams } from "react-router-dom";
+
+const useOpenMcpServersSettingsUnderRouter = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return useCallback(() => {
+    /* eslint-disable lingui/no-unlocalized-strings -- URL query parameter keys */
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("preferencesDialog", "open");
+    nextParams.set("preferencesTab", "serversTools");
+    /* eslint-enable lingui/no-unlocalized-strings */
+    setSearchParams(nextParams);
+  }, [searchParams, setSearchParams]);
+};
+
+/**
+ * Opens the settings dialog on the MCP servers tab. The dialog opener lives in
+ * `UserProfileDropdown`, which watches exactly this query-param pair wherever
+ * the sidebar chrome is mounted — every "connect this server" affordance must
+ * mint the same spelling, so this hook is the single place it is written.
+ *
+ * Returns `null` where no react-router `Router` is mounted (component-kit and
+ * add-in hosts): nothing watches the query params there, so consumers must
+ * treat `null` as "no settings shortcut available" and drop their affordance
+ * instead of rendering a dead button.
+ */
+export const useOpenMcpServersSettings = (): (() => void) | null => {
+  const isRouterMounted = useInRouterContext();
+
+  // Router presence cannot change for a mounted component instance, so hook
+  // order stays stable across renders despite the conditional call.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return isRouterMounted ? useOpenMcpServersSettingsUnderRouter() : null;
+};

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1829,6 +1829,16 @@ msgid "chat.message.link.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.connect"
+msgstr "Verbinden"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.text"
+msgstr "{serverCount, plural, one {{serverList} ist in diesem Chat verfügbar, aber nicht verbunden – seine Tools wurden daher nicht verwendet.} other {{serverList} sind in diesem Chat verfügbar, aber nicht verbunden – ihre Tools wurden daher nicht verwendet.}}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/MermaidBlock.tsx
 msgid "chat.message.mermaid.diagram"
 msgstr ""

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1829,6 +1829,16 @@ msgid "chat.message.link.fallback"
 msgstr "Link"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.connect"
+msgstr "Connect"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.text"
+msgstr "{serverCount, plural, one {{serverList} is available in this chat but not connected, so its tools were not used.} other {{serverList} are available in this chat but not connected, so their tools were not used.}}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/MermaidBlock.tsx
 msgid "chat.message.mermaid.diagram"
 msgstr "Mermaid diagram"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1829,6 +1829,16 @@ msgid "chat.message.link.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.connect"
+msgstr "Conectar"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.text"
+msgstr "{serverCount, plural, one {{serverList} está disponible en este chat pero no está conectado, por lo que no se usaron sus herramientas.} other {{serverList} están disponibles en este chat pero no están conectados, por lo que no se usaron sus herramientas.}}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/MermaidBlock.tsx
 msgid "chat.message.mermaid.diagram"
 msgstr ""

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1829,6 +1829,16 @@ msgid "chat.message.link.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.connect"
+msgstr "Connecter"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.text"
+msgstr "{serverCount, plural, one {{serverList} est disponible dans ce chat mais n'est pas connecté, ses outils n'ont donc pas été utilisés.} other {{serverList} sont disponibles dans ce chat mais ne sont pas connectés, leurs outils n'ont donc pas été utilisés.}}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/MermaidBlock.tsx
 msgid "chat.message.mermaid.diagram"
 msgstr ""

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1829,6 +1829,16 @@ msgid "chat.message.link.fallback"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.connect"
+msgstr "Połącz"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/McpNeedsAuthNotice.tsx
+msgid "chat.message.mcpNeedsAuth.text"
+msgstr "{serverCount, plural, one {{serverList} jest dostępny w tym czacie, ale nie jest połączony, więc jego narzędzia nie zostały użyte.} few {{serverList} są dostępne w tym czacie, ale nie są połączone, więc ich narzędzia nie zostały użyte.} other {{serverList} jest dostępnych w tym czacie, ale nie są połączone, więc ich narzędzia nie zostały użyte.}}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/MermaidBlock.tsx
 msgid "chat.message.mermaid.diagram"
 msgstr ""

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -18,6 +18,7 @@ export { ChatMessage } from "@/components/ui/Chat/ChatMessage";
 export type { ChatMessageHostComponents } from "@/components/ui/Chat/ChatMessage";
 export type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
 export type { ChatTopLeftAccessoryProps } from "@/components/ui/Chat/ChatTopLeftAccessory";
+export { McpNeedsAuthNotice } from "@/components/ui/Chat/McpNeedsAuthNotice";
 export { DefaultStarterPromptsSection } from "@/components/ui/Chat/StarterPromptsSection";
 export { StarterPromptsSection } from "@/components/ui/Chat/StarterPromptsSection";
 export type { StarterPromptsRendererProps } from "@/components/ui/Chat/StarterPromptsSection";

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -143,6 +143,13 @@ export interface Message {
   error?: MessageError;
   error_report?: string;
   mcp_servers_unavailable?: string[];
+  /**
+   * MCP servers skipped for this generation only because the user has not
+   * completed their OAuth connection — unlike `mcp_servers_unavailable`
+   * (broken/unreachable), these work the moment the user connects them in
+   * settings, so the UI offers a connect affordance instead of an error.
+   */
+  mcp_servers_needing_auth?: string[];
   previous_message_id?: string;
   // Whether this message is in the active thread per backend lineage logic
   is_message_in_active_thread?: boolean;

--- a/frontend/src/utils/adapters/messageAdapter.ts
+++ b/frontend/src/utils/adapters/messageAdapter.ts
@@ -30,6 +30,8 @@ export interface UiChatMessage extends Message {
   action_facet_args?: Record<string, string>;
   /** MCP server IDs that were unavailable while preparing this generation */
   mcp_servers_unavailable?: string[];
+  /** MCP server IDs skipped because this user has not connected them yet */
+  mcp_servers_needing_auth?: string[];
   /** Backend-rendered assistant error report for support/debugging */
   error_report?: string;
 }
@@ -70,6 +72,7 @@ export function mapApiMessageToUiMessage(
     error: isMessageError(error) ? error : undefined,
     error_report: apiMessage.error_report ?? undefined,
     mcp_servers_unavailable: apiMessage.mcp_servers_unavailable ?? undefined,
+    mcp_servers_needing_auth: apiMessage.mcp_servers_needing_auth ?? undefined,
     action_facet_id: apiMessage.action_facet_id ?? undefined,
     action_facet_args: apiMessage.action_facet_args ?? undefined,
   };

--- a/site/content/docs/features/mcp_servers.mdx
+++ b/site/content/docs/features/mcp_servers.mdx
@@ -243,6 +243,12 @@ With this setup:
 
 This affects which MCP servers can be attached to assistants and which servers are available during generation for a given user.
 
+## Server selection in chats
+
+Within a chat, there is deliberately no per-server toggle: facets are the chat-side tool-selection primitive. A facet contributes tool allowlist patterns (qualified by server ID), so selecting facets narrows the offered tools to those patterns. Independently, an assistant can be restricted to a subset of servers in the assistant editor.
+
+In a chat with no selected facets (and no assistant restriction), the tools of every server the user is authorized for — and, for `oauth2` servers, has connected — are offered. A server the user has not connected yet is skipped without failing the response; the affected reply shows a short notice with a shortcut to the connection settings.
+
 ## Deployment Considerations
 
 When deploying Erato with MCP servers:


### PR DESCRIPTION
Top of the ERMAIN-657 stack, on #1017. Stack: #1016 record skips → #1017 assistant UI → **this**.

The user-visible half of layer 1: when a generation skipped MCP servers because *this* user hasn't connected them, the affected assistant message now carries a quiet footnote — muted, informational, never error-toned — naming the servers ("X is available in this chat but not connected, so its tools were not used") with a link-variant **Connect** that opens Settings on the MCP servers tab. Triggered strictly by `mcp_servers_needing_auth`; a genuinely broken server (`mcp_servers_unavailable`) never renders it.

Details that came out of review:

- On share-link surfaces the informational text stays but the Connect button is suppressed (`isSharedDialog`, the same signal the message controls already gate on) — a viewer without the settings chrome shouldn't get a dead button. The add-in exposes no equivalent capability signal at this depth; recorded as a known caveat in code.
- The settings-dialog query-param contract now lives in one shared hook (`useOpenMcpServersSettings`), also consumed by #1017's selector, so the deep-link has a single spelling.
- The server listing exposes no display name beyond the id, so the notice shows ids — identical to what Settings shows.

Also closes the issue's third build item as decided-and-documented rather than built: the MCP docs page gains a "Server selection in chats" section stating that facets remain the chat-side tool-selection primitive, servers reach a chat via facet allowlists or assistant attachment, and a facet-less chat offers all authorized, connected servers.

## Tests

Single and multiple needing-auth servers render the notice (ICU plural); absence of the field renders nothing; `mcp_servers_unavailable` alone renders nothing (separation asserted); shared-dialog render keeps the text, drops Connect; the Connect action targets the settings dialog. Full gates at the tip: frontend suite, prettier/eslint/both tsc configs, i18n catalogs (5 locales), component registry clean; backend fmt/clippy/codegen checks, 90 mcp+assistant tests.
