### PR TITLE
Draw sent-message attachments with the shared tile

### DIFF
--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -3,14 +3,7 @@ import { Trans } from "@lingui/react/macro";
 import clsx from "clsx";
 import { memo, useCallback, useMemo, useState } from "react";
 
-import { InteractiveContainer } from "@/components/ui/Container/InteractiveContainer";
-import {
-  getFileName,
-  type FileResource,
-} from "@/components/ui/FileUpload/FilePreviewBase";
-import { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
 import { useImageLightbox } from "@/hooks/ui/useImageLightbox";
-import { useGetFile } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import {
   useErrorReportFeature,
   useMessageFeedbackFeature,
@@ -20,10 +13,9 @@ import {
   type MessageErrorFilterDetails,
 } from "@/types/chat";
 import { hasToolCalls as messageHasToolCalls } from "@/utils/adapters/toolCallAdapter";
-import { isImageFile } from "@/utils/file/fileTypeUtils";
-import { teamsUploadDisplayName } from "@/utils/teams/teamsUploadName";
 
 import { McpNeedsAuthNotice } from "./McpNeedsAuthNotice";
+import { MessageAttachments } from "./MessageAttachments";
 import { Alert } from "../Feedback/Alert";
 import { Avatar } from "../Feedback/Avatar";
 import { CopyErrorButton } from "../Feedback/CopyErrorButton";
@@ -45,11 +37,6 @@ import type {
   UserProfile,
 } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type { UiChatMessage } from "@/utils/adapters/messageAdapter";
-
-const getPreviewUrl = (
-  file: Pick<FileUploadItem, "preview_url" | "download_url">,
-): string =>
-  typeof file.preview_url === "string" ? file.preview_url : file.download_url;
 
 /**
  * Host-implemented building blocks handed to `ChatMessageRenderer` overrides.
@@ -292,16 +279,12 @@ export const ChatMessage = memo(function ChatMessage({
 
           {/* Display attached files if any */}
           {message.input_files_ids && message.input_files_ids.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-2">
-              {message.input_files_ids.map((fileId) => (
-                <AttachedFile
-                  key={fileId}
-                  fileId={fileId}
-                  relatedFiles={siblingFiles}
-                  onFilePreview={onFilePreview}
-                />
-              ))}
-            </div>
+            <MessageAttachments
+              fileIds={message.input_files_ids}
+              filesById={filesById}
+              relatedFiles={siblingFiles}
+              onFilePreview={onFilePreview}
+            />
           )}
 
           {message.loading && message.content.length === 0 && (
@@ -572,114 +555,6 @@ const formatFilterLabel = (value: string) =>
     .split("_")
     .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
     .join(" ");
-
-// Helper component to fetch and display a single attached file
-const AttachedFile = ({
-  fileId,
-  relatedFiles,
-  onFilePreview,
-}: {
-  fileId: string;
-  relatedFiles: readonly FileUploadItem[];
-  onFilePreview?: (
-    file: FileUploadItem,
-    relatedFiles?: readonly FileUploadItem[],
-  ) => void;
-}) => {
-  const {
-    data: fileData,
-    isLoading,
-    error,
-  } = useGetFile(
-    { pathParams: { fileId } },
-    {
-      // Optional: configure react-query options like staleTime, cacheTime, etc.
-      staleTime: Infinity, // Assume file metadata doesn't change often
-    },
-  );
-
-  if (isLoading) {
-    return (
-      <div className="text-xs text-theme-fg-muted">
-        {t({ id: "chat.file.loading", message: "Loading file..." })}
-      </div>
-    );
-  }
-
-  if (error || !fileData) {
-    console.error(`Failed to load file ${fileId}:`, error);
-    return (
-      <div className="text-xs text-theme-error-fg">
-        {t({ id: "chat.file.error", message: "Error loading file" })}
-      </div>
-    );
-  }
-
-  const previewUrl = getPreviewUrl(fileData);
-  // A Teams upload is named after its bytes so the backend can join it to the
-  // message that carried it. That name is a key, not something to read; the
-  // transcript's own index holds the exact one, and this recovers the readable
-  // part for a chip that has only the upload.
-  const readableName = teamsUploadDisplayName(fileData.filename);
-  const shownFile: FileResource = readableName
-    ? { ...fileData, displayName: readableName }
-    : fileData;
-
-  // Check if it's an image using centralized utility
-  if (isImageFile(fileData.filename) && previewUrl) {
-    return (
-      <InteractiveContainer
-        useDiv={true}
-        fullWidth={false}
-        className="relative inline-block cursor-pointer"
-        aria-label={`${t({ id: "chat.file.preview.aria", message: "Preview attached file:" })} ${fileData.filename}`}
-        onClick={() => {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (onFilePreview && fileData) {
-            onFilePreview(fileData, relatedFiles);
-          } else if (previewUrl) {
-            window.open(previewUrl, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
-          }
-        }}
-      >
-        <img
-          src={previewUrl}
-          alt={fileData.filename}
-          className="size-24 rounded-lg border border-theme-border-primary object-cover transition-transform hover:scale-105"
-        />
-        <div className="mt-1 max-w-[96px] truncate text-xs text-theme-fg-muted">
-          {getFileName(shownFile)}
-        </div>
-      </InteractiveContainer>
-    );
-  }
-
-  // For non-images, show the regular file button
-  return (
-    <InteractiveContainer
-      onClick={() => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (onFilePreview && fileData) {
-          onFilePreview(fileData, relatedFiles);
-        } else if (previewUrl) {
-          window.open(previewUrl, "_blank", "noopener,noreferrer"); // eslint-disable-line lingui/no-unlocalized-strings
-        }
-      }}
-      aria-label={`${t({ id: "chat.file.preview.aria", message: "Preview attached file:" })} ${fileData.filename}`}
-      className="cursor-pointer hover:bg-theme-bg-accent"
-      useDiv={true}
-    >
-      <FilePreviewButton
-        file={shownFile}
-        onRemove={() => {}}
-        disabled={true}
-        showFileType={true}
-        showSize={true}
-        filenameTruncateLength={25}
-      />
-    </InteractiveContainer>
-  );
-};
 
 // Add display name for better debugging
 // eslint-disable-next-line lingui/no-unlocalized-strings

--- a/frontend/src/components/ui/Chat/MessageAttachments.test.tsx
+++ b/frontend/src/components/ui/Chat/MessageAttachments.test.tsx
@@ -1,0 +1,176 @@
+import { I18nProvider } from "@lingui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { messages as enMessages } from "@/locales/en/messages.json";
+
+import { MessageAttachments } from "./MessageAttachments";
+
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type { Messages } from "@lingui/core";
+
+const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+async function renderWithProviders(ui: React.ReactElement) {
+  const { i18n } = await import("@lingui/core");
+  i18n.load("en", enMessages as unknown as Messages);
+  i18n.activate("en");
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider i18n={i18n}>
+        <ThemeProvider
+          enableCustomTheme={false}
+          initialThemeMode="light"
+          persistThemeMode={false}
+        >
+          {ui}
+        </ThemeProvider>
+      </I18nProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const file = (
+  id: string,
+  filename: string,
+  previewUrl?: string,
+): FileUploadItem =>
+  ({
+    id,
+    filename,
+    download_url: `https://example.invalid/${id}`,
+    preview_url: previewUrl,
+  }) as FileUploadItem;
+
+const byId = (...files: FileUploadItem[]) =>
+  Object.fromEntries(files.map((entry) => [entry.id, entry]));
+
+describe("MessageAttachments", () => {
+  it("resolves attachments from the conversation's own file map", async () => {
+    const files = [file("1", "spec.pdf"), file("2", "notes.txt")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1", "2"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+      />,
+    );
+
+    expect(screen.getByText("spec.pdf")).toBeInTheDocument();
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+  });
+
+  it("does not request files the conversation already knows about", async () => {
+    fetchSpy.mockClear();
+    const files = [file("1", "spec.pdf")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+      />,
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("offers no remove affordance, because a sent attachment cannot be removed", async () => {
+    const files = [file("1", "spec.pdf")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /^Remove/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names each attachment for assistive tech, since tiles carry no caption", async () => {
+    const files = [
+      file("1", "shot.png", "https://example.invalid/preview/1"),
+      file("2", "revenue.csv"),
+    ];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1", "2"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+        onFilePreview={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Preview attachment shot.png, PNG" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Preview attachment revenue.csv, CSV",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("hands the activated file and its siblings to the preview", async () => {
+    const onFilePreview = vi.fn();
+    const files = [file("1", "spec.pdf"), file("2", "notes.txt")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+        onFilePreview={onFilePreview}
+      />,
+    );
+
+    screen
+      .getByRole("button", { name: /Preview attachment spec\.pdf/ })
+      .click();
+
+    expect(onFilePreview).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "1" }),
+      files,
+    );
+  });
+
+  it("skips ids it cannot resolve rather than rendering a broken tile", async () => {
+    const files = [file("1", "spec.pdf")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1", "not-in-the-map"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+      />,
+    );
+
+    expect(screen.getByText("spec.pdf")).toBeInTheDocument();
+    expect(screen.queryByText(/not-in-the-map/)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when no attachment resolves", async () => {
+    const { container } = await renderWithProviders(
+      <MessageAttachments
+        fileIds={["missing"]}
+        filesById={{}}
+        relatedFiles={[]}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/ui/Chat/MessageAttachments.tsx
+++ b/frontend/src/components/ui/Chat/MessageAttachments.tsx
@@ -1,0 +1,112 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { AttachmentTileList } from "@/components/ui/FileUpload/AttachmentTileList";
+import { getFileQuery } from "@/lib/generated/v1betaApi/v1betaApiComponents";
+import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
+import { teamsUploadDisplayName } from "@/utils/teams/teamsUploadName";
+
+import type { AttachmentTileItem } from "@/components/ui/FileUpload/AttachmentTileList";
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+import type React from "react";
+
+export interface MessageAttachmentsProps {
+  /** File ids carried by the message, in the order they were attached. */
+  fileIds: string[];
+  /** Everything the conversation already knows, keyed by id. */
+  filesById: Record<string, FileUploadItem>;
+  /** Handed to the preview so it can offer navigation between siblings. */
+  relatedFiles: readonly FileUploadItem[];
+  onFilePreview?: (
+    file: FileUploadItem,
+    relatedFiles?: readonly FileUploadItem[],
+  ) => void;
+}
+
+const getPreviewUrl = (file: FileUploadItem): string =>
+  typeof file.preview_url === "string" ? file.preview_url : file.download_url;
+
+/**
+ * Attachments of a sent message, drawn with the shared tile.
+ *
+ * The conversation already carries its file records, so ids are resolved from
+ * that map rather than refetched one request per attachment. Only ids missing
+ * from it fall back to a fetch — an optimistic message can name a file before
+ * its metadata has been rehydrated.
+ */
+export const MessageAttachments: React.FC<MessageAttachmentsProps> = ({
+  fileIds,
+  filesById,
+  relatedFiles,
+  onFilePreview,
+}) => {
+  const { queryOptions, fetcherOptions } = useV1betaApiContext({});
+
+  const missingIds = useMemo(
+    () => fileIds.filter((fileId) => !(fileId in filesById)),
+    [fileIds, filesById],
+  );
+
+  const fetched = useQueries({
+    queries: missingIds.map((fileId) => ({
+      ...getFileQuery({ ...fetcherOptions, pathParams: { fileId } }),
+      ...queryOptions,
+      staleTime: Infinity,
+    })),
+  });
+
+  // `Partial` because a lookup can genuinely miss — a file still in flight —
+  // while a plain index signature would claim every key resolves.
+  const resolvedById = useMemo<Partial<Record<string, FileUploadItem>>>(() => {
+    const map: Partial<Record<string, FileUploadItem>> = {};
+    missingIds.forEach((fileId, index) => {
+      const file = fetched[index]?.data;
+      if (file) {
+        map[fileId] = file;
+      }
+    });
+    // The conversation's own records are the freshest, so they win.
+    return { ...map, ...filesById };
+  }, [missingIds, fetched, filesById]);
+
+  const items = useMemo<AttachmentTileItem[]>(
+    () =>
+      fileIds.flatMap((fileId) => {
+        const file = resolvedById[fileId];
+        if (!file) {
+          return [];
+        }
+
+        // A Teams upload is named after its bytes so the backend can join it
+        // to the message that carried it. That name is a key, not something to
+        // read, so recover the readable part where one exists.
+        const displayName = teamsUploadDisplayName(file.filename);
+
+        return [
+          {
+            id: fileId,
+            file: displayName ? { ...file, displayName } : file,
+            previewUrl: getPreviewUrl(file),
+          },
+        ];
+      }),
+    [fileIds, resolvedById],
+  );
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <AttachmentTileList
+      items={items}
+      size="medium"
+      className="mt-2"
+      onActivate={
+        onFilePreview
+          ? (item) => onFilePreview(item.file as FileUploadItem, relatedFiles)
+          : undefined
+      }
+    />
+  );
+};

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -130,10 +130,14 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
   // caller to pre-filter what it passes.
   const isMedia = Boolean(previewUrl) && fileType === "image" && !imageFailed;
 
+  // A thumbnail carries no caption, so the filename has to reach assistive
+  // tech some other way. Inside an activatable tile the button's own label
+  // says it, and repeating it on the image would announce it twice; standalone,
+  // the alt text is the only carrier.
   const face = isMedia ? (
     <img
       src={previewUrl ?? undefined}
-      alt={filename}
+      alt={onActivate ? "" : filename}
       onError={() => setImageFailed(true)}
       className={clsx(
         geometry.media,
@@ -145,6 +149,8 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       className={clsx(
         "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border p-2 text-left",
         "border-[var(--theme-border)] bg-[var(--theme-bg-secondary)]",
+        onActivate &&
+          "transition-colors group-hover:border-[var(--theme-border-focus)] group-hover:bg-[var(--theme-bg-accent)]",
       )}
     >
       <span
@@ -185,20 +191,24 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       data-filetype={fileType}
     >
       {onActivate ? (
+        // Opening a preview mutates nothing, so it stays available even while
+        // the surface is disabled — `disabled` gates removal only.
         <button
           type="button"
           onClick={onActivate}
           title={filename}
-          aria-label={`${t`Preview attachment`} ${filename}`}
+          aria-label={`${t`Preview attachment`} ${filename}, ${typeLabel}`}
           className={clsx(
-            "block w-full rounded-[var(--theme-radius-base)] text-left",
+            "block w-full cursor-pointer rounded-[var(--theme-radius-base)] text-left",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2",
-            !disabled && "cursor-pointer hover:opacity-90",
+            isMedia && "hover:opacity-90",
           )}
         >
           {face}
         </button>
       ) : (
+        // Not interactive, so it cannot hold focus — the title serves hover and
+        // the image's alt text serves assistive tech.
         <div title={filename}>{face}</div>
       )}
 

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1389,18 +1389,18 @@ msgstr "Tool {facetDisplayName} abwählen"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.error"
-msgstr "Fehler beim Laden der Datei"
+#~ msgid "chat.file.error"
+#~ msgstr "Fehler beim Laden der Datei"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.loading"
-msgstr "Datei wird geladen..."
+#~ msgid "chat.file.loading"
+#~ msgstr "Datei wird geladen..."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.preview.aria"
-msgstr "Angehängte Datei anzeigen:"
+#~ msgid "chat.file.preview.aria"
+#~ msgstr "Angehängte Datei anzeigen:"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1389,18 +1389,18 @@ msgstr "Deselect {facetDisplayName}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.error"
-msgstr "Error loading file"
+#~ msgid "chat.file.error"
+#~ msgstr "Error loading file"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.loading"
-msgstr "Loading file..."
+#~ msgid "chat.file.loading"
+#~ msgstr "Loading file..."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.preview.aria"
-msgstr "Preview attached file:"
+#~ msgid "chat.file.preview.aria"
+#~ msgstr "Preview attached file:"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1389,18 +1389,18 @@ msgstr "Deseleccionar {facetDisplayName}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.error"
-msgstr "Error al cargar el archivo"
+#~ msgid "chat.file.error"
+#~ msgstr "Error al cargar el archivo"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.loading"
-msgstr "Cargando archivo..."
+#~ msgid "chat.file.loading"
+#~ msgstr "Cargando archivo..."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.preview.aria"
-msgstr "Vista previa del archivo adjunto:"
+#~ msgid "chat.file.preview.aria"
+#~ msgstr "Vista previa del archivo adjunto:"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1389,18 +1389,18 @@ msgstr "Désélectionner {facetDisplayName}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.error"
-msgstr "Erreur lors du chargement du fichier"
+#~ msgid "chat.file.error"
+#~ msgstr "Erreur lors du chargement du fichier"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.loading"
-msgstr "Chargement du fichier..."
+#~ msgid "chat.file.loading"
+#~ msgstr "Chargement du fichier..."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.preview.aria"
-msgstr "Aperçu du fichier joint :"
+#~ msgid "chat.file.preview.aria"
+#~ msgstr "Aperçu du fichier joint :"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1389,18 +1389,18 @@ msgstr "Odznacz {facetDisplayName}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.error"
-msgstr "Błąd wczytywania pliku"
+#~ msgid "chat.file.error"
+#~ msgstr "Błąd wczytywania pliku"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.loading"
-msgstr "Ładowanie pliku..."
+#~ msgid "chat.file.loading"
+#~ msgstr "Ładowanie pliku..."
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
-msgid "chat.file.preview.aria"
-msgstr "Podgląd załączonego pliku:"
+#~ msgid "chat.file.preview.aria"
+#~ msgstr "Podgląd załączonego pliku:"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -19,6 +19,8 @@ export type { ChatMessageHostComponents } from "@/components/ui/Chat/ChatMessage
 export type { ChatMessageProps } from "@/components/ui/Chat/ChatMessage";
 export type { ChatTopLeftAccessoryProps } from "@/components/ui/Chat/ChatTopLeftAccessory";
 export { McpNeedsAuthNotice } from "@/components/ui/Chat/McpNeedsAuthNotice";
+export { MessageAttachments } from "@/components/ui/Chat/MessageAttachments";
+export type { MessageAttachmentsProps } from "@/components/ui/Chat/MessageAttachments";
 export { DefaultStarterPromptsSection } from "@/components/ui/Chat/StarterPromptsSection";
 export { StarterPromptsSection } from "@/components/ui/Chat/StarterPromptsSection";
 export type { StarterPromptsRendererProps } from "@/components/ui/Chat/StarterPromptsSection";

--- a/frontend/src/stories/ui/AttachmentTile.stories.tsx
+++ b/frontend/src/stories/ui/AttachmentTile.stories.tsx
@@ -1,6 +1,7 @@
 import { action } from "@storybook/addon-actions";
 
 import { ChatInput } from "../../components/ui/Chat/ChatInput";
+import { ChatMessage } from "../../components/ui/Chat/ChatMessage";
 import { AttachmentTile } from "../../components/ui/FileUpload/AttachmentTile";
 import { AttachmentTileList } from "../../components/ui/FileUpload/AttachmentTileList";
 import { FILE_TYPES } from "../../utils/fileTypes";
@@ -273,4 +274,57 @@ export const RecipeInChatInput: Story = {
       ]}
     />
   ),
+};
+
+/**
+ * Recipe: the tile in a sent message, via the real `ChatMessage`. Read-only —
+ * a sent attachment has no remove affordance, because nothing can be removed
+ * from it. With captions off, the filename lives in the tile's `title` and its
+ * button label.
+ *
+ * `ChatMessage` resolves attachments from the `allFilesById` map the
+ * conversation already holds, so this needs no API.
+ */
+export const RecipeInSentMessage: Story = {
+  args: { items: [] },
+  render: () => {
+    const files = [
+      uploaded(
+        "m1",
+        "screenshot-pricing-slide.png",
+        photo("#8ec5fc", "#e0c3fc"),
+      ),
+      uploaded("m2", "team-offsite-photo.jpg", photo("#f6d365", "#fda085")),
+      uploaded("m3", "Erato_One-Pager_IT-Digital-Leitung.pdf"),
+      uploaded("m4", "Acme_Inc_Revenue_2000_2025.csv"),
+    ];
+
+    return (
+      <ChatMessage
+        message={{
+          id: "msg-1",
+          role: "user",
+          sender: "user",
+          authorId: "user_1",
+          createdAt: new Date(2026, 7, 26, 12, 0).toISOString(),
+          content: [
+            {
+              content_type: "text",
+              text: "What do you see in these attachments?",
+            },
+          ],
+          input_files_ids: files.map((file) => file.id),
+        }}
+        showAvatar
+        controlsContext={{
+          currentUserId: "user_1",
+          dialogOwnerId: "user_1",
+          isSharedDialog: false,
+        }}
+        onMessageAction={async () => true}
+        onFilePreview={action("file preview")}
+        allFilesById={Object.fromEntries(files.map((file) => [file.id, file]))}
+      />
+    );
+  },
 };


### PR DESCRIPTION
Stacked on #1046.

Sent-message attachments now use the same tile as the composer, at `medium`. Read-only, so the greyed-out remove button that could never do anything is gone by construction (ERMAIN-691 item 1), along with the separate `max-w-[96px]` caption rule (item 4).

`ChatMessage` already receives `allFilesById`, so attachments resolve from it instead of one `useGetFile` request per attachment; only ids missing from that map still fetch. That also makes the surface renderable in Storybook without a backend, hence the `RecipeInSentMessage` story using the real `ChatMessage`.

Captions are off, so the filename reaches users via the tile's `title` and a button label carrying name and type (`Preview attachment report.pdf, PDF`); a thumbnail inside a labelled button gets empty `alt` to avoid announcing the name twice, and keeps it when standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qo1WDT7hnFn7ZWzAvpRRAV
