### PR TITLE
Route local admin panel through auth proxies

### DIFF
--- a/frontend/local-auth/nginx-jwt/main.js
+++ b/frontend/local-auth/nginx-jwt/main.js
@@ -70,6 +70,16 @@ function parseCookies(cookieHeader) {
   return cookies;
 }
 
+function targetLocationForUri(uri) {
+  if (uri === "/admin" || uri.startsWith("/admin/")) {
+    return "@admin";
+  }
+  if (uri.startsWith("/api/")) {
+    return "@backend";
+  }
+  return "@frontend";
+}
+
 function handleRequest(r) {
   // JWT secret key - should be stored securely
   const jwtSecret = "erato-nginx-jwt-secret-key-change-in-production";
@@ -125,10 +135,7 @@ function handleRequest(r) {
     }
 
     // Determine which upstream to use based on the path
-    let targetLocation = "@frontend";
-    if (r.uri.startsWith("/api/")) {
-      targetLocation = "@backend";
-    }
+    const targetLocation = targetLocationForUri(r.uri);
 
     // Forward to appropriate upstream with cleaned URL
     const newUri = r.uri + (newArgs ? "?" + newArgs : "");
@@ -141,10 +148,7 @@ function handleRequest(r) {
       // Existing auth header, forward as-is
       r.variables.auth_jwt = authHeader;
 
-      let targetLocation = "@frontend";
-      if (r.uri.startsWith("/api/")) {
-        targetLocation = "@backend";
-      }
+      const targetLocation = targetLocationForUri(r.uri);
       r.internalRedirect(targetLocation);
     } else {
       // No authentication provided

--- a/frontend/local-auth/nginx-jwt/nginx.conf
+++ b/frontend/local-auth/nginx-jwt/nginx.conf
@@ -19,6 +19,10 @@ http {
         server host.docker.internal:3130;
     }
 
+    upstream admin_backend {
+        server host.docker.internal:3131;
+    }
+
     server {
         listen 80;
         server_name localhost;
@@ -65,6 +69,18 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             
+            # Forward the JWT from the njs variable
+            proxy_set_header Authorization $auth_jwt;
+        }
+
+        # Internal location for the admin panel, including its frontend and API
+        location @admin {
+            proxy_pass http://admin_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
             # Forward the JWT from the njs variable
             proxy_set_header Authorization $auth_jwt;
         }

--- a/frontend/local-auth/oauth2-proxy-entra-id.template.cfg
+++ b/frontend/local-auth/oauth2-proxy-entra-id.template.cfg
@@ -7,11 +7,13 @@ scope="openid profile email offline_access"
 redirect_url = "http://localhost:4180/oauth2/callback"
 upstreams = [
     "http://localhost:3130/public/common/#/public/common/",
+    "http://localhost:3131/admin#/admin",
+    "http://localhost:3131/admin/#/admin/",
     "http://localhost:3000/#/",
     "http://localhost:3130/api/#/api/"
 ]
 skip_auth_routes = ["^/public/.*$", "^/office-addin/manifest\\.xml$"]
-api_routes = ["^/api/.*$"]
+api_routes = ["^/api/.*$", "^/admin/api/.*$"]
 email_domains = ["*"]
 http_address = "localhost:4180"
 cookie_secret = "{{COOKIE_SECRET}}"
@@ -21,7 +23,8 @@ cookie_name = "_oauth2_proxy"
 whitelist_domains = [
     ".localhost:4180",
     ".localhost:3000",
-    ".localhost:3130"
+    ".localhost:3130",
+    ".localhost:3131"
 ]
 set_xauthrequest = true
 pass_authorization_header = true

--- a/frontend/local-auth/oauth2-proxy-keycloak.cfg
+++ b/frontend/local-auth/oauth2-proxy-keycloak.cfg
@@ -13,6 +13,9 @@ upstreams = [
 #    "http://localhost:3130/#/",
 #     Shared public assets and locales should always come from the backend bundle
     "http://localhost:3130/public/common/#/public/common/",
+#     Admin panel routes (exact path and nested routes)
+    "http://localhost:3131/admin#/admin",
+    "http://localhost:3131/admin/#/admin/",
      "http://localhost:3000/#/",
 #     Api routes
     "http://localhost:3130/api/#/api/"
@@ -26,7 +29,8 @@ cookie_name = "_oauth2_proxy"
 whitelist_domains = [
     ".localhost:4180",
     ".localhost:3000",
-    ".localhost:3130"
+    ".localhost:3130",
+    ".localhost:3131"
 ]
 set_xauthrequest = true
 pass_authorization_header = true

--- a/frontend/local-auth/oauth2-proxy.cfg
+++ b/frontend/local-auth/oauth2-proxy.cfg
@@ -12,6 +12,9 @@ upstreams = [
 #    "http://localhost:3130/#/",
 #     Shared public assets and locales should always come from the backend bundle
     "http://localhost:3130/public/common/#/public/common/",
+#     Admin panel routes (exact path and nested routes)
+    "http://localhost:3131/admin#/admin",
+    "http://localhost:3131/admin/#/admin/",
      "http://localhost:3000/#/",
 #     Api routes
     "http://localhost:3130/api/#/api/"
@@ -25,7 +28,8 @@ cookie_name = "_oauth2_proxy"
 whitelist_domains = [
     ".localhost:4180",
     ".localhost:3000",
-    ".localhost:3130"
+    ".localhost:3130",
+    ".localhost:3131"
 ]
 set_xauthrequest = true
 pass_authorization_header = true 


### PR DESCRIPTION
This pull request adds support for routing admin panel requests through a dedicated backend and updates authentication proxy configurations to recognize and handle admin panel routes. The main changes include updating NGINX and OAuth2 Proxy configurations, as well as refactoring the NGINX JWT authentication logic to support the new admin backend.

**NGINX and routing changes:**

* Added a new `admin_backend` upstream and corresponding `@admin` internal location in `nginx.conf` to route `/admin` and `/admin/*` requests to a dedicated backend service. [[1]](diffhunk://#diff-ab5261fccc07c655a2c97def3ae12e49ea440a10feed8e528bd77a7ec01b466dR22-R25) [[2]](diffhunk://#diff-ab5261fccc07c655a2c97def3ae12e49ea440a10feed8e528bd77a7ec01b466dR75-R86)
* Refactored the NGINX JWT authentication script (`main.js`) to use a new `targetLocationForUri` helper for determining the appropriate upstream (`@admin`, `@backend`, or `@frontend`) based on the request URI, ensuring admin routes are handled correctly. [[1]](diffhunk://#diff-ae996ef39ec6074abc6bfdc0d078b26f7e3de7116504685386ba53a78213e9a9R73-R82) [[2]](diffhunk://#diff-ae996ef39ec6074abc6bfdc0d078b26f7e3de7116504685386ba53a78213e9a9L128-R138) [[3]](diffhunk://#diff-ae996ef39ec6074abc6bfdc0d078b26f7e3de7116504685386ba53a78213e9a9L144-R151)

**OAuth2 Proxy configuration updates:**

* Updated all OAuth2 Proxy config files (`oauth2-proxy.cfg`, `oauth2-proxy-keycloak.cfg`, `oauth2-proxy-entra-id.template.cfg`) to include admin panel routes in the `upstreams` list, allowing the proxy to forward requests to the admin backend. [[1]](diffhunk://#diff-01c81a3ed489a1c0bc37fc8b97e905c7be6c60e8159ff764354747d39dbc6e59R15-R17) [[2]](diffhunk://#diff-5bf44553fce05572ac59ebddf2857cb7bd8d8b9a6670b1d6eea69f06ef982fd9R16-R18) [[3]](diffhunk://#diff-76efa6277fe5cb2e5960539588e4f59929537dd4891da5e76e08ab671ec17077R10-R16)
* Added `/admin/api/.*` to the `api_routes` setting in `oauth2-proxy-entra-id.template.cfg` to ensure admin API endpoints are properly authenticated.
* Extended `whitelist_domains` in all OAuth2 Proxy config files to include `.localhost:3131`, supporting cookies and authentication for the admin backend. [[1]](diffhunk://#diff-01c81a3ed489a1c0bc37fc8b97e905c7be6c60e8159ff764354747d39dbc6e59L28-R32) [[2]](diffhunk://#diff-5bf44553fce05572ac59ebddf2857cb7bd8d8b9a6670b1d6eea69f06ef982fd9L29-R33) [[3]](diffhunk://#diff-76efa6277fe5cb2e5960539588e4f59929537dd4891da5e76e08ab671ec17077L24-R27)