### PR TITLE
Draw grouped attachment items with the shared tile

### DIFF
--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -7,6 +7,7 @@ import { FILE_TYPES, getFileTypeIcon } from "@/utils/fileTypes";
 
 import {
   getFileName,
+  getFileSize,
   getFileType,
   splitFilenameForDisplay,
   type FileResource,
@@ -48,6 +49,12 @@ export interface AttachmentTileProps {
   onRemove?: () => void;
   /** Presence makes the tile activatable — typically opening the file preview. */
   onActivate?: () => void;
+  /**
+   * Verb for the activation label. Defaults to previewing the file; an item
+   * whose activation goes somewhere else (the conversation behind a Teams
+   * transcript, say) should say so instead.
+   */
+  activateLabel?: string;
   /** Overrides the type label under the filename, e.g. labelling an `.html` synthetic file as "Email". */
   labelOverride?: string;
   /** Filename under a media tile. Document tiles always carry their name inline. */
@@ -95,6 +102,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
   size = "compact",
   onRemove,
   onActivate,
+  activateLabel,
   labelOverride,
   showCaption = false,
   disabled = false,
@@ -123,6 +131,12 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       ? extension.slice(1).toUpperCase()
       : FILE_TYPES[fileType].displayName || t`File`;
   }, [labelOverride, filename, fileType]);
+  // Only locally staged files carry a size — the API type has no such field —
+  // so the separator has to survive its absence.
+  const metaLabel = useMemo(() => {
+    const fileSize = getFileSize(file);
+    return fileSize ? `${typeLabel} · ${fileSize}` : typeLabel;
+  }, [file, typeLabel]);
   const geometry = TILE_GEOMETRY[size];
   // Every upload carries a `preview_url`, including PDFs and spreadsheets —
   // it proxies the raw bytes, not a rendered thumbnail. Only an image can be
@@ -172,7 +186,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           {filename}
         </span>
         <span className="block truncate text-xs text-[var(--theme-fg-muted)]">
-          {typeLabel}
+          {metaLabel}
         </span>
       </span>
     </div>
@@ -197,7 +211,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           type="button"
           onClick={onActivate}
           title={filename}
-          aria-label={`${t`Preview attachment`} ${filename}, ${typeLabel}`}
+          aria-label={`${activateLabel ?? t`Preview attachment`} ${filename}, ${metaLabel}`}
           className={clsx(
             "block w-full cursor-pointer rounded-[var(--theme-radius-base)] text-left",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2",

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -73,19 +73,16 @@ describe("GroupedFileAttachmentsPreview", () => {
     );
 
     expect(screen.getByText("Current email")).toBeVisible();
-    expect(screen.getByText("message")).toBeVisible();
-    expect(screen.getByText(".html")).toBeVisible();
-    expect(screen.getByText("invoice")).toBeVisible();
-    expect(screen.getByText(".pdf")).toBeVisible();
-    expect(screen.queryByText("notes")).toBeNull();
+    expect(screen.getByText("message.html")).toBeVisible();
+    expect(screen.getByText("invoice.pdf")).toBeVisible();
+    expect(screen.queryByText("notes.docx")).toBeNull();
     expect(
       screen.getByRole("button", { name: /show 1 more item/i }),
     ).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: /show 1 more item/i }));
 
-    expect(screen.getByText("notes")).toBeVisible();
-    expect(screen.getByText(".docx")).toBeVisible();
+    expect(screen.getByText("notes.docx")).toBeVisible();
   });
 
   it("renders loading items inline with the standardized loading row", async () => {
@@ -193,12 +190,12 @@ describe("GroupedFileAttachmentsPreview", () => {
       name: /current email/i,
     });
     expect(groupToggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("invoice")).toBeNull();
+    expect(screen.queryByText("invoice.pdf")).toBeNull();
 
     fireEvent.click(groupToggle);
 
     expect(groupToggle).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("invoice")).toBeVisible();
+    expect(screen.getByText("invoice.pdf")).toBeVisible();
   });
 
   it("keeps each group at its own default when several are shown at once", async () => {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -4,12 +4,12 @@ import { useId, useState } from "react";
 
 import { componentRegistry } from "@/config/componentRegistry";
 
+import { AttachmentTile } from "./AttachmentTile";
 import {
   FilePreviewBase,
   getFileName,
   type FileResource,
 } from "./FilePreviewBase";
-import { FilePreviewButton } from "./FilePreviewButton";
 import { FilePreviewLoading } from "./FilePreviewLoading";
 import { FILE_PREVIEW_STYLES } from "./fileUploadStyles";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
@@ -564,8 +564,18 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                 : "rounded-t-[var(--theme-radius-input)]",
             ),
         );
+        // Tiles wrap into rows; checkbox rows and notices stay a column. In
+        // practice a group is homogeneous — staged emails are all selectable,
+        // compose-mode attachments all plain — so this never mixes.
+        const tilesOnly =
+          visibleItems.length > 0 &&
+          visibleItems.every(
+            (item) => item.kind === "attachment" || item.kind === "context",
+          );
         const itemsClassName = clsx(
-          "flex flex-col gap-2",
+          tilesOnly
+            ? "flex flex-wrap items-start gap-2"
+            : "flex flex-col gap-2",
           stickyGroupHeaders &&
             "rounded-b-md border-x border-b border-[var(--theme-border)] bg-[var(--theme-bg-primary)] px-3 pb-3 pt-2",
         );
