### PR TITLE
Model switch marker: add-in parity and shared transcript notice

### DIFF
--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -125,6 +125,7 @@ vi.mock("@/hooks/chat", () => ({
     modelsError: null,
     isSelectionReady: false,
   }),
+  useModelSwitches: () => ({}),
   useStandardMessageActions: () => vi.fn().mockResolvedValue(false),
 }));
 

--- a/frontend/src/components/ui/Chat/Chat.test.tsx
+++ b/frontend/src/components/ui/Chat/Chat.test.tsx
@@ -80,6 +80,7 @@ vi.mock("@/hooks/chat", () => ({
     handleSendMessage: vi.fn().mockResolvedValue(undefined),
     handleMessageAction: vi.fn(),
   }),
+  useModelSwitches: () => ({}),
   useStandardMessageActions: () => vi.fn(),
 }));
 

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -19,6 +19,7 @@ import {
 import {
   useActiveModelSelection,
   useChatActions,
+  useModelSwitches,
   useStandardMessageActions,
 } from "@/hooks/chat";
 import { useMessageFeedback } from "@/hooks/chat/useMessageFeedback";
@@ -36,7 +37,6 @@ import {
   useSidebarFeature,
 } from "@/providers/FeatureConfigProvider";
 import { isPromptInjectionFilterDetails } from "@/types/chat";
-import { getModelSwitches } from "@/utils/chat/modelSwitches";
 import { mapRecentChatToSession } from "@/utils/chat/recentChatSession";
 import { createLogger } from "@/utils/debugLogger";
 
@@ -307,15 +307,11 @@ export const Chat = ({
   const canEditForCurrentChat = Array.isArray(chatHistory)
     ? !!chatHistory.find((c) => c.id === (currentChatId ?? ""))?.can_edit
     : false;
-  const modelSwitches = useMemo(() => {
-    const modelNames = new Map(
-      availableModels.map((model) => [
-        model.chat_provider_id,
-        model.model_display_name,
-      ]),
-    );
-    return getModelSwitches(messages, messageOrder, modelNames);
-  }, [availableModels, messageOrder, messages]);
+  const modelSwitches = useModelSwitches(
+    messages,
+    messageOrder,
+    availableModels,
+  );
   const lastMessage =
     messageOrder.length > 0
       ? messages[messageOrder[messageOrder.length - 1]]

--- a/frontend/src/components/ui/Message/ConversationIndicator.tsx
+++ b/frontend/src/components/ui/Message/ConversationIndicator.tsx
@@ -2,6 +2,8 @@ import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { memo } from "react";
 
+import { TranscriptNotice } from "./TranscriptNotice";
+
 interface ConversationIndicatorProps {
   /**
    * The type of indicator to show
@@ -38,14 +40,11 @@ export const ConversationIndicator = memo<ConversationIndicatorProps>(
     };
 
     return (
-      <div
-        className={clsx(
-          "flex justify-center py-2 text-xs text-theme-fg-secondary",
-          className,
-        )}
+      <TranscriptNotice
+        className={clsx("py-2 text-theme-fg-secondary", className)}
       >
-        <span>{text ?? getDefaultText()}</span>
-      </div>
+        {text ?? getDefaultText()}
+      </TranscriptNotice>
     );
   },
 );

--- a/frontend/src/components/ui/Message/ModelSwitchMarker.test.tsx
+++ b/frontend/src/components/ui/Message/ModelSwitchMarker.test.tsx
@@ -15,7 +15,7 @@ beforeAll(() => {
 });
 
 describe("ModelSwitchMarker", () => {
-  it("explains the impact of continuing with a different model", () => {
+  it("names both sides of the transition", () => {
     render(
       <I18nProvider i18n={i18n}>
         <ModelSwitchMarker fromModel="Model One" toModel="Model Two" />
@@ -25,9 +25,22 @@ describe("ModelSwitchMarker", () => {
     const marker = screen.getByTestId("model-switch-marker");
 
     expect(marker).toHaveAttribute("role", "note");
-    expect(marker).toHaveClass("w-full", "justify-center", "mb-4");
+    expect(marker).toHaveClass("w-full", "justify-center");
     expect(
       screen.getByText("Model changed from Model One to Model Two"),
     ).toBeInTheDocument();
+  });
+
+  it("takes its spacing from theme tokens so customer themes can retune it", () => {
+    render(
+      <I18nProvider i18n={i18n}>
+        <ModelSwitchMarker fromModel="Model One" toModel="Model Two" />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("model-switch-marker")).toHaveStyle({
+      gap: "var(--theme-spacing-control-gap)",
+      marginBottom: "var(--theme-spacing-message-padding-y)",
+    });
   });
 });

--- a/frontend/src/components/ui/Message/ModelSwitchMarker.tsx
+++ b/frontend/src/components/ui/Message/ModelSwitchMarker.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/react/macro";
 
+import { TranscriptNotice } from "./TranscriptNotice";
 import { InfoIcon } from "../icons";
 
 /**
@@ -12,16 +13,17 @@ export const ModelSwitchMarker = ({
   fromModel: string;
   toModel: string;
 }) => (
-  <div
+  <TranscriptNotice
     role="note"
     data-testid="model-switch-marker"
-    className="mb-4 flex w-full items-center justify-center gap-2 text-xs text-theme-fg-muted"
+    className="text-theme-fg-muted"
+    // Separates the marker from the turn it introduces, on the same scale as
+    // the message padding so a theme that loosens messages loosens this too.
+    style={{ marginBottom: "var(--theme-spacing-message-padding-y)" }}
+    icon={<InfoIcon className="size-3.5 shrink-0" aria-hidden="true" />}
   >
-    <InfoIcon className="size-3.5 shrink-0" aria-hidden="true" />
-    <span>
-      <Trans id="chat.message.modelChanged">
-        Model changed from {fromModel} to {toModel}
-      </Trans>
-    </span>
-  </div>
+    <Trans id="chat.message.modelChanged">
+      Model changed from {fromModel} to {toModel}
+    </Trans>
+  </TranscriptNotice>
 );

--- a/frontend/src/components/ui/Message/TranscriptNotice.tsx
+++ b/frontend/src/components/ui/Message/TranscriptNotice.tsx
@@ -1,0 +1,43 @@
+import clsx from "clsx";
+
+import type { ReactNode } from "react";
+
+interface TranscriptNoticeProps {
+  /** The notice text. */
+  children: ReactNode;
+  /** Optional leading icon; render it `aria-hidden`, the text carries the meaning. */
+  icon?: ReactNode;
+  /** Vertical spacing and tone are the caller's, so each notice keeps its own rhythm. */
+  className?: string;
+  style?: React.CSSProperties;
+  role?: "note";
+  "data-testid"?: string;
+}
+
+/**
+ * Centered, quiet annotation between messages — the shared shape for anything
+ * that comments on the transcript itself rather than on one message's content.
+ * Message-scoped footnotes align with the message text instead and do not
+ * belong here.
+ */
+export const TranscriptNotice = ({
+  children,
+  icon,
+  className,
+  style,
+  role,
+  "data-testid": dataTestId,
+}: TranscriptNoticeProps) => (
+  <div
+    role={role}
+    data-testid={dataTestId}
+    className={clsx(
+      "flex w-full items-center justify-center text-xs",
+      className,
+    )}
+    style={{ gap: "var(--theme-spacing-control-gap)", ...style }}
+  >
+    {icon}
+    <span>{children}</span>
+  </div>
+);

--- a/frontend/src/components/ui/Message/index.ts
+++ b/frontend/src/components/ui/Message/index.ts
@@ -4,4 +4,5 @@ export * from "./MessageContent";
 export * from "./MessageTimestamp";
 export * from "./DefaultMessageControls";
 export * from "./ConversationIndicator";
+export * from "./TranscriptNotice";
 export * from "./LoadMoreButton";

--- a/frontend/src/components/ui/MessageList/MessageList.test.tsx
+++ b/frontend/src/components/ui/MessageList/MessageList.test.tsx
@@ -1,7 +1,18 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { messages as enMessages } from "@/locales/en/messages.json";
 
 import { MessageList } from "./MessageList";
+
+import type { Messages } from "@lingui/core";
+
+beforeAll(() => {
+  i18n.load("en", enMessages as unknown as Messages);
+  i18n.activate("en");
+});
 
 describe("MessageList", () => {
   it("centers empty state components independently from message width", () => {
@@ -58,6 +69,52 @@ describe("MessageList", () => {
     expect(contentShell).toHaveStyle({
       maxWidth: "var(--theme-layout-chat-content-max-width)",
     });
+  });
+
+  it("renders a model-switch marker only on the turn it belongs to", () => {
+    const messages = {
+      user1: {
+        id: "user1",
+        role: "user" as const,
+        content: [{ content_type: "text" as const, text: "first" }],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        sender: "user",
+        authorId: "author-1",
+      },
+      user2: {
+        id: "user2",
+        role: "user" as const,
+        content: [{ content_type: "text" as const, text: "second" }],
+        createdAt: "2026-01-01T00:01:00.000Z",
+        sender: "user",
+        authorId: "author-1",
+      },
+    };
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <MessageList
+          messages={messages}
+          messageOrder={["user1", "user2"]}
+          loadOlderMessages={vi.fn()}
+          hasOlderMessages={false}
+          isPending={false}
+          currentSessionId="chat-1"
+          controlsContext={{}}
+          onMessageAction={vi.fn(async () => true)}
+          messageRenderer={({ message }) => <div>{message.id}</div>}
+          modelSwitches={{
+            user2: { fromModel: "Model One", toModel: "Model Two" },
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    const markers = screen.getAllByTestId("model-switch-marker");
+
+    expect(markers).toHaveLength(1);
+    // The marker introduces the turn that changed model, so it must precede it.
+    expect(markers[0].nextElementSibling?.textContent).toBe("user2");
   });
 
   it("preserves an explicit numeric width override when provided", () => {

--- a/frontend/src/hooks/chat/index.ts
+++ b/frontend/src/hooks/chat/index.ts
@@ -11,4 +11,5 @@ export * from "./useChatActions";
 export * from "./useStandardMessageActions";
 export * from "./useTokenManagement";
 export * from "./useModelHistory";
+export * from "./useModelSwitches";
 export * from "./useActiveModelSelection";

--- a/frontend/src/hooks/chat/useModelSwitches.ts
+++ b/frontend/src/hooks/chat/useModelSwitches.ts
@@ -1,0 +1,29 @@
+/**
+ * Custom hook for historical model switches
+ *
+ * Resolves the transcript's model transitions to display names, so every chat
+ * surface derives them the same way instead of each host re-deriving its own.
+ */
+import { useMemo } from "react";
+
+import { getModelSwitches } from "@/utils/chat/modelSwitches";
+
+import type { ChatModel } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { Message } from "@/types/chat";
+import type { ModelSwitch } from "@/utils/chat/modelSwitches";
+
+export function useModelSwitches(
+  messages: Record<string, Message>,
+  messageOrder: readonly string[],
+  availableModels: readonly ChatModel[],
+): Record<string, ModelSwitch> {
+  return useMemo(() => {
+    const modelNames = new Map(
+      availableModels.map((model) => [
+        model.chat_provider_id,
+        model.model_display_name,
+      ]),
+    );
+    return getModelSwitches(messages, messageOrder, modelNames);
+  }, [availableModels, messageOrder, messages]);
+}

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -273,6 +273,7 @@ export {
   useChatHistory,
   useChatMessaging,
   useModelHistory,
+  useModelSwitches,
   useStandardMessageActions,
   useTokenManagement,
   useActiveModelSelection,

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -27,6 +27,7 @@ import {
   useFilePreviewModal,
   useFileUploadWithTokenCheck,
   useMessageFeedback,
+  useModelSwitches,
   useProfile,
   useStandardMessageActions,
   type ActionFacetRequest,
@@ -125,6 +126,7 @@ export interface AddinChatController {
   hostCallbacksRef: MutableRefObject<AddinChatHostCallbacks>;
   messages: ReturnType<typeof useChatContext>["messages"];
   messageOrder: string[];
+  modelSwitches: ReturnType<typeof useModelSwitches>;
   isMessagingLoading: boolean;
   isPendingResponse: boolean;
   chats: ReturnType<typeof useChatContext>["chats"];
@@ -252,6 +254,11 @@ function useAddinChatController({
   >((run) => openChatById(run.id), [openChatById]);
   const { availableModels, selectedModel, setSelectedModel, isSelectionReady } =
     useActiveModelSelection({ initialModel: chat.currentChatLastModel });
+  const modelSwitches = useModelSwitches(
+    chat.messages,
+    chat.messageOrder,
+    availableModels,
+  );
   const acceptedFileTypes = useMemo(
     () => getSupportedFileTypes(capabilities),
     [capabilities],
@@ -442,6 +449,7 @@ function useAddinChatController({
     hostCallbacksRef,
     messages: chat.messages,
     messageOrder: chat.messageOrder,
+    modelSwitches,
     isMessagingLoading: chat.isMessagingLoading,
     isPendingResponse: chat.isPendingResponse,
     chats: chat.chats,
@@ -697,6 +705,7 @@ export function AddinChatCoreView({
                   virtualizationThreshold={30}
                   onFilePreview={controller.openPreviewModal}
                   onViewFeedback={feedback.openFeedbackViewDialog}
+                  modelSwitches={controller.modelSwitches}
                   className="overscroll-none"
                 />
               </MessageEditProvider>

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -207,7 +207,12 @@ vi.mock("@erato/frontend/library", async () => {
     FeedbackCommentDialog: () => null,
     FeedbackViewDialog: () => null,
     FilePreviewModal: () => null,
-    MessageList: () => <div data-testid="neutral-message-list" />,
+    MessageList: ({ modelSwitches }: { modelSwitches?: unknown }) => (
+      <div
+        data-testid="neutral-message-list"
+        data-model-switches={JSON.stringify(modelSwitches ?? null)}
+      />
+    ),
     MessageEditProvider: ({ children }: { children?: ReactNode }) => children,
     chatMessagesQuery: () => ({ queryKey: ["chat-messages"] }),
     componentRegistry: {},
@@ -220,6 +225,9 @@ vi.mock("@erato/frontend/library", async () => {
       selectedModel: null,
       setSelectedModel: vi.fn(),
       isSelectionReady: true,
+    }),
+    useModelSwitches: () => ({
+      "message-2": { fromModel: "Model One", toModel: "Model Two" },
     }),
     useConversationDropzone: () => ({
       getRootProps: () => ({}),
@@ -337,6 +345,17 @@ describe("NeutralAddinChatPage host boundary", () => {
           new URL(node.src).hostname === "appsforoffice.microsoft.com",
       ),
     ).toBe(false);
+  });
+
+  it("shows model switches in the transcript, like the web surface", () => {
+    renderPage();
+
+    expect(screen.getByTestId("neutral-message-list")).toHaveAttribute(
+      "data-model-switches",
+      JSON.stringify({
+        "message-2": { fromModel: "Model One", toModel: "Model Two" },
+      }),
+    );
   });
 
   it("uses the chat body surface behind both messages and the composer", () => {

--- a/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
+++ b/office-addin/src/outlook/__tests__/OutlookAddinChat.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@erato/frontend/library", () => ({
     setSelectedModel: vi.fn(),
     isSelectionReady: true,
   }),
+  useModelSwitches: () => ({}),
   useChatContext: () => ({
     messages: {},
     messageOrder: [],

--- a/office-addin/src/teams/__tests__/TeamsApp.test.tsx
+++ b/office-addin/src/teams/__tests__/TeamsApp.test.tsx
@@ -274,6 +274,7 @@ vi.mock("@erato/frontend/library", async () => {
       setSelectedModel: vi.fn(),
       isSelectionReady: true,
     }),
+    useModelSwitches: () => ({}),
     useConversationDropzone: () => ({
       getRootProps: () => ({}),
       getInputProps: () => ({}),


### PR DESCRIPTION
Stacked on #1041 — review that first, this PR's diff is only the delta.

Follow-ups from reviewing #1041. The marker's data model is right; these are the gaps around it.

## Add-in / Teams / Outlook parity

`Chat.tsx` derived the switches locally, so only the web surface rendered them — even though `AddinChatCore` already holds `messages`, `messageOrder` and `availableModels` at the same call site.

The derivation now lives in `useModelSwitches`, exported from the library barrel and consumed by both surfaces. It stays a hook rather than moving into `ChatProvider` because `selectedModel`/`availableModels` come from `useActiveModelSelection`, which is component state at three independent call sites — the provider never sees it.

## Shared transcript notice

`ModelSwitchMarker` and `ConversationIndicator` are the same information type: a centered, quiet annotation about the transcript rather than about one message's content. They were two separate implementations of that shape, so `TranscriptNotice` now carries it and both render through it.

`ConversationIndicator` keeps its exact current look (`py-2`, `text-theme-fg-secondary`) — the tone difference between the two is left alone deliberately, see below.

## Theme compliance

The marker's spacing was hard-coded (`mb-4`, `gap-2`), which a customer theme cannot retune. Both now come from theme tokens:

- icon gap → `--theme-spacing-control-gap`
- bottom spacing → `--theme-spacing-message-padding-y` (same 1rem as before, but on the message scale, so a theme that loosens messages loosens this too)

`text-xs` and `text-theme-fg-muted` were already themed — Tailwind's `fontSize` maps to `--theme-font-size-*`.

Centering also happens to fix the Beckhoff kit case: that kit swaps `ChatMessageRenderer` for right-aligned bubbles, and anything rendered as a sibling of the renderer is full-width, so a left-flush marker would have landed on the opposite side of the column from the turn it annotates.

## Tests

- `MessageList` — the marker renders once, on the right turn, and *precedes* it (uses the public `messageRenderer` prop, no module mocks).
- `ModelSwitchMarker` — spacing resolves to theme tokens.
- `NeutralAddinChatPage` — `modelSwitches` actually reaches `MessageList` on the add-in surface.
- Three add-in test files wholesale-mock the library barrel, so they needed the new export added; likewise `Chat.test.tsx` and `ChatPage.test.tsx` for `@/hooks/chat`.

Full suites green: frontend 1473 passed / 11 skipped, add-in 1084 passed. `tsc --noEmit` clean on both. Lint and prettier clean.

## Not addressed here

- **Retired models show a raw provider id.** `modelNames` is built from `availableModels`, so a historical switch involving a retired model renders e.g. `bifrost_claude_opus_4_8` instead of a display name. There is no other source for the name — worth a decision rather than a silent fallback.
- **Pre-existing, and now user-visible:** `AssistantChatSpacePage.tsx` passes `initialModelOverride={assistantDefaultModel}` ungated on `chatId`, unlike the adjacent `assistantId`. Opening an existing assistant chat silently resets the composer to the assistant default, so the next turn can go out on a different model than the user last chose — which this marker will then correctly record as a switch the user never made. Fix is `chatId ? undefined : assistantDefaultModel`, but it changes composer behaviour, so it belongs in its own PR.