### PR TITLE
Render tracked assistant mentions in sent user messages (ERMAIN-661)

### DIFF
--- a/backend/erato/src/models/assistant.rs
+++ b/backend/erato/src/models/assistant.rs
@@ -61,6 +61,29 @@ pub struct AssistantWithFiles {
     pub files: Vec<FileInfo>,
 }
 
+/// Display names for a set of assistants in one query, keyed by id. Ids that
+/// no longer resolve are simply absent from the map. Deliberately without a
+/// per-assistant access check: callers use this to label references the
+/// requester already legitimately holds (their own persisted mentions, their
+/// chat's assistant), mirroring how recent-chat listings resolve
+/// `assistant_name`. Do not reach for this where the id itself is untrusted.
+pub async fn get_assistant_names_by_ids(
+    conn: &DatabaseConnection,
+    assistant_ids: &[Uuid],
+) -> Result<std::collections::HashMap<Uuid, String>, Report> {
+    if assistant_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    Ok(Assistants::find()
+        .filter(assistants::Column::Id.is_in(assistant_ids.iter().copied()))
+        .all(conn)
+        .await
+        .wrap_err("Failed to resolve assistant names")?
+        .into_iter()
+        .map(|assistant| (assistant.id, assistant.name))
+        .collect())
+}
+
 /// Dedupes while collapsing an empty list to `None`. Generation-time filters
 /// treat `None` as "no restriction" but an empty list as "restrict to
 /// nothing", so storing `Some([])` would brick the assistant; clients clear a

--- a/backend/erato/src/server/api/v1beta/message_streaming.rs
+++ b/backend/erato/src/server/api/v1beta/message_streaming.rs
@@ -1599,8 +1599,12 @@ async fn bg_stream_save_user_message(
     .await
     .wrap_err("Failed to submit user message")?;
 
+    // Resolved here so the live event carries the same display pairs the read
+    // API serves — the just-sent message highlights without a refetch.
     let saved_user_message_wrapped = ChatMessage::from_model(saved_user_message.clone())
-        .wrap_err("Failed to convert user message")?;
+        .wrap_err("Failed to convert user message")?
+        .with_mentioned_assistants(&app_state.db, &saved_user_message)
+        .await;
 
     task.send_event(StreamingEvent::UserMessageSaved {
         message_id: saved_user_message.id,
@@ -9078,8 +9082,13 @@ pub async fn edit_message_sse(
             .await
             .wrap_err("Failed to submit edited user message")?;
 
+            // Resolved here so the live event carries the same display pairs
+            // the read API serves — the edited message highlights without a
+            // refetch (the edit composer does not re-send mention names).
             let saved_user_message_wrapped = ChatMessage::from_model(saved_user_message.clone())
-                .wrap_err("Failed to convert saved edited user message")?;
+                .wrap_err("Failed to convert saved edited user message")?
+                .with_mentioned_assistants(&app_state.db, &saved_user_message)
+                .await;
 
             let user_message_saved: EditMessageStreamingResponseMessage =
                 MessageSubmitStreamingResponseUserMessageSaved {

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -454,6 +454,7 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         StarterPromptInfo,
         StarterPromptsResponse,
         ChatMessage,
+        MentionedAssistant,
         ChatMessageStats,
         ChatMessagesResponse,
         RecentChatStats,
@@ -1413,6 +1414,15 @@ pub struct MessageFeedback {
     updated_at: DateTime<FixedOffset>,
 }
 
+/// An assistant the user @-mentioned in a message, resolved for display.
+#[derive(Debug, Clone, ToSchema, Serialize, Deserialize)]
+pub struct MentionedAssistant {
+    /// The unique ID of the mentioned assistant
+    id: String,
+    /// The assistant's display name at read time
+    name: String,
+}
+
 /// A message in a chat
 #[derive(Debug, Clone, ToSchema, Serialize, Deserialize)]
 pub struct ChatMessage {
@@ -1471,6 +1481,11 @@ pub struct ChatMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(nullable = false)]
     action_facet_args: Option<HashMap<String, String>>,
+    /// Assistants the user @-mentioned in this message, resolved to display
+    /// names at read time. Mentions whose assistant no longer resolves are
+    /// omitted; absent on assistant messages and mention-less user messages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    mentioned_assistants: Vec<MentionedAssistant>,
 }
 
 /// Statistics for a list of chat messages
@@ -2227,8 +2242,87 @@ impl ChatMessage {
                         .ok()
                 })
                 .and_then(|p| p.action_facet_args),
+            // Needs the assistants table for names, so it is filled separately
+            // (like `files`) — batched per page, or per message on SSE.
+            mentioned_assistants: vec![],
         })
     }
