### PR TITLE
Move staged attachments inside the composer shell

### DIFF
--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -963,12 +963,13 @@ describe("ChatInput", () => {
     fireEvent.click(screen.getByTestId("grouped-remove-file"));
     expect(removeFile).toHaveBeenCalledWith("file-1");
 
-    // The override replaces the region above the shell, so it must not land
-    // inside the shell the way ChatInputAttachmentPreview does.
+    // Staged attachments are part of what is about to be sent, so the override
+    // renders inside the shell alongside the default preview rather than as a
+    // separate card floating above it.
     const shell = container.querySelector('[data-ui="chat-input-shell"]');
     expect(
       shell?.querySelector('[data-testid="grouped-attachments-preview"]'),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it("renders the attachment preview override inline inside the input shell and suppresses the external preview", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2374,7 +2374,6 @@ export const ChatInput = ({
 
   const ChatInputAttachmentPreview =
     componentRegistry.ChatInputAttachmentPreview;
-  const hasAttachmentPreviewOverride = ChatInputAttachmentPreview !== null;
   const AttachmentsPreview = resolveComponentOverride(
     componentRegistry.ChatAttachmentsPreview,
     FileAttachmentsPreview,
@@ -2491,19 +2490,6 @@ export const ChatInput = ({
               })(),
             )}
           </div>
-        )}
-
-        {!hasAttachmentPreviewOverride && (
-          <AttachmentsPreview
-            attachedFiles={attachedFiles}
-            maxFiles={maxFiles}
-            onRemoveFile={handleRemoveFileById}
-            onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
-            onFilePreview={onFilePreview}
-            disabled={composeLocked}
-            showFileTypes={showFileTypes}
-            surfaceVariant="message"
-          />
         )}
 
         {/* File error message */}
@@ -2682,7 +2668,10 @@ export const ChatInput = ({
             </div>
           )}
 
-          {ChatInputAttachmentPreview && (
+          {/* Staged attachments belong inside the shell, above the textarea:
+              they are part of what is about to be sent, not a separate card
+              floating over the composer. The shell's own gap spaces them. */}
+          {ChatInputAttachmentPreview ? (
             <ChatInputAttachmentPreview
               attachedFiles={attachedFiles}
               maxFiles={maxFiles}
@@ -2691,6 +2680,17 @@ export const ChatInput = ({
               onFilePreview={onFilePreview}
               disabled={composeLocked}
               showFileTypes={showFileTypes}
+            />
+          ) : (
+            <AttachmentsPreview
+              attachedFiles={attachedFiles}
+              maxFiles={maxFiles}
+              onRemoveFile={handleRemoveFileById}
+              onRemoveAllFiles={handleRemoveAllFilesWithTokenReset}
+              onFilePreview={onFilePreview}
+              disabled={composeLocked}
+              showFileTypes={showFileTypes}
+              surfaceVariant="message"
             />
           )}
 

--- a/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
@@ -73,9 +73,6 @@ export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
     : count === 1
       ? t`1 file`
       : t`${count} files`;
-  // Only staging needs either affordance; a sent message has a fixed set and
-  // nothing to remove.
-  const showFooter = showRemoveAll || capHeight;
 
   // Thumbnails and pills have different heights, so interleaving them leaves
   // ragged holes wherever the wrap breaks. Banding by kind keeps each row one
@@ -125,25 +122,24 @@ export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
           </div>
         )}
       </div>
-      {showFooter && (
+      {/* The count rides along with the bulk control rather than appearing
+          on its own: a list short enough not to need one is also too short to
+          overflow the cap, so there is nothing the count would warn about. */}
+      {showRemoveAll && (
         <div className="flex items-center justify-between gap-2">
-          {/* A capped list can hide rows with nothing to say so; the count is
-              what tells the user there is more than they can see. */}
           <span className="text-xs text-[var(--theme-fg-muted)]">
             {countLabel}
           </span>
-          {showRemoveAll && (
-            <Button
-              onClick={onRemoveAll}
-              variant="ghost"
-              size="sm"
-              className="px-0 text-xs text-[var(--theme-fg-muted)]"
-              aria-label={t`Remove all attachments`}
-              disabled={disabled}
-            >
-              {t`Remove all`}
-            </Button>
-          )}
+          <Button
+            onClick={onRemoveAll}
+            variant="ghost"
+            size="sm"
+            className="px-0 text-xs text-[var(--theme-fg-muted)]"
+            aria-label={t`Remove all attachments`}
+            disabled={disabled}
+          >
+            {t`Remove all`}
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/ui/FileUpload/FileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/FileAttachmentsPreview.test.tsx
@@ -163,14 +163,18 @@ describe("FileAttachmentsPreview", () => {
     // there is more attached than is visible.
     await renderWithProviders(
       <FileAttachmentsPreview
-        attachedFiles={[file("1", "spec.pdf"), file("2", "notes.txt")]}
+        attachedFiles={[
+          file("1", "spec.pdf"),
+          file("2", "notes.txt"),
+          file("3", "data.csv"),
+        ]}
         maxFiles={50}
         onRemoveFile={vi.fn()}
         onRemoveAllFiles={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("2/50")).toBeInTheDocument();
+    expect(screen.getByText("3/50")).toBeInTheDocument();
   });
 
   it("renders nothing when there is nothing attached", async () => {

--- a/frontend/src/components/ui/FileUpload/FileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/FileAttachmentsPreview.tsx
@@ -1,4 +1,3 @@
-import clsx from "clsx";
 import { useMemo } from "react";
 
 import { AttachmentTileList } from "./AttachmentTileList";
@@ -77,7 +76,7 @@ export const FileAttachmentsPreview: React.FC<FileAttachmentsPreviewProps> = ({
       disabled={disabled}
       capHeight
       maxFiles={maxFiles}
-      className={clsx("mb-3", className)}
+      className={className}
     />
   );
 };

--- a/frontend/src/config/componentRegistry.ts
+++ b/frontend/src/config/componentRegistry.ts
@@ -142,14 +142,13 @@ export interface ComponentRegistry {
   ChatInputAttachmentPreview: ComponentType<ChatInputAttachmentPreviewProps> | null;
 
   /**
-   * Override for the attachments region the composer renders above the chat
-   * input shell. It receives exactly the props the default flat preview gets,
-   * so a replacement can render its own layout (e.g. grouped cards) and still
-   * handle removal and preview.
+   * Override for the staged-attachments region, which the composer renders
+   * inside the chat input shell, above the textarea. It receives exactly the
+   * props the default preview gets, so a replacement can render its own layout
+   * (e.g. grouped cards) and still handle removal and preview.
    *
    * When null, the default `FileAttachmentsPreview` renders. Ignored while
-   * `ChatInputAttachmentPreview` is set — that override moves the preview
-   * inside the shell instead of replacing this region.
+   * `ChatInputAttachmentPreview` is set — that override occupies the same slot.
    */
   ChatAttachmentsPreview: ComponentType<FileAttachmentsPreviewProps> | null;
 


### PR DESCRIPTION
Stacked on #1047.

Staged attachments move inside the composer shell, above the textarea, where both reference products put them — they are part of what is about to be sent, not a separate card floating over the composer. The shell's own gap spaces them, so `FileAttachmentsPreview` no longer carries its own bottom margin.

The shell already had an in-shell slot (`ChatInputAttachmentPreview`); the default preview now renders in that same position rather than above the shell.

Also narrows when the count/Remove-all footer appears: it rides with the bulk control instead of showing whenever the list is capped, since a list short enough not to need a bulk remove is also too short to overflow the cap. (The cap itself landed in #1046.)

**Contract change worth a look:** a `ChatAttachmentsPreview` override now also renders inside the shell. The Teams route registers `TeamsAttachmentsPreview` through that slot, so its grouped preview moves inside too. `ChatInput.test.tsx` asserted the old placement and has been flipped to the new one. I could not exercise the Teams route locally.