### PR TITLE
Do not clear a still-unlisted chat's placeholder on turn completion (ERMAIN-666)

### DIFF
--- a/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useChatMessaging.test.ts
@@ -1824,7 +1824,10 @@ describe("useChatMessaging", () => {
     ).toBe("Hello from new chat");
   });
 
-  it("should clear the pending chat when the turn completes", async () => {
+  it("should keep the pending chat when the turn completes while still unlisted", async () => {
+    // The placeholder is the open chat's only sidebar row until the list
+    // returns the chat; completion must not drop it. It is cleared by the
+    // listed-row swap or by the user leaving for a new chat.
     mockUseChatMessages.mockReturnValue({
       data: undefined,
       isLoading: false,
@@ -1872,7 +1875,9 @@ describe("useChatMessaging", () => {
       });
     });
 
-    expect(useChatHistoryStore.getState().pendingChat).toBeNull();
+    expect(useChatHistoryStore.getState().pendingChat?.id).toBe(
+      "chat-complete-1",
+    );
   });
 
   it("should clear a leaked pending chat when its resume stream closes", async () => {

--- a/frontend/src/hooks/chat/useChatMessaging.ts
+++ b/frontend/src/hooks/chat/useChatMessaging.ts
@@ -1077,12 +1077,11 @@ export function useChatMessaging(
               invalidate: true,
               logContext: "Assistant message completed",
             }).then(() => {
-              // Backstop for a placeholder the listed-row swap missed (a
-              // chat that never became listable for this user). Deferred
-              // until the awaited listing invalidation has landed, so a
-              // normally-listable chat swaps placeholder for real row
-              // without a frame where the sidebar shows neither.
-              clearPendingChat(activeStreamKey);
+              // Deliberately no clearPendingChat here: a chat the refetched
+              // list still does not return (filtered out, on a later page)
+              // has the placeholder as its only sidebar row, which must
+              // survive the finished turn. The listed-row swap clears it when
+              // the chat shows up; leaving for a new chat clears it otherwise.
               // Reset submission flag after refetch completes
               setSubmittingForKey(activeStreamKey, false);
               logger.log(


### PR DESCRIPTION
Main's e2e many-models shards have been red since #1023: `sidebar-new-chat.many-models.spec.ts:353` ("starting a new chat drops a finished but still-unlisted chat's placeholder") fails deterministically on both browsers.

#1023's actual fix — skipping new-chat bookkeeping for replayed `chat_created` frames — is untouched. But its extra "hygiene backstop" (`clearPendingChat` in the `assistant_message_completed` path, after the listing invalidation) was justified with "by completion the chat is listable", and that premise doesn't hold: a chat the refetched list still does not return (filtered out, on a later page, or deliberately excluded as in the e2e test) has the placeholder as its **only** sidebar row. The backstop deleted the open chat's row the moment its first turn finished. Since replays no longer seed placeholders, every placeholder now belongs to a chat this client genuinely submitted, so the backstop only ever fired on the healthy path.

This removes that one clear. All other #1023 hygiene (resume `onError`/`onClose` clears) and the pre-existing clearing paths (listed-row swap, New Chat, archive, stream errors) stay. The unit test that enshrined the backstop is inverted to pin the contract instead.

## Validation

- Reproduced the e2e failure locally on unfixed main (same assertion, all retries), then with the fix: passes on chromium and firefox, 3/3 stable on repeat.
- The neighboring `:168` test fails locally with and without the fix (known pre-existing race; passes in CI), so it is unrelated.
- Full frontend suite 151 files / 1452 passed; tsc, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGArgqk7ktB2C5CEKmpUAs