### PR TITLE
Delegated runs list: surface a background run the moment it is dispatched (ERMAIN-664)

### DIFF
--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
@@ -11,6 +11,7 @@ import {
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { useRecentChats } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useAssistantsFeature } from "@/providers/FeatureConfigProvider";
+import { delegatedRunsListingParams } from "@/utils/chat/delegatedRunDispatch";
 import {
   isBackgroundRun,
   resolveRecentChatTitle,
@@ -174,20 +175,11 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
     const { enabled: assistantsEnabled, delegationEnabled } =
       useAssistantsFeature();
     const canHaveRuns = assistantsEnabled && delegationEnabled;
-    // The origin filter composes with `include_delegated` rather than
-    // implying it — without the latter, delegated children stay hidden and
-    // this query returns nothing.
+    // The params come from the shared builder so a dispatch frame's cache
+    // seed lands under exactly this key.
     const { data } = useRecentChats(
       canHaveRuns && chatId
-        ? {
-            queryParams: {
-              origin_chat_id: chatId,
-              include_delegated: true,
-              // The section is a recency window, not a paginated history:
-              // one page, sized to comfortably cover a chat's recent runs.
-              limit: 50,
-            },
-          }
+        ? { queryParams: delegatedRunsListingParams(chatId) }
         : skipToken,
     );
     const [dismissedRunIds, setDismissedRunIds] = usePersistedState(

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -29,6 +29,7 @@ import {
   useChatMessages,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { mapApiMessageToUiMessage } from "@/utils/adapters/messageAdapter";
+import { seedDispatchedDelegatedRun } from "@/utils/chat/delegatedRunDispatch";
 import {
   createOptimisticUserMessage,
   collectSupersededMessageIds,
@@ -1080,13 +1081,30 @@ export function useChatMessaging(
             handleToolCallProposed(responseData, activeStreamKey);
             break;
 
-          case "tool_call_update":
+          case "tool_call_update": {
             logger.log(
               "[DEBUG_STREAMING] processStreamEvent: tool_call_update event received. Full payload:",
               responseData,
             );
             handleToolCallUpdate(responseData, activeStreamKey);
+            // A background dispatch surfaces in this chat's delegated-runs
+            // listing right away, without waiting for the turn to end; the
+            // terminal invalidation later replaces the seed with server truth.
+            const dispatchOriginChatId =
+              activeStreamKey !== NEW_CHAT_STREAM_KEY
+                ? activeStreamKey
+                : (chatId ??
+                  useMessagingStore.getState().newlyCreatedChatId ??
+                  null);
+            if (dispatchOriginChatId) {
+              seedDispatchedDelegatedRun(
+                queryClient,
+                dispatchOriginChatId,
+                responseData,
+              );
+            }
             break;
+          }
 
           case "client_tool_call":
             // Run the registered executor and POST the result to resume the

--- a/frontend/src/utils/chat/delegatedRunDispatch.test.ts
+++ b/frontend/src/utils/chat/delegatedRunDispatch.test.ts
@@ -1,0 +1,197 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DELEGATION_TOOL_NAME } from "@/lib/delegation/delegationEnvelope";
+import { recentChatsQuery } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import {
+  delegatedRunsListingParams,
+  seedDispatchedDelegatedRun,
+} from "@/utils/chat/delegatedRunDispatch";
+import { isBackgroundRun } from "@/utils/chat/recentChatSession";
+
+import type {
+  MessageSubmitStreamingResponseToolCallUpdate,
+  RecentChat,
+  RecentChatsResponse,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+const ORIGIN_CHAT_ID = "origin-1";
+
+const listingKey = (originChatId: string) =>
+  recentChatsQuery({ queryParams: delegatedRunsListingParams(originChatId) })
+    .queryKey;
+
+// The generated `Value` type erases tool outputs to `void`, so the fixture
+// carries them as `unknown` and casts once, like the DelegationStep tests.
+const dispatchUpdate = (
+  overrides: Partial<
+    Omit<MessageSubmitStreamingResponseToolCallUpdate, "output">
+  > & { output?: unknown } = {},
+): MessageSubmitStreamingResponseToolCallUpdate =>
+  ({
+    content_index: 0,
+    message_id: "6e1a3f34-6f0f-4f6e-9a63-3c1f6f6e5a01",
+    tool_call_id: "call-1",
+    tool_name: DELEGATION_TOOL_NAME,
+    status: "success",
+    output: {
+      background: true,
+      delegate_chat_id: "run-1",
+      assistant_id: "assistant-1",
+      assistant_name: "Linear Ticket Analyst",
+    },
+    ...overrides,
+  }) as MessageSubmitStreamingResponseToolCallUpdate;
+
+const existingRun = (id: string): RecentChat => ({
+  id,
+  title_resolved: `Title of ${id}`,
+  can_edit: true,
+  file_uploads: [],
+  last_message_at: "2026-08-19T12:00:00.000Z",
+  is_pinned: false,
+  provenance_kind: "delegation",
+  provenance_run_mode: "background",
+  origin_chat_id: ORIGIN_CHAT_ID,
+});
+
+const listingOf = (chats: RecentChat[]): RecentChatsResponse => ({
+  chats,
+  stats: {
+    current_offset: 0,
+    has_more: false,
+    returned_count: chats.length,
+    total_count: chats.length,
+  },
+});
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  queryClient = new QueryClient();
+});
+
+describe("seedDispatchedDelegatedRun", () => {
+  it("seeds a listing entry for a background dispatch when none is cached", () => {
+    const seeded = seedDispatchedDelegatedRun(
+      queryClient,
+      ORIGIN_CHAT_ID,
+      dispatchUpdate(),
+    );
+
+    expect(seeded).toBe(true);
+    const listing = queryClient.getQueryData<RecentChatsResponse>(
+      listingKey(ORIGIN_CHAT_ID),
+    );
+    expect(listing?.chats).toHaveLength(1);
+    const row = listing?.chats[0];
+    expect(row?.id).toBe("run-1");
+    expect(row?.assistant_name).toBe("Linear Ticket Analyst");
+    expect(row?.origin_chat_id).toBe(ORIGIN_CHAT_ID);
+    // The row must pass the section's own filter, or seeding shows nothing.
+    expect(row && isBackgroundRun(row)).toBe(true);
+  });
+
+  it("prepends to an existing listing and keeps the cached rows", () => {
+    queryClient.setQueryData(
+      listingKey(ORIGIN_CHAT_ID),
+      listingOf([existingRun("run-0")]),
+    );
+
+    seedDispatchedDelegatedRun(queryClient, ORIGIN_CHAT_ID, dispatchUpdate());
+
+    const listing = queryClient.getQueryData<RecentChatsResponse>(
+      listingKey(ORIGIN_CHAT_ID),
+    );
+    expect(listing?.chats.map((chat) => chat.id)).toEqual(["run-1", "run-0"]);
+  });
+
+  it("does not duplicate a run the listing already carries", () => {
+    queryClient.setQueryData(
+      listingKey(ORIGIN_CHAT_ID),
+      listingOf([existingRun("run-1")]),
+    );
+
+    const seeded = seedDispatchedDelegatedRun(
+      queryClient,
+      ORIGIN_CHAT_ID,
+      dispatchUpdate(),
+    );
+
+    expect(seeded).toBe(false);
+    const listing = queryClient.getQueryData<RecentChatsResponse>(
+      listingKey(ORIGIN_CHAT_ID),
+    );
+    expect(listing?.chats).toHaveLength(1);
+  });
+
+  it("leaves other origins' listings alone", () => {
+    queryClient.setQueryData(listingKey("origin-2"), listingOf([]));
+
+    seedDispatchedDelegatedRun(queryClient, ORIGIN_CHAT_ID, dispatchUpdate());
+
+    expect(
+      queryClient.getQueryData<RecentChatsResponse>(listingKey("origin-2"))
+        ?.chats,
+    ).toHaveLength(0);
+  });
+
+  it("ignores updates from other tools", () => {
+    const seeded = seedDispatchedDelegatedRun(
+      queryClient,
+      ORIGIN_CHAT_ID,
+      dispatchUpdate({ tool_name: "web_search" }),
+    );
+
+    expect(seeded).toBe(false);
+    expect(
+      queryClient.getQueryData(listingKey(ORIGIN_CHAT_ID)),
+    ).toBeUndefined();
+  });
+
+  it("ignores awaited delegations, which deliver inline instead", () => {
+    const seeded = seedDispatchedDelegatedRun(
+      queryClient,
+      ORIGIN_CHAT_ID,
+      dispatchUpdate({
+        output: {
+          status: "completed",
+          delegate_chat_id: "run-1",
+          result: "the answer",
+        },
+      }),
+    );
+
+    expect(seeded).toBe(false);
+    expect(
+      queryClient.getQueryData(listingKey(ORIGIN_CHAT_ID)),
+    ).toBeUndefined();
+  });
+
+  it("ignores a dispatch frame without a run to point at", () => {
+    const seeded = seedDispatchedDelegatedRun(
+      queryClient,
+      ORIGIN_CHAT_ID,
+      dispatchUpdate({ output: { background: true } }),
+    );
+
+    expect(seeded).toBe(false);
+    expect(
+      queryClient.getQueryData(listingKey(ORIGIN_CHAT_ID)),
+    ).toBeUndefined();
+  });
+
+  it("ignores absent or malformed outputs", () => {
+    for (const output of [undefined, null, "text", 7, ["nope"]]) {
+      const seeded = seedDispatchedDelegatedRun(
+        queryClient,
+        ORIGIN_CHAT_ID,
+        dispatchUpdate({ output }),
+      );
+      expect(seeded).toBe(false);
+    }
+    expect(
+      queryClient.getQueryData(listingKey(ORIGIN_CHAT_ID)),
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/chat/delegatedRunDispatch.ts
+++ b/frontend/src/utils/chat/delegatedRunDispatch.ts
@@ -1,0 +1,116 @@
+/**
+ * Surfaces a background delegated run above the composer the moment its
+ * dispatch frame arrives on the stream, instead of when the turn ends.
+ *
+ * The run's chat exists server-side from launch, but the origin-filtered
+ * listing only refetches on the terminal invalidation — and an immediate
+ * refetch would race the detached run's first message write, which the
+ * listing's join requires. So the dispatch frame seeds the listing cache
+ * with a provisional row instead; the turn-end invalidation replaces it
+ * with server truth.
+ *
+ * The row carries no generation markers on purpose: a run between dispatch
+ * and its generation lease resolves as running anyway, and a fabricated
+ * marker would enroll the run in the generating poll before its lease
+ * exists, inviting a false terminal transition.
+ */
+import {
+  DELEGATION_TOOL_NAME,
+  parseDelegationEnvelope,
+} from "@/lib/delegation/delegationEnvelope";
+import { recentChatsQuery } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+
+import {
+  BACKGROUND_RUN_MODE,
+  DELEGATION_PROVENANCE_KIND,
+  UNTITLED_BACKEND_SENTINEL,
+} from "./recentChatSession";
+
+import type {
+  MessageSubmitStreamingResponseToolCallUpdate,
+  RecentChat,
+  RecentChatsResponse,
+} from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The section is a recency window, not a paginated history: one page, sized
+ * to comfortably cover a chat's recent runs.
+ */
+export const DELEGATED_RUNS_LISTING_LIMIT = 50;
+
+/**
+ * The one query-params shape the delegated-runs listing is cached under.
+ * The seeding below writes to the cache by exact key, so the listing surface
+ * and the seed must build their params here and nowhere else.
+ *
+ * The origin filter composes with `include_delegated` rather than implying
+ * it — without the latter, delegated children stay hidden and the query
+ * returns nothing.
+ */
+export const delegatedRunsListingParams = (originChatId: string) => ({
+  origin_chat_id: originChatId,
+  include_delegated: true,
+  limit: DELEGATED_RUNS_LISTING_LIMIT,
+});
+
+/**
+ * Seed the origin chat's delegated-runs listing from a dispatch frame.
+ *
+ * Acts only on the frozen background-dispatch part (`background: true`, a
+ * run to point at, no status) of the delegation tool; every other tool
+ * update passes through untouched. Returns whether a row was seeded.
+ */
+export function seedDispatchedDelegatedRun(
+  queryClient: QueryClient,
+  originChatId: string,
+  update: MessageSubmitStreamingResponseToolCallUpdate,
+): boolean {
+  if (update.tool_name !== DELEGATION_TOOL_NAME) {
+    return false;
+  }
+  const envelope = parseDelegationEnvelope(update.output ?? undefined);
+  const delegateChatId = envelope?.delegateChatId;
+  if (!envelope?.background || delegateChatId === undefined) {
+    return false;
+  }
+
+  const { queryKey } = recentChatsQuery({
+    queryParams: delegatedRunsListingParams(originChatId),
+  });
+  let seeded = false;
+  queryClient.setQueryData<RecentChatsResponse>(queryKey, (current) => {
+    if (current?.chats.some((chat) => chat.id === delegateChatId)) {
+      return current;
+    }
+    seeded = true;
+    // The sentinel title lets the row fall through to the assistant's name;
+    // the run's real title arrives with the refetched listing.
+    const row: RecentChat = {
+      id: delegateChatId,
+      title_resolved: UNTITLED_BACKEND_SENTINEL,
+      assistant_id: envelope.assistantId,
+      assistant_name: envelope.assistantName,
+      provenance_kind: DELEGATION_PROVENANCE_KIND,
+      provenance_run_mode: BACKGROUND_RUN_MODE,
+      origin_chat_id: originChatId,
+      last_message_at: new Date().toISOString(),
+      can_edit: true,
+      is_pinned: false,
+      file_uploads: [],
+    };
+    if (!current) {
+      return {
+        chats: [row],
+        stats: {
+          current_offset: 0,
+          has_more: false,
+          returned_count: 1,
+          total_count: 1,
+        },
+      };
+    }
+    return { ...current, chats: [row, ...current.chats] };
+  });
+  return seeded;
+}


### PR DESCRIPTION
The "Delegated runs" bar above the composer (ERMAIN-642/643) only populated when the parent turn ended: its sole non-mount refresh was the terminal invalidation in `handleRefetchAndClear`. A background run dispatched mid-stream stayed invisible above the composer until streaming finished — even though the child chat exists server-side from launch and the client already receives `{assistant_id, assistant_name, delegate_chat_id, background: true}` mid-stream on the delegation `tool_call_update`. Linear: ERMAIN-664.

Now the dispatch frame seeds the origin-filtered recent-chats cache with a provisional row, so the bar appears the moment the run launches. The existing turn-end invalidation then replaces the seed with server truth.

**Design choices**

- **Cache seed, not refetch.** The listing's join requires the child chat's first message, which the detached task writes moments after the dispatch frame is emitted — an immediate refetch would race it and come back empty.
- **No fabricated generation markers.** The provisional row carries no `active_generation_started_at`: the status column already resolves a marker-less run as running (the documented dispatch→lease state), and a fabricated marker would enroll the run in the generating poll before its lease exists, inviting a false terminal transition.
- Only the frozen background-dispatch frame triggers (`background: true`, a run to point at, no status); awaited delegations, foreign tools, and malformed outputs pass through untouched, and an already-listed run is never duplicated.
- The listing params move into a shared `delegatedRunsListingParams()` used by both the section's query and the seed, so the cache key cannot drift apart.

Note: touches the same file as #1021 (ERMAIN-665) in different hunks — whichever merges second has a trivial rebase.

## Tests

8 new unit tests for the seeder: seeds into an empty cache, prepends and keeps cached rows, no duplication, other origins' listings untouched, and rejection of foreign tools / awaited delegations / missing run id / malformed outputs (the seeded row is asserted to pass the section's own `isBackgroundRun` filter). Full frontend suite: 149 files / 1438 passed; tsc, eslint, prettier clean.
