### PR TITLE
Add-in: AddinStartView extension point with start/chat view switcher

### DIFF
--- a/frontend/src/components/ui/icons/index.tsx
+++ b/frontend/src/components/ui/icons/index.tsx
@@ -13,6 +13,7 @@ import {
   SunLight,
   HalfMoon,
   Computer,
+  ChatBubbleEmpty,
   Plus,
   CandlestickChart,
   Check,
@@ -268,6 +269,10 @@ export const MultiplePagesIcon = ({ className, ...props }: IconProps) => (
 
 export const MailIcon = ({ className, ...props }: IconProps) => (
   <Mail className={className} {...props} />
+);
+
+export const ChatBubbleIcon = ({ className, ...props }: IconProps) => (
+  <ChatBubbleEmpty className={className} {...props} />
 );
 
 export const SearchIcon = ({ className, ...props }: IconProps) => (

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -76,6 +76,36 @@ export interface ChatAddMenuExtraContentProps {
 }
 
 /**
+ * Props for a kit/customer-provided start view hosted by the Office add-in
+ * shell. When registered, the Outlook task pane opens on this view instead of
+ * the chat and the shell renders an affordance to switch between the two.
+ * Everything the view may need is injected via props — registry components
+ * cannot import add-in-internal hooks.
+ */
+export interface AddinStartViewProps {
+  /** Switch the task pane to the regular chat view. */
+  openChat: () => void;
+  /** Host platform identifier (e.g. "outlook"), as stamped on X-Erato-Platform. */
+  platform: string;
+  /**
+   * Acquire an access token for the given scopes via the shell's auth source
+   * (MSAL NAA or standard PCA). Custom API resource scopes must be requested
+   * alone (MSAL forbids mixing resources in one request), and callers should
+   * pass `suppressSignInPrompt` for optional scopes whose absence they degrade
+   * on. Absent on hosts without client-side auth (e.g. Exchange on-prem behind
+   * oauth2-proxy) — the view MUST render a usable state without it.
+   */
+  acquireToken?: (
+    scopes: string[],
+    options?: {
+      forceRefresh?: boolean;
+      allowInteraction?: boolean;
+      suppressSignInPrompt?: boolean;
+    },
+  ) => Promise<string>;
+}
+
+/**
  * Registry of overridable components.
  * Each key maps to either a custom component or null (use default).
  */
@@ -221,6 +251,17 @@ export interface ComponentRegistry {
    * summary card (`DefaultEratoAppointmentCodeBlock`).
    */
   EratoAppointmentCodeBlock: ComponentType<EratoAppointmentCodeBlockProps> | null;
+
+  /**
+   * Start view hosted by the Office add-in shell (Outlook task pane). When a
+   * kit registers it, the task pane opens on this view first and the shell
+   * shows a toggle to switch to the regular chat and back. When null, the
+   * add-in opens directly in chat (default behavior).
+   *
+   * Consulted only by the Outlook add-in shell — the web app and the Teams
+   * tab never read it.
+   */
+  AddinStartView: ComponentType<AddinStartViewProps> | null;
 }
 
 type ComponentRegistryComponent<TKey extends keyof ComponentRegistry> = Exclude<
@@ -269,6 +310,7 @@ const emptyComponentRegistry = (): ComponentRegistry => ({
   ChatTopLeftAccessory: null,
   EratoEmailCodeBlock: null,
   EratoAppointmentCodeBlock: null,
+  AddinStartView: null,
 });
 
 const buildComponentRegistry = (

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -286,6 +286,7 @@ export {
   useStandaloneFileUpload,
 } from "@/hooks/files";
 export {
+  ChatBubbleIcon,
   CloseIcon,
   ComputerIcon,
   DocumentIcon,
@@ -405,6 +406,7 @@ export {
   type EratoEmailCodeBlockProps,
   type EratoAppointmentCodeBlockProps,
   type ChatAddMenuExtraContentProps,
+  type AddinStartViewProps,
 } from "@/config/componentRegistry";
 export {
   registerClientToolExecutor,

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -89,6 +89,7 @@ export { ArrowUp } from "@/components/ui/icons/index";
 export { ArrowUpIcon } from "@/components/ui/icons/index";
 export { AtSignIcon } from "@/components/ui/icons/index";
 export { BrainIcon } from "@/components/ui/icons/index";
+export { ChatBubbleIcon } from "@/components/ui/icons/index";
 export { Check } from "@/components/ui/icons/index";
 export { CheckCircle } from "@/components/ui/icons/index";
 export { CheckCircleIcon } from "@/components/ui/icons/index";

--- a/office-addin/pnpm-lock.yaml
+++ b/office-addin/pnpm-lock.yaml
@@ -203,6 +203,10 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
@@ -273,6 +277,10 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -503,7 +511,7 @@ packages:
     hasBin: true
 
   '@erato/frontend@file:../frontend/dist-package/erato-frontend.tgz':
-    resolution: {integrity: sha512-GOgNrKrDpwO1Qjc1JNWymnRczkYuzdn7Sc12yo0VOclZs0Lh/QdT8Ureh0oWuMIeAU5nhzJJOAzclDostbEpFA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
+    resolution: {integrity: sha512-vIQsUXpJn6qRqDSRKqyu/T9MI1keZT0+yHgbQe/LLfyjHwb3pIjyzLJY2u5yy/sk3gZY5zR+4GgeSE9/4HvwAA==, tarball: file:../frontend/dist-package/erato-frontend.tgz}
     version: 0.1.0
     peerDependencies:
       '@lingui/core': ^5.9.4
@@ -1093,8 +1101,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@sveltejs/acorn-typescript@1.0.12':
-    resolution: {integrity: sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA==}
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -1611,6 +1619,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   adler-32@1.3.1:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
@@ -1755,8 +1768,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.42:
-    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+  baseline-browser-mapping@2.11.15:
+    resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1781,8 +1794,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.5:
-    resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1809,8 +1822,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001803:
-    resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2217,8 +2230,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.389:
-    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+  electron-to-chromium@1.5.411:
+    resolution: {integrity: sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -2431,8 +2444,8 @@ packages:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
-  esrap@2.3.1:
-    resolution: {integrity: sha512-MXjVkrBAjuwIZ8xq9+a1MOOnLIwANZOx/4gtdWHfSJtXOrUh2QQK2I5mMC3urLli559jTlq2j+kSqht80uRgog==}
+  esrap@2.3.5:
+    resolution: {integrity: sha512-KciPkeZZX8srrh6xELzLR2cBaWOzgBQ4CwggO6Dh/KMlrfOcIcfyXCVy/Vvc3/OlS5gvFOd5tcxUYuaGM8o45A==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -3316,8 +3329,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3351,8 +3364,8 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-releases@2.0.51:
-    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
   non.geist@1.0.4:
@@ -4155,8 +4168,8 @@ packages:
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -4461,13 +4474,13 @@ snapshots:
   '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -4486,11 +4499,19 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4498,7 +4519,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -4508,7 +4529,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4517,7 +4538,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4564,6 +4585,18 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
       '@babel/helper-globals': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
@@ -5374,9 +5407,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@sveltejs/acorn-typescript@1.0.12(acorn@8.17.0)':
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
   '@tanstack/query-core@5.100.10': {}
 
@@ -5951,6 +5984,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  acorn@8.18.0: {}
+
   adler-32@1.3.1: {}
 
   adm-zip@0.5.16: {}
@@ -6099,7 +6134,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.42: {}
+  baseline-browser-mapping@2.11.15: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -6126,13 +6161,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.5:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001803
-      electron-to-chromium: 1.5.389
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.5)
+      baseline-browser-mapping: 2.11.15
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.411
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   buffer@5.7.1:
     dependencies:
@@ -6160,7 +6195,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001803: {}
+  caniuse-lite@1.0.30001809: {}
 
   ccount@2.0.1: {}
 
@@ -6578,7 +6613,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.389: {}
+  electron-to-chromium@1.5.411: {}
 
   emoji-regex@9.2.2: {}
 
@@ -6942,7 +6977,7 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@2.3.1(@typescript-eslint/types@8.61.1):
+  esrap@2.3.5(@typescript-eslint/types@8.61.1):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
     optionalDependencies:
@@ -8093,7 +8128,7 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8118,7 +8153,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-releases@2.0.51: {}
+  node-releases@2.0.53: {}
 
   non.geist@1.0.4: {}
 
@@ -8331,7 +8366,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8906,16 +8941,16 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.12(acorn@8.17.0)
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.17.0
+      acorn: 8.18.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
       devalue: 5.9.0
       esm-env: 1.2.2
-      esrap: 2.3.1(@typescript-eslint/types@8.61.1)
+      esrap: 2.3.5(@typescript-eslint/types@8.61.1)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
@@ -9140,9 +9175,9 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
-  update-browserslist-db@1.2.3(browserslist@4.28.5):
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -557,6 +557,10 @@ export function AddinChatCoreView({
   drawerSectionsAfterHistory?: ReactNode;
 }) {
   const TopLeftAccessory = componentRegistry.ChatTopLeftAccessory;
+  // When a kit registers a start view, its toggle floats at the top RIGHT
+  // (mirroring the drawer trigger), so the trigger-clearance rows need the
+  // symmetric pr-10 as well.
+  const hasStartViewToggle = componentRegistry.AddinStartView !== null;
   const feedback = controller.feedback;
   const { setIsHistoryMenuOpen, setIsSettingsOpen } = controller;
   // Stable identities for the drawer: fresh arrows here would churn its
@@ -654,14 +658,16 @@ export function AddinChatCoreView({
               {controller.delegatedRunHeader ? (
                 // pl-10 clears the floating drawer trigger, which otherwise
                 // sits on the header's title.
-                <div className="relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 pl-10">
+                <div
+                  className={`relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 pl-10${hasStartViewToggle ? " pr-10" : ""}`}
+                >
                   {controller.delegatedRunHeader}
                 </div>
               ) : null}
               {TopLeftAccessory ? (
                 // Cleared past the floating drawer trigger, which otherwise
                 // sits exactly on a top-left accessory.
-                <div className="pl-10">
+                <div className={`pl-10${hasStartViewToggle ? " pr-10" : ""}`}>
                   <TopLeftAccessory
                     availableModels={controller.availableModels}
                     selectedModel={controller.selectedModel}

--- a/office-addin/src/locales/de/messages.po
+++ b/office-addin/src/locales/de/messages.po
@@ -1150,6 +1150,16 @@ msgstr "Generiertes Manifest hochladen"
 #~ msgstr "und laden Sie die heruntergeladene Datei dort hoch."
 
 #. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openChat"
+msgstr "Zum Chat wechseln"
+
+#. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openStart"
+msgstr "Zur Startansicht wechseln"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatAddMenuExtraContent.tsx
 msgid "officeAddin.teams.fileSource.chats"
 msgstr "Teams-Chats…"

--- a/office-addin/src/locales/en/messages.po
+++ b/office-addin/src/locales/en/messages.po
@@ -1150,6 +1150,16 @@ msgstr "Upload the generated manifest"
 #~ msgstr "and upload the downloaded file there."
 
 #. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openChat"
+msgstr "Switch to chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openStart"
+msgstr "Switch to start view"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatAddMenuExtraContent.tsx
 msgid "officeAddin.teams.fileSource.chats"
 msgstr "Teams chats…"

--- a/office-addin/src/locales/es/messages.po
+++ b/office-addin/src/locales/es/messages.po
@@ -1150,6 +1150,16 @@ msgstr "Cargue el manifiesto generado"
 #~ msgstr "y cargue allí el archivo descargado."
 
 #. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openChat"
+msgstr "Cambiar al chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openStart"
+msgstr "Cambiar a la vista de inicio"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatAddMenuExtraContent.tsx
 msgid "officeAddin.teams.fileSource.chats"
 msgstr "Chats de Teams…"

--- a/office-addin/src/locales/fr/messages.po
+++ b/office-addin/src/locales/fr/messages.po
@@ -1150,6 +1150,16 @@ msgstr "Téléverser le manifeste généré"
 #~ msgstr "et téléversez-y le fichier téléchargé."
 
 #. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openChat"
+msgstr "Passer au chat"
+
+#. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openStart"
+msgstr "Passer à la vue de démarrage"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatAddMenuExtraContent.tsx
 msgid "officeAddin.teams.fileSource.chats"
 msgstr "Conversations Teams…"

--- a/office-addin/src/locales/pl/messages.po
+++ b/office-addin/src/locales/pl/messages.po
@@ -1150,6 +1150,16 @@ msgstr "Prześlij wygenerowany manifest"
 #~ msgstr "i prześlij tam pobrany plik."
 
 #. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openChat"
+msgstr "Przełącz na czat"
+
+#. js-lingui-explicit-id
+#: src/outlook/OutlookStartViewSwitcher.tsx
+msgid "officeAddin.startView.openStart"
+msgstr "Przełącz na widok startowy"
+
+#. js-lingui-explicit-id
 #: src/teams/components/TeamsChatAddMenuExtraContent.tsx
 msgid "officeAddin.teams.fileSource.chats"
 msgstr "Czaty Teams…"

--- a/office-addin/src/outlook/OutlookAddinChatPage.tsx
+++ b/office-addin/src/outlook/OutlookAddinChatPage.tsx
@@ -5,6 +5,7 @@ import {
 
 import { OutlookAddinChat } from "./OutlookAddinChat";
 import { OutlookAddinSessionController } from "./OutlookAddinSessionController";
+import { OutlookStartViewSwitcher } from "./OutlookStartViewSwitcher";
 import { AddinChatProviderCore } from "../core/AddinChatProviderCore";
 
 /** Outlook composition of generic chat data with Outlook session policy. */
@@ -16,7 +17,9 @@ export function OutlookAddinChatPage() {
           platform="outlook"
           SessionController={OutlookAddinSessionController}
         >
-          <OutlookAddinChat />
+          <OutlookStartViewSwitcher platform="outlook">
+            <OutlookAddinChat />
+          </OutlookStartViewSwitcher>
         </AddinChatProviderCore>
       </FileCapabilitiesProvider>
     </ProfileProvider>

--- a/office-addin/src/outlook/OutlookStartViewSwitcher.tsx
+++ b/office-addin/src/outlook/OutlookStartViewSwitcher.tsx
@@ -1,0 +1,102 @@
+import {
+  Button,
+  ChatBubbleIcon,
+  MailIcon,
+  componentRegistry,
+} from "@erato/frontend/library";
+import { t } from "@lingui/core/macro";
+import { useCallback, useMemo, useState } from "react";
+
+import { useGraphTokenOptional } from "../core/auth/GraphTokenProvider";
+
+import type { AddinStartViewProps } from "@erato/frontend/library";
+import type { CSSProperties, ReactNode } from "react";
+
+// Same composite recipe as the shell's floating controls: an opaque shell-app
+// base with the sidebar tone layered on top, so the control stays readable on
+// glass themes where the sidebar tone alone is translucent.
+const floatingToggleStyle: CSSProperties = {
+  backgroundColor: "var(--theme-shell-app, var(--theme-bg-primary))",
+  backgroundImage:
+    "linear-gradient(var(--theme-shell-sidebar), var(--theme-shell-sidebar))",
+  borderColor: "var(--theme-border-divider)",
+  borderRadius: "var(--theme-radius-shell)",
+  boxShadow: "var(--theme-elevation-shell)",
+};
+
+/**
+ * Hosts a kit-registered start view (`componentRegistry.AddinStartView`) in
+ * the Outlook task pane. With no registration it renders its children
+ * untouched — the add-in opens straight into chat exactly as before. With
+ * one, the pane opens on the start view and a floating toggle at the top
+ * right switches between the start view and the chat.
+ *
+ * Mounted INSIDE AddinChatProviderCore so chat context, session policy, and
+ * any active stream survive the toggle.
+ */
+export function OutlookStartViewSwitcher({
+  platform,
+  children,
+}: {
+  /** Host identifier forwarded to the start view (e.g. "outlook"). */
+  platform: string;
+  children: ReactNode;
+}) {
+  const StartView = componentRegistry.AddinStartView;
+  const graph = useGraphTokenOptional();
+  const [view, setView] = useState<"start" | "chat">("start");
+
+  const openChat = useCallback(() => setView("chat"), []);
+
+  // Start views request custom-audience API tokens; warming the oauth2-proxy
+  // session with one would hand the proxy a token it cannot redeem, so the
+  // opportunistic session refresh is skipped for everything acquired here.
+  const acquireToken = useMemo<AddinStartViewProps["acquireToken"]>(() => {
+    if (!graph) return undefined;
+    return (scopes, options) =>
+      graph.acquireToken(scopes, { ...options, skipSessionWarm: true });
+  }, [graph]);
+
+  if (!StartView) {
+    return <>{children}</>;
+  }
+
+  const inChat = view === "chat";
+  return (
+    <div className="relative flex size-full min-w-0 flex-col">
+      <Button
+        variant="sidebar-icon"
+        icon={inChat ? <MailIcon /> : <ChatBubbleIcon />}
+        onClick={() => setView(inChat ? "start" : "chat")}
+        className="absolute right-2 top-2 z-20 border"
+        style={floatingToggleStyle}
+        aria-label={
+          inChat
+            ? t({
+                id: "officeAddin.startView.openStart",
+                message: "Switch to start view",
+              })
+            : t({
+                id: "officeAddin.startView.openChat",
+                message: "Switch to chat",
+              })
+        }
+        data-testid="addin-start-view-toggle"
+      />
+      {inChat ? (
+        children
+      ) : (
+        <div
+          className="min-h-0 flex-1 overflow-y-auto"
+          data-testid="addin-start-view"
+        >
+          <StartView
+            platform={platform}
+            openChat={openChat}
+            acquireToken={acquireToken}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/office-addin/src/outlook/OutlookStartViewSwitcher.tsx
+++ b/office-addin/src/outlook/OutlookStartViewSwitcher.tsx
@@ -5,8 +5,10 @@ import {
   componentRegistry,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { dismissSessionToasts } from "./components/sessionAskToast";
+import { holdSessionPolicy, releaseSessionPolicy } from "./sessionPolicy";
 import { useGraphTokenOptional } from "../core/auth/GraphTokenProvider";
 
 import type { AddinStartViewProps } from "@erato/frontend/library";
@@ -47,6 +49,18 @@ export function OutlookStartViewSwitcher({
   const [view, setView] = useState<"start" | "chat">("start");
 
   const openChat = useCallback(() => setView("chat"), []);
+
+  // While the start view is shown, mail-item switches must not surface a
+  // session ask toast on top of it (toasts float at z-1000). Same counted
+  // gate the history drawer uses: hold defers the anchor policy, releasing
+  // re-evaluates the latest state exactly once.
+  const startViewActive = StartView !== null && view === "start";
+  useEffect(() => {
+    if (!startViewActive) return;
+    holdSessionPolicy();
+    dismissSessionToasts();
+    return () => releaseSessionPolicy();
+  }, [startViewActive]);
 
   // Start views request custom-audience API tokens; warming the oauth2-proxy
   // session with one would hand the proxy a token it cannot redeem, so the

--- a/office-addin/src/outlook/__tests__/OutlookStartViewSwitcher.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookStartViewSwitcher.test.tsx
@@ -1,0 +1,92 @@
+import { componentRegistry } from "@erato/frontend/library";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { OutlookStartViewSwitcher } from "../OutlookStartViewSwitcher";
+
+import type { AddinStartViewProps } from "@erato/frontend/library";
+
+function StubStartView({
+  openChat,
+  platform,
+  acquireToken,
+}: AddinStartViewProps) {
+  return (
+    <div data-testid="stub-start-view">
+      <span data-testid="stub-platform">{platform}</span>
+      <span data-testid="stub-token-availability">
+        {acquireToken ? "token-capable" : "no-token"}
+      </span>
+      <button type="button" onClick={openChat} data-testid="stub-open-chat">
+        open chat
+      </button>
+    </div>
+  );
+}
+
+describe("OutlookStartViewSwitcher", () => {
+  afterEach(() => {
+    componentRegistry.AddinStartView = null;
+    cleanup();
+  });
+
+  it("renders children untouched when no start view is registered", () => {
+    render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("addin-start-view-toggle"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("addin-start-view")).not.toBeInTheDocument();
+  });
+
+  it("opens on the registered start view and toggles to chat and back", () => {
+    componentRegistry.AddinStartView = StubStartView;
+    render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    expect(screen.getByTestId("stub-start-view")).toBeInTheDocument();
+    expect(screen.getByTestId("stub-platform")).toHaveTextContent("outlook");
+    expect(screen.queryByTestId("chat-surface")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("addin-start-view-toggle"));
+    expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
+    expect(screen.queryByTestId("stub-start-view")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("addin-start-view-toggle"));
+    expect(screen.getByTestId("stub-start-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-surface")).not.toBeInTheDocument();
+  });
+
+  it("switches to chat via the start view's openChat prop", () => {
+    componentRegistry.AddinStartView = StubStartView;
+    render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    fireEvent.click(screen.getByTestId("stub-open-chat"));
+    expect(screen.getByTestId("chat-surface")).toBeInTheDocument();
+  });
+
+  it("passes no acquireToken when no Graph-capable auth provider is mounted", () => {
+    componentRegistry.AddinStartView = StubStartView;
+    render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    expect(screen.getByTestId("stub-token-availability")).toHaveTextContent(
+      "no-token",
+    );
+  });
+});

--- a/office-addin/src/outlook/__tests__/OutlookStartViewSwitcher.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookStartViewSwitcher.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { OutlookStartViewSwitcher } from "../OutlookStartViewSwitcher";
+import { isSessionPolicyHeld } from "../sessionPolicy";
 
 import type { AddinStartViewProps } from "@erato/frontend/library";
 
@@ -88,5 +89,35 @@ describe("OutlookStartViewSwitcher", () => {
     expect(screen.getByTestId("stub-token-availability")).toHaveTextContent(
       "no-token",
     );
+  });
+
+  it("holds the session policy only while the start view is shown", () => {
+    componentRegistry.AddinStartView = StubStartView;
+    const { unmount } = render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    expect(isSessionPolicyHeld()).toBe(true);
+
+    fireEvent.click(screen.getByTestId("addin-start-view-toggle"));
+    expect(isSessionPolicyHeld()).toBe(false);
+
+    fireEvent.click(screen.getByTestId("addin-start-view-toggle"));
+    expect(isSessionPolicyHeld()).toBe(true);
+
+    unmount();
+    expect(isSessionPolicyHeld()).toBe(false);
+  });
+
+  it("does not touch the session policy when no start view is registered", () => {
+    render(
+      <OutlookStartViewSwitcher platform="outlook">
+        <div data-testid="chat-surface" />
+      </OutlookStartViewSwitcher>,
+    );
+
+    expect(isSessionPolicyHeld()).toBe(false);
   });
 });

--- a/office-addin/src/outlook/components/AddinPinHintBanner.tsx
+++ b/office-addin/src/outlook/components/AddinPinHintBanner.tsx
@@ -1,3 +1,4 @@
+import { componentRegistry } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
 
 export interface AddinPinHintBannerProps {
@@ -67,6 +68,9 @@ function DismissIcon({ className }: { className?: string }) {
  * best we can do is teach the user to pin. Dismissible.
  */
 export function AddinPinHintBanner({ onDismiss }: AddinPinHintBannerProps) {
+  // Mirror the left trigger clearance on the right when a kit-registered
+  // start view adds its floating toggle there.
+  const hasStartViewToggle = componentRegistry.AddinStartView !== null;
   return (
     <div
       role="status"
@@ -75,7 +79,7 @@ export function AddinPinHintBanner({ onDismiss }: AddinPinHintBannerProps) {
       data-ui="addin-pin-hint-banner"
       // pl-10 clears the floating drawer trigger, which overlays the pane's
       // top-left corner now that no header row reserves space for it.
-      className="flex items-start gap-2 border-b border-theme-warning-border bg-theme-warning-bg py-2 pl-10 pr-4 text-theme-warning-fg"
+      className={`flex items-start gap-2 border-b border-theme-warning-border bg-theme-warning-bg py-2 pl-10 ${hasStartViewToggle ? "pr-10" : "pr-4"} text-theme-warning-fg`}
     >
       <PinIcon className="mt-0.5 size-4 shrink-0" />
       <div className="flex min-w-0 flex-1 flex-col gap-1">


### PR DESCRIPTION
**Stacked on #1029** (base = `feature/cfms-3-skip-session-warm`; retarget/auto-retarget to `main` once that merges).

## What

Lets a component kit register `componentRegistry.AddinStartView`: the Outlook task pane then opens on that view, with a floating toggle at the top right (mirroring the drawer trigger, same glass-safe composite recipe) switching between the start view and the regular chat. **With no registration the shell renders exactly as before — the switcher is a strict no-op**, verified by the untouched existing suite.

## How

- `AddinStartViewProps` + registry key in `componentRegistry.ts`, type exported through the library barrel. Props: `openChat()`, `platform`, and optional `acquireToken(scopes)` backed by the shell's auth source (absent on hosts without client-side auth, e.g. Exchange SE — views must degrade). Acquisitions pass `skipSessionWarm` (#1029).
- `OutlookStartViewSwitcher` mounts inside `AddinChatProviderCore` at `OutlookAddinChatPage`, so chat context, session policy, listings, and active streams survive toggling.
- While the start view is shown, the switcher holds the Outlook session-policy gate (same counted gate as the history drawer) and dismisses pending ask toasts; toggling to chat releases and re-evaluates once.
- The `pl-10` trigger-clearance rows (pin banner, delegated-run header, TopLeftAccessory wrapper) gain a symmetric `pr-10` — only while a start view is registered.
- New shared `ChatBubbleIcon` (iconoir `ChatBubbleEmpty`), also exported to the kit-shared surface.
- i18n: catalogs extracted for en/de/es/fr/pl with translations filled.

## Testing

6 new switcher tests (no-op path, toggle both directions, `openChat` prop, token degradation, policy-gate hold/release/unmount). Full add-in suite: 1083 passed. Frontend `build:lib`, typecheck, strict eslint, prettier all green.