+
+    /// Fills `mentioned_assistants` from the ids persisted on `model`,
+    /// resolving display names in one query. Single-message counterpart of
+    /// `resolve_mentioned_assistants_for_messages`, for the SSE emission
+    /// sites; resolution failure degrades to no mentions rather than
+    /// aborting the stream (the read APIs still resolve them later).
+    pub async fn with_mentioned_assistants(
+        mut self,
+        db: &sea_orm::DatabaseConnection,
+        model: &messages::Model,
+    ) -> Self {
+        match resolve_mentioned_assistants_for_messages(db, std::slice::from_ref(model)).await {
+            Ok(mut by_message) => {
+                self.mentioned_assistants = by_message.remove(&model.id).unwrap_or_default();
+            }
+            Err(error) => {
+                tracing::warn!(
+                    message_id = %model.id,
+                    "Failed to resolve mentioned assistants: {error}"
+                );
+            }
+        }
+        self
+    }
+}
+
+/// Resolves the assistant mentions persisted on the given message models into
+/// display pairs, with a single assistants query for the whole page. Names are
+/// looked up without per-assistant access checks — the mention was validated
+/// at submit and displaying it in an already-readable message grants nothing —
+/// mirroring how recent-chat listings resolve `assistant_name`. Ids that no
+/// longer resolve are omitted.
+async fn resolve_mentioned_assistants_for_messages(
+    db: &sea_orm::DatabaseConnection,
+    messages: &[messages::Model],
+) -> Result<HashMap<Uuid, Vec<MentionedAssistant>>, Report> {
+    let mut ids_by_message: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    let mut all_ids: HashSet<Uuid> = HashSet::new();
+    for msg in messages {
+        // Unparseable input parameters degrade to "no mentions", matching the
+        // tolerant reads in `from_model_with_feedback`.
+        let Some(ids) = models::message::get_input_mentioned_assistant_ids_from_message(msg)
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+        if ids.is_empty() {
+            continue;
+        }
+        all_ids.extend(ids.iter().copied());
+        ids_by_message.insert(msg.id, ids);
+    }
+
+    if ids_by_message.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let all_ids: Vec<Uuid> = all_ids.into_iter().collect();
+    let names = models::assistant::get_assistant_names_by_ids(db, &all_ids).await?;
+
+    Ok(ids_by_message
+        .into_iter()
+        .map(|(message_id, ids)| {
+            let resolved: Vec<MentionedAssistant> = ids
+                .into_iter()
+                .filter_map(|id| {
+                    names.get(&id).map(|name| MentionedAssistant {
+                        id: id.to_string(),
+                        name: name.clone(),
+                    })
+                })
+                .collect();
+            (message_id, resolved)
+        })
+        .collect())
 }
 
 fn render_message_error_report(
@@ -2603,6 +2697,13 @@ async fn assemble_chat_messages_response(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let assistant_id = chat.and_then(|chat| chat.assistant_id);
 
+    // Batch query: display names for every mention on the page.
+    let mut mentioned_assistants_by_message =
+        resolve_mentioned_assistants_for_messages(&app_state.db, &messages)
+            .await
+            .wrap_err("Failed to resolve mentioned assistants")
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
     // Convert the messages to the API response format with feedback and files
     let converted_messages: Result<Vec<ChatMessage>, Report> = messages
         .into_iter()
@@ -2612,6 +2713,9 @@ async fn assemble_chat_messages_response(
             chat_message.error_report = chat_message.error.as_ref().map(|error| {
                 render_message_error_report(&app_state.config, &msg, assistant_id, error)
             });
+            chat_message.mentioned_assistants = mentioned_assistants_by_message
+                .remove(&msg.id)
+                .unwrap_or_default();
 
             // Populate files for this message
             chat_message.files = msg

--- a/backend/erato/tests/integration_tests/api/delegation.rs
+++ b/backend/erato/tests/integration_tests/api/delegation.rs
@@ -953,6 +953,123 @@ async fn test_regenerate_and_edit_replay_persisted_mentions(pool: Pool<Postgres>
     bad_edit.assert_status(axum::http::StatusCode::BAD_REQUEST);
 }
 
+/// The messages read API resolves persisted mentions into `{id, name}` pairs
+/// on the user message, ids that no longer resolve are omitted, and both
+/// assistant messages and mention-less user messages carry no key at all. The
+/// SSE `user_message_saved` payload carries the same pairs, so the just-sent
+/// message can highlight without waiting for a refetch.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+/// - `sse-streaming`
+/// - `uses-mocked-llm`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_messages_read_resolves_mentioned_assistants(pool: Pool<Postgres>) {
+    let (app_state, _llm) = delegation_enabled_state_with_llm(pool).await;
+    let server = app_server(app_state.clone());
+
+    let alpha = create_assistant(&server, "Mention Alpha", "prompt").await;
+    let beta = create_assistant(&server, "Mention Beta", "prompt").await;
+
+    let response = submit_with_mentions(
+        &server,
+        None,
+        "ask @Mention Alpha and @Mention Beta",
+        &[&alpha, &beta],
+    )
+    .await;
+    response.assert_status_ok();
+    let events = parse_sse_events(&response);
+    let chat_id = crate::test_utils::extract_chat_id(&events).unwrap();
+
+    let expected_pairs = json!([
+        { "id": alpha, "name": "Mention Alpha" },
+        { "id": beta, "name": "Mention Beta" }
+    ]);
+
+    // The live event already carries the resolved pairs.
+    let saved_event = events
+        .iter()
+        .find_map(|event| {
+            let json = serde_json::from_str::<Value>(&event.data).ok()?;
+            (json["message_type"] == "user_message_saved").then_some(json)
+        })
+        .expect("user_message_saved event");
+    assert_eq!(
+        saved_event["message"]["mentioned_assistants"],
+        expected_pairs
+    );
+
+    let list_messages = |chat_id: String| {
+        let server = &server;
+        async move {
+            let response = server
+                .get(&format!("/api/v1beta/chats/{chat_id}/messages"))
+                .with_bearer_token(TEST_JWT_TOKEN)
+                .await;
+            response.assert_status_ok();
+            response.json::<Value>()["messages"].clone()
+        }
+    };
+
+    let messages = list_messages(chat_id.clone()).await;
+    let user_message = messages
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "user")
+        .expect("user message");
+    assert_eq!(user_message["mentioned_assistants"], expected_pairs);
+    let assistant_message = messages
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "assistant")
+        .expect("assistant message");
+    assert!(
+        assistant_message.get("mentioned_assistants").is_none(),
+        "assistant messages must not carry the key"
+    );
+
+    // An id that no longer resolves is omitted while the rest keep resolving.
+    let chat_uuid = Uuid::parse_str(&chat_id).unwrap();
+    let rows = chat_messages_by_created_at(&app_state.db, chat_uuid).await;
+    let user_row = rows
+        .iter()
+        .find(|row| row.raw_message["role"] == "user")
+        .expect("user message row");
+    let mut input_parameters = user_row.input_parameters.clone().unwrap();
+    input_parameters["mentioned_assistant_ids"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!("00000000-0000-0000-0000-00000000dead"));
+    let mut active: erato::db::entity::messages::ActiveModel = user_row.clone().into();
+    active.input_parameters = ActiveValue::Set(Some(input_parameters));
+    active.update(&app_state.db).await.unwrap();
+
+    let messages = list_messages(chat_id.clone()).await;
+    let user_message = messages
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "user")
+        .expect("user message");
+    assert_eq!(user_message["mentioned_assistants"], expected_pairs);
+
+    // A mention-less user message carries no key at all.
+    let plain_chat = create_chat(&server, None).await;
+    submit_message(&server, &plain_chat, None, "no mentions here", vec![]).await;
+    let messages = list_messages(plain_chat).await;
+    let plain_user_message = messages
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "user")
+        .expect("plain user message");
+    assert!(plain_user_message.get("mentioned_assistants").is_none());
+}
+
 /// The requested run mode round-trips into the user message's
 /// `input_parameters`: `background` is persisted verbatim even though
 /// `allow_background` is off — the gate applies at dispatch, not at

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -4861,6 +4861,13 @@
             },
             "description": "MCP server IDs that were unavailable while preparing this generation"
           },