@@ -689,34 +699,6 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                     );
                   }
 
-                  // `context` chips are read-only by contract — no remove
-                  // affordance (there is nothing staged to remove).
-                  const content =
-                    item.kind === "context" ? (
-                      <FilePreviewBase
-                        file={item.file}
-                        onRemove={() => {}}
-                        disabled={disabled}
-                        className="w-full"
-                        showRemoveButton={false}
-                        showFileType={showFileTypes}
-                        showSize={showFileSizes}
-                        filenameTruncateLength={filenameTruncateLength}
-                        filenameClassName="max-w-full"
-                      />
-                    ) : (
-                      <FilePreviewButton
-                        file={item.file}
-                        onRemove={() => onRemoveFile(getFileId(item))}
-                        disabled={disabled}
-                        className="w-full"
-                        showFileType={showFileTypes}
-                        showSize={showFileSizes}
-                        filenameTruncateLength={filenameTruncateLength}
-                        filenameClassName="max-w-full"
-                      />
-                    );
-
                   const onOpen =
                     item.kind === "attachment" ? item.onOpen : undefined;
                   const activate =
@@ -725,20 +707,22 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                       ? () => onFilePreview(item.file)
                       : undefined);
 
-                  if (!activate) {
-                    return <div key={getFileKey(item)}>{content}</div>;
-                  }
-
+                  // `context` chips are read-only by contract — no remove
+                  // affordance (there is nothing staged to remove).
                   return (
-                    <InteractiveContainer
+                    <AttachmentTile
                       key={getFileKey(item)}
-                      onClick={activate}
-                      useDiv={true}
-                      className="w-full cursor-pointer hover:bg-theme-bg-accent"
-                      aria-label={`${onOpen ? t`Open` : t`Preview attachment`} ${getFileName(item.file)}`}
-                    >
-                      {content}
-                    </InteractiveContainer>
+                      file={item.file}
+                      labelOverride={item.labelOverride}
+                      disabled={disabled}
+                      onRemove={
+                        item.kind === "context"
+                          ? undefined
+                          : () => onRemoveFile(getFileId(item))
+                      }
+                      onActivate={activate}
+                      activateLabel={onOpen ? t`Open` : undefined}
+                    />
                   );
                 })}
 

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -73,7 +73,6 @@ export type { FilePreviewBaseProps } from "@/components/ui/FileUpload/FilePrevie
 export type { FileResource } from "@/components/ui/FileUpload/FilePreviewBase";
 export type { FileUploadItemWithSize } from "@/components/ui/FileUpload/FilePreviewBase";
 export type { LocalFilePreviewItem } from "@/components/ui/FileUpload/FilePreviewBase";
-export { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
 export { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
 export { FileSourceSelector } from "@/components/ui/FileUpload/FileSourceSelector";
 export type { FileSourceSelectorProps } from "@/components/ui/FileUpload/FileSourceSelector";

--- a/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
+++ b/office-addin/src/teams/components/__tests__/TeamsAttachmentsPreview.test.tsx
@@ -172,8 +172,9 @@ describe("TeamsAttachmentsPreview", () => {
     await screen.findByText("Product sync");
     fireEvent.click(groupHeader());
     // Matched on the row's own name, not the translated verb: this suite runs
-    // without a message catalogue.
-    fireEvent.click(screen.getByRole("button", { name: /all messages/i }));
+    // without a message catalogue. The trailing comma picks the activate
+    // button over the remove button, which carries the same filename.
+    fireEvent.click(screen.getByRole("button", { name: /all messages,/i }));
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toHaveTextContent("Ada Lovelace");
@@ -193,7 +194,7 @@ describe("TeamsAttachmentsPreview", () => {
 
     await screen.findByText("Product sync");
     fireEvent.click(groupHeader());
-    fireEvent.click(screen.getByRole("button", { name: /all messages/i }));
+    fireEvent.click(screen.getByRole("button", { name: /all messages,/i }));
 
     // Matched on the file's own name: the surrounding "Preview attachment" is a
     // library string, and this suite runs without a catalogue.


### PR DESCRIPTION
Stacked on #1049.

The grouped preview's file items (`attachment`, `context`) now use the shared tile, so the Outlook and Teams panes match the web composer. A group made only of those wraps into rows; selection rows, thread-message groups, loading placeholders and status notices stay a column, because a checkbox with a validation message under it is a different control from a tile and rows serve it better. Groups are homogeneous in practice, so the two never mix.

Restores file sizes, which the tile had dropped: locally staged items (the add-in's email body and Office.js attachments) do carry a `size`, so the meta line reads `PDF · 80 KB` where one exists and `PDF` where it does not. This corrects part of the ERMAIN-691 finding — `showFileSizes` was never fully dead, only dead for server-side `FileUploadItem`, which has no size field.

Adds `activateLabel` to the tile so an item whose activation opens something other than the file (the conversation behind a Teams transcript) is still announced as "Open …" rather than "Preview attachment …". Grouped tests moved from asserting a split stem/extension pair to the whole filename