### PR TITLE
feat: show loading spinner on save button in assistant create/edit form

### DIFF
--- a/frontend/src/components/ui/Assistant/AssistantForm.tsx
+++ b/frontend/src/components/ui/Assistant/AssistantForm.tsx
@@ -1056,6 +1056,7 @@ export const AssistantForm: React.FC<AssistantFormProps> = ({
               type="submit"
               variant="primary"
               disabled={!isFormValid || isSubmitting || isContextExceeded}
+              loading={isSubmitting}
             >
               {isSubmitting
                 ? t`Saving...`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ERMAIN-659.

When saving an assistant, the save button previously only changed its text to "Saving..." and became disabled — there was no visual animation to indicate the operation was in progress. This made the button feel detached from the saving state.

## Changes

- Added `loading={isSubmitting}` to the submit `Button` in `AssistantForm.tsx`

The `Button` component already has a `loading` prop that:
- Replaces the button's icon slot with a spinning `SpinnerIcon`
- Sets `aria-busy` for accessibility
- Disables the button

Since `isSubmitting` is wired to `isPending` from the React Query mutation on both `AssistantCreatePage` and `AssistantEditPage`, this single line change provides the spinner for both the create and edit flows.

## Before / After

| State | Before | After |
|-------|--------|-------|
| Idle | "Save Changes" / "Create Assistant" | unchanged |
| Saving | "Saving..." (disabled, no animation) | "Saving..." (disabled, **spinner icon**) |

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ERMAIN-659](https://linear.app/erato-labs/issue/ERMAIN-659/show-loading-state-when-saving-assistant-updates)

<div><a href="https://cursor.com/agents/bc-79ecc0f2-b73f-408d-91ed-29c3d6f6c542?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79ecc0f2-b73f-408d-91ed-29c3d6f6c542&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