+          "mentioned_assistants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MentionedAssistant"
+            },
+            "description": "Assistants the user @-mentioned in this message, resolved to display\nnames at read time. Mentions whose assistant no longer resolves are\nomitted; absent on assistant messages and mention-less user messages."
+          },
           "previous_message_id": {
             "type": "string",
             "description": "The ID of the previous message in the thread, if any"
@@ -6738,6 +6745,24 @@
           "FAILURE",
           "NEEDS_AUTHENTICATION"
         ]
+      },
+      "MentionedAssistant": {
+        "type": "object",
+        "description": "An assistant the user @-mentioned in a message, resolved for display.",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the mentioned assistant"
+          },
+          "name": {
+            "type": "string",
+            "description": "The assistant's display name at read time"
+          }
+        }
       },
       "Message": {
         "type": "object",

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -70,6 +70,7 @@ import type {
   MessageControlsComponent,
   MessageControlsContext,
 } from "@/types/message-controls";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 import type { FileType } from "@/utils/fileTypes";
 import type React from "react";
 
@@ -357,7 +358,7 @@ export const Chat = ({
       inputFileIds?: string[],
       modelId?: string,
       selectedFacetIds?: string[],
-      mentionedAssistantIds?: string[],
+      mentionedAssistants?: AssistantMention[],
       delegationRunMode?: DelegationRunMode,
     ) => {
       logger.log("[CHAT_FLOW] Chat - handleSendMessage called", {
@@ -365,7 +366,7 @@ export const Chat = ({
         model: modelId,
         assistantId,
         selectedFacetIds,
-        mentionedAssistantIds,
+        mentionedAssistants,
         delegationRunMode,
       });
 
@@ -375,7 +376,7 @@ export const Chat = ({
         modelId,
         assistantId,
         selectedFacetIds,
-        mentionedAssistantIds,
+        mentionedAssistants,
         delegationRunMode,
       ).catch((error) => {
         logger.log("[CHAT_FLOW] Error sending message:", error);

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -4309,7 +4309,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4348,7 +4348,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4420,7 +4420,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4467,7 +4467,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4525,7 +4525,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4900,7 +4900,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
       expect(textarea).toHaveValue("");
     });
@@ -4922,7 +4922,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
         "background",
       );
     });
@@ -4953,7 +4953,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -4987,7 +4987,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -5014,7 +5014,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -5059,7 +5059,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
         "background",
       );
     });
@@ -5092,7 +5092,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
       );
     });
 
