### PR TITLE
Surface delegated background runs in the add-in pane (ERMAIN-644)

### DIFF
--- a/frontend/src/components/ui/Chat/DelegatedRunHeader.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunHeader.test.tsx
@@ -84,6 +84,18 @@ describe("DelegatedRunHeader", () => {
     );
   });
 
+  it("turns the origin into a button when the host opens chats itself", () => {
+    const onOpenOrigin = vi.fn();
+    render(<DelegatedRunHeader {...run()} onOpenOrigin={onOpenOrigin} />);
+
+    const origin = screen.getByTestId("delegated-run-origin-link");
+    expect(origin.tagName).toBe("BUTTON");
+    expect(origin).not.toHaveAttribute("href");
+
+    fireEvent.click(origin);
+    expect(onOpenOrigin).toHaveBeenCalledWith("origin-1");
+  });
+
   it("renders the run parameters as labelled fields and omits absent ones", () => {
     render(
       <DelegatedRunHeader

--- a/frontend/src/components/ui/Chat/DelegatedRunHeader.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunHeader.tsx
@@ -17,6 +17,12 @@ export interface DelegatedRunHeaderProps extends DelegatedRunProvenance {
   isRunning?: boolean;
   /** Archived, possibly by the cascade from the chat that dispatched it. */
   isArchived?: boolean;
+  /**
+   * Opens the origin chat in the host's own way. Left unset, the origin
+   * renders as a link to its chat route; a host without those routes
+   * supplies this and the origin becomes a button.
+   */
+  onOpenOrigin?: (chatId: string) => void;
 }
 
 // dt/dd as flat grid children, so the label column sizes to the widest
@@ -68,6 +74,7 @@ export const DelegatedRunHeader = ({
   constraints,
   isRunning = false,
   isArchived = false,
+  onOpenOrigin,
   ...provenance
 }: DelegatedRunHeaderProps) => {
   const navigate = useNavigate();
@@ -75,6 +82,7 @@ export const DelegatedRunHeader = ({
   if (!origin) {
     return null;
   }
+  const originChatId = origin.chatId;
   const note = stateNote(isRunning, isArchived);
   const hasParameters = Boolean(expectedOutput) || Boolean(constraints);
   const originHref = origin.chatId
@@ -103,25 +111,36 @@ export const DelegatedRunHeader = ({
         <span aria-hidden="true" className="text-theme-fg-muted">
           ·
         </span>
-        {originHref ? (
-          <a
-            href={originHref}
-            onClick={(e) => {
-              // Allow cmd/ctrl-click to open in new tab
-              if (e.metaKey || e.ctrlKey) {
-                return;
-              }
-              e.preventDefault();
-              navigate(originHref);
-            }}
-            // Persistent underline on purpose: a link sitting mid-sentence
-            // needs a resting affordance, like the prose links in message
-            // content — unlike hover-underlined control-style links.
-            className="focus-ring-tight truncate rounded-[var(--theme-radius-base)] text-theme-fg-secondary underline underline-offset-2 hover:text-theme-fg-primary"
-            data-testid="delegated-run-origin-link"
-          >
-            {origin.label}
-          </a>
+        {originChatId && originHref ? (
+          onOpenOrigin ? (
+            <button
+              type="button"
+              onClick={() => onOpenOrigin(originChatId)}
+              className="focus-ring-tight truncate rounded-[var(--theme-radius-base)] text-theme-fg-secondary underline underline-offset-2 hover:text-theme-fg-primary"
+              data-testid="delegated-run-origin-link"
+            >
+              {origin.label}
+            </button>
+          ) : (
+            <a
+              href={originHref}
+              onClick={(e) => {
+                // Allow cmd/ctrl-click to open in new tab
+                if (e.metaKey || e.ctrlKey) {
+                  return;
+                }
+                e.preventDefault();
+                navigate(originHref);
+              }}
+              // Persistent underline on purpose: a link sitting mid-sentence
+              // needs a resting affordance, like the prose links in message
+              // content — unlike hover-underlined control-style links.
+              className="focus-ring-tight truncate rounded-[var(--theme-radius-base)] text-theme-fg-secondary underline underline-offset-2 hover:text-theme-fg-primary"
+              data-testid="delegated-run-origin-link"
+            >
+              {origin.label}
+            </a>
+          )
         ) : (
           <span
             className="truncate text-theme-fg-muted"

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.test.tsx
@@ -73,16 +73,23 @@ const renderSection = (
   config: Parameters<typeof StaticFeatureConfigProvider>[0]["config"] = {
     assistants: { enabled: true, delegationEnabled: true },
   },
+  onOpenRun?: (chat: RecentChat) => void,
 ) =>
   render(
     <StaticFeatureConfigProvider config={config}>
       <I18nProvider i18n={i18n}>
         <MemoryRouter>
-          <DelegatedRunsSection chatId={chatId} />
+          <DelegatedRunsSection chatId={chatId} onOpenRun={onOpenRun} />
         </MemoryRouter>
       </I18nProvider>
     </StaticFeatureConfigProvider>,
   );
+
+const DELEGATION_ON: Parameters<
+  typeof StaticFeatureConfigProvider
+>[0]["config"] = {
+  assistants: { enabled: true, delegationEnabled: true },
+};
 
 /** The bar starts collapsed; row-level assertions unfold it first. */
 const expandRuns = () =>
@@ -502,6 +509,64 @@ describe("DelegatedRunsSection check-off", () => {
     fireEvent.click(within(rows[0]).getByTestId("delegated-run-dismiss"));
     expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.getAllByTestId("delegated-run-item")).toHaveLength(1);
+  });
+});
+
+describe("DelegatedRunsSection host-open seam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useGenerationStatusStore.getState().reset();
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+  });
+
+  it("rows hand the run to onOpenRun and render without an href", () => {
+    mockRuns([recentChat({ id: "run-1" })]);
+    const onOpenRun = vi.fn();
+
+    renderSection("origin-1", DELEGATION_ON, onOpenRun);
+    expandRuns();
+
+    const row = screen.getByTestId("delegated-run-item");
+    // No href: a middle- or cmd-click cannot land on a chat route the host
+    // does not serve.
+    expect(row).not.toHaveAttribute("href");
+    expect(row).toHaveAttribute("role", "button");
+
+    fireEvent.click(row);
+    expect(onOpenRun).toHaveBeenCalledTimes(1);
+    expect(onOpenRun).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1" }),
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("activates from the keyboard like any button", () => {
+    mockRuns([recentChat({ id: "run-1" })]);
+    const onOpenRun = vi.fn();
+
+    renderSection("origin-1", DELEGATION_ON, onOpenRun);
+    expandRuns();
+
+    fireEvent.keyDown(screen.getByTestId("delegated-run-item"), {
+      key: "Enter",
+    });
+    expect(onOpenRun).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "run-1" }),
+    );
+  });
+
+  it("checking a run off dismisses it without opening it", () => {
+    mockRuns([recentChat({ id: "run-1", delegated_run_outcome: "completed" })]);
+    const onOpenRun = vi.fn();
+
+    renderSection("origin-1", DELEGATION_ON, onOpenRun);
+    expandRuns();
+
+    fireEvent.click(screen.getByTestId("delegated-run-dismiss"));
+    expect(onOpenRun).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("delegated-run-item")).toBeNull();
   });
 });
 

--- a/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
+++ b/frontend/src/components/ui/Chat/DelegatedRunsSection.tsx
@@ -64,7 +64,8 @@ const DISMISSED_RUN_IDS_OPTIONS = { parse: parseDismissedRunIds };
 const DelegatedRunRow = memo<{
   chat: RecentChat;
   onDismiss: (chatId: string) => void;
-}>(({ chat, onDismiss }) => {
+  onOpen?: (chat: RecentChat) => void;
+}>(({ chat, onDismiss, onOpen }) => {
   const navigate = useNavigate();
   const storeStatus = useGenerationStatusStore(
     (state) => state.statusByChatId[chat.id],
@@ -92,6 +93,73 @@ const DelegatedRunRow = memo<{
   const timestamp =
     isLive && liveStartedAt ? liveStartedAt : chat.last_message_at;
 
+  const ariaLabel = status
+    ? `${name}, ${chatAttentionStatusLabel(status)}`
+    : name;
+
+  const rowContent = (
+    <>
+      {status && <ChatAttentionStatusDot status={status} />}
+      <span
+        className="min-w-0 flex-1 truncate text-sm font-medium"
+        title={name}
+      >
+        {name}
+      </span>
+      <span className="shrink-0 text-xs text-theme-fg-secondary">
+        <MessageTimestamp createdAt={new Date(timestamp)} autoUpdate={isLive} />
+      </span>
+      <OpenNewWindowIcon
+        className="size-3.5 shrink-0 text-theme-fg-muted opacity-0 group-hover/run:opacity-100 group-focus-visible/run:opacity-100"
+        aria-hidden="true"
+      />
+      {isSettled && (
+        /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- div exists to prevent bubbling */
+        <div
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <Button
+            variant="icon-only"
+            size="sm"
+            // The row under the pointer is already painted with
+            // --theme-bg-hover, so the variant's own hover is invisible
+            // here; the strong step keeps the chip readable. Important,
+            // because the variant's own hover class wins the cascade.
+            className="hover:!bg-[var(--theme-bg-hover-strong)]"
+            icon={<CloseIcon className="size-4" />}
+            aria-label={dismissLabel}
+            title={dismissLabel}
+            onClick={() => onDismiss(chat.id)}
+            data-testid="delegated-run-dismiss"
+          />
+        </div>
+      )}
+    </>
+  );
+
+  // A host without the web app's chat routes (the add-in pane) opens a run
+  // through its own session machinery; rendering no href there keeps a
+  // middle- or cmd-click off routes the host does not serve.
+  if (onOpen) {
+    return (
+      <InteractiveContainer
+        useDiv={true}
+        showFocusRing={false}
+        onClick={() => onOpen(chat)}
+        className="focus-ring-inset theme-transition group/run flex cursor-pointer items-center gap-2 rounded-[var(--theme-radius-base)] px-2 py-1.5 text-left hover:bg-theme-bg-hover"
+        aria-label={ariaLabel}
+        data-chat-id={chat.id}
+        data-ui="delegated-run-item"
+        data-testid="delegated-run-item"
+      >
+        {rowContent}
+      </InteractiveContainer>
+    );
+  }
+
   return (
     <a
       href={href}
@@ -106,9 +174,7 @@ const DelegatedRunRow = memo<{
       // The group lives here, on the element that actually receives focus,
       // so the keyboard reveal below has a :focus-visible source.
       className="focus-ring-inset group/run block rounded-[var(--theme-radius-base)]"
-      aria-label={
-        status ? `${name}, ${chatAttentionStatusLabel(status)}` : name
-      }
+      aria-label={ariaLabel}
       data-testid="delegated-run-item"
     >
       <InteractiveContainer
@@ -118,47 +184,7 @@ const DelegatedRunRow = memo<{
         data-chat-id={chat.id}
         data-ui="delegated-run-item"
       >
-        {status && <ChatAttentionStatusDot status={status} />}
-        <span
-          className="min-w-0 flex-1 truncate text-sm font-medium"
-          title={name}
-        >
-          {name}
-        </span>
-        <span className="shrink-0 text-xs text-theme-fg-secondary">
-          <MessageTimestamp
-            createdAt={new Date(timestamp)}
-            autoUpdate={isLive}
-          />
-        </span>
-        <OpenNewWindowIcon
-          className="size-3.5 shrink-0 text-theme-fg-muted opacity-0 group-hover/run:opacity-100 group-focus-visible/run:opacity-100"
-          aria-hidden="true"
-        />
-        {isSettled && (
-          /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- div exists to prevent bubbling */
-          <div
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-          >
-            <Button
-              variant="icon-only"
-              size="sm"
-              // The row under the pointer is already painted with
-              // --theme-bg-hover, so the variant's own hover is invisible
-              // here; the strong step keeps the chip readable. Important,
-              // because the variant's own hover class wins the cascade.
-              className="hover:!bg-[var(--theme-bg-hover-strong)]"
-              icon={<CloseIcon className="size-4" />}
-              aria-label={dismissLabel}
-              title={dismissLabel}
-              onClick={() => onDismiss(chat.id)}
-              data-testid="delegated-run-dismiss"
-            />
-          </div>
-        )}
+        {rowContent}
       </InteractiveContainer>
     </a>
   );
@@ -171,6 +197,12 @@ export interface DelegatedRunsSectionProps {
   /** Chat the user is viewing; the listed runs are the ones it dispatched.
    * Callers with no open chat pass null or "". */
   chatId: string | null;
+  /**
+   * Opens a run in the host's own way. Left unset, rows navigate to the
+   * run's chat route; a host without those routes supplies this instead and
+   * rows render without an href.
+   */
+  onOpenRun?: (chat: RecentChat) => void;
 }
 
 /**
@@ -181,7 +213,7 @@ export interface DelegatedRunsSectionProps {
  * state deserves to outlive the visit.
  */
 export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
-  ({ chatId }) => {
+  ({ chatId, onOpenRun }) => {
     const { enabled: assistantsEnabled, delegationEnabled } =
       useAssistantsFeature();
     const canHaveRuns = assistantsEnabled && delegationEnabled;
@@ -316,6 +348,7 @@ export const DelegatedRunsSection = memo<DelegatedRunsSectionProps>(
                     key={chat.id}
                     chat={chat}
                     onDismiss={dismissRun}
+                    onOpen={onOpenRun}
                   />
                 ))}
             </div>

--- a/frontend/src/components/ui/Trace/steps/DelegationStep.test.tsx
+++ b/frontend/src/components/ui/Trace/steps/DelegationStep.test.tsx
@@ -1,10 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
 import { useSidecarLocalTraceStore } from "@/lib/desktopSidecar/localTraceStore";
 import { recentChatsQuery } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import { DelegatedRunOpenProvider } from "@/providers/DelegatedRunOpenProvider";
 
 import { ToolUseStep } from "./ToolUseStep";
 
@@ -213,6 +214,32 @@ describe("delegation step", () => {
     expect(
       screen.queryByRole("button", { name: /Delegated to Research/ }),
     ).toBeNull();
+  });
+
+  it("opens the run through the host's opener when one is provided", () => {
+    const openRun = vi.fn();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DelegatedRunOpenProvider onOpen={openRun}>
+          <ToolUseStep
+            part={part({ ...IDENTITY, background: true })}
+            status="done"
+            isStreaming={false}
+            isCollapsed={false}
+            isLastStep
+          />
+        </DelegatedRunOpenProvider>
+      </QueryClientProvider>,
+    );
+
+    const control = screen.getByTestId("delegation-open-run");
+    // No href: a host that supplies an opener serves no chat routes for a
+    // new tab to land on.
+    expect(control.tagName).toBe("BUTTON");
+    expect(control).not.toHaveAttribute("href");
+
+    fireEvent.click(control);
+    expect(openRun).toHaveBeenCalledWith("chat-7");
   });
 
   it("says the detachment even over an approval decision", () => {

--- a/frontend/src/components/ui/Trace/steps/DelegationStep.tsx
+++ b/frontend/src/components/ui/Trace/steps/DelegationStep.tsx
@@ -3,6 +3,7 @@ import { t } from "@lingui/core/macro";
 import { OpenNewWindowIcon } from "@/components/ui/icons";
 import { useDelegatedRunLiveStatus } from "@/hooks/chat/useDelegatedRunLiveStatus";
 import { useSidecarLocalTrace } from "@/lib/desktopSidecar/localTraceStore";
+import { useDelegatedRunOpener } from "@/providers/DelegatedRunOpenProvider";
 import { getChatUrl } from "@/utils/chat/urlUtils";
 
 import { NestedTraceView } from "../NestedTraceView";
@@ -154,10 +155,25 @@ const OpenDelegatedRunLink = ({
   chatId: string;
   assistantId: string | undefined;
 }) => {
+  const openRun = useDelegatedRunOpener();
   const label = t({
     id: "trace.delegation.openRun",
     message: "Open delegated run",
   });
+  if (openRun) {
+    return (
+      <button
+        type="button"
+        onClick={() => openRun(chatId)}
+        aria-label={label}
+        title={label}
+        data-testid="delegation-open-run"
+        className="focus-ring-tight inline-flex size-5 shrink-0 items-center justify-center rounded-[var(--theme-radius-base)] text-theme-fg-muted hover:text-theme-fg-primary"
+      >
+        <OpenNewWindowIcon className="size-3.5" />
+      </button>
+    );
+  }
   return (
     <a
       href={getChatUrl(chatId, assistantId)}

--- a/frontend/src/hooks/chat/useDelegatedRunHeader.tsx
+++ b/frontend/src/hooks/chat/useDelegatedRunHeader.tsx
@@ -43,7 +43,12 @@ const delegateIsWriting = (
 
 export const useDelegatedRunHeader = (
   chatId: string | null | undefined,
+  options?: {
+    /** Forwarded to the header's origin link; see `DelegatedRunHeaderProps`. */
+    onOpenOrigin?: (chatId: string) => void;
+  },
 ): DelegatedRunHeaderState => {
+  const onOpenOrigin = options?.onOpenOrigin;
   const { data: chat } = useChatDetail(
     chatId ? { pathParams: { chatId } } : skipToken,
   );
@@ -69,9 +74,10 @@ export const useDelegatedRunHeader = (
           constraints={chat.constraints}
           isRunning={isRunning}
           isArchived={isArchived}
+          onOpenOrigin={onOpenOrigin}
         />
       ),
       composerLocked: isRunning || isArchived,
     };
-  }, [chat, generationKind]);
+  }, [chat, generationKind, onOpenOrigin]);
 };

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -399,6 +399,7 @@ export type {
 export type { ChatInputControlsHandle } from "@/components/ui/Chat/ChatInputControlsContext";
 export type { ChatInputAttachmentPreviewProps } from "@/types/chat-input-attachment-preview";
 export type { AssistantMention } from "@/utils/chat/assistantMentions";
+export type { DelegationRunMode } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 export type {
   ActionFacetInfo,
   ActionFacetRequest,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -23,6 +23,7 @@ export {
   useDelegatedRunHeader,
   type DelegatedRunHeaderState,
 } from "@/hooks/chat/useDelegatedRunHeader";
+export { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
 export {
   ChatMessage,
   type ChatMessageHostComponents,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -12,8 +12,17 @@ export {
   type ThemeProviderProps,
 } from "@/components/providers/ThemeProvider";
 export { ApiProvider } from "@/components/providers/ApiProvider";
+export { GenerationStatusPoller } from "@/components/providers/GenerationStatusPoller";
 export * from "@/components/ui/Chat";
 export { ChatInputControlsProvider } from "@/components/ui/Chat/ChatInputControlsContext";
+export {
+  DelegatedRunsSection,
+  type DelegatedRunsSectionProps,
+} from "@/components/ui/Chat/DelegatedRunsSection";
+export {
+  useDelegatedRunHeader,
+  type DelegatedRunHeaderState,
+} from "@/hooks/chat/useDelegatedRunHeader";
 export {
   ChatMessage,
   type ChatMessageHostComponents,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -24,6 +24,7 @@ export {
   type DelegatedRunHeaderState,
 } from "@/hooks/chat/useDelegatedRunHeader";
 export { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
+export { DelegatedRunOpenProvider } from "@/providers/DelegatedRunOpenProvider";
 export {
   ChatMessage,
   type ChatMessageHostComponents,

--- a/frontend/src/providers/DelegatedRunOpenProvider.tsx
+++ b/frontend/src/providers/DelegatedRunOpenProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from "react";
+
+import type { ReactNode } from "react";
+
+const DelegatedRunOpenContext = createContext<
+  ((chatId: string) => void) | null
+>(null);
+
+/**
+ * How the host opens a delegated run from surfaces buried deep in the
+ * message tree (the trace's open-run affordance), where prop threading
+ * would have to survive custom message renderers. Web surfaces mount no
+ * provider and keep the default new-tab link; a host without chat routes
+ * (the add-in pane) supplies its own opener instead.
+ */
+export function DelegatedRunOpenProvider({
+  onOpen,
+  children,
+}: {
+  onOpen: (chatId: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <DelegatedRunOpenContext.Provider value={onOpen}>
+      {children}
+    </DelegatedRunOpenContext.Provider>
+  );
+}
+
+export const useDelegatedRunOpener = () => useContext(DelegatedRunOpenContext);

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-hnvxFvv7uSfhUyWckwcW4dq8AmWc6cgqU+0h4j1P55XKDk7PHpcV50MMXq7a5IaKSqKcehoF+anO23H5Q5VI3w==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-7Ly79ubqeKxq0z3aqHPVmYTz+REbeFJ21WwrhW2B5HvhYcMmVKy0/xWFq37aMqjtNL0IyJcLnpMeiq3ZI84vTA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-Gf2G1hRRWv181Q2t4wCJ/KVOfrsV05rMIUISijzQAoOb5f5u91BYQSX7XhObXJqnz2tPNrXrFQSgQjSus69oyQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-hnvxFvv7uSfhUyWckwcW4dq8AmWc6cgqU+0h4j1P55XKDk7PHpcV50MMXq7a5IaKSqKcehoF+anO23H5Q5VI3w==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-XgaDN3xk7S8jqzvGGS8DrV0OjSmHuMD3EskP0FZEMTAjubwu3KVsUW4ciHH390k3y2e04NgF+7/NiNcE3FltBQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-Gf2G1hRRWv181Q2t4wCJ/KVOfrsV05rMIUISijzQAoOb5f5u91BYQSX7XhObXJqnz2tPNrXrFQSgQjSus69oyQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-KbQY0l26MtyGFohK+MOxvs7ArtvJNGjmn+CBbVp1LP2Fc1y+z2kQpzkf/X0iV6NbrC4rtqy1z0icWEwFfK1NbQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-XgaDN3xk7S8jqzvGGS8DrV0OjSmHuMD3EskP0FZEMTAjubwu3KVsUW4ciHH390k3y2e04NgF+7/NiNcE3FltBQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -813,10 +813,6 @@ packages:
     resolution: {integrity: sha512-crF3AQgYXg52Caz4ffJKSTXWUU/4iOGOBRnSeOkw8lsOtOYlPTaWxeSGyDTEwaGCFl6P/1aew+pvHOSCxOAyrg==}
     engines: {node: '>=20.0.0'}
 
-  '@lingui/conf@5.9.5':
-    resolution: {integrity: sha512-k5r9ssOZirhS5BlqdsK5L0rzlqnHeryoJHAQIpUpeh8g5ymgpbUN7L4+4C4hAX/tddAFiCFN8boHTiu6Wbt83Q==}
-    engines: {node: '>=20.0.0'}
-
   '@lingui/core@5.9.4':
     resolution: {integrity: sha512-MsYYc8ue/w1C8bgAbC3h4cNik64bqZ6xGxMjsVdoGQBUe+b/ij+rOEiuJXbwvlo4GXBsvsan7EzeH7sx11IsYQ==}
     engines: {node: '>=20.0.0'}
@@ -829,24 +825,16 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  '@lingui/detect-locale@5.9.5':
-    resolution: {integrity: sha512-QJFl1PiPOnCL9jv/zHLu+/5gIuajtsNg3eQ5JbwOVdxWWBdoyXJpgDJSiKUh5nQDQixTHp0hGSxyAgpCVWEscQ==}
+  '@lingui/detect-locale@5.9.4':
+    resolution: {integrity: sha512-XYVyhu7H9+RlDa2rGK/nXEZ4ABu7xFlKrrU7ZRihxCKXZi98DUdFbiw63vB3GX8yI8qWC8xf7RySe7f/hBuWgw==}
     engines: {node: '>=20.0.0'}
 
   '@lingui/format-po@5.9.4':
     resolution: {integrity: sha512-B+e8YF6S5EOUPF6i3gaSX69pPs/QkP6MIE97vYA48W9Lty7KFOHuYBk/YzCY9CSQaF7gW3GAI5ZsXX2+ZLVyZw==}
     engines: {node: '>=20.0.0'}
 
-  '@lingui/format-po@5.9.5':
-    resolution: {integrity: sha512-abawxkaEMhAUCqxrnim2NTTeu2gd55X9tkFN8jfRM0B1LE2KjZLWCA8gSD90J/DblDwej8jK8A2BynXlcQdluQ==}
-    engines: {node: '>=20.0.0'}
-
   '@lingui/message-utils@5.9.4':
     resolution: {integrity: sha512-YzAVzILdsqdUqwHmryl7rfwZXRHYs6QY2wPLH5gxrV7wlieiCaskaKPeSk2SuN/gmC8im1GDrQHcwgKapFU3Sg==}
-    engines: {node: '>=20.0.0'}
-
-  '@lingui/message-utils@5.9.5':
-    resolution: {integrity: sha512-t3dNbjb1dWkvcpXGMXIEyBDO3l4B8J2ColZXi0NTG1ioAj+sDfFxFB8fepVgd3JAk+AwARlOLvF14oS0mAdgpw==}
     engines: {node: '>=20.0.0'}
 
   '@lingui/react@5.9.4':
@@ -4833,8 +4821,8 @@ snapshots:
       '@extend-ai/react-xlsx': 0.15.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@lingui/babel-plugin-lingui-macro': 5.9.4(typescript@5.9.3)
       '@lingui/core': 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(typescript@5.9.3))
-      '@lingui/detect-locale': 5.9.5
-      '@lingui/format-po': 5.9.5(typescript@5.9.3)
+      '@lingui/detect-locale': 5.9.4
+      '@lingui/format-po': 5.9.4(typescript@5.9.3)
       '@lingui/react': 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(typescript@5.9.3))(react@19.2.7)
       '@lingui/vite-plugin': 5.9.4(typescript@5.9.3)(vite@6.4.3(@types/node@25.9.3)(jiti@2.7.0))
       '@react-hook/resize-observer': 2.0.2(react@19.2.7)
@@ -5168,16 +5156,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@lingui/conf@5.9.5(typescript@5.9.3)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      cosmiconfig: 8.3.6(typescript@5.9.3)
-      jest-validate: 29.7.0
-      jiti: 2.7.0
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - typescript
-
   '@lingui/core@5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(typescript@5.9.3))':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -5185,7 +5163,7 @@ snapshots:
     optionalDependencies:
       '@lingui/babel-plugin-lingui-macro': 5.9.4(typescript@5.9.3)
 
-  '@lingui/detect-locale@5.9.5': {}
+  '@lingui/detect-locale@5.9.4': {}
 
   '@lingui/format-po@5.9.4(typescript@5.9.3)':
     dependencies:
@@ -5196,21 +5174,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@lingui/format-po@5.9.5(typescript@5.9.3)':
-    dependencies:
-      '@lingui/conf': 5.9.5(typescript@5.9.3)
-      '@lingui/message-utils': 5.9.5
-      date-fns: 3.6.0
-      pofile: 1.1.4
-    transitivePeerDependencies:
-      - typescript
-
   '@lingui/message-utils@5.9.4':
-    dependencies:
-      '@messageformat/parser': 5.1.1
-      js-sha256: 0.10.1
-
-  '@lingui/message-utils@5.9.5':
     dependencies:
       '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1

--- a/office-addin/src/app/__tests__/env.test.ts
+++ b/office-addin/src/app/__tests__/env.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { injectFrontendEnv } from "../env";
+
+const FLAG_WINDOW_KEYS = [
+  "ASSISTANTS_ENABLED",
+  "ASSISTANTS_DELEGATION_ENABLED",
+  "ASSISTANTS_DELEGATION_ALLOW_BACKGROUND",
+] as const;
+
+describe("injectFrontendEnv assistants flags", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of FLAG_WINDOW_KEYS) {
+      Reflect.deleteProperty(window, key);
+    }
+  });
+
+  it("mirrors enabled flags onto window for a bundle packed without them", () => {
+    vi.stubEnv("VITE_ASSISTANTS_ENABLED", "true");
+    vi.stubEnv("VITE_ASSISTANTS_DELEGATION_ENABLED", "true");
+    vi.stubEnv("VITE_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND", "true");
+
+    injectFrontendEnv();
+
+    expect(window.ASSISTANTS_ENABLED).toBe(true);
+    expect(window.ASSISTANTS_DELEGATION_ENABLED).toBe(true);
+    expect(window.ASSISTANTS_DELEGATION_ALLOW_BACKGROUND).toBe(true);
+  });
+
+  it("leaves flags unset when the env does not enable them", () => {
+    // The test process inherits the developer's real .env.local; force the
+    // disabled case explicitly.
+    vi.stubEnv("VITE_ASSISTANTS_ENABLED", "");
+    vi.stubEnv("VITE_ASSISTANTS_DELEGATION_ENABLED", "");
+    vi.stubEnv("VITE_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND", "");
+
+    injectFrontendEnv();
+
+    for (const key of FLAG_WINDOW_KEYS) {
+      expect(window[key]).toBeUndefined();
+    }
+  });
+
+  it("never overrides values the serving backend already injected", () => {
+    vi.stubEnv("VITE_ASSISTANTS_DELEGATION_ENABLED", "true");
+    window.ASSISTANTS_DELEGATION_ENABLED = false;
+
+    injectFrontendEnv();
+
+    expect(window.ASSISTANTS_DELEGATION_ENABLED).toBe(false);
+  });
+});

--- a/office-addin/src/app/env.ts
+++ b/office-addin/src/app/env.ts
@@ -33,4 +33,18 @@ export function injectFrontendEnv() {
   if (import.meta.env.VITE_MSAL_AUTHORITY) {
     window.MSAL_AUTHORITY ??= import.meta.env.VITE_MSAL_AUTHORITY;
   }
+
+  // The assistants flags reach the library through `window.*`: the library
+  // bundle bakes `import.meta.env` at pack time, so a tarball packed without
+  // them (CI, a fresh worktree) resolves them from here. `??=` keeps the
+  // backend's HTML injection authoritative when it served the page.
+  if (import.meta.env.VITE_ASSISTANTS_ENABLED === "true") {
+    window.ASSISTANTS_ENABLED ??= true;
+  }
+  if (import.meta.env.VITE_ASSISTANTS_DELEGATION_ENABLED === "true") {
+    window.ASSISTANTS_DELEGATION_ENABLED ??= true;
+  }
+  if (import.meta.env.VITE_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND === "true") {
+    window.ASSISTANTS_DELEGATION_ALLOW_BACKGROUND ??= true;
+  }
 }

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -33,6 +33,7 @@ import {
   type ChatInputControlsHandle,
   type ChatMessageProps,
   type DelegatedRunsSectionProps,
+  type DelegationRunMode,
   type DropdownMenuItem,
   type FileUploadItem,
   type MessageAction,
@@ -69,6 +70,7 @@ export interface AddinChatInputRenderProps {
     actionFacet?: ActionFacetRequest,
     hostContextIdentity?: string | null,
     mentionedAssistants?: AssistantMention[],
+    delegationRunMode?: DelegationRunMode,
   ) => void;
   onFilePreview: (file: FileUploadItem) => void;
   handleFileAttachments: (files: FileUploadItem[]) => void;
@@ -270,6 +272,7 @@ function useAddinChatController({
       actionFacet,
       hostContextIdentity,
       mentionedAssistants,
+      delegationRunMode,
     ) => {
       hostCallbacksRef.current.beforeSend?.(hostContextIdentity);
       void chat
@@ -281,6 +284,7 @@ function useAddinChatController({
           selectedFacetIds,
           actionFacet,
           mentionedAssistants,
+          delegationRunMode,
         )
         .then(() => chat.refetchHistory());
     },
@@ -493,6 +497,7 @@ function NeutralAddinChatHost({ controller }: AddinChatHostProps) {
             modelId,
             selectedFacetIds,
             mentionedAssistants,
+            delegationRunMode,
           ) =>
             props.onSendMessage(
               message,
@@ -502,6 +507,7 @@ function NeutralAddinChatHost({ controller }: AddinChatHostProps) {
               undefined,
               undefined,
               mentionedAssistants,
+              delegationRunMode,
             )
           }
         />

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -3,6 +3,7 @@ import {
   ChatInputControlsProvider,
   ChatMessage,
   DefaultMessageControls,
+  DelegatedRunsSection,
   DocumentIcon,
   DropdownMenu,
   FeedbackCommentDialog,
@@ -19,6 +20,7 @@ import {
   useActiveModelSelection,
   useChatContext,
   useConversationDropzone,
+  useDelegatedRunHeader,
   useFileCapabilitiesContext,
   useFilePreviewModal,
   useFileUploadWithTokenCheck,
@@ -29,6 +31,7 @@ import {
   type AssistantMention,
   type ChatInputControlsHandle,
   type ChatMessageProps,
+  type DelegatedRunsSectionProps,
   type DropdownMenuItem,
   type FileUploadItem,
   type MessageAction,
@@ -71,6 +74,7 @@ export interface AddinChatInputRenderProps {
   chatId: string | null;
   assistantId?: string;
   isLoading: boolean;
+  disabled: boolean;
   controlledAvailableModels: AddinChatController["availableModels"];
   controlledSelectedModel: AddinChatController["selectedModel"];
   onControlledSelectedModelChange: AddinChatController["setSelectedModel"];
@@ -138,6 +142,12 @@ export interface AddinChatController {
   isSettingsOpen: boolean;
   setIsSettingsOpen: (isOpen: boolean) => void;
   headerMenuItems: DropdownMenuItem[];
+  /** Banner identifying the open chat as a delegated run; null otherwise. */
+  delegatedRunHeader: ReactNode;
+  /** A delegate still writing the run refuses sends with a 409; closing the
+   * composer is how the user learns that instead of by sending into it. */
+  composerLocked: boolean;
+  openDelegatedRun: NonNullable<DelegatedRunsSectionProps["onOpenRun"]>;
 }
 
 export interface AddinChatHostProps {
@@ -195,6 +205,24 @@ function useAddinChatController({
   const chat = useChatContext();
   const { profile } = useProfile();
   const { capabilities } = useFileCapabilitiesContext();
+  // In the pane a chat opens through the session controller, the same path
+  // the recent-chats picker takes; the pane serves no chat routes to
+  // navigate to.
+  const openChatInPane = useCallback(
+    (chatId: string) => chat.navigateToChat(chatId),
+    [chat],
+  );
+  const runHeaderOptions = useMemo(
+    () => ({ onOpenOrigin: openChatInPane }),
+    [openChatInPane],
+  );
+  const { header: delegatedRunHeader, composerLocked } = useDelegatedRunHeader(
+    chat.currentChatId,
+    runHeaderOptions,
+  );
+  const openDelegatedRun = useCallback<
+    NonNullable<DelegatedRunsSectionProps["onOpenRun"]>
+  >((run) => openChatInPane(run.id), [openChatInPane]);
   const { availableModels, selectedModel, setSelectedModel, isSelectionReady } =
     useActiveModelSelection({ initialModel: chat.currentChatLastModel });
   const acceptedFileTypes = useMemo(
@@ -430,6 +458,9 @@ function useAddinChatController({
     isSettingsOpen,
     setIsSettingsOpen,
     headerMenuItems,
+    delegatedRunHeader,
+    composerLocked,
+    openDelegatedRun,
   };
 }
 
@@ -508,6 +539,7 @@ export function AddinChatCoreView({
     chatId: controller.currentChatId,
     assistantId: controller.assistantId,
     isLoading: controller.isMessagingLoading,
+    disabled: controller.composerLocked,
     controlledAvailableModels: controller.availableModels,
     controlledSelectedModel: controller.selectedModel,
     onControlledSelectedModelChange: controller.setSelectedModel,
@@ -572,6 +604,11 @@ export function AddinChatCoreView({
               </div>
             ) : null}
             {beforeMessages}
+            {controller.delegatedRunHeader ? (
+              <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3">
+                {controller.delegatedRunHeader}
+              </div>
+            ) : null}
             {TopLeftAccessory ? (
               <TopLeftAccessory
                 availableModels={controller.availableModels}
@@ -604,6 +641,10 @@ export function AddinChatCoreView({
                 className="overscroll-none"
               />
             </MessageEditProvider>
+            <DelegatedRunsSection
+              chatId={controller.currentChatId}
+              onOpenRun={controller.openDelegatedRun}
+            />
             {renderInput(inputProps)}
           </div>
         </ChatErrorBoundary>

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -3,6 +3,7 @@ import {
   ChatInputControlsProvider,
   ChatMessage,
   DefaultMessageControls,
+  DelegatedRunOpenProvider,
   DelegatedRunsSection,
   DocumentIcon,
   DropdownMenu,
@@ -148,6 +149,9 @@ export interface AddinChatController {
    * composer is how the user learns that instead of by sending into it. */
   composerLocked: boolean;
   openDelegatedRun: NonNullable<DelegatedRunsSectionProps["onOpenRun"]>;
+  /** Opens any chat in-pane via the session controller; also handed to deep
+   * surfaces (the trace's open-run affordance) through context. */
+  openChatById: (chatId: string) => void;
 }
 
 export interface AddinChatHostProps {
@@ -208,13 +212,13 @@ function useAddinChatController({
   // In the pane a chat opens through the session controller, the same path
   // the recent-chats picker takes; the pane serves no chat routes to
   // navigate to.
-  const openChatInPane = useCallback(
+  const openChatById = useCallback(
     (chatId: string) => chat.navigateToChat(chatId),
     [chat],
   );
   const runHeaderOptions = useMemo(
-    () => ({ onOpenOrigin: openChatInPane }),
-    [openChatInPane],
+    () => ({ onOpenOrigin: openChatById }),
+    [openChatById],
   );
   const { header: delegatedRunHeader, composerLocked } = useDelegatedRunHeader(
     chat.currentChatId,
@@ -222,7 +226,7 @@ function useAddinChatController({
   );
   const openDelegatedRun = useCallback<
     NonNullable<DelegatedRunsSectionProps["onOpenRun"]>
-  >((run) => openChatInPane(run.id), [openChatInPane]);
+  >((run) => openChatById(run.id), [openChatById]);
   const { availableModels, selectedModel, setSelectedModel, isSelectionReady } =
     useActiveModelSelection({ initialModel: chat.currentChatLastModel });
   const acceptedFileTypes = useMemo(
@@ -461,6 +465,7 @@ function useAddinChatController({
     delegatedRunHeader,
     composerLocked,
     openDelegatedRun,
+    openChatById,
   };
 }
 
@@ -553,137 +558,141 @@ export function AddinChatCoreView({
 
   return (
     <ChatInputControlsProvider value={controller.chatInputControls}>
-      <div className="app-shell-skin flex size-full min-w-0 flex-col">
-        <div className="chat-header-skin flex items-center justify-between border-b border-theme-border px-4 py-2">
-          <DropdownMenu
-            id="addin-header-menu"
-            align="left"
-            items={controller.headerMenuItems}
-          />
-          <button
-            type="button"
-            onClick={() => void controller.createNewChat()}
-            className="rounded-[var(--theme-radius-control)] bg-theme-bg-tertiary px-3 py-1 text-xs font-medium text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover"
-          >
-            {t({ id: "officeAddin.chat.newChat", message: "New Chat" })}
-          </button>
-        </div>
-
-        <ChatErrorBoundary onReset={() => void controller.refetchHistory()}>
-          <div
-            {...dropzone.getRootProps()}
-            className="chat-body-skin relative flex min-h-0 min-w-0 flex-1 flex-col"
-            role="region"
-            aria-label={t({
-              id: "officeAddin.chat.conversation.aria",
-              message: "Chat conversation",
-            })}
-            data-ui="addin-chat-conversation-dropzone"
-          >
-            <input
-              {...dropzone.getInputProps()}
-              aria-label={t({
-                id: "officeAddin.chat.conversation.dropzone.ariaLabel",
-                message: "Drop files anywhere in the conversation to upload",
-              })}
+      {/* Deep message surfaces (the trace's open-run affordance) open chats
+          through the session controller instead of routes the pane lacks. */}
+      <DelegatedRunOpenProvider onOpen={controller.openChatById}>
+        <div className="app-shell-skin flex size-full min-w-0 flex-col">
+          <div className="chat-header-skin flex items-center justify-between border-b border-theme-border px-4 py-2">
+            <DropdownMenu
+              id="addin-header-menu"
+              align="left"
+              items={controller.headerMenuItems}
             />
-            {showDropOverlay ? (
-              <div
-                className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center overflow-hidden bg-[color:color-mix(in_srgb,var(--theme-shell-chat-body)_75%,transparent)]"
-                data-testid="addin-chat-drop-overlay"
-              >
-                <div className="relative flex flex-col items-center gap-2 px-6 py-5 text-center">
-                  <DocumentIcon className="size-10 text-[var(--theme-fg-primary)] drop-shadow-[0_8px_24px_rgba(0,0,0,0.18)]" />
-                  <p className="text-sm font-medium text-[var(--theme-fg-primary)]">
-                    {t({
-                      id: "officeAddin.chat.fileDrop.overlay.label",
-                      message: "Drop to upload",
-                    })}
-                  </p>
-                </div>
-              </div>
-            ) : null}
-            {beforeMessages}
-            {controller.delegatedRunHeader ? (
-              <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3">
-                {controller.delegatedRunHeader}
-              </div>
-            ) : null}
-            {TopLeftAccessory ? (
-              <TopLeftAccessory
-                availableModels={controller.availableModels}
-                selectedModel={controller.selectedModel}
-                onModelChange={controller.setSelectedModel}
-                isModelSelectionReady={controller.isSelectionReady}
-              />
-            ) : null}
-            <MessageEditProvider value={controller.messageEditValue}>
-              <MessageList
-                messages={messages}
-                messageOrder={controller.messageOrder}
-                loadOlderMessages={() => {}}
-                hasOlderMessages={false}
-                isPending={controller.isMessagingLoading}
-                currentSessionId={controller.currentChatId ?? ""}
-                pageSize={6}
-                maxWidth={768}
-                showTimestamps={true}
-                showAvatars={false}
-                userProfile={controller.profile ?? undefined}
-                controls={controller.resolvedMessageControls}
-                messageRenderer={controller.resolvedMessageRenderer}
-                controlsContext={controller.controlsContext}
-                onMessageAction={controller.standardMessageActionHandler}
-                useVirtualization={controller.messageOrder.length > 30}
-                virtualizationThreshold={30}
-                onFilePreview={controller.openPreviewModal}
-                onViewFeedback={feedback.openFeedbackViewDialog}
-                className="overscroll-none"
-              />
-            </MessageEditProvider>
-            <DelegatedRunsSection
-              chatId={controller.currentChatId}
-              onOpenRun={controller.openDelegatedRun}
-            />
-            {renderInput(inputProps)}
+            <button
+              type="button"
+              onClick={() => void controller.createNewChat()}
+              className="rounded-[var(--theme-radius-control)] bg-theme-bg-tertiary px-3 py-1 text-xs font-medium text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover"
+            >
+              {t({ id: "officeAddin.chat.newChat", message: "New Chat" })}
+            </button>
           </div>
-        </ChatErrorBoundary>
 
-        <FilePreviewModal
-          isOpen={controller.isPreviewModalOpen}
-          onClose={controller.closePreviewModal}
-          file={controller.fileToPreview}
-          relatedFiles={controller.relatedFiles}
-        />
-        <FeedbackViewDialog
-          isOpen={feedback.feedbackViewDialogState.isOpen}
-          onClose={feedback.closeFeedbackViewDialog}
-          onEdit={feedback.switchToEditMode}
-          onRemove={() => void feedback.handleFeedbackViewDialogRemove()}
-          feedback={feedback.feedbackViewDialogState.feedback}
-          canEdit={
-            feedback.feedbackViewDialogState.feedback
-              ? feedback.canEditFeedback(
-                  feedback.feedbackViewDialogState.feedback,
-                )
-              : false
-          }
-          error={feedback.feedbackViewDialogState.error}
-        />
-        <FeedbackCommentDialog
-          isOpen={feedback.feedbackDialogState.isOpen}
-          onClose={feedback.closeFeedbackDialog}
-          onSubmit={feedback.handleFeedbackDialogSubmit}
-          sentiment={feedback.feedbackDialogState.sentiment}
-          mode={feedback.feedbackDialogState.mode}
-          initialComment={feedback.feedbackDialogState.initialComment}
-          error={feedback.feedbackDialogState.error}
-        />
-        {renderSettings({
-          isOpen: controller.isSettingsOpen,
-          onClose: () => controller.setIsSettingsOpen(false),
-        })}
-      </div>
+          <ChatErrorBoundary onReset={() => void controller.refetchHistory()}>
+            <div
+              {...dropzone.getRootProps()}
+              className="chat-body-skin relative flex min-h-0 min-w-0 flex-1 flex-col"
+              role="region"
+              aria-label={t({
+                id: "officeAddin.chat.conversation.aria",
+                message: "Chat conversation",
+              })}
+              data-ui="addin-chat-conversation-dropzone"
+            >
+              <input
+                {...dropzone.getInputProps()}
+                aria-label={t({
+                  id: "officeAddin.chat.conversation.dropzone.ariaLabel",
+                  message: "Drop files anywhere in the conversation to upload",
+                })}
+              />
+              {showDropOverlay ? (
+                <div
+                  className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center overflow-hidden bg-[color:color-mix(in_srgb,var(--theme-shell-chat-body)_75%,transparent)]"
+                  data-testid="addin-chat-drop-overlay"
+                >
+                  <div className="relative flex flex-col items-center gap-2 px-6 py-5 text-center">
+                    <DocumentIcon className="size-10 text-[var(--theme-fg-primary)] drop-shadow-[0_8px_24px_rgba(0,0,0,0.18)]" />
+                    <p className="text-sm font-medium text-[var(--theme-fg-primary)]">
+                      {t({
+                        id: "officeAddin.chat.fileDrop.overlay.label",
+                        message: "Drop to upload",
+                      })}
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+              {beforeMessages}
+              {controller.delegatedRunHeader ? (
+                <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3">
+                  {controller.delegatedRunHeader}
+                </div>
+              ) : null}
+              {TopLeftAccessory ? (
+                <TopLeftAccessory
+                  availableModels={controller.availableModels}
+                  selectedModel={controller.selectedModel}
+                  onModelChange={controller.setSelectedModel}
+                  isModelSelectionReady={controller.isSelectionReady}
+                />
+              ) : null}
+              <MessageEditProvider value={controller.messageEditValue}>
+                <MessageList
+                  messages={messages}
+                  messageOrder={controller.messageOrder}
+                  loadOlderMessages={() => {}}
+                  hasOlderMessages={false}
+                  isPending={controller.isMessagingLoading}
+                  currentSessionId={controller.currentChatId ?? ""}
+                  pageSize={6}
+                  maxWidth={768}
+                  showTimestamps={true}
+                  showAvatars={false}
+                  userProfile={controller.profile ?? undefined}
+                  controls={controller.resolvedMessageControls}
+                  messageRenderer={controller.resolvedMessageRenderer}
+                  controlsContext={controller.controlsContext}
+                  onMessageAction={controller.standardMessageActionHandler}
+                  useVirtualization={controller.messageOrder.length > 30}
+                  virtualizationThreshold={30}
+                  onFilePreview={controller.openPreviewModal}
+                  onViewFeedback={feedback.openFeedbackViewDialog}
+                  className="overscroll-none"
+                />
+              </MessageEditProvider>
+              <DelegatedRunsSection
+                chatId={controller.currentChatId}
+                onOpenRun={controller.openDelegatedRun}
+              />
+              {renderInput(inputProps)}
+            </div>
+          </ChatErrorBoundary>
+
+          <FilePreviewModal
+            isOpen={controller.isPreviewModalOpen}
+            onClose={controller.closePreviewModal}
+            file={controller.fileToPreview}
+            relatedFiles={controller.relatedFiles}
+          />
+          <FeedbackViewDialog
+            isOpen={feedback.feedbackViewDialogState.isOpen}
+            onClose={feedback.closeFeedbackViewDialog}
+            onEdit={feedback.switchToEditMode}
+            onRemove={() => void feedback.handleFeedbackViewDialogRemove()}
+            feedback={feedback.feedbackViewDialogState.feedback}
+            canEdit={
+              feedback.feedbackViewDialogState.feedback
+                ? feedback.canEditFeedback(
+                    feedback.feedbackViewDialogState.feedback,
+                  )
+                : false
+            }
+            error={feedback.feedbackViewDialogState.error}
+          />
+          <FeedbackCommentDialog
+            isOpen={feedback.feedbackDialogState.isOpen}
+            onClose={feedback.closeFeedbackDialog}
+            onSubmit={feedback.handleFeedbackDialogSubmit}
+            sentiment={feedback.feedbackDialogState.sentiment}
+            mode={feedback.feedbackDialogState.mode}
+            initialComment={feedback.feedbackDialogState.initialComment}
+            error={feedback.feedbackDialogState.error}
+          />
+          {renderSettings({
+            isOpen: controller.isSettingsOpen,
+            onClose: () => controller.setIsSettingsOpen(false),
+          })}
+        </div>
+      </DelegatedRunOpenProvider>
     </ChatInputControlsProvider>
   );
 }

--- a/office-addin/src/core/AddinChatInputCore.tsx
+++ b/office-addin/src/core/AddinChatInputCore.tsx
@@ -3,6 +3,7 @@ import {
   type AssistantMention,
   type ChatInputControlsHandle,
   type ChatModel,
+  type DelegationRunMode,
   type FileType,
   type FileUploadItem,
 } from "@erato/frontend/library";
@@ -15,6 +16,7 @@ export interface AddinChatInputCoreProps {
     modelId?: string,
     selectedFacetIds?: string[],
     mentionedAssistants?: AssistantMention[],
+    delegationRunMode?: DelegationRunMode,
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -9,6 +9,7 @@ import {
   useFileCapabilitiesContext,
   useFileDropzone,
   useFileUploadStore,
+  useGenerationStatusStore,
   useMessagingStore,
   useModelHistory,
   usePersistedState,
@@ -155,6 +156,13 @@ function AddinChatDataProvider({
     currentChatId: session.currentChatId,
     chats,
   });
+
+  // Mirror the viewed chat into the generation-status store, as the web
+  // ChatProvider does: opening a settled run consumes its terminal
+  // notification, and the chat in view never carries an attention marker.
+  useEffect(() => {
+    useGenerationStatusStore.getState().setCurrentChatId(session.currentChatId);
+  }, [session.currentChatId]);
 
   const resetMessagingForNewChat = useCallback(() => {
     useMessagingStore.getState().abortActiveSSE();

--- a/office-addin/src/core/SharedAddinShell.tsx
+++ b/office-addin/src/core/SharedAddinShell.tsx
@@ -2,6 +2,7 @@ import {
   ApiProvider,
   DesktopSidecarProvider,
   FeatureConfigProvider,
+  GenerationStatusPoller,
   I18nProvider,
   ThemeProvider,
   Toaster,
@@ -95,6 +96,9 @@ export function SharedAddinShell({
           <FeatureConfigProvider config={SHARED_ADDIN_FEATURE_CONFIG}>
             <ApiProvider enableDevtools={false}>
               {children}
+              {/* Self-gated on the generation-status store: fully idle until
+                  a dispatch or a listing seeds a running chat. */}
+              <GenerationStatusPoller />
               <Toaster placement="bottom-center" />
             </ApiProvider>
           </FeatureConfigProvider>

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -24,6 +24,19 @@ const spies = vi.hoisted(() => ({
   clearNewlyCreatedChatId: vi.fn(),
   setGenerationCurrentChatId: vi.fn(),
   runOpenHandler: { current: null as ((chatId: string) => void) | null },
+  sendMessage: vi.fn(async () => undefined),
+  inputProps: {
+    current: null as null | {
+      onSendMessage: (
+        message: string,
+        inputFileIds?: string[],
+        modelId?: string,
+        selectedFacetIds?: string[],
+        mentionedAssistants?: { id: string; name: string }[],
+        delegationRunMode?: "wait" | "background",
+      ) => void;
+    },
+  },
   useDelegatedRunHeader: vi.fn(
     (): { header: ReactNode; composerLocked: boolean } => ({
       header: null,
@@ -44,7 +57,7 @@ const spies = vi.hoisted(() => ({
     isFinalizing: false,
     streamingContent: null,
     error: null,
-    sendMessage: vi.fn(async () => undefined),
+    sendMessage: spies.sendMessage,
     editMessage: vi.fn(async () => undefined),
     regenerateMessage: vi.fn(async () => undefined),
     cancelMessage: vi.fn(),
@@ -193,12 +206,19 @@ vi.mock("@erato/frontend/library", async () => {
 });
 
 vi.mock("../AddinChatInputCore", () => ({
-  AddinChatInputCore: ({ disabled }: { disabled?: boolean }) => (
-    <div
-      data-testid="neutral-chat-input"
-      data-disabled={disabled ? "true" : "false"}
-    />
-  ),
+  AddinChatInputCore: (
+    props: NonNullable<(typeof spies.inputProps)["current"]> & {
+      disabled?: boolean;
+    },
+  ) => {
+    spies.inputProps.current = props;
+    return (
+      <div
+        data-testid="neutral-chat-input"
+        data-disabled={props.disabled ? "true" : "false"}
+      />
+    );
+  },
 }));
 vi.mock("../AddinSettingsDialogCore", () => ({
   AddinSettingsDialogCore: () => null,
@@ -335,6 +355,33 @@ describe("NeutralAddinChatPage host boundary", () => {
 
     expect(spies.useChatMessaging).toHaveBeenLastCalledWith(
       expect.objectContaining({ chatId: "run-88" }),
+    );
+  });
+
+  it("carries the background run-mode choice through to the send", () => {
+    renderPage();
+
+    // The composer's wait-or-background decision arrives as ChatInput's
+    // sixth argument; every hop of the add-in chain must hand it on, or a
+    // "background" dispatch silently degrades to an awaited one.
+    spies.inputProps.current?.onSendMessage(
+      "look into this",
+      undefined,
+      undefined,
+      undefined,
+      [{ id: "assistant-9", name: "Research" }],
+      "background",
+    );
+
+    expect(spies.sendMessage).toHaveBeenCalledWith(
+      "look into this",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [{ id: "assistant-9", name: "Research" }],
+      "background",
     );
   });
 

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -16,6 +16,7 @@ const spies = vi.hoisted(() => ({
     setNavigationTransition: vi.fn(),
   },
   clearNewlyCreatedChatId: vi.fn(),
+  setGenerationCurrentChatId: vi.fn(),
   useDelegatedRunHeader: vi.fn(
     (): { header: ReactNode; composerLocked: boolean } => ({
       header: null,
@@ -86,6 +87,11 @@ vi.mock("@erato/frontend/library", async () => {
     useFileUploadStore: (
       selector: (state: { silentChatId: string | null }) => unknown,
     ) => selector({ silentChatId: null }),
+    useGenerationStatusStore: Object.assign(vi.fn(), {
+      getState: () => ({
+        setCurrentChatId: spies.setGenerationCurrentChatId,
+      }),
+    }),
     useMessagingStore: Object.assign(() => spies.messagingStore, {
       getState: () => spies.messagingStore,
     }),
@@ -300,6 +306,17 @@ describe("NeutralAddinChatPage host boundary", () => {
     expect(spies.useChatMessaging).toHaveBeenLastCalledWith(
       expect.objectContaining({ chatId: "run-77" }),
     );
+  });
+
+  it("mirrors the open chat into the generation-status store", () => {
+    renderPage();
+    expect(spies.setGenerationCurrentChatId).toHaveBeenLastCalledWith(null);
+
+    // Opening a run marks it viewed, which consumes a settled run's
+    // attention notification exactly like the web ChatProvider does.
+    fireEvent.click(screen.getByTestId("neutral-delegated-runs"));
+
+    expect(spies.setGenerationCurrentChatId).toHaveBeenLastCalledWith("run-77");
   });
 
   it("locks the composer while a delegate still writes the open run", () => {

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -1,6 +1,12 @@
 import { i18n } from "@lingui/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NeutralAddinChatPage } from "../NeutralAddinChatPage";
@@ -17,6 +23,7 @@ const spies = vi.hoisted(() => ({
   },
   clearNewlyCreatedChatId: vi.fn(),
   setGenerationCurrentChatId: vi.fn(),
+  runOpenHandler: { current: null as ((chatId: string) => void) | null },
   useDelegatedRunHeader: vi.fn(
     (): { header: ReactNode; composerLocked: boolean } => ({
       header: null,
@@ -105,6 +112,16 @@ vi.mock("@erato/frontend/library", async () => {
       children,
     ChatMessage: () => null,
     DefaultMessageControls: () => null,
+    DelegatedRunOpenProvider: ({
+      onOpen,
+      children,
+    }: {
+      onOpen: (chatId: string) => void;
+      children?: ReactNode;
+    }) => {
+      spies.runOpenHandler.current = onOpen;
+      return children;
+    },
     DelegatedRunsSection: ({
       chatId,
       onOpenRun,
@@ -305,6 +322,19 @@ describe("NeutralAddinChatPage host boundary", () => {
     );
     expect(spies.useChatMessaging).toHaveBeenLastCalledWith(
       expect.objectContaining({ chatId: "run-77" }),
+    );
+  });
+
+  it("routes deep-surface run opens through the session controller", () => {
+    renderPage();
+    expect(spies.runOpenHandler.current).toBeTypeOf("function");
+
+    // The trace's open-run affordance reaches this handler via context; it
+    // must land on the same in-pane path as a picker selection.
+    act(() => spies.runOpenHandler.current?.("run-88"));
+
+    expect(spies.useChatMessaging).toHaveBeenLastCalledWith(
+      expect.objectContaining({ chatId: "run-88" }),
     );
   });
 

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -16,6 +16,12 @@ const spies = vi.hoisted(() => ({
     setNavigationTransition: vi.fn(),
   },
   clearNewlyCreatedChatId: vi.fn(),
+  useDelegatedRunHeader: vi.fn(
+    (): { header: ReactNode; composerLocked: boolean } => ({
+      header: null,
+      composerLocked: false,
+    }),
+  ),
   useRecentChats: vi.fn(() => ({
     data: { chats: [] },
     isLoading: false,
@@ -93,6 +99,21 @@ vi.mock("@erato/frontend/library", async () => {
       children,
     ChatMessage: () => null,
     DefaultMessageControls: () => null,
+    DelegatedRunsSection: ({
+      chatId,
+      onOpenRun,
+    }: {
+      chatId: string | null;
+      onOpenRun?: (chat: { id: string }) => void;
+    }) => (
+      <button
+        type="button"
+        data-testid="neutral-delegated-runs"
+        data-chat-id={chatId ?? ""}
+        onClick={() => onOpenRun?.({ id: "run-77" })}
+      />
+    ),
+    useDelegatedRunHeader: spies.useDelegatedRunHeader,
     DocumentIcon: () => null,
     DropdownMenu: () => null,
     FeedbackCommentDialog: () => null,
@@ -149,7 +170,12 @@ vi.mock("@erato/frontend/library", async () => {
 });
 
 vi.mock("../AddinChatInputCore", () => ({
-  AddinChatInputCore: () => <div data-testid="neutral-chat-input" />,
+  AddinChatInputCore: ({ disabled }: { disabled?: boolean }) => (
+    <div
+      data-testid="neutral-chat-input"
+      data-disabled={disabled ? "true" : "false"}
+    />
+  ),
 }));
 vi.mock("../AddinSettingsDialogCore", () => ({
   AddinSettingsDialogCore: () => null,
@@ -255,5 +281,39 @@ describe("NeutralAddinChatPage host boundary", () => {
     expect(spies.messagingStore.clearUserMessages).toHaveBeenCalled();
     expect(spies.messagingStore.resetStreaming).toHaveBeenCalled();
     expect(spies.clearNewlyCreatedChatId).toHaveBeenCalled();
+  });
+
+  it("hands the session's chat to the delegated-runs bar and opens a run in-pane", () => {
+    renderPage();
+
+    const bar = screen.getByTestId("neutral-delegated-runs");
+    expect(bar).toHaveAttribute("data-chat-id", "");
+
+    // The bar's open callback goes through the session controller, so the
+    // pane itself rebinds: messaging re-keys and the bar follows the run.
+    fireEvent.click(bar);
+
+    expect(screen.getByTestId("neutral-delegated-runs")).toHaveAttribute(
+      "data-chat-id",
+      "run-77",
+    );
+    expect(spies.useChatMessaging).toHaveBeenLastCalledWith(
+      expect.objectContaining({ chatId: "run-77" }),
+    );
+  });
+
+  it("locks the composer while a delegate still writes the open run", () => {
+    spies.useDelegatedRunHeader.mockReturnValue({
+      header: <div data-testid="neutral-run-banner" />,
+      composerLocked: true,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId("neutral-run-banner")).toBeInTheDocument();
+    expect(screen.getByTestId("neutral-chat-input")).toHaveAttribute(
+      "data-disabled",
+      "true",
+    );
   });
 });

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -52,6 +52,8 @@ vi.mock("@erato/frontend/library", () => ({
     children,
   ChatMessage: () => null,
   DefaultMessageControls: () => null,
+  DelegatedRunOpenProvider: ({ children }: { children?: ReactNode }) =>
+    children,
   DelegatedRunsSection: () => null,
   useDelegatedRunHeader: () => ({ header: null, composerLocked: false }),
   DocumentIcon: () => null,

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -52,6 +52,8 @@ vi.mock("@erato/frontend/library", () => ({
     children,
   ChatMessage: () => null,
   DefaultMessageControls: () => null,
+  DelegatedRunsSection: () => null,
+  useDelegatedRunHeader: () => ({ header: null, composerLocked: false }),
   DocumentIcon: () => null,
   DropdownMenu: () => null,
   FeedbackCommentDialog: () => null,

--- a/office-addin/src/outlook/components/AddinChatInput.tsx
+++ b/office-addin/src/outlook/components/AddinChatInput.tsx
@@ -10,6 +10,7 @@ import {
   type FileAttachmentGroupItem,
   type ActionFacetRequest,
   type AssistantMention,
+  type DelegationRunMode,
   type FileType,
   type FileUploadItem,
 } from "@erato/frontend/library";
@@ -85,6 +86,7 @@ interface AddinChatInputProps {
      */
     sendItemIdentity?: string | null,
     mentionedAssistants?: AssistantMention[],
+    delegationRunMode?: DelegationRunMode,
   ) => void;
   handleFileAttachments?: (files: FileUploadItem[]) => void;
   isLoading?: boolean;
@@ -665,6 +667,7 @@ export const AddinChatInput = forwardRef<
       modelId?: string,
       selectedFacetIds?: string[],
       mentionedAssistants?: AssistantMention[],
+      delegationRunMode?: DelegationRunMode,
     ) => {
       // Capture the item identity BEFORE any await: the uploads below can
       // take long enough for the user to switch emails, and the wrong-item
@@ -814,6 +817,7 @@ export const AddinChatInput = forwardRef<
           actionFacet,
           sendItemIdentity,
           mentionedAssistants,
+          delegationRunMode,
         );
         return;
       }
@@ -837,6 +841,7 @@ export const AddinChatInput = forwardRef<
             actionFacet,
             sendItemIdentity,
             mentionedAssistants,
+            delegationRunMode,
           );
           // No upload was attempted (e.g. only dismissed drops remain) and
           // nothing failed, so the staged drops are safe to clear.
@@ -878,6 +883,7 @@ export const AddinChatInput = forwardRef<
         actionFacet,
         sendItemIdentity,
         mentionedAssistants,
+        delegationRunMode,
       );
 
       // Clear the drops only when their files actually uploaded. On a failed
@@ -1039,6 +1045,7 @@ export const AddinChatInput = forwardRef<
           modelId,
           selectedFacetIds,
           mentionedAssistants,
+          delegationRunMode,
         ) => {
           void wrappedOnSendMessage(
             message,
@@ -1046,6 +1053,7 @@ export const AddinChatInput = forwardRef<
             modelId,
             selectedFacetIds,
             mentionedAssistants,
+            delegationRunMode,
           );
         }}
         disabled={

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -149,6 +149,9 @@ vi.mock("@erato/frontend/library", async () => {
     FeatureConfigProvider: passthrough,
     FileCapabilitiesProvider: passthrough,
     GenerationStatusPoller: () => null,
+    useGenerationStatusStore: Object.assign(() => undefined, {
+      getState: () => ({ setCurrentChatId: () => undefined }),
+    }),
     I18nProvider: passthrough,
     ProfileProvider: passthrough,
     ThemeProvider: passthrough,

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -148,10 +148,13 @@ vi.mock("@erato/frontend/library", async () => {
     DesktopSidecarProvider: passthrough,
     FeatureConfigProvider: passthrough,
     FileCapabilitiesProvider: passthrough,
+    GenerationStatusPoller: () => null,
     I18nProvider: passthrough,
     ProfileProvider: passthrough,
     ThemeProvider: passthrough,
     Toaster: () => null,
+    DelegatedRunsSection: () => null,
+    useDelegatedRunHeader: () => ({ header: null, composerLocked: false }),
     toast: {
       info: vi.fn(),
       success: vi.fn(),

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -156,6 +156,7 @@ vi.mock("@erato/frontend/library", async () => {
     ProfileProvider: passthrough,
     ThemeProvider: passthrough,
     Toaster: () => null,
+    DelegatedRunOpenProvider: passthrough,
     DelegatedRunsSection: () => null,
     useDelegatedRunHeader: () => ({ header: null, composerLocked: false }),
     toast: {

--- a/office-addin/src/vite-env.d.ts
+++ b/office-addin/src/vite-env.d.ts
@@ -4,4 +4,7 @@
 interface ImportMetaEnv {
   readonly VITE_MSAL_CLIENT_ID?: string;
   readonly VITE_MSAL_AUTHORITY?: string;
+  readonly VITE_ASSISTANTS_ENABLED?: string;
+  readonly VITE_ASSISTANTS_DELEGATION_ENABLED?: string;
+  readonly VITE_ASSISTANTS_DELEGATION_ALLOW_BACKGROUND?: string;
 }


### PR DESCRIPTION
This pull request introduces a new "host seam" for delegated chat runs, allowing the host application (such as an add-in pane) to open delegated runs and their origin chats using its own navigation or session logic instead of relying on in-app routes. This is accomplished by making key UI components accept callback props (`onOpenRun`, `onOpenOrigin`), which, when provided, render buttons instead of links and invoke the host-supplied handler. The changes are covered by new and updated tests, and relevant components and hooks are now exported for host use. Additionally, some dependency versions in `pnpm-lock.yaml` were adjusted.

**Host Integration for Delegated Runs and Origin Chats:**

- `DelegatedRunsSection` and `DelegatedRunRow` now accept an optional `onOpenRun` prop. When provided, run items render as accessible buttons (not links) and invoke the host's handler instead of navigating to a chat route. [[1]](diffhunk://#diff-9852c0b3ef9271fe978b7ae7cf03beee275754638de557a440d7e3bdfe75e377L67-R68) [[2]](diffhunk://#diff-9852c0b3ef9271fe978b7ae7cf03beee275754638de557a440d7e3bdfe75e377R200-R205) [[3]](diffhunk://#diff-9852c0b3ef9271fe978b7ae7cf03beee275754638de557a440d7e3bdfe75e377L184-R216) [[4]](diffhunk://#diff-9852c0b3ef9271fe978b7ae7cf03beee275754638de557a440d7e3bdfe75e377R351)
- `DelegatedRunHeader` now accepts an optional `onOpenOrigin` prop. When provided, the origin chat is rendered as a button (not a link) and invokes the host's handler. [[1]](diffhunk://#diff-92e37b026dc3d4eed03a84a789fde026d1df5759a166c5e534a0d072b0b9b2e5R20-R25) [[2]](diffhunk://#diff-92e37b026dc3d4eed03a84a789fde026d1df5759a166c5e534a0d072b0b9b2e5R77-R85) [[3]](diffhunk://#diff-92e37b026dc3d4eed03a84a789fde026d1df5759a166c5e534a0d072b0b9b2e5L106-R124) [[4]](diffhunk://#diff-92e37b026dc3d4eed03a84a789fde026d1df5759a166c5e534a0d072b0b9b2e5R143)
- The `useDelegatedRunHeader` hook is updated to forward the `onOpenOrigin` option to `DelegatedRunHeader`. [[1]](diffhunk://#diff-bbeba0402bfd533a58c248b7474233b02f79ac9e5308ee7c72ff2900b53985aaR46-R51) [[2]](diffhunk://#diff-bbeba0402bfd533a58c248b7474233b02f79ac9e5308ee7c72ff2900b53985aaR77-R82)

**Testing and Exports:**

- New and updated tests verify that delegated run rows and origin buttons invoke the correct handlers and do not render as links when host handlers are supplied. [[1]](diffhunk://#diff-782ddaba00c4f24ee66ac2f06a0b9618f7f1b819d9fb2713a616fb541e615a9cR87-R98) [[2]](diffhunk://#diff-6114cc9be3aead87f40b181e23e28347d5c60ec6821bc6d46a9c124b76d504c1R76-R93) [[3]](diffhunk://#diff-6114cc9be3aead87f40b181e23e28347d5c60ec6821bc6d46a9c124b76d504c1R515-R572)
- The new props and hooks are exported from the library for host integration.

**Dependency Updates:**

- The `pnpm-lock.yaml` file is updated to use consistent Lingui package versions, removing some `5.9.5` entries in favor of `5.9.4`. [[1]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L506-R506) [[2]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L816-L819) [[3]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L832-L851) [[4]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L4836-R4825) [[5]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L5171-R5166) [[6]](diffhunk://#diff-e9ace989cdd607ea6ee04e5b9b6baa25388d0d7caa3c97016170976dfe1f8132L5199-L5217)