### PR TITLE
Delegation surfaces: kit-aligned badges and chevrons, keyboard reveal, SPA origin link (ERMAIN-665)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -57,6 +57,7 @@ import {
 } from "./SidebarResizeHandle";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { Button } from "../Controls/Button";
+import { CountBadge } from "../Controls/CountBadge";
 import { UserProfileThemeDropdown } from "../Controls/UserProfileThemeDropdown";
 import { CopyErrorButton } from "../Feedback/CopyErrorButton";
 import {
@@ -87,10 +88,6 @@ const ASSISTANTS_SECTION_EXPANDED_STORAGE_KEY =
   "erato.sidebar.assistantsSectionExpanded";
 
 const GENERATION_ANNOUNCE_DEBOUNCE_MS = 1000;
-
-const generationBadgeClassName =
-  // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS utility classes, not user-facing text
-  "flex min-w-4 items-center justify-center rounded-full bg-theme-action-primary-bg px-1 text-[10px] font-semibold leading-4 text-theme-action-primary-fg";
 
 /**
  * Running + session-observed finished/error + chats awaiting a tool
@@ -129,13 +126,13 @@ const GenerationRailBadge = () => {
   if (count === 0) return null;
 
   return (
-    <span
+    <CountBadge
+      variant="attention"
       data-testid="sidebar-generation-badge"
-      aria-hidden="true"
-      className={clsx("absolute -right-0.5 -top-0.5", generationBadgeClassName)}
+      className="absolute -right-0.5 -top-0.5"
     >
       {count}
-    </span>
+    </CountBadge>
   );
 };
 

--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -13,6 +13,7 @@ import { useRovingMenuFocus } from "@/hooks/ui/useRovingMenuFocus";
 
 import { AnchoredPopover } from "../Controls/AnchoredPopover";
 import { Button } from "../Controls/Button";
+import { CountBadge } from "../Controls/CountBadge";
 import { CheckIcon, LoadingIcon, PlusIcon } from "../icons";
 
 import type React from "react";
@@ -451,12 +452,16 @@ export function ChatInputAddMenu({
           }
         >
           {showBadge && !isProcessing && (
-            <span
+            <CountBadge
+              variant="attention"
+              // Stays in the accessibility tree: the trigger's label does
+              // not carry the selection count, so the badge must.
+              aria-hidden={false}
               data-testid="chat-input-add-menu-badge"
-              className="absolute -right-0.5 -top-0.5 flex min-w-4 items-center justify-center rounded-full bg-theme-action-primary-bg px-1 text-[10px] font-semibold leading-4 text-theme-action-primary-fg"
+              className="absolute -right-0.5 -top-0.5"
             >
               {selectedCount}
-            </span>
+            </CountBadge>
           )}
         </Button>
       )}

--- a/frontend/src/components/ui/Chat/DelegatedRunHeader.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunHeader.test.tsx
@@ -1,9 +1,18 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DelegatedRunHeader } from "./DelegatedRunHeader";
 
 import type { DelegatedRunHeaderProps } from "./DelegatedRunHeader";
+
+const navigateMock = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 const run = (
   overrides: Partial<DelegatedRunHeaderProps> = {},
@@ -17,6 +26,28 @@ const run = (
 });
 
 describe("DelegatedRunHeader", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+  });
+
+  it("routes the origin link through the SPA instead of reloading", () => {
+    render(<DelegatedRunHeader {...run()} />);
+
+    fireEvent.click(screen.getByTestId("delegated-run-origin-link"));
+    expect(navigateMock).toHaveBeenCalledWith("/a/assistant-9/origin-1");
+
+    // Cmd/ctrl-click keeps the browser's open-in-new-tab behaviour. The
+    // document-level listener only keeps jsdom from following the href.
+    navigateMock.mockClear();
+    const swallowNavigation = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener("click", swallowNavigation);
+    fireEvent.click(screen.getByTestId("delegated-run-origin-link"), {
+      metaKey: true,
+    });
+    document.removeEventListener("click", swallowNavigation);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
   it("names the run, its delegate and the conversation that dispatched it", () => {
     render(<DelegatedRunHeader {...run()} />);
 

--- a/frontend/src/components/ui/Chat/DelegatedRunHeader.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunHeader.tsx
@@ -1,4 +1,5 @@
 import { t } from "@lingui/core/macro";
+import { useNavigate } from "react-router-dom";
 
 import { delegatedRunOrigin } from "@/utils/chat/delegatedRunOrigin";
 import { getChatUrl } from "@/utils/chat/urlUtils";
@@ -18,13 +19,15 @@ export interface DelegatedRunHeaderProps extends DelegatedRunProvenance {
   isArchived?: boolean;
 }
 
+// dt/dd as flat grid children, so the label column sizes to the widest
+// label instead of a fixed width that clips longer translations.
 const Field = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-2">
-    <dt className="shrink-0 text-theme-fg-muted sm:w-32">{label}</dt>
+  <>
+    <dt className="text-theme-fg-muted">{label}</dt>
     <dd className="min-w-0 whitespace-pre-wrap text-theme-fg-secondary">
       {value}
     </dd>
-  </div>
+  </>
 );
 
 /**
@@ -67,12 +70,16 @@ export const DelegatedRunHeader = ({
   isArchived = false,
   ...provenance
 }: DelegatedRunHeaderProps) => {
+  const navigate = useNavigate();
   const origin = delegatedRunOrigin(provenance);
   if (!origin) {
     return null;
   }
   const note = stateNote(isRunning, isArchived);
   const hasParameters = Boolean(expectedOutput) || Boolean(constraints);
+  const originHref = origin.chatId
+    ? getChatUrl(origin.chatId, origin.assistantId)
+    : null;
 
   return (
     <div
@@ -85,7 +92,7 @@ export const DelegatedRunHeader = ({
         </span>
         {assistantName ? (
           <>
-            <span aria-hidden className="text-theme-fg-muted">
+            <span aria-hidden="true" className="text-theme-fg-muted">
               ·
             </span>
             <span className="truncate text-theme-fg-secondary">
@@ -93,12 +100,23 @@ export const DelegatedRunHeader = ({
             </span>
           </>
         ) : null}
-        <span aria-hidden className="text-theme-fg-muted">
+        <span aria-hidden="true" className="text-theme-fg-muted">
           ·
         </span>
-        {origin.chatId ? (
+        {originHref ? (
           <a
-            href={getChatUrl(origin.chatId, origin.assistantId)}
+            href={originHref}
+            onClick={(e) => {
+              // Allow cmd/ctrl-click to open in new tab
+              if (e.metaKey || e.ctrlKey) {
+                return;
+              }
+              e.preventDefault();
+              navigate(originHref);
+            }}
+            // Persistent underline on purpose: a link sitting mid-sentence
+            // needs a resting affordance, like the prose links in message
+            // content — unlike hover-underlined control-style links.
             className="focus-ring-tight truncate rounded-[var(--theme-radius-base)] text-theme-fg-secondary underline underline-offset-2 hover:text-theme-fg-primary"
             data-testid="delegated-run-origin-link"
           >
@@ -114,7 +132,7 @@ export const DelegatedRunHeader = ({
         )}
       </div>
       {hasParameters ? (
-        <dl className="min-w-0 space-y-1">
+        <dl className="grid min-w-0 grid-cols-1 gap-y-0.5 sm:grid-cols-[auto,1fr] sm:gap-x-3 sm:gap-y-1">
           {expectedOutput ? (
             <Field
               label={t({

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
@@ -389,6 +389,10 @@ describe("DelegatedRunsSection check-off", () => {
     expect(dismissButtons[0].closest('[data-chat-id="run-2"]')).not.toBeNull();
     expect(dismissButtons[0]).toHaveAccessibleName("Dismiss run");
     expect(dismissButtons[0]).toHaveAttribute("title", "Dismiss run");
+    // The strong hover step — the row hover already paints --theme-bg-hover.
+    expect(dismissButtons[0]).toHaveClass(
+      "hover:!bg-[var(--theme-bg-hover-strong)]",
+    );
   });
 
   it("removes the checked-off row, keeps the others, and survives a reload", () => {

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
@@ -308,6 +308,38 @@ describe("DelegatedRunsSection", () => {
     });
   });
 
+  it("labels the toggle with the count and status, wired to the list panel", () => {
+    mockRuns([
+      recentChat({ id: "run-1", delegated_run_outcome: "completed" }),
+      recentChat({ id: "run-2", delegated_run_outcome: "failed" }),
+    ]);
+    renderSection("origin-1");
+
+    // The badge and the dot are aria-hidden, so the name carries both.
+    const toggle = screen.getByTestId("delegated-runs-toggle");
+    expect(toggle).toHaveAccessibleName("Delegated runs (2), Error");
+
+    const panelId = toggle.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+    expandRuns();
+    const panel = document.getElementById(panelId ?? "");
+    expect(panel).not.toBeNull();
+    expect(
+      within(panel as HTMLElement).getAllByTestId("delegated-run-item"),
+    ).toHaveLength(2);
+  });
+
+  it("reveals the open-in-new-window hint from the focusable row itself", () => {
+    mockRuns([recentChat({ id: "run-1" })]);
+    renderSection("origin-1");
+    expandRuns();
+
+    // The reveal group must sit on the anchor that receives focus — on an
+    // inner div, group-focus-visible never fires and keyboard users never
+    // see the icon.
+    expect(screen.getByTestId("delegated-run-item")).toHaveClass("group/run");
+  });
+
   it("expands as a plain disclosure without capturing focus", () => {
     mockRuns([recentChat({ id: "run-1" })]);
     renderSection("origin-1");
@@ -356,6 +388,7 @@ describe("DelegatedRunsSection check-off", () => {
     expect(dismissButtons).toHaveLength(1);
     expect(dismissButtons[0].closest('[data-chat-id="run-2"]')).not.toBeNull();
     expect(dismissButtons[0]).toHaveAccessibleName("Dismiss run");
+    expect(dismissButtons[0]).toHaveAttribute("title", "Dismiss run");
   });
 
   it("removes the checked-off row, keeps the others, and survives a reload", () => {

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
@@ -145,6 +145,11 @@ const DelegatedRunRow = memo<{
             <Button
               variant="icon-only"
               size="sm"
+              // The row under the pointer is already painted with
+              // --theme-bg-hover, so the variant's own hover is invisible
+              // here; the strong step keeps the chip readable. Important,
+              // because the variant's own hover class wins the cascade.
+              className="hover:!bg-[var(--theme-bg-hover-strong)]"
               icon={<CloseIcon className="size-4" />}
               aria-label={dismissLabel}
               title={dismissLabel}

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
@@ -1,7 +1,6 @@
 import { t } from "@lingui/core/macro";
 import { skipToken } from "@tanstack/react-query";
-import clsx from "clsx";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -26,8 +25,10 @@ import { ChatAttentionStatusDot } from "./ChatAttentionStatusDot";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { Button } from "../Controls/Button";
 import { Collapse } from "../Controls/Collapse";
+import { CountBadge } from "../Controls/CountBadge";
+import { DisclosureChevron } from "../Controls/DisclosureChevron";
 import { MessageTimestamp } from "../Message/MessageTimestamp";
-import { OpenNewWindowIcon, CheckIcon, ChevronRightIcon } from "../icons";
+import { OpenNewWindowIcon, CloseIcon } from "../icons";
 
 import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
@@ -77,6 +78,10 @@ const DelegatedRunRow = memo<{
 
   const isLive = status === "running" || status === "action_required";
   const isSettled = status === "finished" || status === "error";
+  const dismissLabel = t({
+    id: "chat.history.delegatedRuns.dismiss",
+    message: "Dismiss run",
+  });
   // Elapsed anchors to the live generation's start when one is known; a
   // settled run shows when it last wrote instead.
   const liveStartedAt =
@@ -97,7 +102,9 @@ const DelegatedRunRow = memo<{
         e.preventDefault();
         navigate(href);
       }}
-      className="focus-ring-inset block rounded-[var(--theme-radius-base)]"
+      // The group lives here, on the element that actually receives focus,
+      // so the keyboard reveal below has a :focus-visible source.
+      className="focus-ring-inset group/run block rounded-[var(--theme-radius-base)]"
       aria-label={
         status ? `${name}, ${chatAttentionStatusLabel(status)}` : name
       }
@@ -106,7 +113,7 @@ const DelegatedRunRow = memo<{
       <InteractiveContainer
         useDiv={true}
         showFocusRing={false}
-        className="theme-transition group/run flex items-center gap-2 rounded-[var(--theme-radius-base)] px-2 py-1.5 text-left hover:bg-theme-bg-hover"
+        className="theme-transition flex items-center gap-2 rounded-[var(--theme-radius-base)] px-2 py-1.5 text-left hover:bg-theme-bg-hover"
         data-chat-id={chat.id}
         data-ui="delegated-run-item"
       >
@@ -138,11 +145,9 @@ const DelegatedRunRow = memo<{
             <Button
               variant="icon-only"
               size="sm"
-              icon={<CheckIcon className="size-4" />}
-              aria-label={t({
-                id: "chat.history.delegatedRuns.dismiss",
-                message: "Dismiss run",
-              })}
+              icon={<CloseIcon className="size-4" />}
+              aria-label={dismissLabel}
+              title={dismissLabel}
               onClick={() => onDismiss(chat.id)}
               data-testid="delegated-run-dismiss"
             />
@@ -231,6 +236,7 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
     }, [runs]);
 
     const [isExpanded, setIsExpanded] = useState(false);
+    const panelId = useId();
 
     // The header's hint follows the runs' own status vocabulary; a run that
     // is merely running asks for nothing, so it never raises the hint.
@@ -249,6 +255,20 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
       return null;
     }
 
+    const runCount = runs.length;
+    const attentionLabel = attentionStatus
+      ? chatAttentionStatusLabel(attentionStatus)
+      : null;
+    const toggleLabel = attentionLabel
+      ? t({
+          id: "chat.history.delegatedRuns.toggleStatus",
+          message: `Delegated runs (${runCount}), ${attentionLabel}`,
+        })
+      : t({
+          id: "chat.history.delegatedRuns.toggle",
+          message: `Delegated runs (${runCount})`,
+        });
+
     return (
       <div
         // Mirrors the composer's own width channel so the bar and the input
@@ -262,47 +282,46 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
             type="button"
             onClick={() => setIsExpanded((expanded) => !expanded)}
             aria-expanded={isExpanded}
+            aria-controls={panelId}
+            // The count badge and the status dot are visual-only, so the
+            // name must say what they show (the dot's own contract).
+            aria-label={toggleLabel}
             className="focus-ring-inset theme-transition flex w-full items-center gap-2 rounded-[var(--theme-radius-message)] px-3 py-2 text-left hover:bg-theme-bg-hover"
             data-testid="delegated-runs-toggle"
           >
-            <ChevronRightIcon
-              className={clsx(
-                "theme-transition size-3 shrink-0 text-theme-fg-muted",
-                isExpanded ? "rotate-90" : "rotate-0",
-              )}
-              aria-hidden="true"
-            />
+            <DisclosureChevron open={isExpanded} />
             <span className="truncate text-xs font-semibold text-theme-fg-secondary">
               {t({
                 id: "chat.history.delegatedRuns",
                 message: "Delegated runs",
               })}
             </span>
-            <span
-              className="flex min-w-4 shrink-0 items-center justify-center rounded-full bg-theme-bg-secondary px-1 text-[10px] font-semibold leading-4 text-theme-fg-secondary"
+            <CountBadge
+              variant="count"
+              className="shrink-0"
               data-testid="delegated-runs-count"
             >
               {runs.length}
-            </span>
+            </CountBadge>
             {attentionStatus && (
               <ChatAttentionStatusDot status={attentionStatus} />
             )}
           </button>
           <Collapse isOpen={isExpanded}>
-            {isExpanded && (
-              <div
-                className="flex w-full min-w-0 flex-col gap-0.5 px-1.5 pb-1.5"
-                data-ui="delegated-runs-list"
-              >
-                {runs.map((chat) => (
+            <div
+              id={panelId}
+              className="flex w-full min-w-0 flex-col gap-0.5 px-1.5 pb-1.5"
+              data-ui="delegated-runs-list"
+            >
+              {isExpanded &&
+                runs.map((chat) => (
                   <DelegatedRunRow
                     key={chat.id}
                     chat={chat}
                     onDismiss={dismissRun}
                   />
                 ))}
-              </div>
-            )}
+            </div>
           </Collapse>
         </div>
       </div>

--- a/frontend/src/components/ui/Chat/SidebarCollapsibleSection.tsx
+++ b/frontend/src/components/ui/Chat/SidebarCollapsibleSection.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { memo, useEffect, useState } from "react";
 
 import { Collapse, COLLAPSE_DURATION_MS } from "../Controls/Collapse";
-import { ChevronRightIcon } from "../icons";
+import { DisclosureChevron } from "../Controls/DisclosureChevron";
 
 // Nav rows and chat rows share one themeable geometry class so a single
 // theme.css channel reaches both row families.
@@ -78,14 +78,14 @@ export const SidebarCollapsibleSection = memo<{
             <h3 className="theme-transition truncate text-xs font-semibold uppercase tracking-wide text-theme-fg-muted group-hover/toggle:text-theme-fg-primary group-focus-visible/toggle:text-theme-fg-primary">
               {title}
             </h3>
-            <ChevronRightIcon
+            <DisclosureChevron
+              open={isExpanded}
               className={clsx(
-                "theme-transition size-3 shrink-0 text-theme-fg-muted group-hover/toggle:text-theme-fg-primary group-focus-visible/toggle:text-theme-fg-primary",
+                "group-hover/toggle:text-theme-fg-primary group-focus-visible/toggle:text-theme-fg-primary",
                 "opacity-0 group-hover:opacity-100 group-focus-visible/toggle:opacity-100",
                 // Touch devices get no hover reveal, so the non-default
                 // collapsed state must stay visible on its own.
                 !isExpanded && "opacity-100",
-                isExpanded ? "rotate-90" : "rotate-0",
               )}
             />
           </button>

--- a/frontend/src/components/ui/Controls/CountBadge.tsx
+++ b/frontend/src/components/ui/Controls/CountBadge.tsx
@@ -1,0 +1,43 @@
+import clsx from "clsx";
+
+import type { ComponentPropsWithoutRef } from "react";
+
+const VARIANT_STYLES = {
+  // Overlay badge on a control (collapsed rail, menu trigger): something
+  // offscreen wants the user's eye, so it carries the action-primary tone.
+  attention: "bg-theme-action-primary-bg text-theme-action-primary-fg",
+  // Inline passive count next to a label the user is already reading;
+  // attention on such a row travels separately (e.g. a status dot).
+  count: "bg-theme-bg-secondary text-theme-fg-secondary",
+} as const;
+
+export type CountBadgeVariant = keyof typeof VARIANT_STYLES;
+
+export interface CountBadgeProps extends ComponentPropsWithoutRef<"span"> {
+  variant: CountBadgeVariant;
+}
+
+/**
+ * The rounded numeric badge. Hidden from the accessibility tree by default —
+ * a bare number is noise in an accessible name, so the owning control should
+ * say the count in its own label. Pass `aria-hidden={false}` only where that
+ * label does not carry the count.
+ */
+export const CountBadge = ({
+  variant,
+  className,
+  children,
+  ...props
+}: CountBadgeProps) => (
+  <span
+    aria-hidden="true"
+    {...props}
+    className={clsx(
+      "flex min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-4",
+      VARIANT_STYLES[variant],
+      className,
+    )}
+  >
+    {children}
+  </span>
+);

--- a/frontend/src/components/ui/Controls/DisclosureChevron.tsx
+++ b/frontend/src/components/ui/Controls/DisclosureChevron.tsx
@@ -1,0 +1,39 @@
+import clsx from "clsx";
+
+import { ChevronRightIcon } from "../icons";
+
+// Sized to the two disclosure families in use: sidebar/panel headers ("sm")
+// and entity-card rows ("md").
+const SIZE_STYLES = {
+  sm: "size-3",
+  md: "size-4",
+} as const;
+
+export type DisclosureChevronSize = keyof typeof SIZE_STYLES;
+
+export interface DisclosureChevronProps {
+  open: boolean;
+  size?: DisclosureChevronSize;
+  className?: string;
+}
+
+/**
+ * The house disclosure affordance: a right-pointing chevron that rotates 90°
+ * while open. Purely decorative — the owning toggle carries `aria-expanded`
+ * (and the accessible name), so the icon stays out of the accessibility tree.
+ */
+export const DisclosureChevron = ({
+  open,
+  size = "sm",
+  className,
+}: DisclosureChevronProps) => (
+  <ChevronRightIcon
+    aria-hidden="true"
+    className={clsx(
+      "theme-transition shrink-0 text-theme-fg-muted",
+      SIZE_STYLES[size],
+      open ? "rotate-90" : "rotate-0",
+      className,
+    )}
+  />
+);

--- a/frontend/src/components/ui/Controls/__tests__/CountBadge.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/CountBadge.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CountBadge } from "../CountBadge";
+
+describe("CountBadge", () => {
+  it("tones an attention badge with the action-primary pair", () => {
+    render(
+      <CountBadge variant="attention" data-testid="badge">
+        3
+      </CountBadge>,
+    );
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveTextContent("3");
+    expect(badge).toHaveClass("bg-theme-action-primary-bg");
+    expect(badge).toHaveClass("text-theme-action-primary-fg");
+  });
+
+  it("tones a passive count with the secondary pair", () => {
+    render(
+      <CountBadge variant="count" data-testid="badge">
+        7
+      </CountBadge>,
+    );
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveClass("bg-theme-bg-secondary");
+    expect(badge).toHaveClass("text-theme-fg-secondary");
+  });
+
+  it("stays out of the accessibility tree unless opted in", () => {
+    const { rerender } = render(
+      <CountBadge variant="count" data-testid="badge">
+        7
+      </CountBadge>,
+    );
+    expect(screen.getByTestId("badge")).toHaveAttribute("aria-hidden", "true");
+
+    rerender(
+      <CountBadge variant="count" aria-hidden={false} data-testid="badge">
+        7
+      </CountBadge>,
+    );
+    expect(screen.getByTestId("badge")).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("appends caller classes to the shared geometry", () => {
+    render(
+      <CountBadge variant="count" className="shrink-0" data-testid="badge">
+        1
+      </CountBadge>,
+    );
+
+    const badge = screen.getByTestId("badge");
+    expect(badge).toHaveClass("rounded-full");
+    expect(badge).toHaveClass("shrink-0");
+  });
+});

--- a/frontend/src/components/ui/Controls/__tests__/DisclosureChevron.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/DisclosureChevron.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DisclosureChevron } from "../DisclosureChevron";
+
+const renderChevron = (
+  props: Partial<Parameters<typeof DisclosureChevron>[0]> = {},
+) => {
+  const { container } = render(<DisclosureChevron open={false} {...props} />);
+  const icon = container.querySelector("svg");
+  expect(icon).not.toBeNull();
+  return icon as SVGElement;
+};
+
+describe("DisclosureChevron", () => {
+  it("rotates 90° while open and rests at 0 while closed", () => {
+    expect(renderChevron({ open: true })).toHaveClass("rotate-90");
+    expect(renderChevron({ open: false })).toHaveClass("rotate-0");
+  });
+
+  it("sizes to its disclosure family", () => {
+    expect(renderChevron()).toHaveClass("size-3");
+    expect(renderChevron({ size: "md" })).toHaveClass("size-4");
+  });
+
+  it("stays decorative and accepts site-specific classes", () => {
+    const icon = renderChevron({ className: "opacity-0" });
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).toHaveClass("opacity-0");
+    expect(icon).toHaveClass("theme-transition");
+  });
+});