@@ -5207,7 +5207,7 @@ describe("ChatInput", () => {
         undefined,
         undefined,
         [],
-        ["assistant-research"],
+        [{ id: "assistant-research", name: "Researcher" }],
         "background",
       );
       expect(

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -61,6 +61,7 @@ import {
   detectMentionTrigger,
   pruneTrackedMentions,
   resolveMentionedAssistantIds,
+  resolveMentionedAssistants,
 } from "@/utils/chat/assistantMentions";
 import { resolveChatSendErrorMessage } from "@/utils/chatSendErrorMessage";
 import { createLogger } from "@/utils/debugLogger";
@@ -231,7 +232,11 @@ interface ChatInputProps {
     inputFileIds?: string[],
     modelId?: string,
     selectedFacetIds?: string[],
-    mentionedAssistantIds?: string[],
+    /**
+     * Resolved `{id, name}` pairs rather than bare ids: the optimistic
+     * message needs the names to highlight before the server echoes them.
+     */
+    mentionedAssistants?: AssistantMention[],
     delegationRunMode?: DelegationRunMode,
   ) => void;
   onRegenerate?: () => void;
@@ -1391,7 +1396,7 @@ export const ChatInput = ({
         return;
       }
 
-      const mentionedAssistantIds = resolveMentionedAssistantIds(
+      const resolvedMentions = resolveMentionedAssistants(
         messageContent,
         mentionedAssistants,
       );
@@ -1406,7 +1411,7 @@ export const ChatInput = ({
         files: inputFileIds,
         model: selectedModel?.chat_provider_id,
         selectedFacetIds,
-        mentionedAssistantIds,
+        mentionedAssistantIds: resolvedMentions.map((mention) => mention.id),
         delegationRunMode,
       });
       if (delegationRunMode) {
@@ -1415,7 +1420,7 @@ export const ChatInput = ({
           inputFileIds,
           selectedModel?.chat_provider_id,
           selectedFacetIds,
-          mentionedAssistantIds,
+          resolvedMentions,
           delegationRunMode,
         );
       } else {
@@ -1424,7 +1429,7 @@ export const ChatInput = ({
           inputFileIds,
           selectedModel?.chat_provider_id,
           selectedFacetIds,
-          mentionedAssistantIds,
+          resolvedMentions,
         );
       }
     },
@@ -1536,7 +1541,7 @@ export const ChatInput = ({
         stillQueued.attachedFiles.length > 0
           ? stillQueued.attachedFiles.map((file) => file.id)
           : undefined;
-      const queuedMentionedAssistantIds = resolveMentionedAssistantIds(
+      const queuedMentionedAssistants = resolveMentionedAssistants(
         stillQueued.message,
         stillQueued.mentionedAssistants,
       );
@@ -1546,7 +1551,7 @@ export const ChatInput = ({
           queuedInputFileIds,
           selectedModel?.chat_provider_id,
           selectedFacetIds,
-          queuedMentionedAssistantIds,
+          queuedMentionedAssistants,
           stillQueued.delegationRunMode,
         );
       } else {
@@ -1555,7 +1560,7 @@ export const ChatInput = ({
           queuedInputFileIds,
           selectedModel?.chat_provider_id,
           selectedFacetIds,
-          queuedMentionedAssistantIds,
+          queuedMentionedAssistants,
         );
       }
     }, 0);

--- a/frontend/src/components/ui/Chat/ChatMessage.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.test.tsx
@@ -421,4 +421,65 @@ describe("ChatMessage", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("assistant mentions", () => {
+    const renderMessage = async (message: UiChatMessage) => {
+      const Controls = () => <div data-testid="message-controls-probe" />;
+
+      const { i18n } = await import("@lingui/core");
+      i18n.load("en", enMessages as unknown as Messages);
+      i18n.activate("en");
+
+      render(
+        <I18nProvider i18n={i18n}>
+          <ChatMessage
+            message={message}
+            controls={Controls}
+            controlsContext={{
+              currentUserId: "user_1",
+              dialogOwnerId: "user_1",
+              isSharedDialog: false,
+            }}
+            onMessageAction={async () => true}
+          />
+        </I18nProvider>,
+      );
+    };
+
+    it("hands a user message's resolved mentions to the content renderer", async () => {
+      await renderMessage({
+        id: "msg_user_mentions",
+        content: [{ content_type: "text", text: "ask @Researcher" }],
+        role: "user",
+        sender: "user",
+        authorId: "user_1",
+        createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+        status: "complete",
+        mentioned_assistants: [{ id: "assistant-1", name: "Researcher" }],
+      });
+
+      expect(messageContentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mentionedAssistants: [{ id: "assistant-1", name: "Researcher" }],
+        }),
+      );
+    });
+
+    it("withholds mentions from assistant messages", async () => {
+      await renderMessage({
+        id: "msg_assistant_mentions",
+        content: [{ content_type: "text", text: "quoting @Researcher" }],
+        role: "assistant",
+        sender: "assistant",
+        authorId: "assistant_1",
+        createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+        status: "complete",
+        mentioned_assistants: [{ id: "assistant-1", name: "Researcher" }],
+      });
+
+      expect(messageContentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ mentionedAssistants: undefined }),
+      );
+    });
+  });
 });

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -247,6 +247,11 @@ export const ChatMessage = memo(function ChatMessage({
             updatedAt={message.updatedAt}
             hasError={!!message.error}
             outlookArtifact={message.outlookArtifact}
+            // Mentions are a user-message affordance; an assistant echoing
+            // "@Name" is quoting, not addressing, so it never highlights.
+            mentionedAssistants={
+              isUser ? message.mentioned_assistants : undefined
+            }
           />
 
           {/* Only the assistant message of the affected generation carries

--- a/frontend/src/components/ui/Message/MessageContent.test.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.test.tsx
@@ -1316,4 +1316,81 @@ describe("MessageContent", () => {
       expect(rawBlock).toHaveTextContent("Final answer");
     });
   });
+
+  describe("assistant mentions", () => {
+    const dataMention = { id: "assistant-data", name: "Data Analyst" };
+    const bobMention = { id: "assistant-bob", name: "Bob" };
+
+    it("highlights resolved mentions while markdown keeps working around them", () => {
+      renderWithTheme(
+        <MessageContent
+          content={textContent(
+            "Please ask @Data Analyst about **quarterly numbers**",
+          )}
+          preserveSoftLineBreaks
+          mentionedAssistants={[dataMention]}
+        />,
+      );
+
+      const mention = screen.getByTestId("message-assistant-mention");
+      expect(mention).toHaveTextContent("@Data Analyst");
+      expect(mention).toHaveAttribute("data-mention-id", "assistant-data");
+      // Same tone tokens as the composer backdrop highlight.
+      expect(mention.className).toContain("bg-theme-info-bg");
+      expect(screen.getByText("quarterly numbers").tagName).toBe("STRONG");
+    });
+
+    it("highlights each of several mentions", () => {
+      renderWithTheme(
+        <MessageContent
+          content={textContent("ask @Data Analyst and @Bob please")}
+          mentionedAssistants={[dataMention, bobMention]}
+        />,
+      );
+
+      const mentions = screen.getAllByTestId("message-assistant-mention");
+      expect(mentions).toHaveLength(2);
+      expect(mentions[0]).toHaveTextContent("@Data Analyst");
+      expect(mentions[1]).toHaveTextContent("@Bob");
+    });
+
+    it("leaves tokens that resolve to no mention as plain text", () => {
+      renderWithTheme(
+        <MessageContent
+          content={textContent("ask @Ghost and @Data Analyst")}
+          mentionedAssistants={[dataMention]}
+        />,
+      );
+
+      expect(screen.getByTestId("message-assistant-mention")).toHaveTextContent(
+        "@Data Analyst",
+      );
+      expect(screen.getByText(/@Ghost/)).toBeInTheDocument();
+    });
+
+    it("renders identical text unchanged without the mentions prop", () => {
+      renderWithTheme(
+        <MessageContent content={textContent("ask @Data Analyst please")} />,
+      );
+
+      expect(
+        screen.queryByTestId("message-assistant-mention"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/ask @Data Analyst please/)).toBeInTheDocument();
+    });
+
+    it("does not style a hand-typed erato-mention link for a foreign id", () => {
+      renderWithTheme(
+        <MessageContent
+          content={textContent("[@Faker](erato-mention://other-id)")}
+          mentionedAssistants={[dataMention]}
+        />,
+      );
+
+      expect(
+        screen.queryByTestId("message-assistant-mention"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("@Faker")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -15,6 +15,7 @@ import {
 import { CheckIcon, CopyIcon } from "@/components/ui/icons";
 import { useOptionalTranslation } from "@/hooks/i18n";
 import { useTraceFeature } from "@/providers/FeatureConfigProvider";
+import { findMentionRanges } from "@/utils/chat/assistantMentions";
 import { FileTypeUtil } from "@/utils/fileTypes";
 
 import { EratoAppointmentBlock } from "./EratoAppointmentBlock";
@@ -31,6 +32,7 @@ import type {
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { UiImagePart } from "@/utils/adapters/contentPartAdapter";
 import type { OutlookArtifact } from "@/utils/adapters/messageAdapter";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 import type { Components } from "react-markdown";
 
 interface MessageContentProps {
@@ -61,6 +63,12 @@ interface MessageContentProps {
    * unchanged. See {@link OutlookArtifact}.
    */
   outlookArtifact?: OutlookArtifact;
+  /**
+   * Resolved `{id, name}` mentions of this (user) message. When present,
+   * `@Name` tokens matching them render as highlighted pills; names that do
+   * not resolve are never passed in, so their tokens stay plain text.
+   */
+  mentionedAssistants?: AssistantMention[];
 }
 
 /**
@@ -345,6 +353,42 @@ const isImageFile = (file: FileUploadItem): boolean =>
     file.file_capability.mime_types[0] ?? "",
   ) === "image";
 
+// eslint-disable-next-line lingui/no-unlocalized-strings -- URL scheme
+const ERATO_MENTION_SCHEME = "erato-mention://";
+
+/**
+ * Rewrites each resolved `@Name` token into a markdown link on an
+ * `erato-mention://<id>` URL, following the `autolinkEratoFiles` pattern of
+ * preprocessing the source text and letting the `a` component override give
+ * the token its real rendering (a highlight pill, not a link). Ranges come
+ * from `findMentionRanges` over the raw text — the same reading the composer
+ * highlight and the submitted ids use — never a bare `@word` regex.
+ */
+const linkAssistantMentions = (
+  text: string,
+  mentions: AssistantMention[],
+): string => {
+  const ranges = findMentionRanges(text, mentions);
+  if (ranges.length === 0) {
+    return text;
+  }
+
+  let result = "";
+  let cursor = 0;
+  for (const range of ranges) {
+    // Escape link-text delimiters so a bracketed assistant name cannot break
+    // out of the link syntax.
+    const token = text
+      .slice(range.start, range.end)
+      .replace(/([\\[\]])/g, "\\$1");
+    result += text.slice(cursor, range.start);
+    result += `[${token}](${ERATO_MENTION_SCHEME}${range.id})`;
+    cursor = range.end;
+  }
+  result += text.slice(cursor);
+  return result;
+};
+
 const autolinkEratoFiles = (text: string): string => {
   // eslint-disable-next-line lingui/no-unlocalized-strings
   if (!text.includes("erato-file://")) {
@@ -478,6 +522,7 @@ export const MessageContent = memo(function MessageContent({
   updatedAt,
   hasError = false,
   outlookArtifact,
+  mentionedAssistants,
 }: MessageContentProps) {
   const imageAdvisory = useOptionalTranslation("chat.message.image_advisory");
   const { maskReasoningText } = useTraceFeature();
@@ -588,6 +633,29 @@ export const MessageContent = memo(function MessageContent({
     code: MarkdownCode,
     // Ensure links open in new tab
     a({ href, id, children, node: _node, ...props }) {
+      if (href?.startsWith(ERATO_MENTION_SCHEME)) {
+        const mentionId = href.slice(ERATO_MENTION_SCHEME.length);
+        const mention = mentionedAssistants?.find(
+          (candidate) => candidate.id === mentionId,
+        );
+        // Only ids this message actually mentions get the pill; a hand-typed
+        // erato-mention link degrades to its plain text.
+        if (!mention) {
+          return <>{children}</>;
+        }
+        // Not a link: the token's meaning is "this run of text addressed that
+        // assistant", so it renders as the same pill the composer backdrop
+        // paints — same tone tokens, same inset outline.
+        return (
+          <span
+            className="rounded-[var(--theme-radius-control)] bg-theme-info-bg box-decoration-clone shadow-[inset_0_0_0_1px_var(--theme-info-border)]"
+            data-mention-id={mentionId}
+            data-testid="message-assistant-mention"
+          >
+            {children}
+          </span>
+        );
+      }
       const rewrittenHref = rewriteFootnoteValue(href, messageId);
       const rewrittenId = rewriteFootnoteValue(id, messageId);
       const isHashLink = rewrittenHref?.startsWith("#") ?? false;
@@ -958,7 +1026,11 @@ export const MessageContent = memo(function MessageContent({
   };
 
   const renderMarkdown = (text: string) => {
-    const linkedTextContent = autolinkEratoFiles(text);
+    const mentionLinkedText =
+      mentionedAssistants && mentionedAssistants.length > 0
+        ? linkAssistantMentions(text, mentionedAssistants)
+        : text;
+    const linkedTextContent = autolinkEratoFiles(mentionLinkedText);
 
     return (
       <BlockCodeContext.Provider value={{ isBlockCode: false, isStreaming }}>
@@ -969,7 +1041,10 @@ export const MessageContent = memo(function MessageContent({
             components={components}
             urlTransform={(url) =>
               // eslint-disable-next-line lingui/no-unlocalized-strings
-              url.startsWith("erato-file://") ? url : defaultUrlTransform(url)
+              url.startsWith("erato-file://") ||
+              url.startsWith(ERATO_MENTION_SCHEME)
+                ? url
+                : defaultUrlTransform(url)
             }
             // Handle incomplete markdown patterns gracefully
             skipHtml={false}

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -2099,7 +2099,7 @@ describe("useChatMessaging", () => {
           undefined,
           undefined,
           undefined,
-          ["assistant-research"],
+          [{ id: "assistant-research", name: "Researcher" }],
           "background",
         );
       });
@@ -2128,7 +2128,7 @@ describe("useChatMessaging", () => {
           undefined,
           undefined,
           undefined,
-          ["assistant-research"],
+          [{ id: "assistant-research", name: "Researcher" }],
         );
       });
 

--- a/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
+++ b/frontend/src/hooks/chat/handlers/handleUserMessageSaved.ts
@@ -91,6 +91,9 @@ export function handleUserMessageSaved(
         createdAt: serverConfirmedMessage.created_at,
         status: "complete" as const, // Message is saved, so status is complete
         input_files_ids: serverConfirmedMessage.input_files_ids,
+        // Server-resolved pairs replace the optimistic ones so the mention
+        // highlight survives the temp → real message swap.
+        mentioned_assistants: serverConfirmedMessage.mentioned_assistants,
       };
 
       // Find the temporary message by content comparison (extract text from ContentPart[])

--- a/frontend/src/hooks/chat/useChatActions.ts
+++ b/frontend/src/hooks/chat/useChatActions.ts
@@ -7,6 +7,7 @@ import type {
   DelegationRunMode,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { MessageAction } from "@/types/message-controls";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 
 const logger = createLogger("HOOK", "useChatActions");
 
@@ -19,7 +20,7 @@ interface UseChatActionsProps {
     assistantId?: string,
     selectedFacetIds?: string[],
     actionFacet?: ActionFacetRequest,
-    mentionedAssistantIds?: string[],
+    mentionedAssistants?: AssistantMention[],
     delegationRunMode?: DelegationRunMode,
   ) => Promise<string | undefined>;
   onMessageAction?: (action: MessageAction) => Promise<boolean>;
@@ -64,7 +65,7 @@ export function useChatActions({
       modelId?: string,
       assistantId?: string,
       selectedFacetIds?: string[],
-      mentionedAssistantIds?: string[],
+      mentionedAssistants?: AssistantMention[],
       delegationRunMode?: DelegationRunMode,
     ) => {
       if (message.trim() || (inputFileIds && inputFileIds.length > 0)) {
@@ -75,7 +76,7 @@ export function useChatActions({
           assistantId,
           selectedFacetIds,
           undefined,
-          mentionedAssistantIds,
+          mentionedAssistants,
           delegationRunMode,
         );
       }

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -68,6 +68,7 @@ import type {
   MessageSubmitStreamingResponseMessage,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 
 const logger = createLogger("HOOK", "useChatMessaging");
 const COMPLETION_CLOSE_DEDUP_MS = 5000;
@@ -1382,7 +1383,7 @@ export function useChatMessaging(
       assistantId?: string,
       selectedFacetIds?: string[],
       actionFacet?: ActionFacetRequest,
-      mentionedAssistantIds?: string[],
+      mentionedAssistants?: AssistantMention[],
       delegationRunMode?: DelegationRunMode,
     ): Promise<string | undefined> => {
       // Prevent duplicate submissions
@@ -1396,8 +1397,14 @@ export function useChatMessaging(
         `[DEBUG_STREAMING] sendMessage called. Content: "${content}", Files: ${inputFileIds?.length ?? 0}, Model: ${modelId ?? "default"}, Assistant: ${assistantId ?? "none"}`,
       );
 
-      // Create optimistic user message immediately on submit so UI updates first.
-      const userMessage = createOptimisticUserMessage(content, inputFileIds);
+      // Create optimistic user message immediately on submit so UI updates
+      // first. The tracked mentions ride along so the highlight shows before
+      // the server echoes the resolved pairs in user_message_saved.
+      const userMessage = createOptimisticUserMessage(
+        content,
+        inputFileIds,
+        mentionedAssistants,
+      );
       logger.log(
         "[DEBUG_STREAMING] sendMessage: Adding optimistic user message to store:",
         userMessage,
@@ -1498,7 +1505,7 @@ export function useChatMessaging(
           assistantId,
           selectedFacetIds,
           actionFacet,
-          mentionedAssistantIds,
+          mentionedAssistants?.map((mention) => mention.id),
           delegationRunMode,
         );
 

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -722,6 +722,12 @@ export type ChatMessage = {
    */
   mcp_servers_unavailable?: string[];
   /**
+   * Assistants the user @-mentioned in this message, resolved to display
+   * names at read time. Mentions whose assistant no longer resolves are
+   * omitted; absent on assistant messages and mention-less user messages.
+   */
+  mentioned_assistants?: MentionedAssistant[];
+  /**
    * The ID of the previous message in the thread, if any
    */
   previous_message_id?: string;
@@ -1612,6 +1618,20 @@ export type McpServerStatusValue =
   | "SUCCESS"
   | "FAILURE"
   | "NEEDS_AUTHENTICATION";
+
+/**
+ * An assistant the user @-mentioned in a message, resolved for display.
+ */
+export type MentionedAssistant = {
+  /**
+   * The unique ID of the mentioned assistant
+   */
+  id: string;
+  /**
+   * The assistant's display name at read time
+   */
+  name: string;
+};
 
 export type Message = {
   id: string;

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -387,6 +387,7 @@ export type {
 } from "@/types/message-controls";
 export type { ChatInputControlsHandle } from "@/components/ui/Chat/ChatInputControlsContext";
 export type { ChatInputAttachmentPreviewProps } from "@/types/chat-input-attachment-preview";
+export type { AssistantMention } from "@/utils/chat/assistantMentions";
 export type {
   ActionFacetInfo,
   ActionFacetRequest,

--- a/frontend/src/providers/ChatProvider.tsx
+++ b/frontend/src/providers/ChatProvider.tsx
@@ -31,6 +31,7 @@ import type {
   DelegationRunMode,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 import type { FileType } from "@/utils/fileTypes";
 import type { ReactNode } from "react";
 
@@ -83,7 +84,7 @@ export interface ChatContextValue {
     assistantId?: string,
     selectedFacetIds?: string[],
     actionFacet?: { id: string; args?: Record<string, string> },
-    mentionedAssistantIds?: string[],
+    mentionedAssistants?: AssistantMention[],
     delegationRunMode?: DelegationRunMode,
   ) => Promise<string | undefined>;
   editMessage: (

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -2,7 +2,10 @@
  * Types for chat functionality.
  */
 
-import type { ContentPart } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type {
+  ContentPart,
+  MentionedAssistant,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
 export type ContentFilterCategory =
   | "hate"
@@ -157,6 +160,13 @@ export interface Message {
   action_facet_id?: string;
   /** The action facet arguments supplied with this user message, if any. */
   action_facet_args?: Record<string, string>;
+  /**
+   * Assistants this user message @-mentioned, as resolved `{id, name}` pairs.
+   * Server-provided on persisted messages; on optimistic messages, seeded
+   * from the composer's tracked mentions so the highlight needs no
+   * round-trip.
+   */
+  mentioned_assistants?: MentionedAssistant[];
   /**
    * Set on assistant messages produced under an Outlook action facet — drives
    * insert/replace email-artifact rendering in {@link Message} content

--- a/frontend/src/utils/adapters/messageAdapter.ts
+++ b/frontend/src/utils/adapters/messageAdapter.ts
@@ -75,6 +75,7 @@ export function mapApiMessageToUiMessage(
     mcp_servers_needing_auth: apiMessage.mcp_servers_needing_auth ?? undefined,
     action_facet_id: apiMessage.action_facet_id ?? undefined,
     action_facet_args: apiMessage.action_facet_args ?? undefined,
+    mentioned_assistants: apiMessage.mentioned_assistants ?? undefined,
   };
 }
 

--- a/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
+++ b/frontend/src/utils/chat/__tests__/assistantMentions.test.ts
@@ -7,6 +7,7 @@ import {
   mentionToken,
   pruneTrackedMentions,
   resolveMentionedAssistantIds,
+  resolveMentionedAssistants,
 } from "../assistantMentions";
 
 import type { AssistantMention } from "../assistantMentions";
@@ -176,6 +177,18 @@ describe("findMentionRanges", () => {
     expect(new Set(findMentionRanges(text, tracked).map((r) => r.id))).toEqual(
       new Set(resolveMentionedAssistantIds(text, tracked)),
     );
+  });
+});
+
+describe("resolveMentionedAssistants", () => {
+  it("returns the full pairs the ids are derived from", () => {
+    expect(
+      resolveMentionedAssistants("@Data then @Researcher", [
+        researcher,
+        dataAssistant,
+      ]),
+    ).toEqual([researcher, dataAssistant]);
+    expect(resolveMentionedAssistants("plain text", [researcher])).toEqual([]);
   });
 });
 

--- a/frontend/src/utils/chat/assistantMentions.ts
+++ b/frontend/src/utils/chat/assistantMentions.ts
@@ -116,24 +116,32 @@ export function findMentionRanges(
   return ranges.sort((a, b) => a.start - b.start);
 }
 
-/** The ids the composer should submit: tracked order, deduped, text wins. */
-export function resolveMentionedAssistantIds(
+/** The mentions the composer should submit: tracked order, deduped, text wins. */
+export function resolveMentionedAssistants(
   text: string,
   tracked: AssistantMention[],
-): string[] {
+): AssistantMention[] {
   const present = new Set(
     findMentionRanges(text, tracked).map((range) => range.id),
   );
-  const ids: string[] = [];
+  const mentions: AssistantMention[] = [];
   const seen = new Set<string>();
   for (const mention of tracked) {
     if (seen.has(mention.id) || !present.has(mention.id)) {
       continue;
     }
     seen.add(mention.id);
-    ids.push(mention.id);
+    mentions.push(mention);
   }
-  return ids;
+  return mentions;
+}
+
+/** The ids the composer should submit: tracked order, deduped, text wins. */
+export function resolveMentionedAssistantIds(
+  text: string,
+  tracked: AssistantMention[],
+): string[] {
+  return resolveMentionedAssistants(text, tracked).map((mention) => mention.id);
 }
 
 /**

--- a/frontend/src/utils/chat/messageUtils.test.ts
+++ b/frontend/src/utils/chat/messageUtils.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   collectSupersededMessageIds,
   constructSubmitStreamRequestBody,
+  createOptimisticUserMessage,
 } from "./messageUtils";
 
 import type { Message } from "@/types/chat";
@@ -134,5 +135,29 @@ describe("constructSubmitStreamRequestBody", () => {
         ["assistant-1"],
       ),
     ).not.toHaveProperty("delegation_run_mode");
+  });
+});
+
+describe("createOptimisticUserMessage", () => {
+  it("carries the send-time mentions so the highlight needs no round-trip", () => {
+    const optimistic = createOptimisticUserMessage(
+      "ask @Researcher",
+      undefined,
+      [{ id: "assistant-1", name: "Researcher" }],
+    );
+
+    expect(optimistic.mentioned_assistants).toEqual([
+      { id: "assistant-1", name: "Researcher" },
+    ]);
+    expect(optimistic.status).toBe("sending");
+  });
+
+  it("leaves the field absent without mentions", () => {
+    expect(
+      createOptimisticUserMessage("plain").mentioned_assistants,
+    ).toBeUndefined();
+    expect(
+      createOptimisticUserMessage("plain", undefined, []).mentioned_assistants,
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/utils/chat/messageUtils.ts
+++ b/frontend/src/utils/chat/messageUtils.ts
@@ -5,16 +5,21 @@ import type {
   DelegationRunMode,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { Message } from "@/types/chat";
+import type { AssistantMention } from "@/utils/chat/assistantMentions";
 
 /**
  * Creates an optimistic user message object to be added to the UI immediately.
  * @param content The content of the user message.
  * @param inputFileIds Optional array of input file IDs associated with the message.
+ * @param mentionedAssistants The mentions resolved at send time; carried so the
+ *                            message highlights them before the server echoes
+ *                            its own resolved pairs.
  * @returns A message object with a temporary ID and 'sending' status.
  */
 export function createOptimisticUserMessage(
   content: string,
   inputFileIds?: string[],
+  mentionedAssistants?: AssistantMention[],
 ): Message {
   const timestamp = Date.now();
   const tempUserMessageId = `temp-user-${timestamp}`;
@@ -25,6 +30,10 @@ export function createOptimisticUserMessage(
     createdAt: new Date(timestamp).toISOString(),
     status: "sending",
     input_files_ids: inputFileIds,
+    mentioned_assistants:
+      mentionedAssistants && mentionedAssistants.length > 0
+        ? mentionedAssistants
+        : undefined,
   };
 }
 

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -26,6 +26,7 @@ import {
   useProfile,
   useStandardMessageActions,
   type ActionFacetRequest,
+  type AssistantMention,
   type ChatInputControlsHandle,
   type ChatMessageProps,
   type DropdownMenuItem,
@@ -63,7 +64,7 @@ export interface AddinChatInputRenderProps {
     selectedFacetIds?: string[],
     actionFacet?: ActionFacetRequest,
     hostContextIdentity?: string | null,
-    mentionedAssistantIds?: string[],
+    mentionedAssistants?: AssistantMention[],
   ) => void;
   onFilePreview: (file: FileUploadItem) => void;
   handleFileAttachments: (files: FileUploadItem[]) => void;
@@ -236,7 +237,7 @@ function useAddinChatController({
       selectedFacetIds,
       actionFacet,
       hostContextIdentity,
-      mentionedAssistantIds,
+      mentionedAssistants,
     ) => {
       hostCallbacksRef.current.beforeSend?.(hostContextIdentity);
       void chat
@@ -247,7 +248,7 @@ function useAddinChatController({
           assistantId,
           selectedFacetIds,
           actionFacet,
-          mentionedAssistantIds,
+          mentionedAssistants,
         )
         .then(() => chat.refetchHistory());
     },
@@ -455,7 +456,7 @@ function NeutralAddinChatHost({ controller }: AddinChatHostProps) {
             inputFileIds,
             modelId,
             selectedFacetIds,
-            mentionedAssistantIds,
+            mentionedAssistants,
           ) =>
             props.onSendMessage(
               message,
@@ -464,7 +465,7 @@ function NeutralAddinChatHost({ controller }: AddinChatHostProps) {
               selectedFacetIds,
               undefined,
               undefined,
-              mentionedAssistantIds,
+              mentionedAssistants,
             )
           }
         />

--- a/office-addin/src/core/AddinChatInputCore.tsx
+++ b/office-addin/src/core/AddinChatInputCore.tsx
@@ -1,5 +1,6 @@
 import {
   ChatInput,
+  type AssistantMention,
   type ChatInputControlsHandle,
   type ChatModel,
   type FileType,
@@ -13,7 +14,7 @@ export interface AddinChatInputCoreProps {
     inputFileIds?: string[],
     modelId?: string,
     selectedFacetIds?: string[],
-    mentionedAssistantIds?: string[],
+    mentionedAssistants?: AssistantMention[],
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;

--- a/office-addin/src/outlook/components/AddinChatInput.tsx
+++ b/office-addin/src/outlook/components/AddinChatInput.tsx
@@ -9,6 +9,7 @@ import {
   type FileAttachmentGroup,
   type FileAttachmentGroupItem,
   type ActionFacetRequest,
+  type AssistantMention,
   type FileType,
   type FileUploadItem,
 } from "@erato/frontend/library";
@@ -83,7 +84,7 @@ interface AddinChatInputProps {
      * (the completion's artifact is treated as stale, never unguarded).
      */
     sendItemIdentity?: string | null,
-    mentionedAssistantIds?: string[],
+    mentionedAssistants?: AssistantMention[],
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;
@@ -663,7 +664,7 @@ export const AddinChatInput = forwardRef<
       inputFileIds?: string[],
       modelId?: string,
       selectedFacetIds?: string[],
-      mentionedAssistantIds?: string[],
+      mentionedAssistants?: AssistantMention[],
     ) => {
       // Capture the item identity BEFORE any await: the uploads below can
       // take long enough for the user to switch emails, and the wrong-item
@@ -812,7 +813,7 @@ export const AddinChatInput = forwardRef<
           selectedFacetIds,
           actionFacet,
           sendItemIdentity,
-          mentionedAssistantIds,
+          mentionedAssistants,
         );
         return;
       }
@@ -835,7 +836,7 @@ export const AddinChatInput = forwardRef<
             selectedFacetIds,
             actionFacet,
             sendItemIdentity,
-            mentionedAssistantIds,
+            mentionedAssistants,
           );
           // No upload was attempted (e.g. only dismissed drops remain) and
           // nothing failed, so the staged drops are safe to clear.
@@ -876,7 +877,7 @@ export const AddinChatInput = forwardRef<
         selectedFacetIds,
         actionFacet,
         sendItemIdentity,
-        mentionedAssistantIds,
+        mentionedAssistants,
       );
 
       // Clear the drops only when their files actually uploaded. On a failed
@@ -1037,14 +1038,14 @@ export const AddinChatInput = forwardRef<
           inputFileIds,
           modelId,
           selectedFacetIds,
-          mentionedAssistantIds,
+          mentionedAssistants,
         ) => {
           void wrappedOnSendMessage(
             message,
             inputFileIds,
             modelId,
             selectedFacetIds,
-            mentionedAssistantIds,
+            mentionedAssistants,
           );
         }}
         disabled={


### PR DESCRIPTION
Standalone on main (no stack dependency).

The composer highlights tracked assistant mentions while typing, but the sent user message rendered the `@Name` token as plain prose — highlighting never existed on the read side, which reads as a regression the moment a message is sent. This adds it, end to end.

## Read side

User messages have always persisted `mentioned_assistant_ids`; the messages API now resolves them into `mentioned_assistants: [{id, name}]` — one batch assistants query per page (the `RecentChat.assistant_name` precedent: no per-assistant access check, since the containing chat was already authorized and the ids were validated at submit). Deleted assistants are omitted and their tokens stay plain text. The key is absent on assistant messages and mention-less user messages, so existing payloads are byte-identical. The SSE `user_message_saved` payload is the same type and is populated at both emission sites (submit and edit), so a live client highlights without a refetch.

## Render side

The just-sent message can't wait for the server: the send chain now carries the resolved `{id, name}` pairs from the composer into the optimistic echo, and the temp→real swap keeps them, so the highlight is present from the first frame and survives confirmation.

User messages go through the full markdown pipeline, so the mechanism follows the repo's own `autolinkEratoFiles` precedent: each `findMentionRanges` hit (the same matcher the composer uses — never a bare `@word` regex) is rewritten pre-markdown into an `erato-mention://` link that a component branch renders as a pill using the composer backdrop's exact tone tokens. Hand-typed `erato-mention://` links for ids the message doesn't actually carry degrade to plain text, and assistant messages never highlight — an assistant writing "@Name" is quoting, not addressing.

## Tests

Backend: two mentions resolve on GET and in the SSE event; a ghost id is omitted; assistant/mention-less messages carry no key. Frontend: pill rendering with markdown intact around it, multiple mentions, unresolved stays plain, optimistic message highlights and survives the swap, foreign-link containment, assistant messages withheld. Full frontend suite 1346 passed; backend fmt/clippy/codegen checks + 218 targeted tests green.
