### PR TITLE
Extract router-free chat-history primitives for host reuse (ERMAIN-614)

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -20,6 +20,7 @@ import { Button } from "../Controls/Button";
 import { CheckIcon, ChevronRightIcon, FilterSortIcon } from "../icons";
 
 import type {
+  ChatHistoryFilterStoreHook,
   ChatHistoryGroupBy,
   ChatHistoryStatusFilter,
   ChatHistoryTypeFilter,
@@ -30,6 +31,13 @@ export interface ChatHistoryFilterMenuProps {
   /** Shows the assistant-scoped entries (Type row, group-by-Type option). */
   assistantsEnabled: boolean;
   className?: string;
+  /**
+   * Filter store instance the menu reads and writes. Defaults to the web
+   * sidebar's singleton; surfaces with their own persistence (the add-in
+   * drawer) pass their own. Must stay the same instance for the component's
+   * lifetime.
+   */
+  store?: ChatHistoryFilterStoreHook;
 }
 
 type SubmenuKey = "type" | "status" | "groupBy";
@@ -102,6 +110,7 @@ function buildRow<V extends string>(
 export function ChatHistoryFilterMenu({
   assistantsEnabled,
   className,
+  store = useChatHistoryFilterStore,
 }: ChatHistoryFilterMenuProps) {
   const [isOpen, setIsOpenState] = useState(false);
   const [openSubmenu, setOpenSubmenu] = useState<SubmenuKey | null>(null);
@@ -126,19 +135,13 @@ export function ChatHistoryFilterMenu({
   // "hover, read, then click" gesture), not toggle it away.
   const submenuOpenedByHoverRef = useRef(false);
 
-  const typeFilter = useChatHistoryFilterStore((state) => state.typeFilter);
-  const statusFilter = useChatHistoryFilterStore((state) => state.statusFilter);
-  const groupBy = useChatHistoryFilterStore((state) => state.groupBy);
-  const setTypeFilter = useChatHistoryFilterStore(
-    (state) => state.setTypeFilter,
-  );
-  const setStatusFilter = useChatHistoryFilterStore(
-    (state) => state.setStatusFilter,
-  );
-  const setGroupBy = useChatHistoryFilterStore((state) => state.setGroupBy);
-  const resetToDefaults = useChatHistoryFilterStore(
-    (state) => state.resetToDefaults,
-  );
+  const typeFilter = store((state) => state.typeFilter);
+  const statusFilter = store((state) => state.statusFilter);
+  const groupBy = store((state) => state.groupBy);
+  const setTypeFilter = store((state) => state.setTypeFilter);
+  const setStatusFilter = store((state) => state.setStatusFilter);
+  const setGroupBy = store((state) => state.setGroupBy);
+  const resetToDefaults = store((state) => state.resetToDefaults);
 
   const filters = sanitizeChatHistoryFilters(
     { typeFilter, statusFilter, groupBy },

--- a/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
@@ -13,10 +13,13 @@ import type { ChatSession } from "@/types/chat";
 import type { Messages } from "@lingui/core";
 import type { ReactNode } from "react";
 
+const timestampCreatedAtLog = vi.hoisted(() => [] as Date[]);
+
 vi.mock("@/components/ui", () => ({
-  MessageTimestamp: ({ createdAt }: { createdAt: Date }) => (
-    <span>{createdAt.toISOString()}</span>
-  ),
+  MessageTimestamp: ({ createdAt }: { createdAt: Date }) => {
+    timestampCreatedAtLog.push(createdAt);
+    return <span>{createdAt.toISOString()}</span>;
+  },
 }));
 
 vi.mock("@/hooks/ui", () => ({
@@ -118,6 +121,35 @@ describe("ChatHistoryList", () => {
     const unpinItem = screen.getByRole("button", { name: "Unpin" });
     expect(unpinItem).toBeEnabled();
     expect(unpinItem.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("keeps the MessageTimestamp Date instance stable across list re-renders", async () => {
+    const { i18n } = await import("@lingui/core");
+    // A fresh onSessionSelect per render defeats the list memo, so the rows
+    // themselves re-render — the scenario the stable Date must survive.
+    const makeUi = () => (
+      <I18nProvider i18n={i18n}>
+        <ChatHistoryList
+          sessions={sessions}
+          currentSessionId={null}
+          onSessionSelect={vi.fn()}
+        />
+      </I18nProvider>
+    );
+
+    timestampCreatedAtLog.length = 0;
+    const { rerender } = render(makeUi());
+    const firstRenderDates = [...timestampCreatedAtLog];
+    expect(firstRenderDates).toHaveLength(sessions.length);
+
+    timestampCreatedAtLog.length = 0;
+    rerender(makeUi());
+    const secondRenderDates = [...timestampCreatedAtLog];
+    expect(secondRenderDates).toHaveLength(sessions.length);
+
+    secondRenderDates.forEach((createdAt, index) => {
+      expect(createdAt).toBe(firstRenderDates[index]);
+    });
   });
 
   it("uses the sidebar token surface for active history rows", async () => {

--- a/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
@@ -340,3 +340,48 @@ describe("ChatHistoryList", () => {
     });
   });
 });
+
+describe("disableRowLinks", () => {
+  const renderRows = async (disableRowLinks: boolean, onSelect = vi.fn()) => {
+    const { i18n } = await import("@lingui/core");
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+    render(
+      <I18nProvider i18n={i18n}>
+        <ChatHistoryList
+          sessions={sessions}
+          currentSessionId={null}
+          onSessionSelect={onSelect}
+          disableRowLinks={disableRowLinks}
+        />
+      </I18nProvider>,
+    );
+    return onSelect;
+  };
+
+  it("renders rows without hrefs so no click can navigate the host", async () => {
+    const onSelect = await renderRows(true);
+
+    const row = screen.getByRole("button", { name: "First chat" });
+    expect(row).not.toHaveAttribute("href");
+
+    const { fireEvent } = await import("@testing-library/react");
+    // Modified clicks select in place: the host has no tab to open.
+    fireEvent.click(row, { metaKey: true });
+    expect(onSelect).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("keeps the link escape hatch by default", async () => {
+    const onSelect = await renderRows(false);
+
+    const row = screen.getByRole("link", { name: "First chat" });
+    expect(row).toHaveAttribute("href");
+
+    const { fireEvent } = await import("@testing-library/react");
+    const swallowNavigation = (e: MouseEvent) => e.preventDefault();
+    document.addEventListener("click", swallowNavigation);
+    fireEvent.click(row, { metaKey: true });
+    document.removeEventListener("click", swallowNavigation);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -121,6 +121,12 @@ export interface ChatHistoryListProps {
   hasMore?: boolean;
   isLoadingMore?: boolean;
   onLoadMore?: () => void;
+  /**
+   * For hosts that serve no chat routes (the add-in pane): rows render
+   * without hrefs, and every activation — modified clicks included — goes
+   * through onSessionSelect.
+   */
+  disableRowLinks?: boolean;
 }
 
 const ChatHistoryListItem = memo<{
@@ -138,6 +144,7 @@ const ChatHistoryListItem = memo<{
   canEdit?: boolean;
   onShowDetails?: () => void;
   showTimestamps?: boolean;
+  disableRowLinks?: boolean;
 }>(
   ({
     session,
@@ -154,6 +161,7 @@ const ChatHistoryListItem = memo<{
     canEdit = true,
     onShowDetails,
     showTimestamps = true,
+    disableRowLinks = false,
   }) => {
     const generationStatus = useRowGenerationStatus(session.id);
     const rowTitle = useRowTitle(session);
@@ -172,6 +180,147 @@ const ChatHistoryListItem = memo<{
             id: "chat.history.menu.pin",
             message: "Pin",
           });
+    const rowAriaLabel = generationStatus
+      ? `${rowTitle}, ${chatAttentionStatusLabel(generationStatus)}`
+      : rowTitle;
+    const rowBody = (
+      <InteractiveContainer
+        useDiv={true}
+        showFocusRing={false}
+        className={clsx(
+          "sidebar-content-col-geometry sidebar-trailing-col-geometry sidebar-row-geometry theme-transition flex flex-col py-1.5 pb-3.5 text-left",
+          isActive
+            ? "sidebar-row-selected"
+            : "hover:bg-[var(--theme-shell-sidebar-hover)]",
+          layout === "compact" ? "gap-0.5" : "gap-1",
+        )}
+        data-chat-id={session.id}
+        data-ui="chat-history-item"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <GenerationStatusIndicator chatId={session.id} />
+            <ChatItemIcon />
+            <span className="truncate font-medium" title={rowTitle}>
+              {rowTitle}
+            </span>
+          </div>
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- div exists to prevent bubbling */}
+          <div
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+          >
+            <DropdownMenu
+              triggerButtonVariant="sidebar-icon"
+              items={[
+                ...(onPin
+                  ? [
+                      {
+                        label: pinMenuLabel,
+                        icon: isPinned ? (
+                          <PinSlashIcon className="size-4" />
+                        ) : (
+                          <PinIcon className="size-4" />
+                        ),
+                        onClick: onPin,
+                        disabled: !canEdit || isPinLimitReached,
+                      },
+                    ]
+                  : []),
+                ...(onShare
+                  ? [
+                      {
+                        label: t({
+                          id: "chat.share.button",
+                          message: "Share",
+                        }),
+                        icon: <ShareIcon className="size-4" />,
+                        onClick: onShare,
+                        disabled: !canEdit,
+                      },
+                    ]
+                  : []),
+                ...(onEditTitle
+                  ? [
+                      {
+                        label: t({
+                          id: "chat.history.menu.rename",
+                          message: "Rename",
+                        }),
+                        icon: <EditIcon className="size-4" />,
+                        onClick: onEditTitle,
+                        disabled: !canEdit,
+                      },
+                    ]
+                  : []),
+                {
+                  label: t`Remove`,
+                  icon: <Trash className="size-4" />,
+                  variant: "danger",
+                  onClick: onArchive ?? (() => {}),
+                  confirmAction: true,
+                  confirmTitle: t`Confirm Removal`,
+                  confirmMessage: t`Are you sure you want to remove this chat?`,
+                },
+              ]}
+            />
+          </div>
+        </div>
+        {layout !== "compact" && showTimestamps && (
+          <>
+            <p
+              className={clsx(
+                "truncate text-xs",
+                session.metadata?.fileCount == 0
+                  ? "text-theme-fg-muted"
+                  : "text-theme-fg-secondary",
+              )}
+              title={
+                session.metadata?.fileCount === 0
+                  ? t`No files`
+                  : session.metadata?.fileCount === 1
+                    ? t`1 file`
+                    : `${session.metadata?.fileCount ?? 0} files`
+              }
+            >
+              <Plural
+                value={session.metadata?.fileCount ?? 0}
+                _0="No files"
+                one="# file"
+                other="# files"
+              />
+            </p>
+            {session.updatedAt && (
+              <p className="text-xs text-theme-fg-secondary">
+                <MessageTimestamp createdAt={new Date(session.updatedAt)} />
+              </p>
+            )}
+          </>
+        )}
+      </InteractiveContainer>
+    );
+
+    // A host without the web app's chat routes (the add-in pane) has no tab
+    // for a modified click to open; there every activation selects in place,
+    // and rendering no href keeps a middle click from navigating the webview
+    // itself.
+    if (disableRowLinks) {
+      return (
+        <InteractiveContainer
+          useDiv={true}
+          showFocusRing={false}
+          onClick={() => onSelect()}
+          className={`${sidebarRowLinkClassName} cursor-pointer`}
+          aria-label={rowAriaLabel}
+          aria-current={isActive ? "page" : undefined}
+        >
+          {rowBody}
+        </InteractiveContainer>
+      );
+    }
+
     return (
       <a
         href={getChatUrl(session.id, session.assistantId)}
@@ -180,134 +329,14 @@ const ChatHistoryListItem = memo<{
           if (e.metaKey || e.ctrlKey) {
             return;
           }
-          // Prevent default navigation for normal clicks
           e.preventDefault();
           onSelect();
         }}
         className={sidebarRowLinkClassName}
-        aria-label={
-          generationStatus
-            ? `${rowTitle}, ${chatAttentionStatusLabel(generationStatus)}`
-            : rowTitle
-        }
+        aria-label={rowAriaLabel}
         aria-current={isActive ? "page" : undefined}
       >
-        <InteractiveContainer
-          useDiv={true}
-          showFocusRing={false}
-          className={clsx(
-            "sidebar-content-col-geometry sidebar-trailing-col-geometry sidebar-row-geometry theme-transition flex flex-col py-1.5 pb-3.5 text-left",
-            isActive
-              ? "sidebar-row-selected"
-              : "hover:bg-[var(--theme-shell-sidebar-hover)]",
-            layout === "compact" ? "gap-0.5" : "gap-1",
-          )}
-          data-chat-id={session.id}
-          data-ui="chat-history-item"
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <GenerationStatusIndicator chatId={session.id} />
-              <ChatItemIcon />
-              <span className="truncate font-medium" title={rowTitle}>
-                {rowTitle}
-              </span>
-            </div>
-            {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- div exists to prevent bubbling */}
-            <div
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-            >
-              <DropdownMenu
-                triggerButtonVariant="sidebar-icon"
-                items={[
-                  ...(onPin
-                    ? [
-                        {
-                          label: pinMenuLabel,
-                          icon: isPinned ? (
-                            <PinSlashIcon className="size-4" />
-                          ) : (
-                            <PinIcon className="size-4" />
-                          ),
-                          onClick: onPin,
-                          disabled: !canEdit || isPinLimitReached,
-                        },
-                      ]
-                    : []),
-                  ...(onShare
-                    ? [
-                        {
-                          label: t({
-                            id: "chat.share.button",
-                            message: "Share",
-                          }),
-                          icon: <ShareIcon className="size-4" />,
-                          onClick: onShare,
-                          disabled: !canEdit,
-                        },
-                      ]
-                    : []),
-                  ...(onEditTitle
-                    ? [
-                        {
-                          label: t({
-                            id: "chat.history.menu.rename",
-                            message: "Rename",
-                          }),
-                          icon: <EditIcon className="size-4" />,
-                          onClick: onEditTitle,
-                          disabled: !canEdit,
-                        },
-                      ]
-                    : []),
-                  {
-                    label: t`Remove`,
-                    icon: <Trash className="size-4" />,
-                    variant: "danger",
-                    onClick: onArchive ?? (() => {}),
-                    confirmAction: true,
-                    confirmTitle: t`Confirm Removal`,
-                    confirmMessage: t`Are you sure you want to remove this chat?`,
-                  },
-                ]}
-              />
-            </div>
-          </div>
-          {layout !== "compact" && showTimestamps && (
-            <>
-              <p
-                className={clsx(
-                  "truncate text-xs",
-                  session.metadata?.fileCount == 0
-                    ? "text-theme-fg-muted"
-                    : "text-theme-fg-secondary",
-                )}
-                title={
-                  session.metadata?.fileCount === 0
-                    ? t`No files`
-                    : session.metadata?.fileCount === 1
-                      ? t`1 file`
-                      : `${session.metadata?.fileCount ?? 0} files`
-                }
-              >
-                <Plural
-                  value={session.metadata?.fileCount ?? 0}
-                  _0="No files"
-                  one="# file"
-                  other="# files"
-                />
-              </p>
-              {session.updatedAt && (
-                <p className="text-xs text-theme-fg-secondary">
-                  <MessageTimestamp createdAt={new Date(session.updatedAt)} />
-                </p>
-              )}
-            </>
-          )}
-        </InteractiveContainer>
+        {rowBody}
       </a>
     );
   },
@@ -335,6 +364,7 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
     isLoadingMore = false,
     onLoadMore,
     showTimestamps = true,
+    disableRowLinks = false,
   }) => {
     const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
 
@@ -378,6 +408,7 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
             isActive={currentSessionId === session.id}
             layout={layout}
             showTimestamps={showTimestamps}
+            disableRowLinks={disableRowLinks}
             onSelect={() => {
               logger.log(`Session item click: ${session.id}`);
               onSessionSelect(session.id);

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Plural } from "@lingui/react/macro";
 import clsx from "clsx";
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 
 import { MessageTimestamp } from "@/components/ui";
 import { useHasPendingConfirmation } from "@/hooks/chat/store/confirmationRegistryStore";
@@ -165,6 +165,12 @@ const ChatHistoryListItem = memo<{
   }) => {
     const generationStatus = useRowGenerationStatus(session.id);
     const rowTitle = useRowTitle(session);
+    // A stable Date instance: an inline `new Date(...)` would defeat
+    // MessageTimestamp's shallow memo on every list render.
+    const updatedAtDate = useMemo(
+      () => (session.updatedAt ? new Date(session.updatedAt) : null),
+      [session.updatedAt],
+    );
     const isPinLimitReached = !isPinned && pinnedChatsCount >= pinnedChatsLimit;
     const pinMenuLabel = isPinLimitReached
       ? t({
@@ -292,9 +298,9 @@ const ChatHistoryListItem = memo<{
                 other="# files"
               />
             </p>
-            {session.updatedAt && (
+            {updatedAtDate && (
               <p className="text-xs text-theme-fg-secondary">
-                <MessageTimestamp createdAt={new Date(session.updatedAt)} />
+                <MessageTimestamp createdAt={updatedAtDate} />
               </p>
             )}
           </>

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { plural, t } from "@lingui/core/macro";
-import { useLingui } from "@lingui/react";
 import clsx from "clsx";
 import { memo, useRef, useState, useEffect, useCallback, useMemo } from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -16,8 +15,7 @@ import {
 import { defaultThemeConfig } from "@/config/themeConfig";
 import {
   hasActiveFilters,
-  sanitizeChatHistoryFilters,
-  useChatHistoryFilterStore,
+  useChatHistoryFilterFoldback,
   useSanitizedChatHistoryFilters,
 } from "@/hooks/chat/store/chatHistoryFilterStore";
 import { useConfirmationRegistryStore } from "@/hooks/chat/store/confirmationRegistryStore";
@@ -27,6 +25,7 @@ import {
   useGenerationStatusStore,
 } from "@/hooks/chat/store/generationStatusStore";
 import { useChatHistoryStore } from "@/hooks/chat/useChatHistory";
+import { useGroupedChatSessions } from "@/hooks/chat/useGroupedChatSessions";
 import { useResponsiveCollapsedMode, useThemedIcon } from "@/hooks/ui";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { useAssistantHubConfig } from "@/lib/generated/v1betaApi/v1betaApiComponents";
@@ -35,10 +34,6 @@ import {
   useSidebarFeature,
 } from "@/providers/FeatureConfigProvider";
 import { UNTITLED_BACKEND_SENTINEL } from "@/utils/chat/recentChatSession";
-import {
-  groupChatSessions,
-  resolveChatAttentionStatus,
-} from "@/utils/chatHistoryGrouping";
 import { createLogger } from "@/utils/debugLogger";
 import { checkFileExists } from "@/utils/themeUtils";
 
@@ -49,13 +44,15 @@ import {
   parsePersistedBoolean,
   SidebarCollapsibleSection as CollapsibleSection,
   sidebarInsetClassName,
-  sidebarItemClassName,
 } from "./SidebarCollapsibleSection";
+import {
+  SidebarNavigationItem,
+  sidebarNavigationIconClassName,
+} from "./SidebarNavigationItem";
 import {
   SidebarResizeHandle,
   useApplySidebarWidth,
 } from "./SidebarResizeHandle";
-import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { Button } from "../Controls/Button";
 import { CountBadge } from "../Controls/CountBadge";
 import { UserProfileThemeDropdown } from "../Controls/UserProfileThemeDropdown";
@@ -73,11 +70,6 @@ import type { ChatSession } from "@/types/chat";
 
 // Create logger for this component
 const logger = createLogger("UI", "ChatHistorySidebar");
-const activeSidebarItemClassName = "sidebar-row-geometry sidebar-row-selected";
-// Inset ring for the same reason as the chat rows: the row inset is
-// themeable and can be narrower than an outside-drawn ring.
-const sidebarLinkClassName =
-  "focus-ring-inset block rounded-[var(--theme-radius-shell)]";
 
 const RECENT_CHATS_SECTION_EXPANDED_STORAGE_KEY =
   "erato.sidebar.recentChatsSectionExpanded";
@@ -302,39 +294,21 @@ export const NewChatItem = memo<{
   const newChatIconId = useThemedIcon("navigation", "newChat");
 
   return (
-    <div className={clsx(sidebarInsetClassName, "py-1")}>
-      <InteractiveContainer
-        useDiv={true}
-        showFocusRing={false}
-        onClick={() => {
-          logger.log("[CHAT_FLOW] New chat item clicked");
-          onNewChat?.();
-        }}
-        className={clsx(
-          sidebarItemClassName,
-          "focus-ring-inset theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
-          "sidebar-content-col-geometry gap-3 py-2 pr-3",
-        )}
-        aria-label={t`New Chat`}
-        title={isSlimMode ? t`New Chat` : undefined}
-      >
+    <SidebarNavigationItem
+      label={t`New Chat`}
+      icon={
         <ResolvedIcon
           iconId={newChatIconId}
           fallbackIcon={PlusIcon}
-          className="size-4 shrink-0 text-theme-fg-secondary"
+          className={sidebarNavigationIconClassName}
         />
-        <span
-          className={clsx(
-            "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
-            isSlimMode
-              ? "w-0 overflow-hidden opacity-0"
-              : "opacity-100 delay-150",
-          )}
-        >
-          {t`New Chat`}
-        </span>
-      </InteractiveContainer>
-    </div>
+      }
+      isSlimMode={isSlimMode}
+      onClick={() => {
+        logger.log("[CHAT_FLOW] New chat item clicked");
+        onNewChat?.();
+      }}
+    />
   );
 });
 
@@ -349,82 +323,25 @@ const SearchNavigationItem = memo<{
   const searchIconId = useThemedIcon("navigation", "search");
 
   return (
-    <div className={clsx(sidebarInsetClassName, "py-1")}>
-      {isOnSearchPage ? (
-        <InteractiveContainer
-          useDiv={true}
-          interactive={false}
-          className={clsx(
-            activeSidebarItemClassName,
-            "flex items-center text-left",
-            "sidebar-content-col-geometry gap-3 py-2 pr-3",
-          )}
-          aria-label={t`Search`}
-          title={isSlimMode ? t`Search` : undefined}
-          data-ui="sidebar-search-item"
-        >
-          <ResolvedIcon
-            iconId={searchIconId}
-            fallbackIcon={SearchIcon}
-            className="size-4 shrink-0 text-theme-fg-secondary"
-          />
-          <span
-            className={clsx(
-              "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
-              isSlimMode
-                ? "w-0 overflow-hidden opacity-0"
-                : "opacity-100 delay-150",
-            )}
-          >
-            {t`Search`}
-          </span>
-        </InteractiveContainer>
-      ) : (
-        <a
-          href="/search"
-          onClick={(e) => {
-            // Allow cmd/ctrl-click to open in new tab
-            if (e.metaKey || e.ctrlKey) {
-              return;
-            }
-            // Prevent default navigation for normal clicks
-            e.preventDefault();
-            logger.log("[CHAT_FLOW] Search navigation item clicked");
-            onSearch?.();
-          }}
-          className={sidebarLinkClassName}
-          aria-label={t`Search`}
-          title={isSlimMode ? t`Search` : undefined}
-        >
-          <InteractiveContainer
-            useDiv={true}
-            showFocusRing={false}
-            className={clsx(
-              sidebarItemClassName,
-              "theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
-              "sidebar-content-col-geometry gap-3 py-2 pr-3",
-            )}
-            data-ui="sidebar-search-item"
-          >
-            <ResolvedIcon
-              iconId={searchIconId}
-              fallbackIcon={SearchIcon}
-              className="size-4 shrink-0 text-theme-fg-secondary"
-            />
-            <span
-              className={clsx(
-                "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
-                isSlimMode
-                  ? "w-0 overflow-hidden opacity-0"
-                  : "opacity-100 delay-150",
-              )}
-            >
-              {t`Search`}
-            </span>
-          </InteractiveContainer>
-        </a>
-      )}
-    </div>
+    <SidebarNavigationItem
+      label={t`Search`}
+      icon={
+        <ResolvedIcon
+          iconId={searchIconId}
+          fallbackIcon={SearchIcon}
+          className={sidebarNavigationIconClassName}
+        />
+      }
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- Internal route path
+      href="/search"
+      active={isOnSearchPage}
+      isSlimMode={isSlimMode}
+      onClick={() => {
+        logger.log("[CHAT_FLOW] Search navigation item clicked");
+        onSearch?.();
+      }}
+      data-ui="sidebar-search-item"
+    />
   );
 });
 
@@ -440,82 +357,24 @@ const AssistantsNavigationItem = memo<{
   const assistantsIconId = useThemedIcon("navigation", "assistants");
 
   return (
-    <div className={clsx(sidebarInsetClassName, "py-1")}>
-      {isOnAssistantsPage ? (
-        <InteractiveContainer
-          useDiv={true}
-          interactive={false}
-          className={clsx(
-            activeSidebarItemClassName,
-            "flex items-center text-left",
-            "sidebar-content-col-geometry gap-3 py-2 pr-3",
-          )}
-          aria-label={t`Assistants`}
-          title={isSlimMode ? t`Assistants` : undefined}
-          data-ui="sidebar-assistants-item"
-        >
-          <ResolvedIcon
-            iconId={assistantsIconId}
-            fallbackIcon={EditIcon}
-            className="size-4 shrink-0 text-theme-fg-secondary"
-          />
-          <span
-            className={clsx(
-              "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
-              isSlimMode
-                ? "w-0 overflow-hidden opacity-0"
-                : "opacity-100 delay-150",
-            )}
-          >
-            {t`Assistants`}
-          </span>
-        </InteractiveContainer>
-      ) : (
-        <a
-          href={href}
-          onClick={(e) => {
-            // Allow cmd/ctrl-click to open in new tab
-            if (e.metaKey || e.ctrlKey) {
-              return;
-            }
-            // Prevent default navigation for normal clicks
-            e.preventDefault();
-            logger.log("[ASSISTANTS_FLOW] Assistants navigation item clicked");
-            onAssistants?.();
-          }}
-          className={sidebarLinkClassName}
-          aria-label={t`Assistants`}
-          title={isSlimMode ? t`Assistants` : undefined}
-        >
-          <InteractiveContainer
-            useDiv={true}
-            showFocusRing={false}
-            className={clsx(
-              sidebarItemClassName,
-              "theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
-              "sidebar-content-col-geometry gap-3 py-2 pr-3",
-            )}
-            data-ui="sidebar-assistants-item"
-          >
-            <ResolvedIcon
-              iconId={assistantsIconId}
-              fallbackIcon={EditIcon}
-              className="size-4 shrink-0 text-theme-fg-secondary"
-            />
-            <span
-              className={clsx(
-                "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
-                isSlimMode
-                  ? "w-0 overflow-hidden opacity-0"
-                  : "opacity-100 delay-150",
-              )}
-            >
-              {t`Assistants`}
-            </span>
-          </InteractiveContainer>
-        </a>
-      )}
-    </div>
+    <SidebarNavigationItem
+      label={t`Assistants`}
+      icon={
+        <ResolvedIcon
+          iconId={assistantsIconId}
+          fallbackIcon={EditIcon}
+          className={sidebarNavigationIconClassName}
+        />
+      }
+      href={href}
+      active={isOnAssistantsPage}
+      isSlimMode={isSlimMode}
+      onClick={() => {
+        logger.log("[ASSISTANTS_FLOW] Assistants navigation item clicked");
+        onAssistants?.();
+      }}
+      data-ui="sidebar-assistants-item"
+    />
   );
 });
 
@@ -544,7 +403,8 @@ const ChatHistoryFooter = memo<{
 // eslint-disable-next-line lingui/no-unlocalized-strings
 ChatHistoryFooter.displayName = "ChatHistoryFooter";
 
-const NoFilterMatchesRow = () => (
+/** Exported for the add-in's history drawer, which shows the same row. */
+export const NoFilterMatchesRow = () => (
   <p
     className="sidebar-content-col-geometry py-2 pr-3 text-xs text-theme-fg-muted"
     data-testid="chat-history-no-filter-matches"
@@ -665,21 +525,7 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
       (state) => state.statusByChatId,
     );
 
-    // Fold assistant-scoped filter values back to their defaults in the store
-    // itself: the recent-chats query (and any other reader) consumes the raw
-    // persisted values, so sanitizing only at render would let a stale
-    // persisted value keep filtering the request invisibly.
-    useEffect(() => {
-      if (assistantsEnabled) return;
-      const store = useChatHistoryFilterStore.getState();
-      const sanitized = sanitizeChatHistoryFilters(store, false);
-      if (sanitized.typeFilter !== store.typeFilter) {
-        store.setTypeFilter(sanitized.typeFilter);
-      }
-      if (sanitized.groupBy !== store.groupBy) {
-        store.setGroupBy(sanitized.groupBy);
-      }
-    }, [assistantsEnabled]);
+    useChatHistoryFilterFoldback(assistantsEnabled);
 
     const chatHistoryFilters =
       useSanitizedChatHistoryFilters(assistantsEnabled);
@@ -699,28 +545,9 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
         return next;
       });
     }, []);
-    const pendingConfirmationIdsByChatId = useConfirmationRegistryStore(
-      (state) => state.pendingIdsByChatId,
-    );
-    const { i18n } = useLingui();
-    const recentChatGroups = useMemo(
-      () =>
-        groupChatSessions(sessions, chatHistoryFilters.groupBy, {
-          now: new Date(),
-          locale: i18n.locale,
-          needsAttention: (session) =>
-            resolveChatAttentionStatus(
-              generationStatusByChatId[session.id],
-              (pendingConfirmationIdsByChatId[session.id]?.length ?? 0) > 0,
-            ) !== null,
-        }),
-      [
-        sessions,
-        chatHistoryFilters.groupBy,
-        i18n.locale,
-        generationStatusByChatId,
-        pendingConfirmationIdsByChatId,
-      ],
+    const recentChatGroups = useGroupedChatSessions(
+      sessions,
+      chatHistoryFilters.groupBy,
     );
 
     // The infinite-scroll sentinel must sit inside a visible list, so it

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -293,7 +293,8 @@ const ChatHistoryHeader = memo<{
 // eslint-disable-next-line lingui/no-unlocalized-strings
 ChatHistoryHeader.displayName = "ChatHistoryHeader";
 
-const NewChatItem = memo<{
+/** Exported for the add-in's history drawer, which renders the same row. */
+export const NewChatItem = memo<{
   onNewChat?: () => void;
   isSlimMode?: boolean;
 }>(({ onNewChat, isSlimMode = false }) => {

--- a/frontend/src/components/ui/Chat/SidebarNavigationItem.tsx
+++ b/frontend/src/components/ui/Chat/SidebarNavigationItem.tsx
@@ -1,0 +1,141 @@
+import clsx from "clsx";
+
+import {
+  sidebarInsetClassName,
+  sidebarItemClassName,
+} from "./SidebarCollapsibleSection";
+import { InteractiveContainer } from "../Container/InteractiveContainer";
+
+const activeSidebarItemClassName = "sidebar-row-geometry sidebar-row-selected";
+// Inset ring for the same reason as the chat rows: the row inset is
+// themeable and can be narrower than an outside-drawn ring.
+const sidebarLinkClassName =
+  "focus-ring-inset block rounded-[var(--theme-radius-shell)]";
+
+/** Icon geometry every sidebar nav row shares; apply it to the `icon` node. */
+export const sidebarNavigationIconClassName =
+  "size-4 shrink-0 text-theme-fg-secondary";
+
+export interface SidebarNavigationItemProps {
+  /** Accessible name, visible label and slim-mode tooltip. */
+  label: string;
+  /** Sized icon node, e.g. a ResolvedIcon with sidebarNavigationIconClassName. */
+  icon: React.ReactNode;
+  /**
+   * Plain-click action. With `href` set it replaces the default navigation;
+   * cmd/ctrl-clicks still reach the browser so the link can open in a tab.
+   */
+  onClick?: () => void;
+  /** Renders the row as a real link so modified clicks work on it. */
+  href?: string;
+  /** Selected, non-interactive presentation for the page currently shown. */
+  active?: boolean;
+  isSlimMode?: boolean;
+  /** Test/theme hook on the row container. */
+  "data-ui"?: string;
+}
+
+/**
+ * One sidebar navigation row: sidebar row/content-column geometry channels,
+ * themeable hover surface and the slim-mode label collapse, shared by the web
+ * sidebar's nav rows and the add-in's history drawer.
+ */
+export const SidebarNavigationItem = ({
+  label,
+  icon,
+  onClick,
+  href,
+  active = false,
+  isSlimMode = false,
+  "data-ui": dataUi,
+}: SidebarNavigationItemProps) => {
+  const labelNode = (
+    <span
+      className={clsx(
+        "whitespace-nowrap font-medium text-theme-fg-primary transition-opacity duration-150",
+        isSlimMode ? "w-0 overflow-hidden opacity-0" : "opacity-100 delay-150",
+      )}
+    >
+      {label}
+    </span>
+  );
+
+  if (active) {
+    return (
+      <div className={clsx(sidebarInsetClassName, "py-1")}>
+        <InteractiveContainer
+          useDiv={true}
+          interactive={false}
+          className={clsx(
+            activeSidebarItemClassName,
+            "flex items-center text-left",
+            "sidebar-content-col-geometry gap-3 py-2 pr-3",
+          )}
+          aria-label={label}
+          title={isSlimMode ? label : undefined}
+          data-ui={dataUi}
+        >
+          {icon}
+          {labelNode}
+        </InteractiveContainer>
+      </div>
+    );
+  }
+
+  if (href != null) {
+    return (
+      <div className={clsx(sidebarInsetClassName, "py-1")}>
+        <a
+          href={href}
+          onClick={(e) => {
+            // Allow cmd/ctrl-click to open in new tab
+            if (e.metaKey || e.ctrlKey) {
+              return;
+            }
+            // Prevent default navigation for normal clicks
+            e.preventDefault();
+            onClick?.();
+          }}
+          className={sidebarLinkClassName}
+          aria-label={label}
+          title={isSlimMode ? label : undefined}
+        >
+          <InteractiveContainer
+            useDiv={true}
+            showFocusRing={false}
+            className={clsx(
+              sidebarItemClassName,
+              "theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
+              "sidebar-content-col-geometry gap-3 py-2 pr-3",
+            )}
+            data-ui={dataUi}
+          >
+            {icon}
+            {labelNode}
+          </InteractiveContainer>
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className={clsx(sidebarInsetClassName, "py-1")}>
+      <InteractiveContainer
+        useDiv={true}
+        showFocusRing={false}
+        onClick={() => onClick?.()}
+        className={clsx(
+          sidebarItemClassName,
+          "focus-ring-inset theme-transition flex items-center text-left hover:bg-[var(--theme-shell-sidebar-hover)]",
+          "sidebar-content-col-geometry gap-3 py-2 pr-3",
+        )}
+        aria-label={label}
+        title={isSlimMode ? label : undefined}
+        data-ui={dataUi}
+      >
+        {icon}
+        {labelNode}
+      </InteractiveContainer>
+    </div>
+  );
+};

--- a/frontend/src/hooks/chat/store/__tests__/chatHistoryFilterStore.test.ts
+++ b/frontend/src/hooks/chat/store/__tests__/chatHistoryFilterStore.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   CHAT_HISTORY_FILTER_DEFAULTS,
+  createChatHistoryFilterStore,
   hasActiveFilters,
   isDefaultFilters,
   sanitizeChatHistoryFilters,
@@ -179,5 +180,39 @@ describe("sanitizeChatHistoryFilters", () => {
     } as const;
 
     expect(sanitizeChatHistoryFilters(values, false)).toEqual(values);
+  });
+});
+
+describe("createChatHistoryFilterStore", () => {
+  it("keeps instances with different keys fully isolated", () => {
+    localStorage.clear();
+    const first = createChatHistoryFilterStore("test.filters.first");
+    const second = createChatHistoryFilterStore("test.filters.second");
+
+    first.getState().setTypeFilter("assistant");
+    first.getState().setGroupBy("unread");
+
+    expect(second.getState()).toMatchObject(CHAT_HISTORY_FILTER_DEFAULTS);
+    expect(
+      JSON.parse(localStorage.getItem("test.filters.first") ?? "{}"),
+    ).toMatchObject({ state: { typeFilter: "assistant", groupBy: "unread" } });
+    expect(localStorage.getItem("test.filters.second")).toBeNull();
+  });
+
+  it("rehydrates each instance from its own key only", async () => {
+    localStorage.clear();
+    localStorage.setItem(
+      "test.filters.stored",
+      JSON.stringify({ state: { statusFilter: "all" }, version: 0 }),
+    );
+
+    const stored = createChatHistoryFilterStore("test.filters.stored");
+    const fresh = createChatHistoryFilterStore("test.filters.fresh");
+    await Promise.resolve();
+
+    expect(stored.getState().statusFilter).toBe("all");
+    expect(fresh.getState().statusFilter).toBe(
+      CHAT_HISTORY_FILTER_DEFAULTS.statusFilter,
+    );
   });
 });

--- a/frontend/src/hooks/chat/store/chatHistoryFilterStore.ts
+++ b/frontend/src/hooks/chat/store/chatHistoryFilterStore.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 
@@ -193,4 +193,27 @@ export const useSanitizedChatHistoryFilters = (
       ),
     [typeFilter, statusFilter, groupBy, assistantsEnabled],
   );
+};
+
+/**
+ * Folds assistant-scoped filter values back to their defaults in the store
+ * itself while assistants are disabled: the recent-chats query (and any other
+ * reader) consumes the raw persisted values, so sanitizing only at render
+ * would let a stale persisted value keep filtering the request invisibly.
+ */
+export const useChatHistoryFilterFoldback = (
+  assistantsEnabled: boolean,
+  store: ChatHistoryFilterStoreHook = useChatHistoryFilterStore,
+): void => {
+  useEffect(() => {
+    if (assistantsEnabled) return;
+    const state = store.getState();
+    const sanitized = sanitizeChatHistoryFilters(state, false);
+    if (sanitized.typeFilter !== state.typeFilter) {
+      state.setTypeFilter(sanitized.typeFilter);
+    }
+    if (sanitized.groupBy !== state.groupBy) {
+      state.setGroupBy(sanitized.groupBy);
+    }
+  }, [assistantsEnabled, store]);
 };

--- a/frontend/src/hooks/chat/store/chatHistoryFilterStore.ts
+++ b/frontend/src/hooks/chat/store/chatHistoryFilterStore.ts
@@ -68,72 +68,85 @@ export function hasActiveFilters(values: ChatHistoryFilterValues): boolean {
 }
 
 /**
- * Sidebar chat-list filter/sort preferences, persisted per browser so the
- * list comes back the way the user left it.
+ * Chat-list filter/sort preference store, persisted per browser under the
+ * given key so the list comes back the way the user left it. A factory
+ * because every surface family needs its own persistence: sharing one key
+ * would let a web sidebar filter silently shrink an add-in host's list.
  */
-export const useChatHistoryFilterStore = create<ChatHistoryFilterStore>()(
-  devtools(
-    persist(
-      (set) => ({
-        ...CHAT_HISTORY_FILTER_DEFAULTS,
+export function createChatHistoryFilterStore(persistName: string) {
+  return create<ChatHistoryFilterStore>()(
+    devtools(
+      persist(
+        (set) => ({
+          ...CHAT_HISTORY_FILTER_DEFAULTS,
 
-        setTypeFilter: (typeFilter) =>
-          set({ typeFilter }, false, "chatHistoryFilter/setTypeFilter"),
+          setTypeFilter: (typeFilter) =>
+            set({ typeFilter }, false, "chatHistoryFilter/setTypeFilter"),
 
-        setStatusFilter: (statusFilter) =>
-          set({ statusFilter }, false, "chatHistoryFilter/setStatusFilter"),
+          setStatusFilter: (statusFilter) =>
+            set({ statusFilter }, false, "chatHistoryFilter/setStatusFilter"),
 
-        setGroupBy: (groupBy) =>
-          set({ groupBy }, false, "chatHistoryFilter/setGroupBy"),
+          setGroupBy: (groupBy) =>
+            set({ groupBy }, false, "chatHistoryFilter/setGroupBy"),
 
-        resetToDefaults: () =>
-          set(
-            { ...CHAT_HISTORY_FILTER_DEFAULTS },
-            false,
-            "chatHistoryFilter/resetToDefaults",
-          ),
-      }),
-      {
-        name: "erato.sidebar.chatHistoryFilters",
-        partialize: (state) => ({
-          typeFilter: state.typeFilter,
-          statusFilter: state.statusFilter,
-          groupBy: state.groupBy,
+          resetToDefaults: () =>
+            set(
+              { ...CHAT_HISTORY_FILTER_DEFAULTS },
+              false,
+              "chatHistoryFilter/resetToDefaults",
+            ),
         }),
-        // localStorage is user-editable, so each rehydrated field must be
-        // coerced back into its union; an out-of-union value would otherwise
-        // flow unchecked into query params and the grouping switch.
-        merge: (persisted, current) => {
-          const stored = (persisted ?? {}) as Partial<
-            Record<keyof ChatHistoryFilterValues, unknown>
-          >;
-          return {
-            ...current,
-            typeFilter: coerceToUnion(
-              stored.typeFilter,
-              TYPE_FILTER_VALUES,
-              CHAT_HISTORY_FILTER_DEFAULTS.typeFilter,
-            ),
-            statusFilter: coerceToUnion(
-              stored.statusFilter,
-              STATUS_FILTER_VALUES,
-              CHAT_HISTORY_FILTER_DEFAULTS.statusFilter,
-            ),
-            groupBy: coerceToUnion(
-              stored.groupBy,
-              GROUP_BY_VALUES,
-              CHAT_HISTORY_FILTER_DEFAULTS.groupBy,
-            ),
-          };
+        {
+          name: persistName,
+          partialize: (state) => ({
+            typeFilter: state.typeFilter,
+            statusFilter: state.statusFilter,
+            groupBy: state.groupBy,
+          }),
+          // localStorage is user-editable, so each rehydrated field must be
+          // coerced back into its union; an out-of-union value would otherwise
+          // flow unchecked into query params and the grouping switch.
+          merge: (persisted, current) => {
+            const stored = (persisted ?? {}) as Partial<
+              Record<keyof ChatHistoryFilterValues, unknown>
+            >;
+            return {
+              ...current,
+              typeFilter: coerceToUnion(
+                stored.typeFilter,
+                TYPE_FILTER_VALUES,
+                CHAT_HISTORY_FILTER_DEFAULTS.typeFilter,
+              ),
+              statusFilter: coerceToUnion(
+                stored.statusFilter,
+                STATUS_FILTER_VALUES,
+                CHAT_HISTORY_FILTER_DEFAULTS.statusFilter,
+              ),
+              groupBy: coerceToUnion(
+                stored.groupBy,
+                GROUP_BY_VALUES,
+                CHAT_HISTORY_FILTER_DEFAULTS.groupBy,
+              ),
+            };
+          },
         },
+      ),
+      {
+        name: "Chat History Filter Store",
+        store: persistName,
+        enabled: process.env.NODE_ENV === "development",
       },
     ),
-    {
-      name: "Chat History Filter Store",
-      store: "chat-history-filter-store",
-      enabled: process.env.NODE_ENV === "development",
-    },
-  ),
+  );
+}
+
+export type ChatHistoryFilterStoreHook = ReturnType<
+  typeof createChatHistoryFilterStore
+>;
+
+/** The web sidebar's singleton instance. */
+export const useChatHistoryFilterStore = createChatHistoryFilterStore(
+  "erato.sidebar.chatHistoryFilters",
 );
 
 /**
@@ -159,13 +172,18 @@ export function sanitizeChatHistoryFilters(
   };
 }
 
-/** Store values with assistant-scoped ones sanitized for the current config. */
+/**
+ * Store values with assistant-scoped ones sanitized for the current config.
+ * The store must be the same instance for a component's whole lifetime — it
+ * is read through hooks.
+ */
 export const useSanitizedChatHistoryFilters = (
   assistantsEnabled: boolean,
+  store: ChatHistoryFilterStoreHook = useChatHistoryFilterStore,
 ): ChatHistoryFilterValues => {
-  const typeFilter = useChatHistoryFilterStore((state) => state.typeFilter);
-  const statusFilter = useChatHistoryFilterStore((state) => state.statusFilter);
-  const groupBy = useChatHistoryFilterStore((state) => state.groupBy);
+  const typeFilter = store((state) => state.typeFilter);
+  const statusFilter = store((state) => state.statusFilter);
+  const groupBy = store((state) => state.groupBy);
 
   return useMemo(
     () =>

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -4,11 +4,7 @@
  * Provides a clean interface for fetching, navigating and managing chat history.
  */
 /* eslint-disable lingui/no-unlocalized-strings */
-import {
-  useInfiniteQuery,
-  useQueryClient,
-  type InfiniteData,
-} from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom"; // Added React Router hooks
 import { create } from "zustand";
@@ -33,6 +29,7 @@ import {
 } from "./store/generationStatusStore";
 import { getStreamKey, useMessagingStore } from "./store/messagingStore";
 import {
+  removeArchivedChatFromLists,
   useInfiniteRecentChats,
   type RecentChatsListFilters,
 } from "./useInfiniteRecentChats";
@@ -44,6 +41,8 @@ export {
   CHAT_HISTORY_PAGE_SIZE,
   buildInfiniteChatsQueryKey,
   buildRecentChatsFilterParams,
+  isPaginated,
+  type RecentChatsCacheEntry,
   type RecentChatsListFilters,
 } from "./useInfiniteRecentChats";
 
@@ -73,35 +72,6 @@ export interface PendingChat {
  * to absent here.
  */
 type Complete<T> = { [K in keyof Required<T>]: T[K] };
-
-// Shape of the infinite recent-chats cache entry.
-type RecentChatsPage = Awaited<ReturnType<typeof fetchRecentChats>>;
-type InfiniteRecentChats = InfiniteData<RecentChatsPage>;
-/**
- * The recent-chats key prefix also covers surfaces that read a single page
- * through a plain query, so a cache edit has to expect either shape.
- */
-export type RecentChatsCacheEntry = InfiniteRecentChats | RecentChatsPage;
-
-export const isPaginated = (
-  entry: RecentChatsCacheEntry,
-): entry is InfiniteRecentChats =>
-  Array.isArray((entry as InfiniteRecentChats).pages);
-
-function withoutChat(page: RecentChatsPage, chatId: string): RecentChatsPage {
-  const chats = page.chats.filter((chat) => chat.id !== chatId);
-  if (chats.length === page.chats.length) return page;
-  const removed = page.chats.length - chats.length;
-  return {
-    ...page,
-    chats,
-    stats: {
-      ...page.stats,
-      returned_count: Math.max(0, page.stats.returned_count - removed),
-      total_count: Math.max(0, page.stats.total_count - removed),
-    },
-  };
-}
 
 interface ChatHistoryState {
   isNewChatPending: boolean; // Flag to indicate a new chat navigation is in progress
@@ -229,19 +199,6 @@ export function deriveTitleHint(text: string): string | null {
   const stem =
     lastSpace > TITLE_HINT_MAX_LENGTH / 2 ? cut.slice(0, lastSpace) : cut;
   return `${stem.trimEnd()}…`;
-}
-
-/**
- * Whether a recent-chats cache key belongs to an archived-inclusive list
- * variant, i.e. one whose rows legitimately keep an archived chat.
- */
-function queryKeyIncludesArchived(queryKey: readonly unknown[]): boolean {
-  return queryKey.some(
-    (part) =>
-      typeof part === "object" &&
-      part !== null &&
-      (part as { include_archived?: boolean }).include_archived === true,
-  );
 }
 
 export interface ChatHistoryOptions {
@@ -528,18 +485,6 @@ export function useChatHistory({
         return;
       }
 
-      // Settle in-flight list fetches first (e.g. a focus refetch): one
-      // resolving after the snapshot below would overwrite the optimistic
-      // removal and resurrect the archived row.
-      await queryClient.cancelQueries({
-        queryKey: recentChatsQuery({}).queryKey,
-      });
-
-      // Snapshot every recent-chats cache entry and the pending placeholder so
-      // a failed mutation can roll them all back.
-      const previousEntries = queryClient.getQueriesData<RecentChatsCacheEntry>(
-        { queryKey: recentChatsQuery({}).queryKey },
-      );
       const previousPendingChat = useChatHistoryStore.getState().pendingChat;
 
       // The archived row may be the pending-chat placeholder, which lives
@@ -550,45 +495,10 @@ export function useChatHistory({
       useGenerationStatusStore.getState().clearStatus(chatId);
       useChatHistoryStore.getState().clearTitleHint(chatId);
 
-      // Optimistically remove the archived row from every loaded page of every
-      // cached list variant — the row must not resurface when the user
-      // switches to a sibling filter combination whose cache is still fresh.
-      //
-      // We deliberately mutate the caches in place rather than invalidating
-      // and refetching every page. A full refetch re-derives each page's
-      // offset from getNextPageParam (current_offset + returned_count); once
-      // the archive shrinks the server-side result set, every page boundary
-      // past the archived row shifts by one, so the refetch silently skips the
-      // chat that straddled the boundary (ERMAIN-474). Editing the cache keeps
-      // the list stable and makes the row disappear immediately, without
-      // waiting for a round trip.
-      queryClient.setQueriesData<RecentChatsCacheEntry>(
-        {
-          queryKey: recentChatsQuery({}).queryKey,
-          predicate: (query) => !queryKeyIncludesArchived(query.queryKey),
-        },
-        (current) => {
-          if (!current) return current;
-          if (!isPaginated(current)) return withoutChat(current, chatId);
-          return {
-            ...current,
-            pages: current.pages.map((page) => withoutChat(page, chatId)),
-          };
-        },
+      const rollbackListRemoval = await removeArchivedChatFromLists(
+        queryClient,
+        chatId,
       );
-      // Archived-inclusive variants legitimately keep the row, but its
-      // archived_at changed; mark them stale so they refetch on next mount
-      // (never refetching a mounted paginated list, per the skew above).
-      const hasArchivedListVariant = previousEntries.some(([queryKey]) =>
-        queryKeyIncludesArchived(queryKey),
-      );
-      if (hasArchivedListVariant) {
-        void queryClient.invalidateQueries({
-          queryKey: recentChatsQuery({}).queryKey,
-          predicate: (query) => queryKeyIncludesArchived(query.queryKey),
-          refetchType: "none",
-        });
-      }
 
       try {
         // Call the mutation
@@ -605,11 +515,7 @@ export function useChatHistory({
       } catch (error) {
         logger.log(`Failed to archive chat ${chatId}:`, error);
         // Roll back the optimistic removal so the rows reappear.
-        for (const [queryKey, previousData] of previousEntries) {
-          if (previousData) {
-            queryClient.setQueryData(queryKey, previousData);
-          }
-        }
+        rollbackListRemoval();
         if (previousPendingChat?.id === chatId) {
           useChatHistoryStore.getState().setPendingChat(previousPendingChat);
         }

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -31,6 +31,7 @@ import { getStreamKey, useMessagingStore } from "./store/messagingStore";
 import {
   removeArchivedChatFromLists,
   useInfiniteRecentChats,
+  useUpdateChatTitle,
   type RecentChatsListFilters,
 } from "./useInfiniteRecentChats";
 
@@ -526,27 +527,7 @@ export function useChatHistory({
   );
 
   // Update chat title_by_user_provided
-  const updateChatTitle = useCallback(
-    async (chatId: string, titleByUserProvided?: string) => {
-      const queryKey = recentChatsQuery({}).queryKey;
-
-      try {
-        const trimmedTitle = titleByUserProvided?.trim();
-        await updateChatMutation({
-          pathParams: { chatId },
-          body: trimmedTitle
-            ? { title_by_user_provided: trimmedTitle }
-            : // Empty value removes custom title on backend.
-              {},
-        });
-        await queryClient.invalidateQueries({ queryKey });
-      } catch (error) {
-        logger.log(`Failed to update chat title for ${chatId}:`, error);
-        throw error;
-      }
-    },
-    [queryClient, updateChatMutation],
-  );
+  const updateChatTitle = useUpdateChatTitle();
 
   const pinChat = useCallback(
     async (chatId: string, isPinned: boolean) => {

--- a/frontend/src/hooks/chat/useChatHistory.ts
+++ b/frontend/src/hooks/chat/useChatHistory.ts
@@ -21,27 +21,33 @@ import {
   recentChatsQuery,
   chatMessagesQuery,
   type RecentChatsError,
-  type RecentChatsQueryParams,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
 import { getChatUrl } from "@/utils/chat/urlUtils";
 import { createLogger } from "@/utils/debugLogger";
 
-import {
-  CHAT_HISTORY_FILTER_DEFAULTS,
-  useChatHistoryFilterStore,
-  type ChatHistoryFilterValues,
-} from "./store/chatHistoryFilterStore";
+import { useChatHistoryFilterStore } from "./store/chatHistoryFilterStore";
 import {
   seedGenerationStatusFromListing,
   useGenerationStatusStore,
 } from "./store/generationStatusStore";
 import { getStreamKey, useMessagingStore } from "./store/messagingStore";
+import {
+  useInfiniteRecentChats,
+  type RecentChatsListFilters,
+} from "./useInfiniteRecentChats";
 
 import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 
+// Moved to their router-free home; re-exported for existing import sites.
+export {
+  CHAT_HISTORY_PAGE_SIZE,
+  buildInfiniteChatsQueryKey,
+  buildRecentChatsFilterParams,
+  type RecentChatsListFilters,
+} from "./useInfiniteRecentChats";
+
 const logger = createLogger("HOOK", "useChatHistory");
-const CHAT_HISTORY_PAGE_SIZE = 30;
 
 /**
  * A chat that exists on the backend but is not listable yet, with the moment it
@@ -225,45 +231,6 @@ export function deriveTitleHint(text: string): string | null {
   return `${stem.trimEnd()}…`;
 }
 
-/** The filter-store values that reach the recent-chats request. */
-export type RecentChatsListFilters = Pick<
-  ChatHistoryFilterValues,
-  "typeFilter" | "statusFilter"
->;
-
-/**
- * Query params the sidebar filters add to a recent-chats list request. Key
- * builders and the query itself must agree on these, so both go through here.
- */
-export function buildRecentChatsFilterParams(
-  filters: RecentChatsListFilters,
-): Pick<RecentChatsQueryParams, "type" | "include_archived"> {
-  return {
-    ...(filters.typeFilter === "all" ? {} : { type: filters.typeFilter }),
-    ...(filters.statusFilter === "all" ? { include_archived: true } : {}),
-  };
-}
-
-/**
- * Query key of the infinite recent-chats list; cache edits must target the
- * same key as the query itself.
- */
-export function buildInfiniteChatsQueryKey(
-  pinnedChatsEnabled = false,
-  filters: RecentChatsListFilters = CHAT_HISTORY_FILTER_DEFAULTS,
-) {
-  return [
-    ...recentChatsQuery({
-      queryParams: {
-        ...(pinnedChatsEnabled ? { pinned: false } : {}),
-        ...buildRecentChatsFilterParams(filters),
-      },
-    }).queryKey,
-    "infinite",
-    { limit: CHAT_HISTORY_PAGE_SIZE },
-  ];
-}
-
 /**
  * Whether a recent-chats cache key belongs to an archived-inclusive list
  * variant, i.e. one whose rows legitimately keep an archived chat.
@@ -323,12 +290,6 @@ export function useChatHistory({
     [typeFilter, statusFilter],
   );
 
-  // Stable query key for the infinite recent-chats list. Reused for both the
-  // query itself and for cache mutations (e.g. optimistic archive removal).
-  const infiniteChatsQueryKey = useMemo(
-    () => buildInfiniteChatsQueryKey(pinnedChatsEnabled, listFilters),
-    [pinnedChatsEnabled, listFilters],
-  );
   const pinnedChatsQueryKey = useMemo(
     () =>
       recentChatsQuery({
@@ -338,40 +299,16 @@ export function useChatHistory({
   );
 
   const {
-    data,
+    chats: listedChats,
     isLoading,
     error,
     refetch,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteQuery<
-    Awaited<ReturnType<typeof fetchRecentChats>>,
-    RecentChatsError
-  >({
-    queryKey: infiniteChatsQueryKey,
-    initialPageParam: 0,
-    queryFn: ({ pageParam, signal }) => {
-      const offset = typeof pageParam === "number" ? pageParam : 0;
-      return fetchRecentChats(
-        {
-          ...fetcherOptions,
-          queryParams: {
-            limit: CHAT_HISTORY_PAGE_SIZE,
-            offset,
-            ...(pinnedChatsEnabled ? { pinned: false } : {}),
-            ...buildRecentChatsFilterParams(listFilters),
-          },
-        },
-        signal,
-      );
-    },
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.stats.has_more || lastPage.stats.returned_count === 0) {
-        return undefined;
-      }
-      return lastPage.stats.current_offset + lastPage.stats.returned_count;
-    },
+  } = useInfiniteRecentChats({
+    filters: listFilters,
+    pinnedChatsEnabled,
   });
 
   const { data: pinnedChatsData } = useInfiniteQuery<
@@ -400,11 +337,6 @@ export function useChatHistory({
   // Memoize the empty array reference
   const emptyChats = useMemo(() => [], []);
 
-  // Extract chats from the paginated response structure, defaulting to a stable empty array reference
-  const listedChats = useMemo(
-    () => data?.pages.flatMap((page) => page.chats) ?? emptyChats,
-    [data?.pages, emptyChats],
-  );
   const pinnedChats = useMemo(
     () => pinnedChatsData?.pages.flatMap((page) => page.chats) ?? emptyChats,
     [emptyChats, pinnedChatsData?.pages],

--- a/frontend/src/hooks/chat/useGroupedChatSessions.ts
+++ b/frontend/src/hooks/chat/useGroupedChatSessions.ts
@@ -1,0 +1,46 @@
+import { useLingui } from "@lingui/react";
+import { useMemo } from "react";
+
+import {
+  groupChatSessions,
+  resolveChatAttentionStatus,
+} from "@/utils/chatHistoryGrouping";
+
+import { useConfirmationRegistryStore } from "./store/confirmationRegistryStore";
+import { useGenerationStatusStore } from "./store/generationStatusStore";
+
+import type { ChatHistoryGroupBy } from "./store/chatHistoryFilterStore";
+import type { ChatSession } from "@/types/chat";
+import type { ChatSessionGroup } from "@/utils/chatHistoryGrouping";
+
+/**
+ * `groupChatSessions` wired to its live inputs: the current locale plus the
+ * attention signal a row needs — generation status merged with pending tool
+ * confirmations, the same pair behind the row status dot.
+ */
+export function useGroupedChatSessions(
+  sessions: ChatSession[],
+  groupBy: ChatHistoryGroupBy,
+): ChatSessionGroup[] {
+  const statusByChatId = useGenerationStatusStore(
+    (state) => state.statusByChatId,
+  );
+  const pendingIdsByChatId = useConfirmationRegistryStore(
+    (state) => state.pendingIdsByChatId,
+  );
+  const { i18n } = useLingui();
+
+  return useMemo(
+    () =>
+      groupChatSessions(sessions, groupBy, {
+        now: new Date(),
+        locale: i18n.locale,
+        needsAttention: (session) =>
+          resolveChatAttentionStatus(
+            statusByChatId[session.id],
+            (pendingIdsByChatId[session.id]?.length ?? 0) > 0,
+          ) !== null,
+      }),
+    [sessions, groupBy, i18n.locale, statusByChatId, pendingIdsByChatId],
+  );
+}

--- a/frontend/src/hooks/chat/useInfiniteRecentChats.ts
+++ b/frontend/src/hooks/chat/useInfiniteRecentChats.ts
@@ -1,0 +1,140 @@
+/**
+ * Router-free infinite recent-chats list.
+ *
+ * The shared core of every paginated chat listing: the web sidebar wraps it
+ * with routing, pinned chats and placeholder rows (`useChatHistory`), while
+ * hosts without routes (the add-in) consume it directly. Filters are server
+ * params on purpose — filtering client-side would corrupt the offset-based
+ * pagination this rides on.
+ */
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import {
+  fetchRecentChats,
+  recentChatsQuery,
+  type RecentChatsError,
+  type RecentChatsQueryParams,
+} from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
+
+import {
+  CHAT_HISTORY_FILTER_DEFAULTS,
+  type ChatHistoryFilterValues,
+} from "./store/chatHistoryFilterStore";
+
+import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+export const CHAT_HISTORY_PAGE_SIZE = 30;
+
+/** The filter-store values that reach the recent-chats request. */
+export type RecentChatsListFilters = Pick<
+  ChatHistoryFilterValues,
+  "typeFilter" | "statusFilter"
+>;
+
+/**
+ * Query params the list filters add to a recent-chats request. Key builders
+ * and the query itself must agree on these, so both go through here.
+ */
+export function buildRecentChatsFilterParams(
+  filters: RecentChatsListFilters,
+): Pick<RecentChatsQueryParams, "type" | "include_archived"> {
+  return {
+    ...(filters.typeFilter === "all" ? {} : { type: filters.typeFilter }),
+    ...(filters.statusFilter === "all" ? { include_archived: true } : {}),
+  };
+}
+
+/**
+ * Query key of the infinite recent-chats list; cache edits must target the
+ * same key as the query itself.
+ */
+export function buildInfiniteChatsQueryKey(
+  pinnedChatsEnabled = false,
+  filters: RecentChatsListFilters = CHAT_HISTORY_FILTER_DEFAULTS,
+) {
+  return [
+    ...recentChatsQuery({
+      queryParams: {
+        ...(pinnedChatsEnabled ? { pinned: false } : {}),
+        ...buildRecentChatsFilterParams(filters),
+      },
+    }).queryKey,
+    "infinite",
+    { limit: CHAT_HISTORY_PAGE_SIZE },
+  ];
+}
+
+export interface InfiniteRecentChatsOptions {
+  filters: RecentChatsListFilters;
+  /** Excludes pinned rows so a separate pinned query can own them. */
+  pinnedChatsEnabled?: boolean;
+}
+
+const EMPTY_CHATS: RecentChat[] = [];
+
+export function useInfiniteRecentChats({
+  filters,
+  pinnedChatsEnabled = false,
+}: InfiniteRecentChatsOptions) {
+  const { fetcherOptions } = useV1betaApiContext();
+
+  const queryKey = useMemo(
+    () => buildInfiniteChatsQueryKey(pinnedChatsEnabled, filters),
+    [pinnedChatsEnabled, filters],
+  );
+
+  const {
+    data,
+    isLoading,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<
+    Awaited<ReturnType<typeof fetchRecentChats>>,
+    RecentChatsError
+  >({
+    queryKey,
+    initialPageParam: 0,
+    queryFn: ({ pageParam, signal }) => {
+      const offset = typeof pageParam === "number" ? pageParam : 0;
+      return fetchRecentChats(
+        {
+          ...fetcherOptions,
+          queryParams: {
+            limit: CHAT_HISTORY_PAGE_SIZE,
+            offset,
+            ...(pinnedChatsEnabled ? { pinned: false } : {}),
+            ...buildRecentChatsFilterParams(filters),
+          },
+        },
+        signal,
+      );
+    },
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.stats.has_more || lastPage.stats.returned_count === 0) {
+        return undefined;
+      }
+      return lastPage.stats.current_offset + lastPage.stats.returned_count;
+    },
+  });
+
+  const chats = useMemo(
+    () => data?.pages.flatMap((page) => page.chats) ?? EMPTY_CHATS,
+    [data?.pages],
+  );
+
+  return {
+    chats,
+    isLoading,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    queryKey,
+  };
+}

--- a/frontend/src/hooks/chat/useInfiniteRecentChats.ts
+++ b/frontend/src/hooks/chat/useInfiniteRecentChats.ts
@@ -24,8 +24,113 @@ import {
 } from "./store/chatHistoryFilterStore";
 
 import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
 
 export const CHAT_HISTORY_PAGE_SIZE = 30;
+
+// Shape of the infinite recent-chats cache entry.
+type RecentChatsPage = Awaited<ReturnType<typeof fetchRecentChats>>;
+type InfiniteRecentChats = InfiniteData<RecentChatsPage>;
+/**
+ * The recent-chats key prefix also covers surfaces that read a single page
+ * through a plain query, so a cache edit has to expect either shape.
+ */
+export type RecentChatsCacheEntry = InfiniteRecentChats | RecentChatsPage;
+
+export const isPaginated = (
+  entry: RecentChatsCacheEntry,
+): entry is InfiniteRecentChats =>
+  Array.isArray((entry as InfiniteRecentChats).pages);
+
+function withoutChat(page: RecentChatsPage, chatId: string): RecentChatsPage {
+  const chats = page.chats.filter((chat) => chat.id !== chatId);
+  if (chats.length === page.chats.length) return page;
+  const removed = page.chats.length - chats.length;
+  return {
+    ...page,
+    chats,
+    stats: {
+      ...page.stats,
+      returned_count: Math.max(0, page.stats.returned_count - removed),
+      total_count: Math.max(0, page.stats.total_count - removed),
+    },
+  };
+}
+
+/**
+ * Whether a recent-chats cache key belongs to an archived-inclusive list
+ * variant, i.e. one whose rows legitimately keep an archived chat.
+ */
+function queryKeyIncludesArchived(queryKey: readonly unknown[]): boolean {
+  return queryKey.some(
+    (part) =>
+      typeof part === "object" &&
+      part !== null &&
+      (part as { include_archived?: boolean }).include_archived === true,
+  );
+}
+
+/**
+ * Optimistically remove an archived chat's row from every loaded page of
+ * every cached non-archived list variant, returning a rollback for a failed
+ * mutation.
+ *
+ * The caches are deliberately edited in place rather than invalidated: a
+ * refetch re-derives each page's offset from getNextPageParam, and once the
+ * archive shrinks the server-side result set every page boundary past the
+ * row shifts by one, silently skipping the chat that straddled it. Archived-
+ * inclusive variants legitimately keep the row, but its archived_at changed,
+ * so they are marked stale without refetching while mounted (same skew).
+ */
+export async function removeArchivedChatFromLists(
+  queryClient: QueryClient,
+  chatId: string,
+): Promise<() => void> {
+  // Settle in-flight list fetches first (e.g. a focus refetch): one
+  // resolving after the snapshot below would overwrite the optimistic
+  // removal and resurrect the archived row.
+  await queryClient.cancelQueries({
+    queryKey: recentChatsQuery({}).queryKey,
+  });
+
+  const previousEntries = queryClient.getQueriesData<RecentChatsCacheEntry>({
+    queryKey: recentChatsQuery({}).queryKey,
+  });
+
+  queryClient.setQueriesData<RecentChatsCacheEntry>(
+    {
+      queryKey: recentChatsQuery({}).queryKey,
+      predicate: (query) => !queryKeyIncludesArchived(query.queryKey),
+    },
+    (current) => {
+      if (!current) return current;
+      if (!isPaginated(current)) return withoutChat(current, chatId);
+      return {
+        ...current,
+        pages: current.pages.map((page) => withoutChat(page, chatId)),
+      };
+    },
+  );
+
+  const hasArchivedListVariant = previousEntries.some(([queryKey]) =>
+    queryKeyIncludesArchived(queryKey),
+  );
+  if (hasArchivedListVariant) {
+    void queryClient.invalidateQueries({
+      queryKey: recentChatsQuery({}).queryKey,
+      predicate: (query) => queryKeyIncludesArchived(query.queryKey),
+      refetchType: "none",
+    });
+  }
+
+  return () => {
+    for (const [queryKey, previousData] of previousEntries) {
+      if (previousData) {
+        queryClient.setQueryData(queryKey, previousData);
+      }
+    }
+  };
+}
 
 /** The filter-store values that reach the recent-chats request. */
 export type RecentChatsListFilters = Pick<

--- a/frontend/src/hooks/chat/useInfiniteRecentChats.ts
+++ b/frontend/src/hooks/chat/useInfiniteRecentChats.ts
@@ -7,16 +7,18 @@
  * params on purpose — filtering client-side would corrupt the offset-based
  * pagination this rides on.
  */
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 
 import {
   fetchRecentChats,
   recentChatsQuery,
+  useUpdateChat,
   type RecentChatsError,
   type RecentChatsQueryParams,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
+import { createLogger } from "@/utils/debugLogger";
 
 import {
   CHAT_HISTORY_FILTER_DEFAULTS,
@@ -25,6 +27,8 @@ import {
 
 import type { RecentChat } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+
+const logger = createLogger("HOOK", "useInfiniteRecentChats");
 
 export const CHAT_HISTORY_PAGE_SIZE = 30;
 
@@ -242,4 +246,34 @@ export function useInfiniteRecentChats({
     isFetchingNextPage,
     queryKey,
   };
+}
+
+/**
+ * Callback that renames a chat and refreshes every recent-chats list variant.
+ */
+export function useUpdateChatTitle() {
+  const queryClient = useQueryClient();
+  const { mutateAsync: updateChatMutation } = useUpdateChat();
+
+  return useCallback(
+    async (chatId: string, titleByUserProvided?: string) => {
+      const queryKey = recentChatsQuery({}).queryKey;
+
+      try {
+        const trimmedTitle = titleByUserProvided?.trim();
+        await updateChatMutation({
+          pathParams: { chatId },
+          body: trimmedTitle
+            ? { title_by_user_provided: trimmedTitle }
+            : // Empty value removes custom title on backend.
+              {},
+        });
+        await queryClient.invalidateQueries({ queryKey });
+      } catch (error) {
+        logger.log(`Failed to update chat title for ${chatId}:`, error);
+        throw error;
+      }
+    },
+    [queryClient, updateChatMutation],
+  );
 }

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -275,6 +275,7 @@ export {
   useStandaloneFileUpload,
 } from "@/hooks/files";
 export {
+  CloseIcon,
   ComputerIcon,
   DocumentIcon,
   MailIcon,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -276,8 +276,44 @@ export {
   DocumentIcon,
   MailIcon,
   MoonIcon,
+  SidebarToggleIcon,
   SunIcon,
 } from "@/components/ui/icons";
+export {
+  ChatHistoryFilterMenu,
+  type ChatHistoryFilterMenuProps,
+} from "@/components/ui/Chat/ChatHistoryFilterMenu";
+export { EditChatTitleDialog } from "@/components/ui/Chat/EditChatTitleDialog";
+export { ChatShareDialog } from "@/components/ui/Chat/ChatShareDialog";
+export {
+  CHAT_HISTORY_FILTER_DEFAULTS,
+  createChatHistoryFilterStore,
+  hasActiveFilters,
+  isDefaultFilters,
+  sanitizeChatHistoryFilters,
+  useSanitizedChatHistoryFilters,
+  type ChatHistoryFilterStoreHook,
+  type ChatHistoryFilterValues,
+  type ChatHistoryGroupBy,
+  type ChatHistoryStatusFilter,
+  type ChatHistoryTypeFilter,
+} from "@/hooks/chat/store/chatHistoryFilterStore";
+export {
+  buildInfiniteChatsQueryKey,
+  buildRecentChatsFilterParams,
+  useInfiniteRecentChats,
+  type RecentChatsListFilters,
+} from "@/hooks/chat/useInfiniteRecentChats";
+export {
+  groupChatSessions,
+  resolveChatAttentionStatus,
+  type ChatSessionGroup,
+} from "@/utils/chatHistoryGrouping";
+export {
+  UNTITLED_BACKEND_SENTINEL,
+  mapRecentChatToSession,
+} from "@/utils/chat/recentChatSession";
+export type { ChatSession } from "@/types/chat";
 export {
   useChatInputHandlers,
   useSidebar,
@@ -317,6 +353,7 @@ export {
   useArchiveChatEndpoint,
   useFacets,
   useRecentChats,
+  useUpdateChat,
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 export {
   FeatureConfigProvider,
@@ -324,6 +361,7 @@ export {
   defaultStaticFeatureConfig,
   useAudioConversationalFeature,
   useFeatureConfig,
+  useChatSharingFeature,
   useMessageFeedbackFeature,
   useTraceFeature,
   useUploadFeature,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -287,6 +287,7 @@ export {
   ChatHistoryFilterMenu,
   type ChatHistoryFilterMenuProps,
 } from "@/components/ui/Chat/ChatHistoryFilterMenu";
+export { NewChatItem } from "@/components/ui/Chat/ChatHistorySidebar";
 export { EditChatTitleDialog } from "@/components/ui/Chat/EditChatTitleDialog";
 export { ChatShareDialog } from "@/components/ui/Chat/ChatShareDialog";
 export {

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -92,8 +92,19 @@ export {
 } from "@/components/ui/Assistant/AssistantWelcomeScreen";
 export {
   ChatHistoryList,
+  ChatHistoryListSkeleton,
   type ChatHistoryListProps,
 } from "@/components/ui/Chat/ChatHistoryList";
+export {
+  SidebarCollapsibleSection,
+  sidebarInsetClassName,
+  sidebarItemClassName,
+} from "@/components/ui/Chat/SidebarCollapsibleSection";
+export {
+  SidebarNavigationItem,
+  sidebarNavigationIconClassName,
+  type SidebarNavigationItemProps,
+} from "@/components/ui/Chat/SidebarNavigationItem";
 export type { ChatTopLeftAccessoryProps } from "@/components/ui/Chat/ChatTopLeftAccessory";
 export { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
 export { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
@@ -280,6 +291,7 @@ export {
   DocumentIcon,
   MailIcon,
   MoonIcon,
+  SettingsIcon,
   SidebarToggleIcon,
   SunIcon,
 } from "@/components/ui/icons";
@@ -287,7 +299,10 @@ export {
   ChatHistoryFilterMenu,
   type ChatHistoryFilterMenuProps,
 } from "@/components/ui/Chat/ChatHistoryFilterMenu";
-export { NewChatItem } from "@/components/ui/Chat/ChatHistorySidebar";
+export {
+  NewChatItem,
+  NoFilterMatchesRow,
+} from "@/components/ui/Chat/ChatHistorySidebar";
 export { EditChatTitleDialog } from "@/components/ui/Chat/EditChatTitleDialog";
 export { ChatShareDialog } from "@/components/ui/Chat/ChatShareDialog";
 export {
@@ -296,6 +311,7 @@ export {
   hasActiveFilters,
   isDefaultFilters,
   sanitizeChatHistoryFilters,
+  useChatHistoryFilterFoldback,
   useSanitizedChatHistoryFilters,
   type ChatHistoryFilterStoreHook,
   type ChatHistoryFilterValues,
@@ -308,8 +324,10 @@ export {
   buildRecentChatsFilterParams,
   removeArchivedChatFromLists,
   useInfiniteRecentChats,
+  useUpdateChatTitle,
   type RecentChatsListFilters,
 } from "@/hooks/chat/useInfiniteRecentChats";
+export { useGroupedChatSessions } from "@/hooks/chat/useGroupedChatSessions";
 export {
   groupChatSessions,
   resolveChatAttentionStatus,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -304,6 +304,7 @@ export {
 export {
   buildInfiniteChatsQueryKey,
   buildRecentChatsFilterParams,
+  removeArchivedChatFromLists,
   useInfiniteRecentChats,
   type RecentChatsListFilters,
 } from "@/hooks/chat/useInfiniteRecentChats";
@@ -364,6 +365,7 @@ export {
   defaultStaticFeatureConfig,
   useAudioConversationalFeature,
   useFeatureConfig,
+  useAssistantsFeature,
   useChatSharingFeature,
   useMessageFeedbackFeature,
   useTraceFeature,

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -23,7 +23,10 @@ export {
   useDelegatedRunHeader,
   type DelegatedRunHeaderState,
 } from "@/hooks/chat/useDelegatedRunHeader";
-export { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
+export {
+  seedGenerationStatusFromListing,
+  useGenerationStatusStore,
+} from "@/hooks/chat/store/generationStatusStore";
 export { DelegatedRunOpenProvider } from "@/providers/DelegatedRunOpenProvider";
 export {
   ChatMessage,

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-z8UuLzX5RwaLbyoIUfhE+goAYkkLlzMK+nagqzhDFX1DxcXpU5qMJMeiGKIqEU+/6iGw9BS2oEJl6gYDp9tVqw==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-GOgNrKrDpwO1Qjc1JNWymnRczkYuzdn7Sc12yo0VOclZs0Lh/QdT8Ureh0oWuMIeAU5nhzJJOAzclDostbEpFA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-7Ly79ubqeKxq0z3aqHPVmYTz+REbeFJ21WwrhW2B5HvhYcMmVKy0/xWFq37aMqjtNL0IyJcLnpMeiq3ZI84vTA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-tlTWsrOkwLx9B65xS9ug6vKJ2m16f3wMbrEJ0RDYivVtjSCeQGwrNpLlCWjJMHuPRojTVz3d/sLP1fYLwOg2LQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-kYtP/ekosI2+woNybiHsLj0YkBEEOrAEd4/EAZrR7CMSPYfSVJzxl3oIUYiWG6T0Kggoj3H8OtepBVig6eED7g==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-imVKDZD+TobZU2id1Wl/8Wri43Wh9SCKlwqWVIx2sXNZGVcVd9/mmdm1SVGzdvDnWpQEqevEreluvQFL0duJHA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-nMwqxQU2MlumuUI63tLKom/fyoZBS5jq8P8fulE3qGx51olM2M6CCl1k7gyYF19EDTidsh07QbOi2QNCh3Eexg==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-kYtP/ekosI2+woNybiHsLj0YkBEEOrAEd4/EAZrR7CMSPYfSVJzxl3oIUYiWG6T0Kggoj3H8OtepBVig6eED7g==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-tlTWsrOkwLx9B65xS9ug6vKJ2m16f3wMbrEJ0RDYivVtjSCeQGwrNpLlCWjJMHuPRojTVz3d/sLP1fYLwOg2LQ==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-nMwqxQU2MlumuUI63tLKom/fyoZBS5jq8P8fulE3qGx51olM2M6CCl1k7gyYF19EDTidsh07QbOi2QNCh3Eexg==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -503,7 +503,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-imVKDZD+TobZU2id1Wl/8Wri43Wh9SCKlwqWVIx2sXNZGVcVd9/mmdm1SVGzdvDnWpQEqevEreluvQFL0duJHA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-z8UuLzX5RwaLbyoIUfhE+goAYkkLlzMK+nagqzhDFX1DxcXpU5qMJMeiGKIqEU+/6iGw9BS2oEJl6gYDp9tVqw==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   ChatErrorBoundary,
   ChatInputControlsProvider,
   ChatMessage,
@@ -568,10 +569,12 @@ export function AddinChatCoreView({
         <div className="app-shell-skin relative flex size-full min-w-0 flex-col">
           {/* Floats over the conversation: the pane is too narrow to spend a
               header row on a single trigger, and New Chat lives in the
-              drawer it opens. */}
-          <button
-            type="button"
+              drawer it opens. Same button anatomy as the web sidebar toggle,
+              so the drawer's header toggle reads as the same control. */}
+          <Button
             onClick={() => controller.setIsHistoryMenuOpen(true)}
+            variant="sidebar-icon"
+            icon={<SidebarToggleIcon />}
             aria-haspopup="dialog"
             aria-expanded={controller.isHistoryMenuOpen}
             aria-controls={HISTORY_DRAWER_PANEL_ID}
@@ -579,11 +582,9 @@ export function AddinChatCoreView({
               id: "officeAddin.historyDrawer.open",
               message: "Open menu",
             })}
-            className="focus-ring theme-transition absolute left-2 top-2 z-20 flex size-7 items-center justify-center rounded-[var(--theme-radius-control)] bg-theme-bg-primary text-theme-fg-secondary hover:bg-theme-bg-hover"
+            className="absolute left-2 top-2 z-20 bg-theme-bg-primary"
             data-testid="addin-history-drawer-trigger"
-          >
-            <SidebarToggleIcon className="size-4" aria-hidden="true" />
-          </button>
+          />
 
           <ChatErrorBoundary onReset={() => void controller.refetchHistory()}>
             <div

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -291,18 +291,19 @@ function useAddinChatController({
       delegationRunMode,
     ) => {
       hostCallbacksRef.current.beforeSend?.(hostContextIdentity);
-      void chat
-        .sendMessage(
-          message,
-          inputFileIds,
-          modelId,
-          assistantId,
-          selectedFacetIds,
-          actionFacet,
-          mentionedAssistants,
-          delegationRunMode,
-        )
-        .then(() => chat.refetchHistory());
+      // No history refetch here: sendMessage resolves at dispatch, before
+      // the server lists the chat, and the messaging pipeline already
+      // invalidates the recent-chats listings when the stream completes.
+      void chat.sendMessage(
+        message,
+        inputFileIds,
+        modelId,
+        assistantId,
+        selectedFacetIds,
+        actionFacet,
+        mentionedAssistants,
+        delegationRunMode,
+      );
     },
     [assistantId, chat],
   );
@@ -552,6 +553,18 @@ export function AddinChatCoreView({
 }) {
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
   const feedback = controller.feedback;
+  const { setIsHistoryMenuOpen, setIsSettingsOpen } = controller;
+  // Stable identities for the drawer: fresh arrows here would churn its
+  // onClose/onOpenSettings props every render and defeat the stable-handler
+  // contract its list memoization depends on.
+  const closeHistoryDrawer = useCallback(
+    () => setIsHistoryMenuOpen(false),
+    [setIsHistoryMenuOpen],
+  );
+  const openSettingsFromDrawer = useCallback(
+    () => setIsSettingsOpen(true),
+    [setIsSettingsOpen],
+  );
   const inputProps: AddinChatInputRenderProps = {
     ref: controller.chatInputControlsRef,
     onSendMessage: controller.handleSendMessage,
@@ -634,7 +647,9 @@ export function AddinChatCoreView({
               ) : null}
               {beforeMessages}
               {controller.delegatedRunHeader ? (
-                <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3">
+                // pl-10 clears the floating drawer trigger, which otherwise
+                // sits on the header's title.
+                <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 pl-10">
                   {controller.delegatedRunHeader}
                 </div>
               ) : null}
@@ -718,8 +733,8 @@ export function AddinChatCoreView({
           })}
           <AddinHistoryDrawerCore
             isOpen={controller.isHistoryMenuOpen}
-            onClose={() => controller.setIsHistoryMenuOpen(false)}
-            onOpenSettings={() => controller.setIsSettingsOpen(true)}
+            onClose={closeHistoryDrawer}
+            onOpenSettings={openSettingsFromDrawer}
             panelId={HISTORY_DRAWER_PANEL_ID}
             sectionsBeforeHistory={drawerSectionsBeforeHistory}
             sectionsAfterHistory={drawerSectionsAfterHistory}

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -565,31 +565,25 @@ export function AddinChatCoreView({
       {/* Deep message surfaces (the trace's open-run affordance) open chats
           through the session controller instead of routes the pane lacks. */}
       <DelegatedRunOpenProvider onOpen={controller.openChatById}>
-        <div className="app-shell-skin flex size-full min-w-0 flex-col">
-          <div className="chat-header-skin flex items-center justify-between border-b border-theme-border px-4 py-2">
-            <button
-              type="button"
-              onClick={() => controller.setIsHistoryMenuOpen(true)}
-              aria-haspopup="dialog"
-              aria-expanded={controller.isHistoryMenuOpen}
-              aria-controls={HISTORY_DRAWER_PANEL_ID}
-              aria-label={t({
-                id: "officeAddin.historyDrawer.open",
-                message: "Open menu",
-              })}
-              className="focus-ring theme-transition flex size-7 items-center justify-center rounded-[var(--theme-radius-control)] text-theme-fg-secondary hover:bg-theme-bg-hover"
-              data-testid="addin-history-drawer-trigger"
-            >
-              <SidebarToggleIcon className="size-4" aria-hidden="true" />
-            </button>
-            <button
-              type="button"
-              onClick={() => void controller.createNewChat()}
-              className="rounded-[var(--theme-radius-control)] bg-theme-bg-tertiary px-3 py-1 text-xs font-medium text-theme-fg-secondary transition-colors hover:bg-theme-bg-hover"
-            >
-              {t({ id: "officeAddin.chat.newChat", message: "New Chat" })}
-            </button>
-          </div>
+        <div className="app-shell-skin relative flex size-full min-w-0 flex-col">
+          {/* Floats over the conversation: the pane is too narrow to spend a
+              header row on a single trigger, and New Chat lives in the
+              drawer it opens. */}
+          <button
+            type="button"
+            onClick={() => controller.setIsHistoryMenuOpen(true)}
+            aria-haspopup="dialog"
+            aria-expanded={controller.isHistoryMenuOpen}
+            aria-controls={HISTORY_DRAWER_PANEL_ID}
+            aria-label={t({
+              id: "officeAddin.historyDrawer.open",
+              message: "Open menu",
+            })}
+            className="focus-ring theme-transition absolute left-2 top-2 z-20 flex size-7 items-center justify-center rounded-[var(--theme-radius-control)] bg-theme-bg-primary text-theme-fg-secondary hover:bg-theme-bg-hover"
+            data-testid="addin-history-drawer-trigger"
+          >
+            <SidebarToggleIcon className="size-4" aria-hidden="true" />
+          </button>
 
           <ChatErrorBoundary onReset={() => void controller.refetchHistory()}>
             <div
@@ -632,12 +626,16 @@ export function AddinChatCoreView({
                 </div>
               ) : null}
               {TopLeftAccessory ? (
-                <TopLeftAccessory
-                  availableModels={controller.availableModels}
-                  selectedModel={controller.selectedModel}
-                  onModelChange={controller.setSelectedModel}
-                  isModelSelectionReady={controller.isSelectionReady}
-                />
+                // Cleared past the floating drawer trigger, which otherwise
+                // sits exactly on a top-left accessory.
+                <div className="pl-10">
+                  <TopLeftAccessory
+                    availableModels={controller.availableModels}
+                    selectedModel={controller.selectedModel}
+                    onModelChange={controller.setSelectedModel}
+                    isModelSelectionReady={controller.isSelectionReady}
+                  />
+                </div>
               ) : null}
               <MessageEditProvider value={controller.messageEditValue}>
                 <MessageList

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -63,7 +63,12 @@ const HISTORY_DRAWER_PANEL_ID = "addin-history-drawer-panel";
 // sidebar shell tokens keep the trigger on the sidebar theme channel while
 // it floats over the chat body.
 const floatingTriggerStyle: CSSProperties = {
-  backgroundColor: "var(--theme-shell-sidebar)",
+  // Composited over the shell base: themes may give the sidebar token glass
+  // alpha (see .drawer-panel-skin), and a translucent floating control over
+  // chat content reads as a rendering defect.
+  backgroundColor: "var(--theme-shell-app, var(--theme-bg-primary))",
+  backgroundImage:
+    "linear-gradient(var(--theme-shell-sidebar), var(--theme-shell-sidebar))",
   borderColor: "var(--theme-border-divider)",
   borderRadius: "var(--theme-radius-shell)",
   boxShadow: "var(--theme-elevation-shell)",

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -6,12 +6,12 @@ import {
   DelegatedRunOpenProvider,
   DelegatedRunsSection,
   DocumentIcon,
-  DropdownMenu,
   FeedbackCommentDialog,
   FeedbackViewDialog,
   FilePreviewModal,
   MessageEditProvider,
   MessageList,
+  SidebarToggleIcon,
   chatMessagesQuery,
   componentRegistry,
   extractTextFromContent,
@@ -34,7 +34,6 @@ import {
   type ChatMessageProps,
   type DelegatedRunsSectionProps,
   type DelegationRunMode,
-  type DropdownMenuItem,
   type FileUploadItem,
   type MessageAction,
   type MessageControlsComponent,
@@ -45,6 +44,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { AddinChatInputCore } from "./AddinChatInputCore";
+import { AddinHistoryDrawerCore } from "./AddinHistoryDrawerCore";
 import { AddinSettingsDialogCore } from "./AddinSettingsDialogCore";
 
 import type {
@@ -53,6 +53,9 @@ import type {
   MutableRefObject,
   ReactNode,
 } from "react";
+
+// Links the header trigger's aria-controls to the drawer's dialog panel.
+const HISTORY_DRAWER_PANEL_ID = "addin-history-drawer-panel";
 
 export interface AddinChatHostCallbacks {
   beforeSend?: (hostContextIdentity?: string | null) => void;
@@ -144,7 +147,8 @@ export interface AddinChatController {
   feedback: ReturnType<typeof useMessageFeedback>;
   isSettingsOpen: boolean;
   setIsSettingsOpen: (isOpen: boolean) => void;
-  headerMenuItems: DropdownMenuItem[];
+  isHistoryMenuOpen: boolean;
+  setIsHistoryMenuOpen: (isOpen: boolean) => void;
   /** Banner identifying the open chat as a delegated run; null otherwise. */
   delegatedRunHeader: ReactNode;
   /** A delegate still writing the run refuses sends with a 409; closing the
@@ -410,19 +414,7 @@ function useAddinChatController({
     [],
   );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const headerMenuItems = useMemo<DropdownMenuItem[]>(
-    () => [
-      {
-        id: "settings",
-        label: t({
-          id: "officeAddin.headerMenu.settings",
-          message: "Settings",
-        }),
-        onClick: () => setIsSettingsOpen(true),
-      },
-    ],
-    [],
-  );
+  const [isHistoryMenuOpen, setIsHistoryMenuOpen] = useState(false);
 
   return {
     assistantId,
@@ -465,7 +457,8 @@ function useAddinChatController({
     feedback,
     isSettingsOpen,
     setIsSettingsOpen,
-    headerMenuItems,
+    isHistoryMenuOpen,
+    setIsHistoryMenuOpen,
     delegatedRunHeader,
     composerLocked,
     openDelegatedRun,
@@ -525,6 +518,8 @@ export function AddinChatCoreView({
   beforeMessages,
   renderInput,
   renderSettings,
+  drawerSectionsBeforeHistory,
+  drawerSectionsAfterHistory,
 }: {
   controller: AddinChatController;
   dropzone: Pick<
@@ -539,6 +534,9 @@ export function AddinChatCoreView({
     isOpen: boolean;
     onClose: () => void;
   }) => ReactNode;
+  /** Forwarded into the history drawer's future-section slots. */
+  drawerSectionsBeforeHistory?: ReactNode;
+  drawerSectionsAfterHistory?: ReactNode;
 }) {
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
   const feedback = controller.feedback;
@@ -569,11 +567,21 @@ export function AddinChatCoreView({
       <DelegatedRunOpenProvider onOpen={controller.openChatById}>
         <div className="app-shell-skin flex size-full min-w-0 flex-col">
           <div className="chat-header-skin flex items-center justify-between border-b border-theme-border px-4 py-2">
-            <DropdownMenu
-              id="addin-header-menu"
-              align="left"
-              items={controller.headerMenuItems}
-            />
+            <button
+              type="button"
+              onClick={() => controller.setIsHistoryMenuOpen(true)}
+              aria-haspopup="dialog"
+              aria-expanded={controller.isHistoryMenuOpen}
+              aria-controls={HISTORY_DRAWER_PANEL_ID}
+              aria-label={t({
+                id: "officeAddin.historyDrawer.open",
+                message: "Open menu",
+              })}
+              className="focus-ring theme-transition flex size-7 items-center justify-center rounded-[var(--theme-radius-control)] text-theme-fg-secondary hover:bg-theme-bg-hover"
+              data-testid="addin-history-drawer-trigger"
+            >
+              <SidebarToggleIcon className="size-4" aria-hidden="true" />
+            </button>
             <button
               type="button"
               onClick={() => void controller.createNewChat()}
@@ -697,6 +705,14 @@ export function AddinChatCoreView({
             isOpen: controller.isSettingsOpen,
             onClose: () => controller.setIsSettingsOpen(false),
           })}
+          <AddinHistoryDrawerCore
+            isOpen={controller.isHistoryMenuOpen}
+            onClose={() => controller.setIsHistoryMenuOpen(false)}
+            onOpenSettings={() => controller.setIsSettingsOpen(true)}
+            panelId={HISTORY_DRAWER_PANEL_ID}
+            sectionsBeforeHistory={drawerSectionsBeforeHistory}
+            sectionsAfterHistory={drawerSectionsAfterHistory}
+          />
         </div>
       </DelegatedRunOpenProvider>
     </ChatInputControlsProvider>

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -49,6 +49,7 @@ import { AddinHistoryDrawerCore } from "./AddinHistoryDrawerCore";
 import { AddinSettingsDialogCore } from "./AddinSettingsDialogCore";
 
 import type {
+  CSSProperties,
   ComponentProps,
   ComponentType,
   MutableRefObject,
@@ -57,6 +58,16 @@ import type {
 
 // Links the header trigger's aria-controls to the drawer's dialog panel.
 const HISTORY_DRAWER_PANEL_ID = "addin-history-drawer-panel";
+
+// Same surface recipe as the web sidebar's floating hidden-mode toggle: the
+// sidebar shell tokens keep the trigger on the sidebar theme channel while
+// it floats over the chat body.
+const floatingTriggerStyle: CSSProperties = {
+  backgroundColor: "var(--theme-shell-sidebar)",
+  borderColor: "var(--theme-border-divider)",
+  borderRadius: "var(--theme-radius-shell)",
+  boxShadow: "var(--theme-elevation-shell)",
+};
 
 export interface AddinChatHostCallbacks {
   beforeSend?: (hostContextIdentity?: string | null) => void;
@@ -582,7 +593,8 @@ export function AddinChatCoreView({
               id: "officeAddin.historyDrawer.open",
               message: "Open menu",
             })}
-            className="absolute left-2 top-2 z-20 bg-theme-bg-primary"
+            className="absolute left-2 top-2 z-20 border"
+            style={floatingTriggerStyle}
             data-testid="addin-history-drawer-trigger"
           />
 

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -90,13 +90,16 @@ export function AddinChatProviderCore({
   const history = useInfiniteRecentChats({ filters });
   const chats = history.chats;
 
-  // The session policy's ask toast suggests and lists chats through this
-  // unfiltered listing, never the drawer-filtered one: narrowing a drawer
-  // filter must not silently change which chat the toast offers to resume.
-  // With the filters at their defaults both hooks share one query key, so
-  // this costs nothing until a filter is actually narrowed.
+  // Outlook's session policy suggests and lists chats for its ask toast
+  // through this unfiltered listing, never the drawer-filtered one: narrowing
+  // a drawer filter must not silently change which chat the toast offers to
+  // resume. Only Outlook's session controller consumes these chats — every
+  // other platform reuses the drawer's filters so both hooks share one query
+  // key and this second listing never runs its own request chain.
+  const sessionFilters =
+    platform === "outlook" ? SESSION_LISTING_FILTERS : filters;
   const sessionHistory = useInfiniteRecentChats({
-    filters: SESSION_LISTING_FILTERS,
+    filters: sessionFilters,
   });
 
   return (

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -4,11 +4,11 @@ import {
   mapMessageToUiMessage,
   recentChatsQuery,
   removeArchivedChatFromLists,
-  sanitizeChatHistoryFilters,
   seedGenerationStatusFromListing,
   useArchiveChatEndpoint,
   useAssistantsFeature,
   useBudgetStatus,
+  useChatHistoryFilterFoldback,
   useChatMessaging,
   useFileCapabilitiesContext,
   useFileDropzone,
@@ -18,7 +18,7 @@ import {
   useMessagingStore,
   useModelHistory,
   usePersistedState,
-  useUpdateChat,
+  useUpdateChatTitle,
   type ChatContextValue,
   type Message,
   type PersistedStateOptions,
@@ -73,22 +73,7 @@ export function AddinChatProviderCore({
 }) {
   const filterStore = getAddinChatHistoryFilterStore(platform);
   const { enabled: assistantsEnabled } = useAssistantsFeature();
-
-  // Fold assistant-scoped filter values back to their defaults in the store
-  // itself: the recent-chats query consumes the raw persisted values, so
-  // sanitizing only at render would let a stale persisted value keep
-  // filtering the request invisibly.
-  useEffect(() => {
-    if (assistantsEnabled) return;
-    const state = filterStore.getState();
-    const sanitized = sanitizeChatHistoryFilters(state, false);
-    if (sanitized.typeFilter !== state.typeFilter) {
-      state.setTypeFilter(sanitized.typeFilter);
-    }
-    if (sanitized.groupBy !== state.groupBy) {
-      state.setGroupBy(sanitized.groupBy);
-    }
-  }, [assistantsEnabled, filterStore]);
+  useChatHistoryFilterFoldback(assistantsEnabled, filterStore);
 
   const typeFilter = filterStore((state) => state.typeFilter);
   const statusFilter = filterStore((state) => state.statusFilter);
@@ -223,8 +208,6 @@ function AddinChatDataProvider({
   );
   const archiveChat = useCallback(
     async (chatId: string) => {
-      // An archived chat has no row, so its status must not keep counting.
-      useGenerationStatusStore.getState().clearStatus(chatId);
       if (filters.statusFilter === "all") {
         // The archived-inclusive result set does not shrink, which is what
         // makes refetch-driven offset skew impossible — plain invalidate.
@@ -241,6 +224,11 @@ function AddinChatDataProvider({
           throw error;
         }
       }
+      // An archived chat has no row, so its status must not keep counting.
+      // Cleared only once the mutation succeeded: there is no restore API,
+      // so clearing earlier would drop the marker of a chat whose row a
+      // failed archive puts back.
+      useGenerationStatusStore.getState().clearStatus(chatId);
       if (session.currentChatId === chatId) {
         session.beginNewChat();
         resetMessagingForNewChat();
@@ -255,23 +243,7 @@ function AddinChatDataProvider({
     ],
   );
 
-  const { mutateAsync: updateChatMutation } = useUpdateChat();
-  const updateChatTitle = useCallback(
-    async (chatId: string, titleByUserProvided?: string) => {
-      const trimmedTitle = titleByUserProvided?.trim();
-      await updateChatMutation({
-        pathParams: { chatId },
-        body: trimmedTitle
-          ? { title_by_user_provided: trimmedTitle }
-          : // Empty value removes the custom title on the backend.
-            {},
-      });
-      await queryClient.invalidateQueries({
-        queryKey: recentChatsQuery({}).queryKey,
-      });
-    },
-    [queryClient, updateChatMutation],
-  );
+  const updateChatTitle = useUpdateChatTitle();
 
   // Seed the status store from the backend's running and pending-approval
   // markers, so generations started (or parked) elsewhere get an indicator

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -61,6 +61,12 @@ export interface AddinSessionControllerProps {
 
 type RecentChatsResult = ReturnType<typeof useInfiniteRecentChats>;
 
+// The server-default listing shape (every type, archived excluded).
+const SESSION_LISTING_FILTERS: RecentChatsListFilters = {
+  typeFilter: "all",
+  statusFilter: "active",
+};
+
 export function AddinChatProviderCore({
   children,
   platform,
@@ -84,9 +90,18 @@ export function AddinChatProviderCore({
   const history = useInfiniteRecentChats({ filters });
   const chats = history.chats;
 
+  // The session policy's ask toast suggests and lists chats through this
+  // unfiltered listing, never the drawer-filtered one: narrowing a drawer
+  // filter must not silently change which chat the toast offers to resume.
+  // With the filters at their defaults both hooks share one query key, so
+  // this costs nothing until a filter is actually narrowed.
+  const sessionHistory = useInfiniteRecentChats({
+    filters: SESSION_LISTING_FILTERS,
+  });
+
   return (
     <AddinHistoryFilterStoreContext.Provider value={filterStore}>
-      <SessionController chats={chats}>
+      <SessionController chats={sessionHistory.chats}>
         {(session) => (
           <AddinChatDataProvider
             chats={chats}

--- a/office-addin/src/core/AddinChatProviderCore.tsx
+++ b/office-addin/src/core/AddinChatProviderCore.tsx
@@ -3,23 +3,34 @@ import {
   getSupportedFileTypes,
   mapMessageToUiMessage,
   recentChatsQuery,
+  removeArchivedChatFromLists,
+  sanitizeChatHistoryFilters,
+  seedGenerationStatusFromListing,
   useArchiveChatEndpoint,
+  useAssistantsFeature,
   useBudgetStatus,
   useChatMessaging,
   useFileCapabilitiesContext,
   useFileDropzone,
   useFileUploadStore,
   useGenerationStatusStore,
+  useInfiniteRecentChats,
   useMessagingStore,
   useModelHistory,
   usePersistedState,
-  useRecentChats,
+  useUpdateChat,
   type ChatContextValue,
   type Message,
   type PersistedStateOptions,
+  type RecentChatsListFilters,
 } from "@erato/frontend/library";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  AddinHistoryFilterStoreContext,
+  getAddinChatHistoryFilterStore,
+} from "./addinChatHistoryFilterStore";
 
 import type { ComponentType, MutableRefObject, ReactNode } from "react";
 
@@ -48,7 +59,7 @@ export interface AddinSessionControllerProps {
   children: (session: AddinSessionController) => ReactNode;
 }
 
-type RecentChatsResult = ReturnType<typeof useRecentChats>;
+type RecentChatsResult = ReturnType<typeof useInfiniteRecentChats>;
 
 export function AddinChatProviderCore({
   children,
@@ -60,22 +71,50 @@ export function AddinChatProviderCore({
   platform: string;
   SessionController?: ComponentType<AddinSessionControllerProps>;
 }) {
-  const history = useRecentChats({});
-  const chats = useMemo(() => history.data?.chats ?? [], [history.data]);
+  const filterStore = getAddinChatHistoryFilterStore(platform);
+  const { enabled: assistantsEnabled } = useAssistantsFeature();
+
+  // Fold assistant-scoped filter values back to their defaults in the store
+  // itself: the recent-chats query consumes the raw persisted values, so
+  // sanitizing only at render would let a stale persisted value keep
+  // filtering the request invisibly.
+  useEffect(() => {
+    if (assistantsEnabled) return;
+    const state = filterStore.getState();
+    const sanitized = sanitizeChatHistoryFilters(state, false);
+    if (sanitized.typeFilter !== state.typeFilter) {
+      state.setTypeFilter(sanitized.typeFilter);
+    }
+    if (sanitized.groupBy !== state.groupBy) {
+      state.setGroupBy(sanitized.groupBy);
+    }
+  }, [assistantsEnabled, filterStore]);
+
+  const typeFilter = filterStore((state) => state.typeFilter);
+  const statusFilter = filterStore((state) => state.statusFilter);
+  const filters = useMemo<RecentChatsListFilters>(
+    () => ({ typeFilter, statusFilter }),
+    [typeFilter, statusFilter],
+  );
+  const history = useInfiniteRecentChats({ filters });
+  const chats = history.chats;
 
   return (
-    <SessionController chats={chats}>
-      {(session) => (
-        <AddinChatDataProvider
-          chats={chats}
-          history={history}
-          platform={platform}
-          session={session}
-        >
-          {children}
-        </AddinChatDataProvider>
-      )}
-    </SessionController>
+    <AddinHistoryFilterStoreContext.Provider value={filterStore}>
+      <SessionController chats={chats}>
+        {(session) => (
+          <AddinChatDataProvider
+            chats={chats}
+            history={history}
+            filters={filters}
+            platform={platform}
+            session={session}
+          >
+            {children}
+          </AddinChatDataProvider>
+        )}
+      </SessionController>
+    </AddinHistoryFilterStoreContext.Provider>
   );
 }
 
@@ -131,12 +170,14 @@ function AddinChatDataProvider({
   children,
   chats,
   history,
+  filters,
   platform,
   session,
 }: {
   children: ReactNode;
   chats: ChatContextValue["chats"];
   history: RecentChatsResult;
+  filters: RecentChatsListFilters;
   platform: string;
   session: AddinSessionController;
 }) {
@@ -182,17 +223,62 @@ function AddinChatDataProvider({
   );
   const archiveChat = useCallback(
     async (chatId: string) => {
-      await archiveChatMutation({ pathParams: { chatId }, body: {} });
-      await queryClient.invalidateQueries({
-        queryKey: recentChatsQuery({}).queryKey,
-      });
+      // An archived chat has no row, so its status must not keep counting.
+      useGenerationStatusStore.getState().clearStatus(chatId);
+      if (filters.statusFilter === "all") {
+        // The archived-inclusive result set does not shrink, which is what
+        // makes refetch-driven offset skew impossible — plain invalidate.
+        await archiveChatMutation({ pathParams: { chatId }, body: {} });
+        void queryClient.invalidateQueries({
+          queryKey: recentChatsQuery({}).queryKey,
+        });
+      } else {
+        const rollback = await removeArchivedChatFromLists(queryClient, chatId);
+        try {
+          await archiveChatMutation({ pathParams: { chatId }, body: {} });
+        } catch (error) {
+          rollback();
+          throw error;
+        }
+      }
       if (session.currentChatId === chatId) {
         session.beginNewChat();
         resetMessagingForNewChat();
       }
     },
-    [archiveChatMutation, queryClient, resetMessagingForNewChat, session],
+    [
+      archiveChatMutation,
+      filters.statusFilter,
+      queryClient,
+      resetMessagingForNewChat,
+      session,
+    ],
   );
+
+  const { mutateAsync: updateChatMutation } = useUpdateChat();
+  const updateChatTitle = useCallback(
+    async (chatId: string, titleByUserProvided?: string) => {
+      const trimmedTitle = titleByUserProvided?.trim();
+      await updateChatMutation({
+        pathParams: { chatId },
+        body: trimmedTitle
+          ? { title_by_user_provided: trimmedTitle }
+          : // Empty value removes the custom title on the backend.
+            {},
+      });
+      await queryClient.invalidateQueries({
+        queryKey: recentChatsQuery({}).queryKey,
+      });
+    },
+    [queryClient, updateChatMutation],
+  );
+
+  // Seed the status store from the backend's running and pending-approval
+  // markers, so generations started (or parked) elsewhere get an indicator
+  // without waiting for a poll.
+  useEffect(() => {
+    seedGenerationStatusFromListing(chats);
+  }, [chats]);
 
   const silentChatId = useFileUploadStore((state) => state.silentChatId);
   const {
@@ -245,7 +331,10 @@ function AddinChatDataProvider({
 
   const isLoading = isHistoryLoading || isMessagingLoading;
   const error = historyError ?? messagingError;
-  const fetchNextHistoryPage = useCallback(async () => {}, []);
+  const { fetchNextPage, hasNextPage, isFetchingNextPage } = history;
+  const fetchNextHistoryPage = useCallback(async () => {
+    await fetchNextPage();
+  }, [fetchNextPage]);
   const mountKey = useMemo(
     () => `new-chat-session-${session.newChatCounter}`,
     [session.newChatCounter],
@@ -299,13 +388,13 @@ function AddinChatDataProvider({
       historyError,
       createNewChat,
       archiveChat,
-      updateChatTitle: async () => {},
+      updateChatTitle,
       pinChat: async () => {},
       navigateToChat,
       refetchHistory,
       fetchNextHistoryPage,
-      hasNextHistoryPage: false,
-      isFetchingNextHistoryPage: false,
+      hasNextHistoryPage: hasNextPage ?? false,
+      isFetchingNextHistoryPage: isFetchingNextPage,
       messages: transformedMessages,
       messageOrder,
       isMessagingLoading,
@@ -341,7 +430,9 @@ function AddinChatDataProvider({
     editMessage,
     error,
     fetchNextHistoryPage,
+    hasNextPage,
     historyError,
+    isFetchingNextPage,
     isFinalizing,
     isHistoryLoading,
     isLoading,
@@ -361,6 +452,7 @@ function AddinChatDataProvider({
     session.newChatCounter,
     silentChatId,
     streamingContent,
+    updateChatTitle,
     uploadError,
     uploadFiles,
     uploadedFiles,

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -3,8 +3,9 @@ import {
   ChatHistoryFilterMenu,
   ChatHistoryList,
   ChatShareDialog,
-  CloseIcon,
   EditChatTitleDialog,
+  NewChatItem,
+  SidebarToggleIcon,
   groupChatSessions,
   hasActiveFilters,
   mapRecentChatToSession,
@@ -70,7 +71,7 @@ export function AddinHistoryDrawerCore({
   const { i18n } = useLingui();
 
   const panelRef = useRef<HTMLDivElement>(null);
-  const newChatRef = useRef<HTMLButtonElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
 
   // Slide choreography: mounted through both slides, `isShown` drives the
   // transform/opacity pair (the only animated properties — both composite-
@@ -157,7 +158,7 @@ export function AddinHistoryDrawerCore({
   useEffect(() => {
     if (!isOpen) return;
     const previouslyFocused = document.activeElement;
-    newChatRef.current?.focus();
+    toggleRef.current?.focus();
     return () => {
       if (previouslyFocused instanceof HTMLElement) {
         previouslyFocused.focus();
@@ -266,32 +267,30 @@ export function AddinHistoryDrawerCore({
           data-testid="addin-history-drawer"
           data-ui="addin-history-drawer"
         >
-          <div className="flex items-center justify-between border-b border-theme-border px-3 py-2">
-            <span className="text-sm font-semibold text-theme-fg-primary">
-              {t({ id: "officeAddin.historyDrawer.title", message: "Menu" })}
-            </span>
-            <Button
-              variant="icon-only"
-              size="sm"
-              icon={<CloseIcon className="size-4" />}
-              aria-label={t({
-                id: "officeAddin.historyDrawer.close",
-                message: "Close menu",
-              })}
-              onClick={onClose}
-              data-testid="addin-history-drawer-close"
-            />
+          {/* Same header anatomy as the web sidebar: the toggle sits where
+              the floating trigger sat, so open/close reads as one control. */}
+          <div
+            className="sidebar-section-skin sidebar-band-geometry flex border-b"
+            data-ui="sidebar-header"
+          >
+            <div className="flex w-full items-center">
+              <Button
+                ref={toggleRef}
+                onClick={onClose}
+                variant="sidebar-icon"
+                icon={<SidebarToggleIcon />}
+                className="sidebar-icon-col-geometry rotate-180"
+                aria-label={t({
+                  id: "officeAddin.historyDrawer.close",
+                  message: "Close menu",
+                })}
+                aria-expanded="true"
+                data-testid="addin-history-drawer-close"
+              />
+            </div>
           </div>
 
-          <button
-            ref={newChatRef}
-            type="button"
-            onClick={handleNewChat}
-            className="focus-ring-inset theme-transition mx-1.5 mt-1.5 rounded-[var(--theme-radius-base)] px-2 py-2 text-left text-sm font-medium text-theme-fg-primary hover:bg-theme-bg-hover"
-            data-testid="addin-history-drawer-new-chat"
-          >
-            {t({ id: "officeAddin.chat.newChat", message: "New Chat" })}
-          </button>
+          <NewChatItem onNewChat={handleNewChat} />
 
           {sectionsBeforeHistory}
 

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -382,7 +382,7 @@ export function AddinHistoryDrawerCore({
             message: "Menu",
           })}
           onKeyDown={handlePanelKeyDown}
-          className={`sidebar-skin theme-transition will-change-transform absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col motion-reduce:transition-none ${
+          className={`drawer-panel-skin theme-transition will-change-transform absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col motion-reduce:transition-none ${
             isShown ? "translate-x-0" : "-translate-x-full"
           }`}
           data-testid="addin-history-drawer"

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -15,6 +15,7 @@ import {
   hasActiveFilters,
   mapRecentChatToSession,
   sidebarNavigationIconClassName,
+  toast,
   useAssistantsFeature,
   useChatContext,
   useChatSharingFeature,
@@ -64,6 +65,17 @@ export function AddinHistoryDrawerCore({
   sectionsAfterHistory,
 }: AddinHistoryDrawerCoreProps) {
   const chat = useChatContext();
+  // The context value gets a fresh identity on every streaming tick, but
+  // these members only change when the session changes. Handlers must key on
+  // them — depending on the whole value would re-mint every row callback per
+  // chunk and defeat ChatHistoryList's memo mid-stream.
+  const {
+    archiveChat,
+    createNewChat,
+    fetchNextHistoryPage,
+    navigateToChat,
+    updateChatTitle,
+  } = chat;
   const filterStore = useAddinHistoryFilterStore();
   const { enabled: assistantsEnabled } = useAssistantsFeature();
   const filters = useSanitizedChatHistoryFilters(
@@ -183,29 +195,59 @@ export function AddinHistoryDrawerCore({
 
   const handleSelect = useCallback(
     (sessionId: string) => {
-      chat.navigateToChat(sessionId);
+      navigateToChat(sessionId);
       onClose();
     },
-    [chat, onClose],
+    [navigateToChat, onClose],
   );
 
   const handleNewChat = useCallback(() => {
-    void chat.createNewChat();
+    void createNewChat();
     onClose();
-  }, [chat, onClose]);
+  }, [createNewChat, onClose]);
 
   const handleSubmitTitle = useCallback(
     async (title: string) => {
       if (!titleDialogSessionId) return;
       setIsUpdatingTitle(true);
       try {
-        await chat.updateChatTitle(titleDialogSessionId, title);
+        await updateChatTitle(titleDialogSessionId, title);
         setTitleDialogSessionId(null);
+      } catch {
+        // The dialog stays open on purpose: the typed title survives for a
+        // retry.
+        toast.error({
+          title: t({
+            id: "officeAddin.historyDrawer.renameFailed",
+            message: "Couldn't rename the chat",
+          }),
+        });
       } finally {
         setIsUpdatingTitle(false);
       }
     },
-    [chat, titleDialogSessionId],
+    [titleDialogSessionId, updateChatTitle],
+  );
+
+  const handleArchive = useCallback(
+    (sessionId: string) => {
+      // A failed archive rolls the row back silently (the mutation's
+      // rollback), so the toast is the only signal anything happened.
+      archiveChat(sessionId).catch(() => {
+        toast.error({
+          title: t({
+            id: "officeAddin.historyDrawer.archiveFailed",
+            message: "Couldn't archive the chat",
+          }),
+        });
+      });
+    },
+    [archiveChat],
+  );
+
+  const handleLoadMore = useCallback(
+    () => void fetchNextHistoryPage(),
+    [fetchNextHistoryPage],
   );
 
   const handlePanelKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -259,11 +301,18 @@ export function AddinHistoryDrawerCore({
   const activeTitleSession = titleDialogSessionId
     ? (sessions.find((session) => session.id === titleDialogSessionId) ?? null)
     : null;
-  const isInitialLoading = chat.isLoading && sessions.length === 0;
+  // Keyed on the history fetch alone: the composed isLoading also covers the
+  // open chat's messages fetch, and a skeleton shown for that would hide the
+  // filter row exactly when a narrowed filter needs widening.
+  const isInitialLoading = chat.isHistoryLoading && sessions.length === 0;
   const showNoMatches =
-    !chat.isLoading && sessions.length === 0 && hasActiveFilters(filters);
+    !chat.isHistoryLoading &&
+    sessions.length === 0 &&
+    hasActiveFilters(filters);
   const showEmpty =
-    !chat.isLoading && sessions.length === 0 && !hasActiveFilters(filters);
+    !chat.isHistoryLoading &&
+    sessions.length === 0 &&
+    !hasActiveFilters(filters);
 
   const filterMenu = (
     <ChatHistoryFilterMenu
@@ -290,14 +339,12 @@ export function AddinHistoryDrawerCore({
       // modified clicks included, selects in place.
       disableRowLinks={true}
       onSessionSelect={handleSelect}
-      onSessionArchive={(sessionId) => void chat.archiveChat(sessionId)}
+      onSessionArchive={handleArchive}
       onSessionEditTitle={setTitleDialogSessionId}
       onSessionShare={sharingEnabled ? setShareDialogChatId : undefined}
       hasMore={carriesLoadMore && chat.hasNextHistoryPage}
       isLoadingMore={carriesLoadMore ? chat.isFetchingNextHistoryPage : false}
-      onLoadMore={
-        carriesLoadMore ? () => void chat.fetchNextHistoryPage() : undefined
-      }
+      onLoadMore={carriesLoadMore ? handleLoadMore : undefined}
     />
   );
 
@@ -308,7 +355,11 @@ export function AddinHistoryDrawerCore({
         // sliding panel every frame; the scrim fades on opacity alone.
         // pointer-events-none while hidden lets a click land on the pane the
         // instant the exit slide starts instead of dying on the scrim.
-        className={`drawer-overlay-skin theme-transition fixed inset-0 z-50 ${
+        // will-change pins the scrim's compositor layer for the drawer's
+        // mounted lifetime: WebView2 can ghost stale frame content when a
+        // transitioned layer is de-promoted mid-scene, and the drawer
+        // unmounts when closed so the pinned layer is transient anyway.
+        className={`drawer-overlay-skin theme-transition will-change-[opacity] fixed inset-0 z-50 ${
           isShown ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
         role="presentation"
@@ -326,7 +377,7 @@ export function AddinHistoryDrawerCore({
             message: "Menu",
           })}
           onKeyDown={handlePanelKeyDown}
-          className={`sidebar-skin theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col motion-reduce:transition-none ${
+          className={`sidebar-skin theme-transition will-change-transform absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col motion-reduce:transition-none ${
             isShown ? "translate-x-0" : "-translate-x-full"
           }`}
           data-testid="addin-history-drawer"

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -24,6 +24,7 @@ import {
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { useAddinHistoryFilterStore } from "./addinChatHistoryFilterStore";
 
@@ -348,7 +349,11 @@ export function AddinHistoryDrawerCore({
     />
   );
 
-  return (
+  // Portalled to body like ModalBase: rendered inline, the overlay's z-index
+  // is at the mercy of whatever stacking or compositing context the host
+  // shell happens to create around it — in the Office webviews that showed
+  // up as pre-open frame content painting over the open drawer.
+  return createPortal(
     <>
       <div
         // No blur on purpose: a backdrop-filter re-evaluates under the
@@ -514,6 +519,7 @@ export function AddinHistoryDrawerCore({
         chatId={shareDialogChatId}
         onClose={() => setShareDialogChatId(null)}
       />
-    </>
+    </>,
+    document.body,
   );
 }

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -286,6 +286,9 @@ export function AddinHistoryDrawerCore({
     <ChatHistoryList
       sessions={groupSessions}
       currentSessionId={chat.currentChatId}
+      // The pane serves no chat routes and has no tabs; every activation,
+      // modified clicks included, selects in place.
+      disableRowLinks={true}
       onSessionSelect={handleSelect}
       onSessionArchive={(sessionId) => void chat.archiveChat(sessionId)}
       onSessionEditTitle={setTitleDialogSessionId}

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -27,6 +27,11 @@ import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+/** Unmount backstop for the exit slide: a backgrounded webview can swallow
+ * `transitionend`, and reduced motion never fires one — an invisible drawer
+ * must not stay mounted eating clicks. Just past the 150ms transition. */
+const EXIT_FALLBACK_MS = 250;
+
 export interface AddinHistoryDrawerCoreProps {
   isOpen: boolean;
   onClose: () => void;
@@ -66,6 +71,47 @@ export function AddinHistoryDrawerCore({
 
   const panelRef = useRef<HTMLDivElement>(null);
   const newChatRef = useRef<HTMLButtonElement>(null);
+
+  // Slide choreography: mounted through both slides, `isShown` drives the
+  // transform/opacity pair (the only animated properties — both composite-
+  // only, so the slide stays smooth in the Office webviews).
+  const [isMounted, setIsMounted] = useState(isOpen);
+  const [isShown, setIsShown] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsShown(false);
+      return;
+    }
+    setIsMounted(true);
+    // Two frames so the off-screen start state paints (and the list's heavy
+    // first paint lands) before the slide begins.
+    const second = { id: 0 };
+    const first = window.requestAnimationFrame(() => {
+      second.id = window.requestAnimationFrame(() => setIsShown(true));
+    });
+    return () => {
+      window.cancelAnimationFrame(first);
+      window.cancelAnimationFrame(second.id);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen || !isMounted) return;
+    const panel = panelRef.current;
+    const finish = () => setIsMounted(false);
+    const fallback = window.setTimeout(finish, EXIT_FALLBACK_MS);
+    const handleTransitionEnd = (event: TransitionEvent) => {
+      if (event.target === panel && event.propertyName === "transform") {
+        finish();
+      }
+    };
+    panel?.addEventListener("transitionend", handleTransitionEnd);
+    return () => {
+      window.clearTimeout(fallback);
+      panel?.removeEventListener("transitionend", handleTransitionEnd);
+    };
+  }, [isOpen, isMounted]);
 
   const [titleDialogSessionId, setTitleDialogSessionId] = useState<
     string | null
@@ -179,7 +225,7 @@ export function AddinHistoryDrawerCore({
     }
   };
 
-  if (!isOpen) {
+  if (!isMounted) {
     return null;
   }
 
@@ -192,7 +238,13 @@ export function AddinHistoryDrawerCore({
   return (
     <>
       <div
-        className="modal-overlay-skin fixed inset-0 z-50"
+        // No blur on purpose: a backdrop-filter re-evaluates under the
+        // sliding panel every frame; the scrim fades on opacity alone.
+        // pointer-events-none while hidden lets a click land on the pane the
+        // instant the exit slide starts instead of dying on the scrim.
+        className={`drawer-overlay-skin theme-transition fixed inset-0 z-50 ${
+          isShown ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
         role="presentation"
         onClick={handleBackdropClick}
         data-testid="addin-history-drawer-backdrop"
@@ -208,7 +260,9 @@ export function AddinHistoryDrawerCore({
             message: "Menu",
           })}
           onKeyDown={handlePanelKeyDown}
-          className="theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col bg-theme-bg-primary shadow-xl motion-reduce:transition-none"
+          className={`theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col bg-theme-bg-primary shadow-xl motion-reduce:transition-none ${
+            isShown ? "translate-x-0" : "-translate-x-full"
+          }`}
           data-testid="addin-history-drawer"
           data-ui="addin-history-drawer"
         >

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -1,0 +1,341 @@
+import {
+  Button,
+  ChatHistoryFilterMenu,
+  ChatHistoryList,
+  ChatShareDialog,
+  CloseIcon,
+  EditChatTitleDialog,
+  groupChatSessions,
+  hasActiveFilters,
+  mapRecentChatToSession,
+  resolveChatAttentionStatus,
+  useAssistantsFeature,
+  useChatContext,
+  useChatSharingFeature,
+  useConfirmationRegistryStore,
+  useGenerationStatusStore,
+  useLingui,
+  useSanitizedChatHistoryFilters,
+} from "@erato/frontend/library";
+import { t } from "@lingui/core/macro";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAddinHistoryFilterStore } from "./addinChatHistoryFilterStore";
+
+import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export interface AddinHistoryDrawerCoreProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Opens the settings dialog owned by the chat surface. */
+  onOpenSettings: () => void;
+  /** Id the header trigger references via `aria-controls`. */
+  panelId: string;
+  /** Future sections (assistants row, search, delegated runs). */
+  sectionsBeforeHistory?: ReactNode;
+  sectionsAfterHistory?: ReactNode;
+}
+
+/**
+ * The pane's menu: a left-anchored overlay drawer with New Chat, the
+ * filterable chat history, and Settings. State-driven on purpose — the
+ * add-in performs no router navigation, so opening it can never trip the
+ * Outlook session policy; row selection goes through the same
+ * `navigateToChat` → session-controller path as the ask-toast picker.
+ */
+export function AddinHistoryDrawerCore({
+  isOpen,
+  onClose,
+  onOpenSettings,
+  panelId,
+  sectionsBeforeHistory,
+  sectionsAfterHistory,
+}: AddinHistoryDrawerCoreProps) {
+  const chat = useChatContext();
+  const filterStore = useAddinHistoryFilterStore();
+  const { enabled: assistantsEnabled } = useAssistantsFeature();
+  const filters = useSanitizedChatHistoryFilters(
+    assistantsEnabled,
+    filterStore,
+  );
+  const { enabled: sharingEnabled } = useChatSharingFeature();
+  const { i18n } = useLingui();
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const newChatRef = useRef<HTMLButtonElement>(null);
+
+  const [titleDialogSessionId, setTitleDialogSessionId] = useState<
+    string | null
+  >(null);
+  const [shareDialogChatId, setShareDialogChatId] = useState<string | null>(
+    null,
+  );
+  const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
+
+  const sessions = useMemo(
+    () => (chat.chats ?? []).map(mapRecentChatToSession),
+    [chat.chats],
+  );
+
+  const statusByChatId = useGenerationStatusStore(
+    (state) => state.statusByChatId,
+  );
+  const pendingIdsByChatId = useConfirmationRegistryStore(
+    (state) => state.pendingIdsByChatId,
+  );
+  const groups = useMemo(
+    () =>
+      groupChatSessions(sessions, filters.groupBy, {
+        now: new Date(),
+        locale: i18n.locale,
+        needsAttention: (session) =>
+          resolveChatAttentionStatus(
+            statusByChatId[session.id],
+            (pendingIdsByChatId[session.id]?.length ?? 0) > 0,
+          ) !== null,
+      }),
+    [
+      sessions,
+      filters.groupBy,
+      i18n.locale,
+      statusByChatId,
+      pendingIdsByChatId,
+    ],
+  );
+
+  // Focus moves into the panel on open and back to where it came from on
+  // close, so the trigger keeps its place in the tab order.
+  useEffect(() => {
+    if (!isOpen) return;
+    const previouslyFocused = document.activeElement;
+    newChatRef.current?.focus();
+    return () => {
+      if (previouslyFocused instanceof HTMLElement) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [isOpen]);
+
+  const handleSelect = useCallback(
+    (sessionId: string) => {
+      chat.navigateToChat(sessionId);
+      onClose();
+    },
+    [chat, onClose],
+  );
+
+  const handleNewChat = useCallback(() => {
+    void chat.createNewChat();
+    onClose();
+  }, [chat, onClose]);
+
+  const handleSubmitTitle = useCallback(
+    async (title: string) => {
+      if (!titleDialogSessionId) return;
+      setIsUpdatingTitle(true);
+      try {
+        await chat.updateChatTitle(titleDialogSessionId, title);
+        setTitleDialogSessionId(null);
+      } finally {
+        setIsUpdatingTitle(false);
+      }
+    },
+    [chat, titleDialogSessionId],
+  );
+
+  // Element-scoped on purpose: the filter menu's popover closes itself on a
+  // document-level Escape without the event ever reaching this panel, so the
+  // first Escape closes the menu and only the second closes the drawer.
+  const handlePanelKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      onClose();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusables = panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  // Only the backdrop element itself counts as outside: portalled popover
+  // panels are DOM siblings of this overlay and must not close the drawer.
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const activeTitleSession = titleDialogSessionId
+    ? (sessions.find((session) => session.id === titleDialogSessionId) ?? null)
+    : null;
+  const showNoMatches =
+    sessions.length === 0 && !chat.isLoading && hasActiveFilters(filters);
+
+  return (
+    <>
+      <div
+        className="modal-overlay-skin fixed inset-0 z-50"
+        role="presentation"
+        onClick={handleBackdropClick}
+        data-testid="addin-history-drawer-backdrop"
+      >
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- the dialog owns its element-scoped Escape and Tab-wrap handling */}
+        <div
+          ref={panelRef}
+          id={panelId}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t({
+            id: "officeAddin.historyDrawer.title",
+            message: "Menu",
+          })}
+          onKeyDown={handlePanelKeyDown}
+          className="theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col bg-theme-bg-primary shadow-xl motion-reduce:transition-none"
+          data-testid="addin-history-drawer"
+          data-ui="addin-history-drawer"
+        >
+          <div className="flex items-center justify-between border-b border-theme-border px-3 py-2">
+            <span className="text-sm font-semibold text-theme-fg-primary">
+              {t({ id: "officeAddin.historyDrawer.title", message: "Menu" })}
+            </span>
+            <Button
+              variant="icon-only"
+              size="sm"
+              icon={<CloseIcon className="size-4" />}
+              aria-label={t({
+                id: "officeAddin.historyDrawer.close",
+                message: "Close menu",
+              })}
+              onClick={onClose}
+              data-testid="addin-history-drawer-close"
+            />
+          </div>
+
+          <button
+            ref={newChatRef}
+            type="button"
+            onClick={handleNewChat}
+            className="focus-ring-inset theme-transition mx-1.5 mt-1.5 rounded-[var(--theme-radius-base)] px-2 py-2 text-left text-sm font-medium text-theme-fg-primary hover:bg-theme-bg-hover"
+            data-testid="addin-history-drawer-new-chat"
+          >
+            {t({ id: "officeAddin.chat.newChat", message: "New Chat" })}
+          </button>
+
+          {sectionsBeforeHistory}
+
+          <div className="flex items-center justify-between px-3 pt-2">
+            <span className="text-xs font-semibold text-theme-fg-secondary">
+              {t({ id: "officeAddin.historyDrawer.chats", message: "Chats" })}
+            </span>
+            <ChatHistoryFilterMenu
+              assistantsEnabled={assistantsEnabled}
+              store={filterStore}
+            />
+          </div>
+
+          <div
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-1.5 pb-2"
+            data-ui="addin-history-drawer-list"
+          >
+            {showNoMatches ? (
+              <p
+                className="px-2 py-3 text-xs text-theme-fg-muted"
+                data-testid="addin-history-drawer-empty"
+              >
+                {t({
+                  id: "officeAddin.historyDrawer.noMatches",
+                  message: "No chats match the current filters",
+                })}
+              </p>
+            ) : (
+              groups.map((group, index) => (
+                <div key={group.key}>
+                  {group.label ? (
+                    <p className="px-2 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-wide text-theme-fg-muted">
+                      {group.label}
+                    </p>
+                  ) : null}
+                  <ChatHistoryList
+                    sessions={group.sessions}
+                    currentSessionId={chat.currentChatId}
+                    onSessionSelect={handleSelect}
+                    onSessionArchive={(sessionId) =>
+                      void chat.archiveChat(sessionId)
+                    }
+                    onSessionEditTitle={setTitleDialogSessionId}
+                    onSessionShare={
+                      sharingEnabled ? setShareDialogChatId : undefined
+                    }
+                    isLoading={chat.isLoading && sessions.length === 0}
+                    hasMore={
+                      index === groups.length - 1 && chat.hasNextHistoryPage
+                    }
+                    isLoadingMore={chat.isFetchingNextHistoryPage}
+                    onLoadMore={() => void chat.fetchNextHistoryPage()}
+                  />
+                </div>
+              ))
+            )}
+          </div>
+
+          {sectionsAfterHistory}
+
+          <div className="border-t border-theme-border p-1.5">
+            <button
+              type="button"
+              onClick={() => {
+                onClose();
+                onOpenSettings();
+              }}
+              className="focus-ring-inset theme-transition w-full rounded-[var(--theme-radius-base)] px-2 py-2 text-left text-sm text-theme-fg-primary hover:bg-theme-bg-hover"
+              data-testid="addin-history-drawer-settings"
+            >
+              {t({
+                id: "officeAddin.headerMenu.settings",
+                message: "Settings",
+              })}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <EditChatTitleDialog
+        isOpen={activeTitleSession !== null}
+        generatedTitle={
+          activeTitleSession?.titleBySummary ??
+          t({
+            id: "officeAddin.historyDrawer.rename.generated.fallback",
+            message: "Untitled Chat",
+          })
+        }
+        initialUserProvidedTitle={activeTitleSession?.titleByUserProvided}
+        isSubmitting={isUpdatingTitle}
+        onClose={() => setTitleDialogSessionId(null)}
+        onSubmit={handleSubmitTitle}
+      />
+      <ChatShareDialog
+        isOpen={shareDialogChatId !== null}
+        chatId={shareDialogChatId}
+        onClose={() => setShareDialogChatId(null)}
+      />
+    </>
+  );
+}

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -2,20 +2,23 @@ import {
   Button,
   ChatHistoryFilterMenu,
   ChatHistoryList,
+  ChatHistoryListSkeleton,
   ChatShareDialog,
   EditChatTitleDialog,
   NewChatItem,
+  NoFilterMatchesRow,
+  SettingsIcon,
+  sidebarInsetClassName,
+  SidebarCollapsibleSection,
+  SidebarNavigationItem,
   SidebarToggleIcon,
-  groupChatSessions,
   hasActiveFilters,
   mapRecentChatToSession,
-  resolveChatAttentionStatus,
+  sidebarNavigationIconClassName,
   useAssistantsFeature,
   useChatContext,
   useChatSharingFeature,
-  useConfirmationRegistryStore,
-  useGenerationStatusStore,
-  useLingui,
+  useGroupedChatSessions,
   useSanitizedChatHistoryFilters,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
@@ -68,7 +71,6 @@ export function AddinHistoryDrawerCore({
     filterStore,
   );
   const { enabled: sharingEnabled } = useChatSharingFeature();
-  const { i18n } = useLingui();
 
   const panelRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
@@ -122,41 +124,54 @@ export function AddinHistoryDrawerCore({
   );
   const [isUpdatingTitle, setIsUpdatingTitle] = useState(false);
 
+  // A dialog left open when the drawer closes would otherwise survive the
+  // unmount in this state and resurrect on the next open.
+  useEffect(() => {
+    if (isOpen) return;
+    setTitleDialogSessionId(null);
+    setShareDialogChatId(null);
+  }, [isOpen]);
+
   const sessions = useMemo(
     () => (chat.chats ?? []).map(mapRecentChatToSession),
     [chat.chats],
   );
 
-  const statusByChatId = useGenerationStatusStore(
-    (state) => state.statusByChatId,
-  );
-  const pendingIdsByChatId = useConfirmationRegistryStore(
-    (state) => state.pendingIdsByChatId,
-  );
-  const groups = useMemo(
+  const groups = useGroupedChatSessions(sessions, filters.groupBy);
+
+  // Grouped-mode collapse state is per-mount on purpose: date-bucket keys
+  // churn daily, so persisting them would accumulate stale entries.
+  const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const setGroupExpanded = useCallback((key: string, expanded: boolean) => {
+    setCollapsedGroupKeys((previous) => {
+      const next = new Set(previous);
+      if (expanded) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  // The infinite-scroll sentinel must sit inside a visible list, so it
+  // follows the last still-expanded group rather than simply the last one.
+  // With every group collapsed there is no sentinel at all.
+  const lastExpandedGroupKey = useMemo(
     () =>
-      groupChatSessions(sessions, filters.groupBy, {
-        now: new Date(),
-        locale: i18n.locale,
-        needsAttention: (session) =>
-          resolveChatAttentionStatus(
-            statusByChatId[session.id],
-            (pendingIdsByChatId[session.id]?.length ?? 0) > 0,
-          ) !== null,
-      }),
-    [
-      sessions,
-      filters.groupBy,
-      i18n.locale,
-      statusByChatId,
-      pendingIdsByChatId,
-    ],
+      groups.findLast((group) => !collapsedGroupKeys.has(group.key))?.key ??
+      null,
+    [groups, collapsedGroupKeys],
   );
 
   // Focus moves into the panel on open and back to where it came from on
-  // close, so the trigger keeps its place in the tab order.
+  // close, so the trigger keeps its place in the tab order. Gated on the
+  // mount state: on open the panel is still unmounted in the commit that
+  // flips `isOpen`, so focusing must wait for the commit that mounts it.
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !isMounted) return;
     const previouslyFocused = document.activeElement;
     toggleRef.current?.focus();
     return () => {
@@ -164,7 +179,7 @@ export function AddinHistoryDrawerCore({
         previouslyFocused.focus();
       }
     };
-  }, [isOpen]);
+  }, [isOpen, isMounted]);
 
   const handleSelect = useCallback(
     (sessionId: string) => {
@@ -193,10 +208,21 @@ export function AddinHistoryDrawerCore({
     [chat, titleDialogSessionId],
   );
 
-  // Element-scoped on purpose: the filter menu's popover closes itself on a
-  // document-level Escape without the event ever reaching this panel, so the
-  // first Escape closes the menu and only the second closes the drawer.
   const handlePanelKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    // Popovers (the filter menu, row menus) portal their panels to
+    // document.body but stay React-tree children of this panel, so their
+    // keydowns bubble back through React into this handler. Their own close
+    // handling listens on the document, which the stopPropagation below
+    // would starve — one Escape would close the whole drawer instead of the
+    // popover. An event whose DOM target is outside the panel belongs to
+    // such a portalled layer and is not ours to handle.
+    if (
+      panelRef.current &&
+      event.target instanceof Node &&
+      !panelRef.current.contains(event.target)
+    ) {
+      return;
+    }
     if (event.key === "Escape") {
       event.stopPropagation();
       onClose();
@@ -233,8 +259,44 @@ export function AddinHistoryDrawerCore({
   const activeTitleSession = titleDialogSessionId
     ? (sessions.find((session) => session.id === titleDialogSessionId) ?? null)
     : null;
+  const isInitialLoading = chat.isLoading && sessions.length === 0;
   const showNoMatches =
-    sessions.length === 0 && !chat.isLoading && hasActiveFilters(filters);
+    !chat.isLoading && sessions.length === 0 && hasActiveFilters(filters);
+  const showEmpty =
+    !chat.isLoading && sessions.length === 0 && !hasActiveFilters(filters);
+
+  const filterMenu = (
+    <ChatHistoryFilterMenu
+      assistantsEnabled={assistantsEnabled}
+      store={filterStore}
+    />
+  );
+  const emptyRow = (
+    <p
+      className="sidebar-content-col-geometry py-2 pr-3 text-xs text-theme-fg-muted"
+      data-testid="addin-history-drawer-empty"
+    >
+      {t({ id: "officeAddin.historyDrawer.empty", message: "No chats yet" })}
+    </p>
+  );
+  const renderChatList = (
+    groupSessions: typeof sessions,
+    carriesLoadMore: boolean,
+  ) => (
+    <ChatHistoryList
+      sessions={groupSessions}
+      currentSessionId={chat.currentChatId}
+      onSessionSelect={handleSelect}
+      onSessionArchive={(sessionId) => void chat.archiveChat(sessionId)}
+      onSessionEditTitle={setTitleDialogSessionId}
+      onSessionShare={sharingEnabled ? setShareDialogChatId : undefined}
+      hasMore={carriesLoadMore && chat.hasNextHistoryPage}
+      isLoadingMore={carriesLoadMore ? chat.isFetchingNextHistoryPage : false}
+      onLoadMore={
+        carriesLoadMore ? () => void chat.fetchNextHistoryPage() : undefined
+      }
+    />
+  );
 
   return (
     <>
@@ -261,7 +323,7 @@ export function AddinHistoryDrawerCore({
             message: "Menu",
           })}
           onKeyDown={handlePanelKeyDown}
-          className={`theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col bg-theme-bg-primary shadow-xl motion-reduce:transition-none ${
+          className={`sidebar-skin theme-transition absolute inset-y-0 left-0 flex w-[min(320px,calc(100vw-48px))] flex-col motion-reduce:transition-none ${
             isShown ? "translate-x-0" : "-translate-x-full"
           }`}
           data-testid="addin-history-drawer"
@@ -294,91 +356,100 @@ export function AddinHistoryDrawerCore({
 
           {sectionsBeforeHistory}
 
-          <div className="flex items-center justify-between px-3 pt-2">
-            <span className="text-xs font-semibold text-theme-fg-secondary">
-              {t({ id: "officeAddin.historyDrawer.chats", message: "Chats" })}
-            </span>
-            <ChatHistoryFilterMenu
-              assistantsEnabled={assistantsEnabled}
-              store={filterStore}
-            />
-          </div>
-
           <div
-            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-1.5 pb-2"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-2"
             data-ui="addin-history-drawer-list"
           >
-            {showNoMatches ? (
-              <p
-                className="px-2 py-3 text-xs text-theme-fg-muted"
-                data-testid="addin-history-drawer-empty"
+            {/* Same composition as the web sidebar: group sections are
+                top-level SIBLINGS (never nested — a wrapper section would
+                stack a second sidebar inset under theirs and shift every row
+                off the rail column), with the filter menu riding the first
+                group's actions slot. */}
+            {isInitialLoading ? (
+              <div className={sidebarInsetClassName}>
+                <ChatHistoryListSkeleton />
+              </div>
+            ) : filters.groupBy === "none" ? (
+              <SidebarCollapsibleSection
+                title={t({ id: "chat.history.recent", message: "Recent" })}
+                actions={filterMenu}
               >
-                {t({
-                  id: "officeAddin.historyDrawer.noMatches",
-                  message: "No chats match the current filters",
-                })}
-              </p>
-            ) : (
-              groups.map((group, index) => (
-                <div key={group.key}>
-                  {group.label ? (
-                    <p className="px-2 pb-1 pt-3 text-[11px] font-semibold uppercase tracking-wide text-theme-fg-muted">
-                      {group.label}
-                    </p>
-                  ) : null}
-                  <ChatHistoryList
-                    sessions={group.sessions}
-                    currentSessionId={chat.currentChatId}
-                    onSessionSelect={handleSelect}
-                    onSessionArchive={(sessionId) =>
-                      void chat.archiveChat(sessionId)
-                    }
-                    onSessionEditTitle={setTitleDialogSessionId}
-                    onSessionShare={
-                      sharingEnabled ? setShareDialogChatId : undefined
-                    }
-                    isLoading={chat.isLoading && sessions.length === 0}
-                    hasMore={
-                      index === groups.length - 1 && chat.hasNextHistoryPage
-                    }
-                    isLoadingMore={chat.isFetchingNextHistoryPage}
-                    onLoadMore={() => void chat.fetchNextHistoryPage()}
-                  />
+                {showNoMatches ? (
+                  <NoFilterMatchesRow />
+                ) : showEmpty ? (
+                  emptyRow
+                ) : (
+                  renderChatList(sessions, true)
+                )}
+              </SidebarCollapsibleSection>
+            ) : groups.length === 0 ? (
+              <>
+                {/* No group headers exist to host the filter menu, so a bare
+                    header row keeps its trigger reachable. */}
+                <div
+                  className={`${sidebarInsetClassName} sidebar-trailing-col-geometry flex items-center justify-end py-1`}
+                  data-ui="chat-history-filter-row"
+                >
+                  {filterMenu}
                 </div>
-              ))
+                {showNoMatches ? (
+                  <div className={sidebarInsetClassName}>
+                    <NoFilterMatchesRow />
+                  </div>
+                ) : showEmpty ? (
+                  <div className={sidebarInsetClassName}>{emptyRow}</div>
+                ) : null}
+              </>
+            ) : (
+              groups.map((group, index) => {
+                const carriesLoadMore = group.key === lastExpandedGroupKey;
+                return (
+                  <div key={group.key} data-ui="chat-history-group">
+                    <SidebarCollapsibleSection
+                      title={group.label ?? ""}
+                      expanded={!collapsedGroupKeys.has(group.key)}
+                      onExpandedChange={(expanded) =>
+                        setGroupExpanded(group.key, expanded)
+                      }
+                      actions={index === 0 ? filterMenu : undefined}
+                    >
+                      {renderChatList(group.sessions, carriesLoadMore)}
+                    </SidebarCollapsibleSection>
+                  </div>
+                );
+              })
             )}
           </div>
 
           {sectionsAfterHistory}
 
-          <div className="border-t border-theme-border p-1.5">
-            <button
-              type="button"
+          {/* !p-0: the nav row carries the sidebar inset channel itself, so
+              the band's own padding must lose — and it needs the important
+              modifier because the skin class shares specificity and comes
+              later in the built stylesheet. */}
+          <div
+            className="sidebar-section-skin border-t !p-0"
+            data-ui="sidebar-footer"
+          >
+            <SidebarNavigationItem
+              label={t({
+                id: "officeAddin.headerMenu.settings",
+                message: "Settings",
+              })}
+              icon={<SettingsIcon className={sidebarNavigationIconClassName} />}
               onClick={() => {
                 onClose();
                 onOpenSettings();
               }}
-              className="focus-ring-inset theme-transition w-full rounded-[var(--theme-radius-base)] px-2 py-2 text-left text-sm text-theme-fg-primary hover:bg-theme-bg-hover"
-              data-testid="addin-history-drawer-settings"
-            >
-              {t({
-                id: "officeAddin.headerMenu.settings",
-                message: "Settings",
-              })}
-            </button>
+              data-ui="addin-history-drawer-settings"
+            />
           </div>
         </div>
       </div>
 
       <EditChatTitleDialog
         isOpen={activeTitleSession !== null}
-        generatedTitle={
-          activeTitleSession?.titleBySummary ??
-          t({
-            id: "officeAddin.historyDrawer.rename.generated.fallback",
-            message: "Untitled Chat",
-          })
-        }
+        generatedTitle={activeTitleSession?.titleBySummary ?? ""}
         initialUserProvidedTitle={activeTitleSession?.titleByUserProvided}
         isSubmitting={isUpdatingTitle}
         onClose={() => setTitleDialogSessionId(null)}

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
 } from "@testing-library/react";
+import { createPortal } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AddinHistoryDrawerCore } from "../AddinHistoryDrawerCore";
@@ -39,8 +40,12 @@ const spies = vi.hoisted(() => {
       hasMore?: boolean;
       onLoadMore?: () => void;
       onSessionSelect: (id: string) => void;
+      onSessionEditTitle?: (id: string) => void;
       onSessionShare?: (id: string) => void;
     }>,
+    renameDialogProps: {
+      current: null as { isOpen: boolean; generatedTitle: string } | null,
+    },
     filterMenuStore,
     sharingEnabled: { current: true },
   };
@@ -60,12 +65,18 @@ vi.mock("@erato/frontend/library", () => ({
     return (
       <div data-testid="history-list">
         {props.sessions.map((session) => (
-          <button
-            key={session.id}
-            type="button"
-            data-testid={`row-${session.id}`}
-            onClick={() => props.onSessionSelect(session.id)}
-          />
+          <div key={session.id}>
+            <button
+              type="button"
+              data-testid={`row-${session.id}`}
+              onClick={() => props.onSessionSelect(session.id)}
+            />
+            <button
+              type="button"
+              data-testid={`rename-${session.id}`}
+              onClick={() => props.onSessionEditTitle?.(session.id)}
+            />
+          </div>
         ))}
         {props.hasMore ? (
           <button
@@ -77,6 +88,7 @@ vi.mock("@erato/frontend/library", () => ({
       </div>
     );
   },
+  ChatHistoryListSkeleton: () => <div data-testid="chat-history-skeleton" />,
   ChatShareDialog: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="share-dialog" /> : null,
   NewChatItem: ({ onNewChat }: { onNewChat?: () => void }) => (
@@ -86,20 +98,45 @@ vi.mock("@erato/frontend/library", () => ({
       onClick={() => onNewChat?.()}
     />
   ),
+  NoFilterMatchesRow: () => <p data-testid="chat-history-no-filter-matches" />,
+  sidebarInsetClassName: "sidebar-inset-geometry",
+  SettingsIcon: () => null,
+  SidebarCollapsibleSection: ({
+    title,
+    actions,
+    children,
+  }: {
+    title: string;
+    actions?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <div data-testid="collapsible-section" data-title={title}>
+      {actions}
+      {children}
+    </div>
+  ),
+  SidebarNavigationItem: ({
+    label,
+    onClick,
+    "data-ui": dataUi,
+  }: {
+    label: string;
+    onClick?: () => void;
+    "data-ui"?: string;
+  }) => (
+    <button type="button" data-testid={dataUi} onClick={() => onClick?.()}>
+      {label}
+    </button>
+  ),
   SidebarToggleIcon: () => null,
-  EditChatTitleDialog: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="rename-dialog" /> : null,
-  groupChatSessions: (sessions: { id: string }[]) =>
-    sessions.length === 0
-      ? []
-      : [
-          { key: "a", label: "Group A", sessions: sessions.slice(0, 1) },
-          { key: "b", label: "Group B", sessions: sessions.slice(1) },
-        ].filter((group) => group.sessions.length > 0),
+  EditChatTitleDialog: (props: { isOpen: boolean; generatedTitle: string }) => {
+    spies.renameDialogProps.current = props;
+    return props.isOpen ? <div data-testid="rename-dialog" /> : null;
+  },
   hasActiveFilters: (values: { typeFilter: string; statusFilter: string }) =>
     values.typeFilter !== "all" || values.statusFilter !== "active",
   mapRecentChatToSession: (chat: { id: string }) => ({ id: chat.id }),
-  resolveChatAttentionStatus: () => null,
+  sidebarNavigationIconClassName: "",
   useAssistantsFeature: () => ({ enabled: true }),
   useChatContext: () => ({
     ...spies.chatContext,
@@ -110,15 +147,13 @@ vi.mock("@erato/frontend/library", () => ({
     fetchNextHistoryPage: spies.fetchNextHistoryPage,
   }),
   useChatSharingFeature: () => ({ enabled: spies.sharingEnabled.current }),
-  useConfirmationRegistryStore: (
-    selector: (state: {
-      pendingIdsByChatId: Record<string, string[]>;
-    }) => unknown,
-  ) => selector({ pendingIdsByChatId: {} }),
-  useGenerationStatusStore: (
-    selector: (state: { statusByChatId: Record<string, unknown> }) => unknown,
-  ) => selector({ statusByChatId: {} }),
-  useLingui: () => ({ i18n: { locale: "en" } }),
+  useGroupedChatSessions: (sessions: { id: string }[]) =>
+    sessions.length === 0
+      ? []
+      : [
+          { key: "a", label: "Group A", sessions: sessions.slice(0, 1) },
+          { key: "b", label: "Group B", sessions: sessions.slice(1) },
+        ].filter((group) => group.sessions.length > 0),
   useSanitizedChatHistoryFilters: () => spies.filters,
 }));
 
@@ -129,7 +164,7 @@ const renderDrawer = (
   overrides: Partial<
     Pick<
       Parameters<typeof AddinHistoryDrawerCore>[0],
-      "isOpen" | "onClose" | "onOpenSettings"
+      "isOpen" | "onClose" | "onOpenSettings" | "sectionsBeforeHistory"
     >
   > = {},
 ) => {
@@ -142,6 +177,7 @@ const renderDrawer = (
         onClose={onClose}
         onOpenSettings={onOpenSettings}
         panelId="drawer-panel"
+        sectionsBeforeHistory={overrides.sectionsBeforeHistory}
       />
     </AddinHistoryFilterStoreContext.Provider>,
   );
@@ -157,6 +193,7 @@ describe("AddinHistoryDrawerCore", () => {
     i18n.activate("en");
     vi.clearAllMocks();
     spies.historyListProps.length = 0;
+    spies.renameDialogProps.current = null;
     spies.filterMenuStore.current = null;
     spies.sharingEnabled.current = true;
     spies.chatContext.chats = [{ id: "c1" }, { id: "c2" }];
@@ -203,6 +240,32 @@ describe("AddinHistoryDrawerCore", () => {
     });
 
     expect(onClose).toHaveBeenCalled();
+  });
+
+  // Portalled popover content (the filter menu, row menus) lives under
+  // document.body in the DOM but inside the panel in the React tree, so its
+  // keydowns re-enter the panel handler. The handler must leave those events
+  // alone — the popovers close themselves through document-level listeners
+  // that its stopPropagation would otherwise starve. The portal here stands
+  // in for a real popover: same React parentage, same out-of-panel DOM
+  // target, so the guard is exercised through the genuine event path.
+  it("ignores Escape arriving from portalled popover content", () => {
+    const { onClose } = renderDrawer({
+      sectionsBeforeHistory: createPortal(
+        <button type="button" data-testid="portalled-popover-content" />,
+        document.body,
+      ),
+    });
+
+    fireEvent.keyDown(screen.getByTestId("portalled-popover-content"), {
+      key: "Escape",
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(screen.getByTestId("addin-history-drawer"), {
+      key: "Escape",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("closes only when the backdrop element itself is clicked", () => {
@@ -299,6 +362,101 @@ describe("AddinHistoryDrawerCore", () => {
     }
   });
 
+  // Regression: the panel mounts a commit after `isOpen` flips, so a focus
+  // effect keyed on the open state alone ran against a null ref and keyboard
+  // users never entered the panel.
+  it("moves focus into the panel when opened from closed", () => {
+    vi.useFakeTimers();
+    try {
+      const drawerAt = (isOpen: boolean) => (
+        <AddinHistoryFilterStoreContext.Provider value={fakeFilterStore}>
+          <AddinHistoryDrawerCore
+            isOpen={isOpen}
+            onClose={vi.fn()}
+            onOpenSettings={vi.fn()}
+            panelId="drawer-panel"
+          />
+        </AddinHistoryFilterStoreContext.Provider>
+      );
+      const { rerender } = render(drawerAt(false));
+      expect(screen.queryByTestId("addin-history-drawer")).toBeNull();
+
+      rerender(drawerAt(true));
+      act(() => {
+        vi.advanceTimersByTime(64);
+      });
+
+      const panel = screen.getByTestId("addin-history-drawer");
+      expect(panel.contains(document.activeElement)).toBe(true);
+      expect(document.activeElement).toBe(
+        screen.getByTestId("addin-history-drawer-close"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("disarms open dialogs when the drawer closes", () => {
+    vi.useFakeTimers();
+    try {
+      const drawerAt = (isOpen: boolean) => (
+        <AddinHistoryFilterStoreContext.Provider value={fakeFilterStore}>
+          <AddinHistoryDrawerCore
+            isOpen={isOpen}
+            onClose={vi.fn()}
+            onOpenSettings={vi.fn()}
+            panelId="drawer-panel"
+          />
+        </AddinHistoryFilterStoreContext.Provider>
+      );
+      const { rerender } = render(drawerAt(true));
+      act(() => {
+        vi.advanceTimersByTime(64);
+      });
+
+      fireEvent.click(screen.getByTestId("rename-c1"));
+      expect(screen.getByTestId("rename-dialog")).toBeInTheDocument();
+
+      rerender(drawerAt(false));
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      rerender(drawerAt(true));
+      act(() => {
+        vi.advanceTimersByTime(64);
+      });
+      expect(screen.queryByTestId("rename-dialog")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves the generated-title fallback to the rename dialog", () => {
+    renderDrawer();
+
+    fireEvent.click(screen.getByTestId("rename-c1"));
+
+    expect(spies.renameDialogProps.current?.isOpen).toBe(true);
+    expect(spies.renameDialogProps.current?.generatedTitle).toBe("");
+  });
+
+  it("shows the history skeleton while the first page loads", () => {
+    spies.chatContext.chats = [];
+    spies.chatContext.isLoading = true;
+    renderDrawer();
+
+    expect(screen.getByTestId("chat-history-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows an empty-state row when there are no chats at all", () => {
+    spies.chatContext.chats = [];
+    renderDrawer();
+
+    expect(
+      screen.getByTestId("addin-history-drawer-empty"),
+    ).toBeInTheDocument();
+  });
+
   it("says when active filters match nothing instead of showing an empty void", () => {
     spies.chatContext.chats = [];
     spies.filters = {
@@ -309,7 +467,8 @@ describe("AddinHistoryDrawerCore", () => {
     renderDrawer();
 
     expect(
-      screen.getByTestId("addin-history-drawer-empty"),
+      screen.getByTestId("chat-history-no-filter-matches"),
     ).toBeInTheDocument();
+    expect(screen.queryByTestId("addin-history-drawer-empty")).toBeNull();
   });
 });

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -1,0 +1,247 @@
+import { i18n } from "@lingui/core";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AddinHistoryDrawerCore } from "../AddinHistoryDrawerCore";
+import { AddinHistoryFilterStoreContext } from "../addinChatHistoryFilterStore";
+
+import type { ChatHistoryFilterStoreHook } from "@erato/frontend/library";
+import type { ReactNode } from "react";
+
+const spies = vi.hoisted(() => {
+  const filterMenuStore: { current: unknown } = { current: null };
+  return {
+    navigateToChat: vi.fn(),
+    createNewChat: vi.fn(async () => "temp"),
+    archiveChat: vi.fn(async () => undefined),
+    updateChatTitle: vi.fn(async () => undefined),
+    fetchNextHistoryPage: vi.fn(async () => undefined),
+    chatContext: {
+      chats: [] as { id: string }[],
+      isLoading: false,
+      currentChatId: null as string | null,
+      hasNextHistoryPage: false,
+      isFetchingNextHistoryPage: false,
+    },
+    filters: {
+      typeFilter: "all",
+      statusFilter: "active",
+      groupBy: "date",
+    },
+    historyListProps: [] as Array<{
+      sessions: { id: string }[];
+      hasMore?: boolean;
+      onLoadMore?: () => void;
+      onSessionSelect: (id: string) => void;
+      onSessionShare?: (id: string) => void;
+    }>,
+    filterMenuStore,
+    sharingEnabled: { current: true },
+  };
+});
+
+vi.mock("@erato/frontend/library", () => ({
+  Button: ({
+    icon: _icon,
+    ...props
+  }: Record<string, unknown> & { icon?: ReactNode }) => <button {...props} />,
+  ChatHistoryFilterMenu: ({ store }: { store: unknown }) => {
+    spies.filterMenuStore.current = store;
+    return <div data-testid="filter-menu" />;
+  },
+  ChatHistoryList: (props: (typeof spies.historyListProps)[number]) => {
+    spies.historyListProps.push(props);
+    return (
+      <div data-testid="history-list">
+        {props.sessions.map((session) => (
+          <button
+            key={session.id}
+            type="button"
+            data-testid={`row-${session.id}`}
+            onClick={() => props.onSessionSelect(session.id)}
+          />
+        ))}
+        {props.hasMore ? (
+          <button
+            type="button"
+            data-testid="load-more"
+            onClick={() => props.onLoadMore?.()}
+          />
+        ) : null}
+      </div>
+    );
+  },
+  ChatShareDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="share-dialog" /> : null,
+  CloseIcon: () => null,
+  EditChatTitleDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="rename-dialog" /> : null,
+  groupChatSessions: (sessions: { id: string }[]) =>
+    sessions.length === 0
+      ? []
+      : [
+          { key: "a", label: "Group A", sessions: sessions.slice(0, 1) },
+          { key: "b", label: "Group B", sessions: sessions.slice(1) },
+        ].filter((group) => group.sessions.length > 0),
+  hasActiveFilters: (values: { typeFilter: string; statusFilter: string }) =>
+    values.typeFilter !== "all" || values.statusFilter !== "active",
+  mapRecentChatToSession: (chat: { id: string }) => ({ id: chat.id }),
+  resolveChatAttentionStatus: () => null,
+  useAssistantsFeature: () => ({ enabled: true }),
+  useChatContext: () => ({
+    ...spies.chatContext,
+    navigateToChat: spies.navigateToChat,
+    createNewChat: spies.createNewChat,
+    archiveChat: spies.archiveChat,
+    updateChatTitle: spies.updateChatTitle,
+    fetchNextHistoryPage: spies.fetchNextHistoryPage,
+  }),
+  useChatSharingFeature: () => ({ enabled: spies.sharingEnabled.current }),
+  useConfirmationRegistryStore: (
+    selector: (state: {
+      pendingIdsByChatId: Record<string, string[]>;
+    }) => unknown,
+  ) => selector({ pendingIdsByChatId: {} }),
+  useGenerationStatusStore: (
+    selector: (state: { statusByChatId: Record<string, unknown> }) => unknown,
+  ) => selector({ statusByChatId: {} }),
+  useLingui: () => ({ i18n: { locale: "en" } }),
+  useSanitizedChatHistoryFilters: () => spies.filters,
+}));
+
+const fakeFilterStore = (() =>
+  undefined) as unknown as ChatHistoryFilterStoreHook;
+
+const renderDrawer = (
+  overrides: Partial<
+    Pick<
+      Parameters<typeof AddinHistoryDrawerCore>[0],
+      "isOpen" | "onClose" | "onOpenSettings"
+    >
+  > = {},
+) => {
+  const onClose = overrides.onClose ?? vi.fn();
+  const onOpenSettings = overrides.onOpenSettings ?? vi.fn();
+  const view = render(
+    <AddinHistoryFilterStoreContext.Provider value={fakeFilterStore}>
+      <AddinHistoryDrawerCore
+        isOpen={overrides.isOpen ?? true}
+        onClose={onClose}
+        onOpenSettings={onOpenSettings}
+        panelId="drawer-panel"
+      />
+    </AddinHistoryFilterStoreContext.Provider>,
+  );
+  return { onClose, onOpenSettings, ...view };
+};
+
+describe("AddinHistoryDrawerCore", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    i18n.activate("en");
+    vi.clearAllMocks();
+    spies.historyListProps.length = 0;
+    spies.filterMenuStore.current = null;
+    spies.sharingEnabled.current = true;
+    spies.chatContext.chats = [{ id: "c1" }, { id: "c2" }];
+    spies.chatContext.isLoading = false;
+    spies.chatContext.hasNextHistoryPage = false;
+    spies.filters = {
+      typeFilter: "all",
+      statusFilter: "active",
+      groupBy: "date",
+    };
+  });
+
+  it("renders nothing while closed", () => {
+    renderDrawer({ isOpen: false });
+    expect(screen.queryByTestId("addin-history-drawer")).toBeNull();
+  });
+
+  it("selects a row through the session path and closes", () => {
+    const { onClose } = renderDrawer();
+
+    fireEvent.click(screen.getByTestId("row-c1"));
+
+    expect(spies.navigateToChat).toHaveBeenCalledWith("c1");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("puts the pagination sentinel on the last group only", () => {
+    spies.chatContext.hasNextHistoryPage = true;
+    renderDrawer();
+
+    expect(spies.historyListProps).toHaveLength(2);
+    expect(spies.historyListProps[0]?.hasMore).toBe(false);
+    expect(spies.historyListProps[1]?.hasMore).toBe(true);
+
+    fireEvent.click(screen.getByTestId("load-more"));
+    expect(spies.fetchNextHistoryPage).toHaveBeenCalled();
+  });
+
+  it("closes on an element-scoped Escape", () => {
+    const { onClose } = renderDrawer();
+
+    fireEvent.keyDown(screen.getByTestId("addin-history-drawer"), {
+      key: "Escape",
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes only when the backdrop element itself is clicked", () => {
+    const { onClose } = renderDrawer();
+
+    fireEvent.click(screen.getByTestId("addin-history-drawer"));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("addin-history-drawer-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a new chat and closes", () => {
+    const { onClose } = renderDrawer();
+
+    fireEvent.click(screen.getByTestId("addin-history-drawer-new-chat"));
+
+    expect(spies.createNewChat).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("opens settings after closing itself", () => {
+    const { onClose, onOpenSettings } = renderDrawer();
+
+    fireEvent.click(screen.getByTestId("addin-history-drawer-settings"));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onOpenSettings).toHaveBeenCalled();
+  });
+
+  it("hands the platform's filter store to the filter menu", () => {
+    renderDrawer();
+    expect(spies.filterMenuStore.current).toBe(fakeFilterStore);
+  });
+
+  it("withholds the share action when sharing is disabled", () => {
+    spies.sharingEnabled.current = false;
+    renderDrawer();
+    expect(spies.historyListProps[0]?.onSessionShare).toBeUndefined();
+  });
+
+  it("says when active filters match nothing instead of showing an empty void", () => {
+    spies.chatContext.chats = [];
+    spies.filters = {
+      typeFilter: "assistant",
+      statusFilter: "active",
+      groupBy: "date",
+    };
+    renderDrawer();
+
+    expect(
+      screen.getByTestId("addin-history-drawer-empty"),
+    ).toBeInTheDocument();
+  });
+});

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -79,7 +79,14 @@ vi.mock("@erato/frontend/library", () => ({
   },
   ChatShareDialog: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="share-dialog" /> : null,
-  CloseIcon: () => null,
+  NewChatItem: ({ onNewChat }: { onNewChat?: () => void }) => (
+    <button
+      type="button"
+      data-testid="new-chat-item"
+      onClick={() => onNewChat?.()}
+    />
+  ),
+  SidebarToggleIcon: () => null,
   EditChatTitleDialog: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div data-testid="rename-dialog" /> : null,
   groupChatSessions: (sessions: { id: string }[]) =>
@@ -211,7 +218,7 @@ describe("AddinHistoryDrawerCore", () => {
   it("starts a new chat and closes", () => {
     const { onClose } = renderDrawer();
 
-    fireEvent.click(screen.getByTestId("addin-history-drawer-new-chat"));
+    fireEvent.click(screen.getByTestId("new-chat-item"));
 
     expect(spies.createNewChat).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -42,6 +42,7 @@ const spies = vi.hoisted(() => {
       onSessionSelect: (id: string) => void;
       onSessionEditTitle?: (id: string) => void;
       onSessionShare?: (id: string) => void;
+      disableRowLinks?: boolean;
     }>,
     renameDialogProps: {
       current: null as { isOpen: boolean; generatedTitle: string } | null,
@@ -218,6 +219,8 @@ describe("AddinHistoryDrawerCore", () => {
 
     expect(spies.navigateToChat).toHaveBeenCalledWith("c1");
     expect(onClose).toHaveBeenCalled();
+    // The pane has no tabs: rows must render without link escape hatches.
+    expect(spies.historyListProps[0]?.disableRowLinks).toBe(true);
   });
 
   it("puts the pagination sentinel on the last group only", () => {

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -23,9 +23,11 @@ const spies = vi.hoisted(() => {
     archiveChat: vi.fn(async () => undefined),
     updateChatTitle: vi.fn(async () => undefined),
     fetchNextHistoryPage: vi.fn(async () => undefined),
+    toastError: vi.fn(),
     chatContext: {
       chats: [] as { id: string }[],
       isLoading: false,
+      isHistoryLoading: false,
       currentChatId: null as string | null,
       hasNextHistoryPage: false,
       isFetchingNextHistoryPage: false,
@@ -40,12 +42,17 @@ const spies = vi.hoisted(() => {
       hasMore?: boolean;
       onLoadMore?: () => void;
       onSessionSelect: (id: string) => void;
+      onSessionArchive?: (id: string) => void;
       onSessionEditTitle?: (id: string) => void;
       onSessionShare?: (id: string) => void;
       disableRowLinks?: boolean;
     }>,
     renameDialogProps: {
-      current: null as { isOpen: boolean; generatedTitle: string } | null,
+      current: null as {
+        isOpen: boolean;
+        generatedTitle: string;
+        onSubmit?: (title: string) => Promise<void> | void;
+      } | null,
     },
     filterMenuStore,
     sharingEnabled: { current: true },
@@ -130,10 +137,15 @@ vi.mock("@erato/frontend/library", () => ({
     </button>
   ),
   SidebarToggleIcon: () => null,
-  EditChatTitleDialog: (props: { isOpen: boolean; generatedTitle: string }) => {
+  EditChatTitleDialog: (props: {
+    isOpen: boolean;
+    generatedTitle: string;
+    onSubmit?: (title: string) => Promise<void> | void;
+  }) => {
     spies.renameDialogProps.current = props;
     return props.isOpen ? <div data-testid="rename-dialog" /> : null;
   },
+  toast: { error: spies.toastError },
   hasActiveFilters: (values: { typeFilter: string; statusFilter: string }) =>
     values.typeFilter !== "all" || values.statusFilter !== "active",
   mapRecentChatToSession: (chat: { id: string }) => ({ id: chat.id }),
@@ -199,6 +211,7 @@ describe("AddinHistoryDrawerCore", () => {
     spies.sharingEnabled.current = true;
     spies.chatContext.chats = [{ id: "c1" }, { id: "c2" }];
     spies.chatContext.isLoading = false;
+    spies.chatContext.isHistoryLoading = false;
     spies.chatContext.hasNextHistoryPage = false;
     spies.filters = {
       typeFilter: "all",
@@ -446,9 +459,30 @@ describe("AddinHistoryDrawerCore", () => {
   it("shows the history skeleton while the first page loads", () => {
     spies.chatContext.chats = [];
     spies.chatContext.isLoading = true;
+    spies.chatContext.isHistoryLoading = true;
     renderDrawer();
 
     expect(screen.getByTestId("chat-history-skeleton")).toBeInTheDocument();
+  });
+
+  // The provider's composed isLoading also covers the open chat's messages
+  // fetch; a skeleton keyed on it would hide the filter row exactly when a
+  // narrowed filter matches nothing and needs widening.
+  it("keeps the no-matches row visible while only messages load", () => {
+    spies.chatContext.chats = [];
+    spies.chatContext.isLoading = true;
+    spies.chatContext.isHistoryLoading = false;
+    spies.filters = {
+      typeFilter: "assistant",
+      statusFilter: "active",
+      groupBy: "date",
+    };
+    renderDrawer();
+
+    expect(
+      screen.getByTestId("chat-history-no-filter-matches"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-history-skeleton")).toBeNull();
   });
 
   it("shows an empty-state row when there are no chats at all", () => {
@@ -458,6 +492,41 @@ describe("AddinHistoryDrawerCore", () => {
     expect(
       screen.getByTestId("addin-history-drawer-empty"),
     ).toBeInTheDocument();
+  });
+
+  // Streaming hands the drawer a fresh context value per chunk — mirrored
+  // here by the mocked useChatContext, which mints a new object on every
+  // call around stable member functions, exactly the provider's shape. The
+  // handlers reaching ChatHistoryList must key on those members, or every
+  // chunk would re-render every history row.
+  it("keeps list handler identities stable across context-identity churn", () => {
+    const onClose = vi.fn();
+    const drawer = () => (
+      <AddinHistoryFilterStoreContext.Provider value={fakeFilterStore}>
+        <AddinHistoryDrawerCore
+          isOpen={true}
+          onClose={onClose}
+          onOpenSettings={vi.fn()}
+          panelId="drawer-panel"
+        />
+      </AddinHistoryFilterStoreContext.Provider>
+    );
+    const { rerender } = render(drawer());
+    const firstPass = spies.historyListProps.slice();
+    expect(firstPass.length).toBeGreaterThan(0);
+    // The sentinel-carrying group must hold an actual handler to compare.
+    expect(firstPass.at(-1)?.onLoadMore).toBeTypeOf("function");
+
+    spies.historyListProps.length = 0;
+    rerender(drawer());
+    const secondPass = spies.historyListProps.slice();
+
+    expect(secondPass).toHaveLength(firstPass.length);
+    secondPass.forEach((props, index) => {
+      expect(props.onSessionSelect).toBe(firstPass[index]?.onSessionSelect);
+      expect(props.onSessionArchive).toBe(firstPass[index]?.onSessionArchive);
+      expect(props.onLoadMore).toBe(firstPass[index]?.onLoadMore);
+    });
   });
 
   it("says when active filters match nothing instead of showing an empty void", () => {
@@ -473,5 +542,31 @@ describe("AddinHistoryDrawerCore", () => {
       screen.getByTestId("chat-history-no-filter-matches"),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("addin-history-drawer-empty")).toBeNull();
+  });
+
+  // The archive mutation rolls the row back on failure, so without a toast
+  // the chat silently reappears — and the rejection would escape unhandled.
+  it("toasts when archiving fails", async () => {
+    spies.archiveChat.mockRejectedValueOnce(new Error("archive failed"));
+    renderDrawer();
+
+    await act(async () => {
+      spies.historyListProps[0]?.onSessionArchive?.("c1");
+    });
+
+    expect(spies.toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("toasts when renaming fails and keeps the dialog open for a retry", async () => {
+    spies.updateChatTitle.mockRejectedValueOnce(new Error("rename failed"));
+    renderDrawer();
+
+    fireEvent.click(screen.getByTestId("rename-c1"));
+    await act(async () => {
+      await spies.renameDialogProps.current?.onSubmit?.("New title");
+    });
+
+    expect(spies.toastError).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("rename-dialog")).toBeInTheDocument();
   });
 });

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -1,5 +1,11 @@
 import { i18n } from "@lingui/core";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AddinHistoryDrawerCore } from "../AddinHistoryDrawerCore";
@@ -229,6 +235,61 @@ describe("AddinHistoryDrawerCore", () => {
     spies.sharingEnabled.current = false;
     renderDrawer();
     expect(spies.historyListProps[0]?.onSessionShare).toBeUndefined();
+  });
+
+  it("mounts off-screen and slides in one frame later", () => {
+    vi.useFakeTimers();
+    try {
+      renderDrawer();
+
+      const panel = screen.getByTestId("addin-history-drawer");
+      expect(panel.className).toContain("-translate-x-full");
+
+      // Two animation frames flip the visual state so the slide has a
+      // painted start frame.
+      act(() => {
+        vi.advanceTimersByTime(64);
+      });
+      expect(panel.className).toContain(" translate-x-0");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stays mounted through the exit slide, then unmounts on the backstop", () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      const drawerAt = (isOpen: boolean) => (
+        <AddinHistoryFilterStoreContext.Provider value={fakeFilterStore}>
+          <AddinHistoryDrawerCore
+            isOpen={isOpen}
+            onClose={onClose}
+            onOpenSettings={vi.fn()}
+            panelId="drawer-panel"
+          />
+        </AddinHistoryFilterStoreContext.Provider>
+      );
+      const { rerender } = render(drawerAt(true));
+      act(() => {
+        vi.advanceTimersByTime(64);
+      });
+
+      rerender(drawerAt(false));
+      // Exit phase: still in the DOM, translated away, scrim click-through.
+      const panel = screen.getByTestId("addin-history-drawer");
+      expect(panel.className).toContain("-translate-x-full");
+      expect(
+        screen.getByTestId("addin-history-drawer-backdrop").className,
+      ).toContain("pointer-events-none");
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(screen.queryByTestId("addin-history-drawer")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("says when active filters match nothing instead of showing an empty void", () => {

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -152,6 +152,12 @@ vi.mock("@erato/frontend/library", async () => {
       useState(initialValue),
 
     ChatErrorBoundary: ({ children }: { children?: ReactNode }) => children,
+    Button: ({
+      icon: _icon,
+      ...props
+    }: Record<string, unknown> & { icon?: unknown; ref?: unknown }) => (
+      <button {...(props as Record<string, never>)} />
+    ),
     ChatInputControlsProvider: ({ children }: { children?: ReactNode }) =>
       children,
     ChatMessage: () => null,

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -45,16 +45,29 @@ const spies = vi.hoisted(() => ({
       composerLocked: false,
     }),
   ),
-  useInfiniteRecentChats: vi.fn(() => ({
-    chats: [],
-    isLoading: false,
-    error: null,
-    refetch: vi.fn(async () => undefined),
-    fetchNextPage: vi.fn(async () => undefined),
-    hasNextPage: false,
-    isFetchingNextPage: false,
-    queryKey: ["recent-chats"],
-  })),
+  refetchHistory: vi.fn(async () => undefined),
+  drawerProps: [] as Array<{
+    isOpen: boolean;
+    onClose: () => void;
+    onOpenSettings: () => void;
+  }>,
+  filterStoreState: {
+    typeFilter: "all",
+    statusFilter: "active",
+    groupBy: "date",
+  },
+  useInfiniteRecentChats: vi.fn(
+    (_options: { filters: { typeFilter: string; statusFilter: string } }) => ({
+      chats: [],
+      isLoading: false,
+      error: null,
+      refetch: spies.refetchHistory,
+      fetchNextPage: vi.fn(async () => undefined),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      queryKey: ["recent-chats"],
+    }),
+  ),
   useChatMessaging: vi.fn(() => ({
     messages: {},
     isLoading: false,
@@ -121,18 +134,19 @@ vi.mock("@erato/frontend/library", async () => {
       }),
     }),
     createChatHistoryFilterStore: () => {
-      const state = {
-        typeFilter: "all",
-        statusFilter: "active",
-        groupBy: "date",
+      // Reads through to the spies state on every call so tests can narrow a
+      // filter; the store instance itself is cached per platform across tests.
+      const readState = () => ({
+        ...spies.filterStoreState,
         setTypeFilter: vi.fn(),
         setStatusFilter: vi.fn(),
         setGroupBy: vi.fn(),
         resetToDefaults: vi.fn(),
-      };
+      });
       return Object.assign(
-        (selector: (s: typeof state) => unknown) => selector(state),
-        { getState: () => state },
+        (selector: (s: ReturnType<typeof readState>) => unknown) =>
+          selector(readState()),
+        { getState: readState },
       );
     },
     removeArchivedChatFromLists: vi.fn(async () => () => undefined),
@@ -244,8 +258,10 @@ vi.mock("@erato/frontend/library", async () => {
 });
 
 vi.mock("../AddinHistoryDrawerCore", () => ({
-  AddinHistoryDrawerCore: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid="addin-history-drawer" /> : null,
+  AddinHistoryDrawerCore: (props: (typeof spies.drawerProps)[number]) => {
+    spies.drawerProps.push(props);
+    return props.isOpen ? <div data-testid="addin-history-drawer" /> : null;
+  },
 }));
 vi.mock("../AddinChatInputCore", () => ({
   AddinChatInputCore: (
@@ -272,6 +288,16 @@ describe("NeutralAddinChatPage host boundary", () => {
   beforeEach(() => {
     i18n.activate("en");
     Reflect.deleteProperty(globalThis, "Office");
+    spies.drawerProps.length = 0;
+    spies.filterStoreState.typeFilter = "all";
+    spies.filterStoreState.statusFilter = "active";
+    spies.filterStoreState.groupBy = "date";
+    // vi.restoreAllMocks does not reach vi.fn mocks, so a per-test
+    // mockReturnValue would otherwise leak into later tests.
+    spies.useDelegatedRunHeader.mockImplementation(() => ({
+      header: null,
+      composerLocked: false,
+    }));
   });
 
   afterEach(() => {
@@ -351,6 +377,7 @@ describe("NeutralAddinChatPage host boundary", () => {
   });
 
   it("lists chats through the filtered infinite query, never opting into delegated runs", () => {
+    spies.useInfiniteRecentChats.mockClear();
     renderPage();
 
     // The filters carry no include_delegated: the shared params builder
@@ -358,6 +385,37 @@ describe("NeutralAddinChatPage host boundary", () => {
     expect(spies.useInfiniteRecentChats).toHaveBeenCalledWith({
       filters: { typeFilter: "all", statusFilter: "active" },
     });
+    // Every listing the provider mounts — the drawer history and the session
+    // listing — carries these defaults; none opts into anything wider.
+    for (const [options] of spies.useInfiniteRecentChats.mock.calls) {
+      expect(options.filters).toEqual({
+        typeFilter: "all",
+        statusFilter: "active",
+      });
+    }
+  });
+
+  // Only Outlook's session controller consumes the second (session) listing;
+  // on every other platform it must collapse onto the drawer's filters so
+  // both hooks share one query-cache entry instead of running a duplicate
+  // unfiltered request chain for nobody.
+  it("collapses the session listing onto the drawer filters when narrowed", () => {
+    spies.filterStoreState.typeFilter = "assistant";
+    spies.useInfiniteRecentChats.mockClear();
+
+    renderPage();
+
+    const filterArgs = spies.useInfiniteRecentChats.mock.calls.map(
+      ([options]) => options.filters,
+    );
+    // Two listings per render pass: drawer history + session listing.
+    expect(filterArgs.length).toBeGreaterThanOrEqual(2);
+    for (const filters of filterArgs) {
+      expect(filters).toEqual({
+        typeFilter: "assistant",
+        statusFilter: "active",
+      });
+    }
   });
 
   it("wires New Chat through the provider's context value", () => {
@@ -434,6 +492,44 @@ describe("NeutralAddinChatPage host boundary", () => {
     );
   });
 
+  // The drawer's row handlers key on its onClose identity; a fresh arrow
+  // from this call site would re-mint them all every page render.
+  it("hands the drawer identity-stable close and settings handlers", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const pageAt = () => (
+      <QueryClientProvider client={queryClient}>
+        <NeutralAddinChatPage />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(pageAt());
+    const first = spies.drawerProps.at(-1);
+    expect(first).toBeDefined();
+
+    rerender(pageAt());
+    const second = spies.drawerProps.at(-1);
+
+    // A fresh props object proves the drawer actually re-rendered.
+    expect(second).not.toBe(first);
+    expect(second?.onClose).toBe(first?.onClose);
+    expect(second?.onOpenSettings).toBe(first?.onOpenSettings);
+  });
+
+  // The messaging pipeline invalidates the recent-chats listings when the
+  // stream completes; sendMessage resolves already at dispatch, so a refetch
+  // chained onto it would land before the server lists the chat.
+  it("does not refetch history at dispatch time", async () => {
+    renderPage();
+
+    await act(async () => {
+      spies.inputProps.current?.onSendMessage("hello");
+    });
+
+    expect(spies.sendMessage).toHaveBeenCalled();
+    expect(spies.refetchHistory).not.toHaveBeenCalled();
+  });
+
   it("mirrors the open chat into the generation-status store", () => {
     renderPage();
     expect(spies.setGenerationCurrentChatId).toHaveBeenLastCalledWith(null);
@@ -457,6 +553,22 @@ describe("NeutralAddinChatPage host boundary", () => {
     expect(screen.getByTestId("neutral-chat-input")).toHaveAttribute(
       "data-disabled",
       "true",
+    );
+  });
+
+  // The floating drawer trigger is an opaque click-intercepting button over
+  // the top-left corner; without left clearance it sits on the run header's
+  // title whenever nothing renders above the header.
+  it("clears the delegated-run header past the floating drawer trigger", () => {
+    spies.useDelegatedRunHeader.mockReturnValue({
+      header: <div data-testid="neutral-run-banner" />,
+      composerLocked: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId("neutral-run-banner").parentElement).toHaveClass(
+      "pl-10",
     );
   });
 });

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -23,6 +23,7 @@ const spies = vi.hoisted(() => ({
   },
   clearNewlyCreatedChatId: vi.fn(),
   setGenerationCurrentChatId: vi.fn(),
+  updateChatTitle: vi.fn(async () => undefined),
   runOpenHandler: { current: null as ((chatId: string) => void) | null },
   chatContextValue: { current: null as ChatContextValue | null },
   sendMessage: vi.fn(async () => undefined),
@@ -135,15 +136,15 @@ vi.mock("@erato/frontend/library", async () => {
       );
     },
     removeArchivedChatFromLists: vi.fn(async () => () => undefined),
-    sanitizeChatHistoryFilters: (values: unknown) => values,
     seedGenerationStatusFromListing: vi.fn(),
     useAssistantsFeature: () => ({
       enabled: false,
       delegationEnabled: false,
       delegationAllowBackground: false,
     }),
+    useChatHistoryFilterFoldback: () => undefined,
     useInfiniteRecentChats: spies.useInfiniteRecentChats,
-    useUpdateChat: () => ({ mutateAsync: vi.fn(async () => undefined) }),
+    useUpdateChatTitle: () => spies.updateChatTitle,
     useMessagingStore: Object.assign(() => spies.messagingStore, {
       getState: () => spies.messagingStore,
     }),

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -180,7 +180,7 @@ vi.mock("@erato/frontend/library", async () => {
     ),
     useDelegatedRunHeader: spies.useDelegatedRunHeader,
     DocumentIcon: () => null,
-    DropdownMenu: () => null,
+    SidebarToggleIcon: () => null,
     FeedbackCommentDialog: () => null,
     FeedbackViewDialog: () => null,
     FilePreviewModal: () => null,
@@ -234,6 +234,10 @@ vi.mock("@erato/frontend/library", async () => {
   };
 });
 
+vi.mock("../AddinHistoryDrawerCore", () => ({
+  AddinHistoryDrawerCore: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="addin-history-drawer" /> : null,
+}));
 vi.mock("../AddinChatInputCore", () => ({
   AddinChatInputCore: (
     props: NonNullable<(typeof spies.inputProps)["current"]> & {

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -24,6 +24,7 @@ const spies = vi.hoisted(() => ({
   clearNewlyCreatedChatId: vi.fn(),
   setGenerationCurrentChatId: vi.fn(),
   runOpenHandler: { current: null as ((chatId: string) => void) | null },
+  chatContextValue: { current: null as ChatContextValue | null },
   sendMessage: vi.fn(async () => undefined),
   inputProps: {
     current: null as null | {
@@ -89,6 +90,7 @@ vi.mock("@erato/frontend/library", async () => {
       if (!context) {
         throw new Error("useChatContext must be used within a ChatProvider");
       }
+      spies.chatContextValue.current = context;
       return context;
     },
 
@@ -289,7 +291,9 @@ describe("NeutralAddinChatPage host boundary", () => {
 
     expect(renderPage).not.toThrow();
 
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("addin-history-drawer-trigger"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("neutral-message-list")).toBeInTheDocument();
     expect(screen.getByTestId("neutral-chat-input")).toBeInTheDocument();
     expect(
@@ -352,7 +356,11 @@ describe("NeutralAddinChatPage host boundary", () => {
   it("wires New Chat through the provider's context value", () => {
     renderPage();
 
-    fireEvent.click(screen.getByText("New Chat"));
+    // The header button is gone; New Chat now lives in the drawer, which
+    // reaches the same context action this drives directly.
+    act(() => {
+      void spies.chatContextValue.current?.createNewChat();
+    });
 
     expect(spies.messagingStore.abortActiveSSE).toHaveBeenCalled();
     expect(spies.messagingStore.clearUserMessages).toHaveBeenCalled();

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -43,11 +43,15 @@ const spies = vi.hoisted(() => ({
       composerLocked: false,
     }),
   ),
-  useRecentChats: vi.fn(() => ({
-    data: { chats: [] },
+  useInfiniteRecentChats: vi.fn(() => ({
+    chats: [],
     isLoading: false,
     error: null,
     refetch: vi.fn(async () => undefined),
+    fetchNextPage: vi.fn(async () => undefined),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    queryKey: ["recent-chats"],
   })),
   useChatMessaging: vi.fn(() => ({
     messages: {},
@@ -110,15 +114,40 @@ vi.mock("@erato/frontend/library", async () => {
     useGenerationStatusStore: Object.assign(vi.fn(), {
       getState: () => ({
         setCurrentChatId: spies.setGenerationCurrentChatId,
+        clearStatus: vi.fn(),
       }),
     }),
+    createChatHistoryFilterStore: () => {
+      const state = {
+        typeFilter: "all",
+        statusFilter: "active",
+        groupBy: "date",
+        setTypeFilter: vi.fn(),
+        setStatusFilter: vi.fn(),
+        setGroupBy: vi.fn(),
+        resetToDefaults: vi.fn(),
+      };
+      return Object.assign(
+        (selector: (s: typeof state) => unknown) => selector(state),
+        { getState: () => state },
+      );
+    },
+    removeArchivedChatFromLists: vi.fn(async () => () => undefined),
+    sanitizeChatHistoryFilters: (values: unknown) => values,
+    seedGenerationStatusFromListing: vi.fn(),
+    useAssistantsFeature: () => ({
+      enabled: false,
+      delegationEnabled: false,
+      delegationAllowBackground: false,
+    }),
+    useInfiniteRecentChats: spies.useInfiniteRecentChats,
+    useUpdateChat: () => ({ mutateAsync: vi.fn(async () => undefined) }),
     useMessagingStore: Object.assign(() => spies.messagingStore, {
       getState: () => spies.messagingStore,
     }),
     useModelHistory: () => ({ currentChatLastModel: null }),
     usePersistedState: <T,>(_key: string, initialValue: T) =>
       useState(initialValue),
-    useRecentChats: spies.useRecentChats,
 
     ChatErrorBoundary: ({ children }: { children?: ReactNode }) => children,
     ChatInputControlsProvider: ({ children }: { children?: ReactNode }) =>
@@ -306,13 +335,14 @@ describe("NeutralAddinChatPage host boundary", () => {
     consoleError.mockRestore();
   });
 
-  it("lists chats without opting into delegated runs", () => {
+  it("lists chats through the filtered infinite query, never opting into delegated runs", () => {
     renderPage();
 
-    expect(spies.useRecentChats).toHaveBeenCalled();
-    for (const call of spies.useRecentChats.mock.calls) {
-      expect(call).toEqual([{}]);
-    }
+    // The filters carry no include_delegated: the shared params builder
+    // (covered in frontend tests) never emits it from these values.
+    expect(spies.useInfiniteRecentChats).toHaveBeenCalledWith({
+      filters: { typeFilter: "all", statusFilter: "active" },
+    });
   });
 
   it("wires New Chat through the provider's context value", () => {

--- a/office-addin/src/core/__tests__/addinChatHistoryFilterStore.test.ts
+++ b/office-addin/src/core/__tests__/addinChatHistoryFilterStore.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getAddinChatHistoryFilterStore } from "../addinChatHistoryFilterStore";
+
+describe("getAddinChatHistoryFilterStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("caches one store per platform under a platform-scoped key", () => {
+    const outlook = getAddinChatHistoryFilterStore("outlook");
+    expect(getAddinChatHistoryFilterStore("outlook")).toBe(outlook);
+
+    const teams = getAddinChatHistoryFilterStore("teams");
+    expect(teams).not.toBe(outlook);
+
+    outlook.getState().setStatusFilter("all");
+    expect(teams.getState().statusFilter).toBe("active");
+    expect(
+      localStorage.getItem("erato.addin.outlook.chatHistoryFilters.v1"),
+    ).not.toBeNull();
+    expect(
+      localStorage.getItem("erato.addin.teams.chatHistoryFilters.v1"),
+    ).toBeNull();
+  });
+
+  it("never writes the web sidebar's un-prefixed key", () => {
+    const store = getAddinChatHistoryFilterStore("addin-neutral");
+    store.getState().setGroupBy("none");
+
+    expect(localStorage.getItem("erato.sidebar.chatHistoryFilters")).toBeNull();
+    expect(
+      localStorage.getItem("erato.addin.addin-neutral.chatHistoryFilters.v1"),
+    ).not.toBeNull();
+  });
+});

--- a/office-addin/src/core/addinChatHistoryFilterStore.ts
+++ b/office-addin/src/core/addinChatHistoryFilterStore.ts
@@ -1,0 +1,44 @@
+import {
+  createChatHistoryFilterStore,
+  type ChatHistoryFilterStoreHook,
+} from "@erato/frontend/library";
+import { createContext, useContext } from "react";
+
+const storesByPlatform = new Map<string, ChatHistoryFilterStoreHook>();
+
+/**
+ * Per-platform filter store: each host keeps its own persisted filters, so a
+ * filter set in one surface (or the web sidebar, which owns the un-prefixed
+ * key) can never silently shrink another host's list. Cached per platform so
+ * every resolver gets the same instance.
+ */
+export function getAddinChatHistoryFilterStore(
+  platform: string,
+): ChatHistoryFilterStoreHook {
+  let store = storesByPlatform.get(platform);
+  if (!store) {
+    store = createChatHistoryFilterStore(
+      `erato.addin.${platform}.chatHistoryFilters.v1`,
+    );
+    storesByPlatform.set(platform, store);
+  }
+  return store;
+}
+
+/**
+ * The mounted provider's filter store, carried by context so consumers (the
+ * history drawer's filter menu) never have to agree with the provider on a
+ * platform string.
+ */
+export const AddinHistoryFilterStoreContext =
+  createContext<ChatHistoryFilterStoreHook | null>(null);
+
+export function useAddinHistoryFilterStore(): ChatHistoryFilterStoreHook {
+  const store = useContext(AddinHistoryFilterStoreContext);
+  if (!store) {
+    throw new Error(
+      "useAddinHistoryFilterStore must be used within AddinChatProviderCore",
+    );
+  }
+  return store;
+}

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -203,6 +203,7 @@ msgstr "Zum Hochladen ablegen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Neuer Chat"
 
@@ -537,9 +538,39 @@ msgid "officeAddin.fileSource.updatingThread"
 msgstr "Wird aktualisiert…"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Einstellungen"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.chats"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.noMatches"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinChatCore.tsx
+msgid "officeAddin.historyDrawer.open"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.rename.generated.fallback"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -551,6 +551,11 @@ msgstr "Einstellungen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.archiveFailed"
+msgstr "Chat konnte nicht archiviert werden"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.chats"
 #~ msgstr "Chats"
 
@@ -578,6 +583,11 @@ msgstr "Menü öffnen"
 #: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
 #~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.renameFailed"
+msgstr "Chat konnte nicht umbenannt werden"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -203,8 +203,8 @@ msgstr "Zum Hochladen ablegen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.chat.newChat"
-msgstr "Neuer Chat"
+#~ msgid "officeAddin.chat.newChat"
+#~ msgstr "Neuer Chat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -202,7 +202,6 @@ msgid "officeAddin.chat.fileDrop.overlay.label"
 msgstr "Zum Hochladen ablegen"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Neuer Chat"

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -17,6 +17,14 @@ msgstr ""
 # Explicit IDs
 # ==============================
 #. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "chat.history.recent"
+msgstr ""
+
+# ==============================
+# Explicit IDs
+# ==============================
+#. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoAppointmentRenderer.tsx
 msgid "officeAddin.appointmentRenderer.alwaysAllowLocked"
 msgstr "Ihre Organisation verlangt jedes Mal eine Bestätigung, wenn diese Aktion automatisch ausgeführt wird."
@@ -543,33 +551,38 @@ msgstr "Einstellungen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.chats"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.chats"
+#~ msgstr "Chats"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.close"
-msgstr ""
+msgstr "Menü schließen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.noMatches"
-msgstr ""
+msgid "officeAddin.historyDrawer.empty"
+msgstr "Noch keine Chats"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+#~ msgid "officeAddin.historyDrawer.noMatches"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.historyDrawer.open"
-msgstr ""
+msgstr "Menü öffnen"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.rename.generated.fallback"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.title"
-msgstr ""
+msgstr "Menü"
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -551,6 +551,11 @@ msgstr "Settings"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.archiveFailed"
+msgstr "Couldn't archive the chat"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.chats"
 #~ msgstr "Chats"
 
@@ -578,6 +583,11 @@ msgstr "Open menu"
 #: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
 #~ msgstr "Untitled Chat"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.renameFailed"
+msgstr "Couldn't rename the chat"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -17,6 +17,14 @@ msgstr ""
 # Explicit IDs
 # ==============================
 #. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "chat.history.recent"
+msgstr "Recent"
+
+# ==============================
+# Explicit IDs
+# ==============================
+#. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoAppointmentRenderer.tsx
 msgid "officeAddin.appointmentRenderer.alwaysAllowLocked"
 msgstr "Your organization requires confirmation each time this action runs automatically."
@@ -543,8 +551,8 @@ msgstr "Settings"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.chats"
-msgstr "Chats"
+#~ msgid "officeAddin.historyDrawer.chats"
+#~ msgstr "Chats"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
@@ -553,8 +561,13 @@ msgstr "Close menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.noMatches"
-msgstr "No chats match the current filters"
+msgid "officeAddin.historyDrawer.empty"
+msgstr "No chats yet"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+#~ msgid "officeAddin.historyDrawer.noMatches"
+#~ msgstr "No chats match the current filters"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
@@ -563,8 +576,8 @@ msgstr "Open menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.rename.generated.fallback"
-msgstr "Untitled Chat"
+#~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
+#~ msgstr "Untitled Chat"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -203,8 +203,8 @@ msgstr "Drop to upload"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.chat.newChat"
-msgstr "New Chat"
+#~ msgid "officeAddin.chat.newChat"
+#~ msgstr "New Chat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -203,6 +203,7 @@ msgstr "Drop to upload"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "New Chat"
 
@@ -537,9 +538,39 @@ msgid "officeAddin.fileSource.updatingThread"
 msgstr "Updating…"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Settings"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.chats"
+msgstr "Chats"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.close"
+msgstr "Close menu"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.noMatches"
+msgstr "No chats match the current filters"
+
+#. js-lingui-explicit-id
+#: src/core/AddinChatCore.tsx
+msgid "officeAddin.historyDrawer.open"
+msgstr "Open menu"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.rename.generated.fallback"
+msgstr "Untitled Chat"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.title"
+msgstr "Menu"
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -202,7 +202,6 @@ msgid "officeAddin.chat.fileDrop.overlay.label"
 msgstr "Drop to upload"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "New Chat"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -17,6 +17,14 @@ msgstr ""
 # Explicit IDs
 # ==============================
 #. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "chat.history.recent"
+msgstr ""
+
+# ==============================
+# Explicit IDs
+# ==============================
+#. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoAppointmentRenderer.tsx
 msgid "officeAddin.appointmentRenderer.alwaysAllowLocked"
 msgstr "Su organización requiere confirmación cada vez que esta acción se ejecuta automáticamente."
@@ -543,33 +551,38 @@ msgstr "Configuración"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.chats"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.chats"
+#~ msgstr "Chats"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.close"
-msgstr ""
+msgstr "Cerrar menú"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.noMatches"
-msgstr ""
+msgid "officeAddin.historyDrawer.empty"
+msgstr "Todavía no hay chats"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+#~ msgid "officeAddin.historyDrawer.noMatches"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.historyDrawer.open"
-msgstr ""
+msgstr "Abrir menú"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.rename.generated.fallback"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.title"
-msgstr ""
+msgstr "Menú"
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -202,7 +202,6 @@ msgid "officeAddin.chat.fileDrop.overlay.label"
 msgstr "Suelta para subir"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nuevo chat"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -203,6 +203,7 @@ msgstr "Suelta para subir"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nuevo chat"
 
@@ -537,9 +538,39 @@ msgid "officeAddin.fileSource.updatingThread"
 msgstr "Actualizando…"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Configuración"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.chats"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.noMatches"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinChatCore.tsx
+msgid "officeAddin.historyDrawer.open"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.rename.generated.fallback"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -203,8 +203,8 @@ msgstr "Suelta para subir"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.chat.newChat"
-msgstr "Nuevo chat"
+#~ msgid "officeAddin.chat.newChat"
+#~ msgstr "Nuevo chat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -551,6 +551,11 @@ msgstr "Configuración"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.archiveFailed"
+msgstr "No se pudo archivar el chat"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.chats"
 #~ msgstr "Chats"
 
@@ -578,6 +583,11 @@ msgstr "Abrir menú"
 #: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
 #~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.renameFailed"
+msgstr "No se pudo cambiar el nombre del chat"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -203,6 +203,7 @@ msgstr "Déposez pour téléverser"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nouveau chat"
 
@@ -537,9 +538,39 @@ msgid "officeAddin.fileSource.updatingThread"
 msgstr "Mise à jour…"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Paramètres"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.chats"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.noMatches"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinChatCore.tsx
+msgid "officeAddin.historyDrawer.open"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.rename.generated.fallback"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -203,8 +203,8 @@ msgstr "Déposez pour téléverser"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.chat.newChat"
-msgstr "Nouveau chat"
+#~ msgid "officeAddin.chat.newChat"
+#~ msgstr "Nouveau chat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -17,6 +17,14 @@ msgstr ""
 # Explicit IDs
 # ==============================
 #. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "chat.history.recent"
+msgstr ""
+
+# ==============================
+# Explicit IDs
+# ==============================
+#. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoAppointmentRenderer.tsx
 msgid "officeAddin.appointmentRenderer.alwaysAllowLocked"
 msgstr "Votre organisation exige une confirmation chaque fois que cette action s'exécute automatiquement."
@@ -543,33 +551,38 @@ msgstr "Paramètres"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.chats"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.chats"
+#~ msgstr "Discussions"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.close"
-msgstr ""
+msgstr "Fermer le menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.noMatches"
-msgstr ""
+msgid "officeAddin.historyDrawer.empty"
+msgstr "Aucune discussion pour le moment"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+#~ msgid "officeAddin.historyDrawer.noMatches"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.historyDrawer.open"
-msgstr ""
+msgstr "Ouvrir le menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.rename.generated.fallback"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.title"
-msgstr ""
+msgstr "Menu"
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -551,6 +551,11 @@ msgstr "Paramètres"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.archiveFailed"
+msgstr "Impossible d'archiver la discussion"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.chats"
 #~ msgstr "Discussions"
 
@@ -578,6 +583,11 @@ msgstr "Ouvrir le menu"
 #: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
 #~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.renameFailed"
+msgstr "Impossible de renommer la discussion"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -202,7 +202,6 @@ msgid "officeAddin.chat.fileDrop.overlay.label"
 msgstr "Déposez pour téléverser"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nouveau chat"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -203,6 +203,7 @@ msgstr "Upuść, aby przesłać"
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nowy czat"
 
@@ -537,9 +538,39 @@ msgid "officeAddin.fileSource.updatingThread"
 msgstr "Aktualizowanie…"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
+#: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.headerMenu.settings"
 msgstr "Ustawienia"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.chats"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.close"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.noMatches"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinChatCore.tsx
+msgid "officeAddin.historyDrawer.open"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.rename.generated.fallback"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.title"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -17,6 +17,14 @@ msgstr ""
 # Explicit IDs
 # ==============================
 #. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "chat.history.recent"
+msgstr ""
+
+# ==============================
+# Explicit IDs
+# ==============================
+#. js-lingui-explicit-id
 #: src/outlook/components/OutlookEratoAppointmentRenderer.tsx
 msgid "officeAddin.appointmentRenderer.alwaysAllowLocked"
 msgstr "Twoja organizacja wymaga potwierdzenia za każdym razem, gdy ta akcja jest wykonywana automatycznie."
@@ -543,33 +551,38 @@ msgstr "Ustawienia"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.chats"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.chats"
+#~ msgstr "Czaty"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.close"
-msgstr ""
+msgstr "Zamknij menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.noMatches"
-msgstr ""
+msgid "officeAddin.historyDrawer.empty"
+msgstr "Brak czatów"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+#~ msgid "officeAddin.historyDrawer.noMatches"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinChatCore.tsx
 msgid "officeAddin.historyDrawer.open"
-msgstr ""
+msgstr "Otwórz menu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.historyDrawer.rename.generated.fallback"
-msgstr ""
+#~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.historyDrawer.title"
-msgstr ""
+msgstr "Menu"
 
 #. js-lingui-explicit-id
 #: src/providers/OfficeProvider.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -203,8 +203,8 @@ msgstr "Upuść, aby przesłać"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
-msgid "officeAddin.chat.newChat"
-msgstr "Nowy czat"
+#~ msgid "officeAddin.chat.newChat"
+#~ msgstr "Nowy czat"
 
 #. js-lingui-explicit-id
 #: src/outlook/components/AddinChatInput.tsx

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -202,7 +202,6 @@ msgid "officeAddin.chat.fileDrop.overlay.label"
 msgstr "Upuść, aby przesłać"
 
 #. js-lingui-explicit-id
-#: src/core/AddinChatCore.tsx
 #: src/core/AddinHistoryDrawerCore.tsx
 msgid "officeAddin.chat.newChat"
 msgstr "Nowy czat"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -551,6 +551,11 @@ msgstr "Ustawienia"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.archiveFailed"
+msgstr "Nie udało się zarchiwizować czatu"
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.chats"
 #~ msgstr "Czaty"
 
@@ -578,6 +583,11 @@ msgstr "Otwórz menu"
 #: src/core/AddinHistoryDrawerCore.tsx
 #~ msgid "officeAddin.historyDrawer.rename.generated.fallback"
 #~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/core/AddinHistoryDrawerCore.tsx
+msgid "officeAddin.historyDrawer.renameFailed"
+msgstr "Nie udało się zmienić nazwy czatu"
 
 #. js-lingui-explicit-id
 #: src/core/AddinHistoryDrawerCore.tsx

--- a/office-addin/src/outlook/OutlookAddinChat.tsx
+++ b/office-addin/src/outlook/OutlookAddinChat.tsx
@@ -23,6 +23,7 @@ import { useOutlookMessageFetcher } from "./hooks/useOutlookMessageFetcher";
 import { useOffice } from "../providers/OfficeProvider";
 import { useOutlookEmailSource } from "./providers/OutlookEmailSourceProvider";
 import { useOutlookMailItem } from "./providers/OutlookMailItemProvider";
+import { holdSessionPolicy, releaseSessionPolicy } from "./sessionPolicy";
 import { resolveEditExchangeItemIdentity } from "./utils/exchangeItemIdentity";
 import { FreshCompletionTracker } from "./utils/freshCompletionTracker";
 import {
@@ -64,6 +65,16 @@ export function OutlookAddinChat({
 function OutlookAddinChatHost({ controller }: AddinChatHostProps) {
   useOutlookClientTools();
   const { chatInputControls, uploadFiles } = controller;
+
+  // While the history drawer is open, mail-item switches must not interleave
+  // a session toast underneath it; the gate defers the anchor policy until
+  // the drawer closes (or this host unmounts).
+  const isHistoryMenuOpen = controller.isHistoryMenuOpen;
+  useEffect(() => {
+    if (!isHistoryMenuOpen) return;
+    holdSessionPolicy();
+    return () => releaseSessionPolicy();
+  }, [isHistoryMenuOpen]);
   const lastSchedulingSignalAt = useMemo(
     () =>
       newestSchedulingSignalAt(

--- a/office-addin/src/outlook/OutlookAddinChat.tsx
+++ b/office-addin/src/outlook/OutlookAddinChat.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddinChatInput } from "./components/AddinChatInput";
 import { AddinPinHintBanner } from "./components/AddinPinHintBanner";
 import { AddinSettingsDialog } from "./components/AddinSettingsDialog";
+import { dismissSessionToasts } from "./components/sessionAskToast";
 import {
   AddinChatCore,
   AddinChatCoreView,
@@ -73,6 +74,11 @@ function OutlookAddinChatHost({ controller }: AddinChatHostProps) {
   useEffect(() => {
     if (!isHistoryMenuOpen) return;
     holdSessionPolicy();
+    // A pending ask toast would float interactive above the modal drawer yet
+    // sit outside its focus trap, and the drawer subsumes its choices anyway.
+    // Dismissing is safe: closing without picking releases the gate, which
+    // re-evaluates the anchor policy and re-shows a still-unanswered ask.
+    dismissSessionToasts();
     return () => releaseSessionPolicy();
   }, [isHistoryMenuOpen]);
   const lastSchedulingSignalAt = useMemo(

--- a/office-addin/src/outlook/OutlookAddinSessionController.tsx
+++ b/office-addin/src/outlook/OutlookAddinSessionController.tsx
@@ -3,7 +3,13 @@ import {
   useMessagingStore,
   usePersistedState,
 } from "@erato/frontend/library";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import {
   dismissSessionToasts,
@@ -16,11 +22,13 @@ import {
   OUTLOOK_SESSION_KEY,
   OUTLOOK_SESSION_PREFERENCES_KEY,
   anchorsEqualForPreferences,
+  isSessionPolicyHeld,
   migrateLegacyChatIdKey,
   outlookAnchorFromItem,
   outlookSessionPersistedOptions,
   outlookSessionPreferencesPersistedOptions,
   resolveSupportedMailboxItem,
+  subscribeSessionPolicyGate,
   type OutlookSessionAnchor,
   type OutlookSessionStorageValue,
 } from "./sessionPolicy";
@@ -119,6 +127,8 @@ export function OutlookAddinSessionController({
     clearNewlyCreatedChatIdRef.current();
   }, []);
   const beginNewChat = useCallback(() => {
+    // An explicit decision answers whatever a pending ask toast was asking.
+    dismissSessionToasts();
     setNewChatCounter((value) => value + 1);
     setCurrentChatId(null, currentAnchor);
   }, [currentAnchor, setCurrentChatId]);
@@ -127,8 +137,16 @@ export function OutlookAddinSessionController({
     resetMessaging();
   }, [beginNewChat, resetMessaging]);
   const selectChat = useCallback(
-    (chatId: string) => setCurrentChatId(chatId, currentAnchor),
+    (chatId: string) => {
+      dismissSessionToasts();
+      setCurrentChatId(chatId, currentAnchor);
+    },
     [currentAnchor, setCurrentChatId],
+  );
+
+  const isPolicyHeld = useSyncExternalStore(
+    subscribeSessionPolicyGate,
+    isSessionPolicyHeld,
   );
 
   const lastEvaluatedAnchorRef = useRef<OutlookSessionAnchor | null | "unset">(
@@ -145,6 +163,12 @@ export function OutlookAddinSessionController({
 
   useEffect(() => {
     if (currentAnchor === null) return;
+    // Deferred, not interleaved: while the drawer holds the gate, anchor
+    // changes wait — before the anchor ref moves and before any toast is
+    // touched. Intermediate flickers collapse for free, release re-evaluates
+    // exactly once, and a pick made during the hold has already re-anchored,
+    // so the deferred evaluation resolves silently.
+    if (isPolicyHeld) return;
     const previousAnchor = lastEvaluatedAnchorRef.current;
     const trigger =
       previousAnchor === "unset"
@@ -216,6 +240,7 @@ export function OutlookAddinSessionController({
     );
   }, [
     currentAnchor,
+    isPolicyHeld,
     resetMessaging,
     sessionPreferences,
     setCurrentChatId,

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -162,7 +162,9 @@ describe("AddinChat without any Graph provider mounted (Exchange SE / unsupporte
   it("renders instead of throwing 'Graph auth is not available on this host'", () => {
     expect(() => renderWithoutGraphProvider(<AddinChat />)).not.toThrow();
 
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("addin-history-drawer-trigger"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("addin-chat-input")).toBeInTheDocument();
   });
 
@@ -175,7 +177,9 @@ describe("AddinChat without any Graph provider mounted (Exchange SE / unsupporte
       ),
     ).not.toThrow();
 
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("addin-history-drawer-trigger"),
+    ).toBeInTheDocument();
   });
 
   // With no backend a dropped `.msg` could never be resolved (parseMsgFile

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -57,7 +57,7 @@ vi.mock("@erato/frontend/library", () => ({
   DelegatedRunsSection: () => null,
   useDelegatedRunHeader: () => ({ header: null, composerLocked: false }),
   DocumentIcon: () => null,
-  DropdownMenu: () => null,
+  SidebarToggleIcon: () => null,
   FeedbackCommentDialog: () => null,
   FeedbackViewDialog: () => null,
   FilePreviewModal: () => null,
@@ -144,6 +144,10 @@ function renderWithoutGraphProvider(children: ReactNode) {
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
   );
 }
+
+vi.mock("../../core/AddinHistoryDrawerCore", () => ({
+  AddinHistoryDrawerCore: () => null,
+}));
 
 describe("AddinChat without any Graph provider mounted (Exchange SE / unsupported hosts)", () => {
   beforeEach(() => {

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -1,6 +1,6 @@
 import { i18n } from "@lingui/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OutlookAddinChat as AddinChat } from "../OutlookAddinChat";
@@ -23,15 +23,23 @@ import type { ReactNode } from "react";
 
 // Hoisted so the dropzone stub can record the options AddinChat passes —
 // the `.msg` advertising test below asserts on `extraAcceptMimeTypes`.
-const { useConversationDropzoneMock } = vi.hoisted(() => ({
-  useConversationDropzoneMock: vi.fn(
-    (_options: { extraAcceptMimeTypes?: Record<string, string[]> }) => ({
-      getRootProps: () => ({}),
-      getInputProps: () => ({}),
-      isDragActive: false,
-      isDragAccept: false,
-    }),
-  ),
+const { useConversationDropzoneMock, dismissSessionToastsMock } = vi.hoisted(
+  () => ({
+    useConversationDropzoneMock: vi.fn(
+      (_options: { extraAcceptMimeTypes?: Record<string, string[]> }) => ({
+        getRootProps: () => ({}),
+        getInputProps: () => ({}),
+        isDragActive: false,
+        isDragAccept: false,
+      }),
+    ),
+    dismissSessionToastsMock: vi.fn(),
+  }),
+);
+
+vi.mock("../components/sessionAskToast", () => ({
+  dismissSessionToasts: dismissSessionToastsMock,
+  showSessionAskToast: vi.fn(),
 }));
 
 vi.mock("@erato/frontend/library", () => ({
@@ -200,5 +208,19 @@ describe("AddinChat without any Graph provider mounted (Exchange SE / unsupporte
     expect(dropzoneOptions?.extraAcceptMimeTypes).toEqual({
       "message/rfc822": [".eml"],
     });
+  });
+
+  // A pending ask toast floats interactive above the aria-modal drawer but
+  // outside its focus trap, and the drawer subsumes the toast's choices.
+  // Closing without picking releases the policy gate, whose re-evaluation
+  // re-shows a still-unanswered ask (covered in the session-controller
+  // tests), so dismissing here loses nothing.
+  it("dismisses pending session toasts when the history drawer opens", () => {
+    renderWithoutGraphProvider(<AddinChat />);
+    expect(dismissSessionToastsMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("addin-history-drawer-trigger"));
+
+    expect(dismissSessionToastsMock).toHaveBeenCalled();
   });
 });

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -48,6 +48,12 @@ vi.mock("@erato/frontend/library", () => ({
   },
   // AddinChat's own imports.
   ChatErrorBoundary: ({ children }: { children?: ReactNode }) => children,
+  Button: ({
+    icon: _icon,
+    ...props
+  }: Record<string, unknown> & { icon?: unknown; ref?: unknown }) => (
+    <button {...(props as Record<string, never>)} />
+  ),
   ChatInputControlsProvider: ({ children }: { children?: ReactNode }) =>
     children,
   ChatMessage: () => null,

--- a/office-addin/src/outlook/__tests__/OutlookAddinSessionController.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinSessionController.test.tsx
@@ -1,0 +1,128 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OutlookAddinSessionController } from "../OutlookAddinSessionController";
+import {
+  holdSessionPolicy,
+  isSessionPolicyHeld,
+  releaseSessionPolicy,
+} from "../sessionPolicy";
+
+import type { AddinSessionController } from "../../core/AddinChatProviderCore";
+
+const spies = vi.hoisted(() => ({
+  selectAction: vi.fn(),
+  showToast: vi.fn(),
+  dismissToasts: vi.fn(),
+  anchor: { current: null as { itemKey: string } | null },
+}));
+
+vi.mock("@erato/frontend/library", async () => {
+  const { useState } = await import("react");
+  return {
+    selectAddinSessionAction: spies.selectAction,
+    useMessagingStore: Object.assign(() => ({}), {
+      getState: () => ({
+        abortActiveSSE: vi.fn(),
+        clearUserMessages: vi.fn(),
+        resetStreaming: vi.fn(),
+      }),
+    }),
+    usePersistedState: <T,>(_key: string, initialValue: T) =>
+      useState(initialValue),
+  };
+});
+
+vi.mock("../components/sessionAskToast", () => ({
+  showSessionAskToast: spies.showToast,
+  dismissSessionToasts: spies.dismissToasts,
+}));
+
+vi.mock("../hooks/useOutlookSessionAnchor", () => ({
+  useOutlookSessionAnchor: () => spies.anchor.current,
+}));
+
+const ANCHOR_A = { itemKey: "mail-a" };
+const ANCHOR_B = { itemKey: "mail-b" };
+const ANCHOR_C = { itemKey: "mail-c" };
+
+const captured: { current: AddinSessionController | null } = { current: null };
+
+function Harness({ anchor }: { anchor: { itemKey: string } | null }) {
+  spies.anchor.current = anchor;
+  return (
+    <OutlookAddinSessionController chats={[]}>
+      {(controller) => {
+        captured.current = controller;
+        return null;
+      }}
+    </OutlookAddinSessionController>
+  );
+}
+
+describe("OutlookAddinSessionController policy gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.current = null;
+    spies.anchor.current = null;
+    spies.selectAction.mockReturnValue({ kind: "ask", suggestedChatId: null });
+    while (isSessionPolicyHeld()) {
+      releaseSessionPolicy();
+    }
+  });
+
+  it("defers anchor changes while held and evaluates exactly once on release", () => {
+    const { rerender } = render(<Harness anchor={ANCHOR_A} />);
+    expect(spies.selectAction).toHaveBeenCalledTimes(1);
+
+    act(() => holdSessionPolicy());
+    rerender(<Harness anchor={ANCHOR_B} />);
+    rerender(<Harness anchor={ANCHOR_C} />);
+    // Intermediate flickers collapse: nothing was evaluated during the hold.
+    expect(spies.selectAction).toHaveBeenCalledTimes(1);
+
+    act(() => releaseSessionPolicy());
+    expect(spies.selectAction).toHaveBeenCalledTimes(2);
+    // The deferred evaluation sees the pre-hold anchor as `previous`: the
+    // ref never moved while the gate was held.
+    expect(spies.selectAction.mock.calls[1]?.[0]).toMatchObject({
+      trigger: {
+        kind: "context-change",
+        previous: ANCHOR_A,
+        next: ANCHOR_C,
+      },
+      currentAnchor: ANCHOR_C,
+    });
+  });
+
+  it("lets an explicit pick during the hold win silently", () => {
+    const { rerender } = render(<Harness anchor={ANCHOR_A} />);
+    expect(spies.showToast).toHaveBeenCalledTimes(1);
+
+    act(() => holdSessionPolicy());
+    rerender(<Harness anchor={ANCHOR_B} />);
+    act(() => captured.current?.selectChat("chat-9"));
+    expect(spies.dismissToasts).toHaveBeenCalled();
+
+    // The pick re-anchored the saved session, so the deferred evaluation
+    // resolves as a same-context resume — no second toast.
+    spies.selectAction.mockReturnValue({ kind: "resume", chatId: "chat-9" });
+    act(() => releaseSessionPolicy());
+
+    expect(spies.showToast).toHaveBeenCalledTimes(1);
+    expect(spies.selectAction.mock.calls.at(-1)?.[0]).toMatchObject({
+      saved: { chatId: "chat-9", anchor: ANCHOR_B },
+    });
+  });
+
+  it("dismisses pending session toasts on any explicit decision", () => {
+    render(<Harness anchor={ANCHOR_A} />);
+    spies.dismissToasts.mockClear();
+
+    act(() => captured.current?.selectChat("chat-1"));
+    expect(spies.dismissToasts).toHaveBeenCalledTimes(1);
+
+    act(() => captured.current?.beginNewChat());
+    expect(spies.dismissToasts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/office-addin/src/outlook/__tests__/OutlookAddinSessionController.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinSessionController.test.tsx
@@ -1,5 +1,5 @@
-import { act, render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OutlookAddinSessionController } from "../OutlookAddinSessionController";
 import {
@@ -61,6 +61,12 @@ function Harness({ anchor }: { anchor: { itemKey: string } | null }) {
 }
 
 describe("OutlookAddinSessionController policy gate", () => {
+  // Without cleanup, harnesses from earlier tests stay mounted and
+  // re-evaluate the policy whenever the shared gate notifies.
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     captured.current = null;
@@ -124,5 +130,18 @@ describe("OutlookAddinSessionController policy gate", () => {
 
     act(() => captured.current?.beginNewChat());
     expect(spies.dismissToasts).toHaveBeenCalledTimes(2);
+  });
+
+  // The drawer dismisses a pending ask toast the moment it opens. That is
+  // only safe because a hold released with an unchanged anchor and no pick
+  // re-evaluates the policy, which shows the still-unanswered ask again.
+  it("re-shows a still-unanswered ask after a hold with an unchanged anchor", () => {
+    render(<Harness anchor={ANCHOR_A} />);
+    expect(spies.showToast).toHaveBeenCalledTimes(1);
+
+    act(() => holdSessionPolicy());
+    act(() => releaseSessionPolicy());
+
+    expect(spies.showToast).toHaveBeenCalledTimes(2);
   });
 });

--- a/office-addin/src/outlook/components/AddinPinHintBanner.tsx
+++ b/office-addin/src/outlook/components/AddinPinHintBanner.tsx
@@ -73,7 +73,9 @@ export function AddinPinHintBanner({ onDismiss }: AddinPinHintBannerProps) {
       aria-live="polite"
       data-testid="addin-pin-hint-banner"
       data-ui="addin-pin-hint-banner"
-      className="flex items-start gap-2 border-b border-theme-warning-border bg-theme-warning-bg px-4 py-2 text-theme-warning-fg"
+      // pl-10 clears the floating drawer trigger, which overlays the pane's
+      // top-left corner now that no header row reserves space for it.
+      className="flex items-start gap-2 border-b border-theme-warning-border bg-theme-warning-bg py-2 pl-10 pr-4 text-theme-warning-fg"
     >
       <PinIcon className="mt-0.5 size-4 shrink-0" />
       <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/office-addin/src/outlook/sessionPolicy/__tests__/policyGate.test.ts
+++ b/office-addin/src/outlook/sessionPolicy/__tests__/policyGate.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  holdSessionPolicy,
+  isSessionPolicyHeld,
+  releaseSessionPolicy,
+  subscribeSessionPolicyGate,
+} from "../policyGate";
+
+describe("policyGate", () => {
+  beforeEach(() => {
+    while (isSessionPolicyHeld()) {
+      releaseSessionPolicy();
+    }
+  });
+
+  it("counts holds so independent holders cannot release each other", () => {
+    expect(isSessionPolicyHeld()).toBe(false);
+
+    holdSessionPolicy();
+    holdSessionPolicy();
+    releaseSessionPolicy();
+    expect(isSessionPolicyHeld()).toBe(true);
+
+    releaseSessionPolicy();
+    expect(isSessionPolicyHeld()).toBe(false);
+  });
+
+  it("survives an unbalanced release without going negative", () => {
+    releaseSessionPolicy();
+    expect(isSessionPolicyHeld()).toBe(false);
+
+    holdSessionPolicy();
+    expect(isSessionPolicyHeld()).toBe(true);
+    releaseSessionPolicy();
+  });
+
+  it("notifies subscribers on transitions and stops after unsubscribe", () => {
+    const observed: boolean[] = [];
+    const unsubscribe = subscribeSessionPolicyGate(() => {
+      observed.push(isSessionPolicyHeld());
+    });
+
+    holdSessionPolicy();
+    releaseSessionPolicy();
+    unsubscribe();
+    holdSessionPolicy();
+    releaseSessionPolicy();
+
+    expect(observed).toEqual([true, false]);
+  });
+});

--- a/office-addin/src/outlook/sessionPolicy/index.ts
+++ b/office-addin/src/outlook/sessionPolicy/index.ts
@@ -23,3 +23,9 @@ export {
   type OutlookSessionStorageValue,
 } from "./persistence";
 export type { OutlookSessionAnchor, OutlookSessionPreferences } from "./types";
+export {
+  holdSessionPolicy,
+  isSessionPolicyHeld,
+  releaseSessionPolicy,
+  subscribeSessionPolicyGate,
+} from "./policyGate";

--- a/office-addin/src/outlook/sessionPolicy/policyGate.ts
+++ b/office-addin/src/outlook/sessionPolicy/policyGate.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal external store gating the Outlook anchor-policy evaluation.
+ *
+ * While held (the history drawer is open), mail-item switches defer instead
+ * of interleaving a session toast under the drawer: the anchor effect
+ * returns early without recording the anchor, so releasing re-evaluates the
+ * latest state exactly once — and an explicit pick made during the hold has
+ * already re-anchored, so that evaluation resolves silently.
+ *
+ * Counted rather than boolean so independent holders can never release each
+ * other's hold.
+ */
+let holdCount = 0;
+const listeners = new Set<() => void>();
+
+const notify = () => {
+  for (const listener of listeners) {
+    listener();
+  }
+};
+
+export function holdSessionPolicy(): void {
+  holdCount += 1;
+  notify();
+}
+
+export function releaseSessionPolicy(): void {
+  holdCount = Math.max(0, holdCount - 1);
+  notify();
+}
+
+export function isSessionPolicyHeld(): boolean {
+  return holdCount > 0;
+}
+
+export function subscribeSessionPolicyGate(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/office-addin/src/styles.css
+++ b/office-addin/src/styles.css
@@ -393,3 +393,22 @@ body {
 .drawer-overlay-skin {
   background-color: var(--theme-overlay-modal);
 }
+
+/* Drawer panel surface. Themes may give the sidebar token glass alpha and
+   pair it with a backdrop blur scoped to the web sidebar's data-ui hook; the
+   drawer deliberately skips the blur (it re-filters under the sliding panel
+   every frame in the Office webviews), so a translucent token would read as
+   content bleeding through. Compositing it over the shell base reproduces
+   what the web sidebar shows through its glass, opaquely. */
+.drawer-panel-skin {
+  background-color: var(--theme-shell-app, var(--theme-bg-primary));
+  background-image: linear-gradient(
+    var(--theme-shell-sidebar),
+    var(--theme-shell-sidebar)
+  );
+  border-color: var(
+    --theme-shell-sidebar-divider-color,
+    var(--theme-border-divider)
+  );
+  box-shadow: var(--theme-elevation-shell);
+}

--- a/office-addin/src/styles.css
+++ b/office-addin/src/styles.css
@@ -385,3 +385,11 @@ body {
     width: 100%;
   }
 }
+
+/* Scrim behind the history drawer. Deliberately NOT the modal overlay skin:
+   its backdrop blur re-filters the region behind the scrim on every frame
+   while the panel slides over it — the main drawer-jank source in the
+   Office webviews — and the panel's shadow already carries the depth cue. */
+.drawer-overlay-skin {
+  background-color: var(--theme-overlay-modal);
+}

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -30,6 +30,7 @@ const spies = vi.hoisted(() => ({
   createEntraNaaAuthSource: vi.fn(),
   sessionAuthSource: vi.fn(),
   usePersistedState: vi.fn(),
+  updateChatTitle: vi.fn(async () => undefined),
   messagingStore: {
     abortActiveSSE: vi.fn(),
     clearUserMessages: vi.fn(),
@@ -235,14 +236,14 @@ vi.mock("@erato/frontend/library", async () => {
       );
     },
     removeArchivedChatFromLists: vi.fn(async () => () => undefined),
-    sanitizeChatHistoryFilters: (values: unknown) => values,
     seedGenerationStatusFromListing: vi.fn(),
     useAssistantsFeature: () => ({
       enabled: false,
       delegationEnabled: false,
       delegationAllowBackground: false,
     }),
-    useUpdateChat: () => ({ mutateAsync: vi.fn(async () => undefined) }),
+    useChatHistoryFilterFoldback: () => undefined,
+    useUpdateChatTitle: () => spies.updateChatTitle,
 
     ChatErrorBoundary: passthrough,
     Button: ({

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -351,7 +351,9 @@ describe("Teams personal tab composition", () => {
 
     expect(await screen.findByTestId("teams-message-list")).toBeInTheDocument();
     expect(screen.getByTestId("teams-chat-input")).toBeInTheDocument();
-    expect(screen.getByText("New Chat")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("addin-history-drawer-trigger"),
+    ).toBeInTheDocument();
     expect(globalThis).not.toHaveProperty("Office");
     expect(
       appendChild.mock.calls.some(

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -245,6 +245,12 @@ vi.mock("@erato/frontend/library", async () => {
     useUpdateChat: () => ({ mutateAsync: vi.fn(async () => undefined) }),
 
     ChatErrorBoundary: passthrough,
+    Button: ({
+      icon: _icon,
+      ...props
+    }: Record<string, unknown> & { icon?: unknown; ref?: unknown }) => (
+      <button {...(props as Record<string, never>)} />
+    ),
     ChatInputControlsProvider: passthrough,
     ChatMessage: () => null,
     DefaultMessageControls: () => null,

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -249,7 +249,7 @@ vi.mock("@erato/frontend/library", async () => {
     ChatMessage: () => null,
     DefaultMessageControls: () => null,
     DocumentIcon: () => null,
-    DropdownMenu: () => null,
+    SidebarToggleIcon: () => null,
     FeedbackCommentDialog: () => null,
     FeedbackViewDialog: () => null,
     FilePreviewModal: () => null,
@@ -302,6 +302,10 @@ vi.mock("@erato/frontend/library", async () => {
     useStandardMessageActions: () => vi.fn(),
   };
 });
+
+vi.mock("../../core/AddinHistoryDrawerCore", () => ({
+  AddinHistoryDrawerCore: () => null,
+}));
 
 describe("Teams personal tab composition", () => {
   const originalOffice = Object.getOwnPropertyDescriptor(globalThis, "Office");

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -209,12 +209,40 @@ vi.mock("@erato/frontend/library", async () => {
       spies.usePersistedState(key);
       return useState(initialValue);
     },
-    useRecentChats: () => ({
-      data: { chats: [] },
+    useInfiniteRecentChats: () => ({
+      chats: [],
       isLoading: false,
       error: null,
       refetch: vi.fn(async () => undefined),
+      fetchNextPage: vi.fn(async () => undefined),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      queryKey: ["recent-chats"],
     }),
+    createChatHistoryFilterStore: () => {
+      const state = {
+        typeFilter: "all",
+        statusFilter: "active",
+        groupBy: "date",
+        setTypeFilter: vi.fn(),
+        setStatusFilter: vi.fn(),
+        setGroupBy: vi.fn(),
+        resetToDefaults: vi.fn(),
+      };
+      return Object.assign(
+        (selector: (s: typeof state) => unknown) => selector(state),
+        { getState: () => state },
+      );
+    },
+    removeArchivedChatFromLists: vi.fn(async () => () => undefined),
+    sanitizeChatHistoryFilters: (values: unknown) => values,
+    seedGenerationStatusFromListing: vi.fn(),
+    useAssistantsFeature: () => ({
+      enabled: false,
+      delegationEnabled: false,
+      delegationAllowBackground: false,
+    }),
+    useUpdateChat: () => ({ mutateAsync: vi.fn(async () => undefined) }),
 
     ChatErrorBoundary: passthrough,
     ChatInputControlsProvider: passthrough,


### PR DESCRIPTION
This pull request refactors the chat sidebar navigation and chat history filter logic to improve code reuse, maintainability, and consistency between the main app and add-in surfaces. The main changes include extracting a reusable `SidebarNavigationItem` component, updating navigation items to use this new component, and refactoring chat history filter logic for better encapsulation.

**Sidebar Navigation Refactor:**
- Introduced a new `SidebarNavigationItem` component to unify the appearance and behavior of sidebar navigation rows, including icon, label, active state, and slim mode support. (`frontend/src/components/ui/Chat/SidebarNavigationItem.tsx`, [frontend/src/components/ui/Chat/SidebarNavigationItem.tsxR1-R141](diffhunk://#diff-461acccd6c86af0dbdcebf52aa7879453b63fedbdc2022194201b0e9818b4db3R1-R141))
- Updated `NewChatItem`, `SearchNavigationItem`, and `AssistantsNavigationItem` in `ChatHistorySidebar.tsx` to use `SidebarNavigationItem` instead of duplicating layout and interaction code. (`frontend/src/components/ui/Chat/ChatHistorySidebar.tsx`, [[1]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL296-L336) [[2]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL351-L426) [[3]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL442-L517)

**Chat History Filter Logic Improvements:**
- Replaced direct usage of `useChatHistoryFilterStore` and manual sanitization with a new hook, `useChatHistoryFilterFoldback`, for cleaner state management and to ensure filter values are properly folded back when assistants are disabled. (`frontend/src/components/ui/Chat/ChatHistorySidebar.tsx`, [[1]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL19-R18) [[2]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL667-R528)
- Updated the `ChatHistoryFilterMenu` to accept an optional `store` prop, allowing for custom filter store instances (e.g., for use in add-in drawers) and defaulting to the main sidebar store. (`frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx`, [[1]](diffhunk://#diff-c3b5386c31b73cb526136b850cbd5beb8bfd783c85d6716bfac5148de9d2480eR34-R40) [[2]](diffhunk://#diff-c3b5386c31b73cb526136b850cbd5beb8bfd783c85d6716bfac5148de9d2480eR113) [[3]](diffhunk://#diff-c3b5386c31b73cb526136b850cbd5beb8bfd783c85d6716bfac5148de9d2480eL129-R144)

**Code Cleanup and Reuse:**
- Moved chat session grouping logic into a dedicated hook, `useGroupedChatSessions`, further simplifying the sidebar component. (`frontend/src/components/ui/Chat/ChatHistorySidebar.tsx`, [[1]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bR28) [[2]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL701-L722)
- Exported `NewChatItem` and `NoFilterMatchesRow` for reuse in other surfaces like the add-in's history drawer. (`frontend/src/components/ui/Chat/ChatHistorySidebar.tsx`, [[1]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL296-L336) [[2]](diffhunk://#diff-fdcb36701ef525855027ee9c49900cccd1bd97c6ada02801ca43e4d8f5dd405bL546-R407)

These changes collectively make the sidebar navigation and filter logic more modular, reusable, and easier to maintain.