--- a/frontend/src/components/ui/Settings/EntityRow.tsx
+++ b/frontend/src/components/ui/Settings/EntityRow.tsx
@@ -2,12 +2,8 @@ import clsx from "clsx";
 import { useId, useState } from "react";
 
 import { Collapse } from "../Controls/Collapse";
-import {
-  CheckCircleIcon,
-  ChevronRightIcon,
-  ErrorIcon,
-  WarningCircleIcon,
-} from "../icons";
+import { DisclosureChevron } from "../Controls/DisclosureChevron";
+import { CheckCircleIcon, ErrorIcon, WarningCircleIcon } from "../icons";
 
 import type { ReactNode } from "react";
 
@@ -88,12 +84,7 @@ export function EntityRow({
           onClick={() => setIsExpanded((value) => !value)}
           className="theme-transition focus-ring-tight flex min-w-0 flex-1 items-center gap-3 text-left"
         >
-          <ChevronRightIcon
-            className={clsx(
-              "size-4 shrink-0 text-theme-fg-muted transition-transform duration-200",
-              isExpanded && "rotate-90",
-            )}
-          />
+          <DisclosureChevron open={isExpanded} size="md" />
           <span className="min-w-0 flex-1 space-y-1">
             <span className="flex items-center gap-2">
               <span aria-hidden="true" className="shrink-0">

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1418,6 +1418,16 @@ msgid "chat.history.delegatedRuns.dismiss"
 msgstr "Lauf ausblenden"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggle"
+msgstr "Delegierte Läufe ({runCount})"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggleStatus"
+msgstr "Delegierte Läufe ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Gruppieren nach"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1418,6 +1418,16 @@ msgid "chat.history.delegatedRuns.dismiss"
 msgstr "Dismiss run"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggle"
+msgstr "Delegated runs ({runCount})"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggleStatus"
+msgstr "Delegated runs ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Group by"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1418,6 +1418,16 @@ msgid "chat.history.delegatedRuns.dismiss"
 msgstr "Descartar ejecución"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggle"
+msgstr "Ejecuciones delegadas ({runCount})"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggleStatus"
+msgstr "Ejecuciones delegadas ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Agrupar por"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1418,6 +1418,16 @@ msgid "chat.history.delegatedRuns.dismiss"
 msgstr "Ignorer l'exécution"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggle"
+msgstr "Exécutions déléguées ({runCount})"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggleStatus"
+msgstr "Exécutions déléguées ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Regrouper par"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1418,6 +1418,16 @@ msgid "chat.history.delegatedRuns.dismiss"
 msgstr "Odrzuć uruchomienie"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggle"
+msgstr "Delegowane uruchomienia ({runCount})"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/DelegatedRunsSection.tsx
+msgid "chat.history.delegatedRuns.toggleStatus"
+msgstr "Delegowane uruchomienia ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
 msgid "chat.history.filterMenu.groupBy"
 msgstr "Grupuj według"

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -144,6 +144,10 @@
   --theme-bg-sidebar: #e5e7eb;
   --theme-bg-accent: #e5e7eb; /* Monochrome accent */
   --theme-bg-hover: #e5e7eb;
+  /* One step past the flat hover, for a control hovered inside an
+     already-hovered row — painting --theme-bg-hover there again is
+     invisible. Derived, so custom themes keep the relationship. */
+  --theme-bg-hover-strong: color-mix(in srgb, var(--theme-bg-hover), black 6%);
   --theme-bg-selected: #d1d5db;
 
   /* Foreground colors */


### PR DESCRIPTION
Audit follow-up on the two delegation surfaces — the runs list above the composer (ERMAIN-642/643) and the delegated-run header (ERMAIN-631): align them with the house component kit and fix two interaction bugs found on the way. Linear: ERMAIN-665.

**Bugs**
- The row's hover/focus reveal group sat on an inner div while focus lands on the wrapping anchor, so `group-focus-visible` never fired — the open-in-new-window hint was mouse-only. The group now lives on the anchor that actually receives focus.
- The run header's origin link performed a full page reload; it now SPA-routes with the same cmd/ctrl-click escape hatch as every other chat link.

**Kit alignment**
- New `Controls/CountBadge` (`attention` / `count` variants) replaces the three inline copies of the badge class string (sidebar rail, add-menu trigger, runs toggle). The colour split is kept deliberately: `attention` for overlay badges pointing at something offscreen, `count` for an inline passive count whose row carries attention separately. Hidden from the accessibility tree by default; the add-menu badge opts out because its trigger label does not carry the count.
- New `Controls/DisclosureChevron` replaces the three hand-rolled rotate chevrons (runs toggle, sidebar sections, settings entity rows — the latter normalized from `transition-transform duration-200` to `theme-transition`).
- Dismissing a settled run now uses `CloseIcon` — `CheckIcon` means selected/succeeded in every other use, never an action, and the button's own label already says "Dismiss run" — and carries a `title` alongside the label.
- The runs toggle gets an explicit aria-label carrying the count and the most urgent status (badge and dot are visual-only; the dot's contract says the owning control's name states the status), plus `aria-controls` wired to the list panel.
- Run header parameters: the fixed `sm:w-32` label column becomes `grid-cols-[auto,1fr]`, so the column fits translated labels ("Erwartete Ausgabe") instead of clipping them; bare `aria-hidden` becomes explicit.

Deliberate non-changes, recorded in code where they would be re-flagged: the origin link keeps its persistent underline (the house prose-link convention — hover-underline is for control-style links), and the `text-[10px]` badge type scale stays, now in one place.

## Tests

New: CountBadge (variants, hidden-by-default, opt-out), DisclosureChevron (rotation, sizes, decorative), SPA routing of the origin link incl. cmd-click passthrough, toggle name + `aria-controls` wiring, and a regression test pinning the reveal group to the focusable row. Full frontend suite: 150 files / 1440 passed, tsc, eslint, prettier clean; lingui extract/compile run, new toggle strings translated for de/es/fr/pl.
