### PR TITLE
Do not seed a pending sidebar chat from replayed chat_created frames (ERMAIN-666)

### DIFF
--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { createElement } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
 import { setIdToken } from "@/auth/tokenStore";
@@ -1730,8 +1730,30 @@ describe("useChatMessaging", () => {
       return vi.fn();
     });
 
+    // Park the router on /chat/new — the one route chat_created navigates
+    // away from. A resume connection can outlive its chat's route, so a
+    // replay can arrive here; it must not hijack the route the user is on.
+    let currentPathname = "";
+    const LocationProbe = () => {
+      currentPathname = useLocation().pathname;
+      return null;
+    };
+    const NewChatRouteWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(
+        MemoryRouter,
+        {
+          initialEntries: ["/chat/new"],
+          future: {
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          },
+        },
+        createElement(LocationProbe),
+        children,
+      );
+
     renderHook(() => useChatMessaging("chat-delegated-1"), {
-      wrapper: TestWrapper,
+      wrapper: NewChatRouteWrapper,
     });
 
     expect(resumeCallbacks.onMessage).toBeDefined();
@@ -1754,6 +1776,8 @@ describe("useChatMessaging", () => {
     expect(
       useGenerationStatusStore.getState().statusByChatId["chat-delegated-1"],
     ).toBeUndefined();
+    expect(currentPathname).toBe("/chat/new");
+    expect(useMessagingStore.getState().isInNavigationTransition).toBe(false);
   });
 
   it("should seed the pending sidebar chat for a genuine first-turn chat_created", async () => {

--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -105,6 +105,7 @@ vi.mock("@/utils/sse/sseClient", () => {
 
 import { useGenerationStatusStore } from "../store/generationStatusStore";
 import { useMessagingStore } from "../store/messagingStore";
+import { useChatHistoryStore } from "../useChatHistory";
 import { useChatMessaging } from "../useChatMessaging";
 
 import type { ReactNode } from "react";
@@ -1704,6 +1705,191 @@ describe("useChatMessaging", () => {
     expect(
       orderedMessages.filter((message) => message.id === "msg-inflight-user"),
     ).toHaveLength(1);
+  });
+
+  it("should not seed a pending sidebar chat from a replayed chat_created frame", async () => {
+    // Entering a chat force-resumes its stream, and resumestream replays the
+    // full event history — including a chat_created frame for a chat this
+    // client never submitted (most visibly a background delegated run). The
+    // replay arrives on a stream already keyed by the chat id and must not
+    // trip the new-chat bookkeeping.
+    mockUseChatMessages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue({}),
+    });
+
+    let resumeCallbacks: {
+      onMessage?: (event: SSEEvent) => void;
+    } = {};
+    mockCreateSSEConnection.mockImplementation((url, callbacks) => {
+      if (url.includes("/resumestream")) {
+        resumeCallbacks = callbacks;
+      }
+      return vi.fn();
+    });
+
+    renderHook(() => useChatMessaging("chat-delegated-1"), {
+      wrapper: TestWrapper,
+    });
+
+    expect(resumeCallbacks.onMessage).toBeDefined();
+
+    await act(async () => {
+      resumeCallbacks.onMessage?.({
+        data: JSON.stringify({
+          message_type: "chat_created",
+          chat_id: "chat-delegated-1",
+        }),
+        type: "message",
+      });
+    });
+
+    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
+    expect(useMessagingStore.getState().newlyCreatedChatId).toBeNull();
+    expect(
+      useMessagingStore.getState().isAwaitingFirstStreamChunkForNewChat,
+    ).toBe(false);
+    expect(
+      useGenerationStatusStore.getState().statusByChatId["chat-delegated-1"],
+    ).toBeUndefined();
+  });
+
+  it("should seed the pending sidebar chat for a genuine first-turn chat_created", async () => {
+    mockUseChatMessages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue({}),
+    });
+
+    const { result } = renderHook(() => useChatMessaging(null), {
+      wrapper: TestWrapper,
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("Hello from new chat");
+    });
+
+    await act(async () => {
+      sseCallbacks.onMessage?.({
+        data: JSON.stringify({
+          message_type: "chat_created",
+          chat_id: "chat-new-seed-1",
+        }),
+        type: "message",
+      });
+    });
+
+    expect(useChatHistoryStore.getState().pendingChat?.id).toBe(
+      "chat-new-seed-1",
+    );
+    expect(useMessagingStore.getState().newlyCreatedChatId).toBe(
+      "chat-new-seed-1",
+    );
+    expect(
+      useMessagingStore.getState().isAwaitingFirstStreamChunkForNewChat,
+    ).toBe(true);
+    expect(
+      useGenerationStatusStore.getState().statusByChatId["chat-new-seed-1"]
+        ?.kind,
+    ).toBe("running");
+    expect(
+      useChatHistoryStore.getState().titleHintByChatId["chat-new-seed-1"],
+    ).toBe("Hello from new chat");
+  });
+
+  it("should clear the pending chat when the turn completes", async () => {
+    mockUseChatMessages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue({}),
+    });
+
+    const { result } = renderHook(() => useChatMessaging(null), {
+      wrapper: TestWrapper,
+    });
+
+    await act(async () => {
+      await result.current.sendMessage("Complete me");
+    });
+
+    await act(async () => {
+      sseCallbacks.onMessage?.({
+        data: JSON.stringify({
+          message_type: "chat_created",
+          chat_id: "chat-complete-1",
+        }),
+        type: "message",
+      });
+    });
+    expect(useChatHistoryStore.getState().pendingChat?.id).toBe(
+      "chat-complete-1",
+    );
+
+    await act(async () => {
+      sseCallbacks.onMessage?.({
+        data: JSON.stringify({
+          message_type: "assistant_message_completed",
+          message_id: "assistant-complete-clear-1",
+          message: {
+            id: "assistant-complete-clear-1",
+            role: "assistant",
+            created_at: "2026-02-18T12:00:01.000Z",
+            updated_at: "2026-02-18T12:00:01.000Z",
+            content: [{ content_type: "text", text: "Done" }],
+            input_files_ids: [],
+            is_message_in_active_thread: true,
+          },
+        }),
+        type: "message",
+      });
+    });
+
+    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
+  });
+
+  it("should clear a leaked pending chat when its resume stream closes", async () => {
+    mockUseChatMessages.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn().mockResolvedValue({}),
+    });
+
+    let resumeCallbacks: {
+      onClose?: () => void;
+    } = {};
+    mockCreateSSEConnection.mockImplementation((url, callbacks) => {
+      if (url.includes("/resumestream")) {
+        resumeCallbacks = callbacks;
+      }
+      return vi.fn();
+    });
+
+    renderHook(() => useChatMessaging("chat-leak-1"), {
+      wrapper: TestWrapper,
+    });
+
+    expect(resumeCallbacks.onClose).toBeDefined();
+
+    // A placeholder leaked for this chat earlier in the session. The stream
+    // is not marked as streaming, so only an unconditional clear on stream
+    // end can remove it.
+    act(() => {
+      useChatHistoryStore.getState().setPendingChat({
+        id: "chat-leak-1",
+        createdAt: "2026-02-18T12:00:00.000Z",
+      });
+    });
+
+    await act(async () => {
+      resumeCallbacks.onClose?.();
+    });
+
+    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
   });
 
   it("should remove the replaced user message and every later turn on edit submit", async () => {

--- a/frontend/src/hooks/chat/handlers/handleChatCreated.ts
+++ b/frontend/src/hooks/chat/handlers/handleChatCreated.ts
@@ -11,6 +11,11 @@ import type { MessageSubmitStreamingResponseChatCreated } from "@/lib/generated/
  * This is crucial for navigating the user to the newly created chat or for
  * subsequent API calls that require the chat ID.
  *
+ * Only call this for a chat this client just created on its own submit
+ * stream (`streamKey !== responseData.chat_id`). Resume streams replay the
+ * event history, and a replayed frame must not trip the new-chat
+ * bookkeeping performed here.
+ *
  * @param responseData - The data received from the 'chat_created' SSE event.
  *                       It should contain the 'chat_id' of the newly created chat.
  * @param setNewlyCreatedChatId - A state setter function from a React hook (e.g., useState)

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -902,6 +902,23 @@ export function useChatMessaging(
             );
             {
               const previousStreamKey = activeStreamKey;
+              // A resume stream replays the chat's full event history, so
+              // this frame can announce a chat this client never submitted
+              // (most visibly a delegated run entered mid-generation). Such
+              // a replay arrives on a stream already keyed by the chat id;
+              // only a submit stream still keyed differently (the new-chat
+              // sentinel) carries a chat this client just created. Skip the
+              // new-chat bookkeeping for replays: seeding the pending
+              // sidebar row would leak a ghost "New Chat" entry that no
+              // listing refetch ever replaces, because the chat may never
+              // become listable for this user.
+              if (previousStreamKey === responseData.chat_id) {
+                logger.log(
+                  "[DEBUG_REDIRECT] processStreamEvent: chat_created frame is a replay (stream key already carries the chat id). Skipping new-chat bookkeeping.",
+                );
+                break;
+              }
+
               handleChatCreated(
                 responseData,
                 setNewlyCreatedChatId,
@@ -950,12 +967,7 @@ export function useChatMessaging(
                     .getState()
                     .setTitleHint(responseData.chat_id, titleHint);
                 }
-              }
 
-              if (
-                responseData.chat_id &&
-                previousStreamKey !== responseData.chat_id
-              ) {
                 const existingCleanup = getSSECleanupForKey(previousStreamKey);
                 if (existingCleanup) {
                   setSSECleanupForKey(previousStreamKey, null);
@@ -1061,6 +1073,11 @@ export function useChatMessaging(
               }
             }
             recentlyCompletedByKeyRef.current[activeStreamKey] = Date.now();
+            // By completion the chat is listable (its first message is
+            // saved), so the placeholder row is no longer needed; clearing
+            // it here also guarantees a leaked placeholder cannot outlive
+            // its stream.
+            clearPendingChat(activeStreamKey);
             void handleRefetchAndClear({
               invalidate: true,
               logContext: "Assistant message completed",
@@ -1284,6 +1301,10 @@ export function useChatMessaging(
 
             setSSECleanupForKey(resumeStreamKey, null);
             setSSEAbortCallback(null, resumeStreamKey);
+            // Not gated on stillStreaming: the placeholder can leak past the
+            // point where streaming state was already reset, and clearing is
+            // idempotent and scoped to this stream's chat.
+            clearPendingChat(resumeStreamKey);
 
             const stillStreaming = useMessagingStore
               .getState()
@@ -1291,7 +1312,6 @@ export function useChatMessaging(
             if (stillStreaming) {
               setError(connectionError);
               resetStreaming(resumeStreamKey);
-              clearPendingChat(resumeStreamKey);
               void handleRefetchAndClear({
                 logContext: `Resume stream error (${reason})`,
               });
@@ -1303,6 +1323,11 @@ export function useChatMessaging(
             );
             setSSECleanupForKey(resumeStreamKey, null);
             setSSEAbortCallback(null, resumeStreamKey);
+            // Not gated on stillStreaming: by the time a resume socket
+            // closes normally, streaming state is usually already reset, and
+            // a placeholder leaked earlier in the stream would otherwise
+            // survive forever. Clearing is idempotent and scoped.
+            clearPendingChat(resumeStreamKey);
 
             // A resume that closes while we still think we're streaming ended
             // without a completion event (e.g. the task died sending only
@@ -1316,7 +1341,6 @@ export function useChatMessaging(
                 "[DEBUG_STREAMING] resumestream closed while still streaming — reconciling from server.",
               );
               resetStreaming(resumeStreamKey);
-              clearPendingChat(resumeStreamKey);
               void handleRefetchAndClear({
                 logContext: `Resume stream closed without completion (${reason})`,
               });

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1073,15 +1073,16 @@ export function useChatMessaging(
               }
             }
             recentlyCompletedByKeyRef.current[activeStreamKey] = Date.now();
-            // By completion the chat is listable (its first message is
-            // saved), so the placeholder row is no longer needed; clearing
-            // it here also guarantees a leaked placeholder cannot outlive
-            // its stream.
-            clearPendingChat(activeStreamKey);
             void handleRefetchAndClear({
               invalidate: true,
               logContext: "Assistant message completed",
             }).then(() => {
+              // Backstop for a placeholder the listed-row swap missed (a
+              // chat that never became listable for this user). Deferred
+              // until the awaited listing invalidation has landed, so a
+              // normally-listable chat swaps placeholder for real row
+              // without a frame where the sidebar shows neither.
+              clearPendingChat(activeStreamKey);
               // Reset submission flag after refetch completes
               setSubmittingForKey(activeStreamKey, false);
               logger.log(


### PR DESCRIPTION
Opening a delegated run mid-generation left a ghost "New Chat" row in the sidebar. The cause: `resumestream` replays the chat's full event history, and the replayed `chat_created` frame ran the same new-chat bookkeeping as a genuine first-turn submit — including seeding the pending sidebar placeholder. For a delegated run the chat may never become listable for this user, so no listing refetch ever replaced the placeholder and it lived forever. Linear: ERMAIN-666.

Now the `chat_created` case distinguishes replay from creation by the stream key: a replay arrives on a stream already keyed by the chat id, while a genuine submit stream is still keyed by the new-chat sentinel. Replayed frames skip the bookkeeping entirely (no pending-chat seed, no store writes, no stream-key rebind, no navigation); genuine ones behave exactly as before.

**Design choices**

- **Gate the call site, not the handler.** `handleChatCreated` has a single caller, so gating there subsumes gating its store writes; the handler only gains a doc-comment stating the contract. The previously separate seeding and rebind blocks collapse under one `if (responseData.chat_id)` guard — they were already implicitly conditioned on the same replay check.
- **Hygiene backstops for leaked placeholders.** `assistant_message_completed` now clears the pending placeholder unconditionally (by completion the chat is listable), and the resume `onError`/`onClose` clears moved out of the `stillStreaming` guards so a placeholder cannot outlive its stream even when streaming state was already reset. All `clearPendingChat` calls are idempotent and chat-scoped.
- No backend changes; `chat_was_created` semantics are untouched.

## Tests

4 new tests on the existing resume/submit SSE harness: a replayed `chat_created` seeds nothing (no pending chat, no `newlyCreatedChatId`, no awaiting-first-chunk flag, no generation-status entry), a genuine first-turn `chat_created` still seeds everything, completion clears the placeholder, and a resume close after streaming state was reset clears a leaked one. The 3 regression tests were verified to fail against unfixed code. Full frontend suite: 149 files / 1442 passed; tsc, eslint, prettier clean.