### PR TITLE
Promote attachment tile geometry to theme tokens

### DIFF
--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -202,6 +202,26 @@ const getThemeVariableEntries = (theme: Theme): Array<[string, string]> => {
       "--theme-layout-chat-image-preview-max-height",
       theme.layout.chat.imagePreviewMaxHeight,
     ],
+    [
+      "--theme-layout-attachment-tile-compact-media-size",
+      theme.layout.attachmentTile.compactMediaSize,
+    ],
+    [
+      "--theme-layout-attachment-tile-compact-doc-max-width",
+      theme.layout.attachmentTile.compactDocMaxWidth,
+    ],
+    [
+      "--theme-layout-attachment-tile-medium-media-size",
+      theme.layout.attachmentTile.mediumMediaSize,
+    ],
+    [
+      "--theme-layout-attachment-tile-medium-doc-max-width",
+      theme.layout.attachmentTile.mediumDocMaxWidth,
+    ],
+    [
+      "--theme-layout-attachment-tile-staged-max-height",
+      theme.layout.attachmentTile.stagedMaxHeight,
+    ],
     ["--theme-layout-sidebar-width", theme.layout.sidebar.width],
     ["--theme-layout-sidebar-slim-width", theme.layout.sidebar.slimWidth],
     ["--theme-layout-dropdown-min-width", theme.layout.dropdown.minWidth],

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -23,18 +23,21 @@ import type React from "react";
  */
 export type AttachmentTileSize = "compact" | "medium";
 
+/**
+ * Tile dimensions come from theme tokens so a customer theme can retune them;
+ * the icon plate stays a class because it is proportional chrome, not a
+ * dimension anyone would want to override on its own.
+ */
 const TILE_GEOMETRY = {
   compact: {
-    media: "size-14",
-    mediaWidth: "w-14",
-    docWidth: "max-w-[15rem]",
+    mediaSize: "var(--theme-layout-attachment-tile-compact-media-size)",
+    docMaxWidth: "var(--theme-layout-attachment-tile-compact-doc-max-width)",
     iconBox: "size-8",
     icon: "size-4",
   },
   medium: {
-    media: "size-28",
-    mediaWidth: "w-28",
-    docWidth: "max-w-[18rem]",
+    mediaSize: "var(--theme-layout-attachment-tile-medium-media-size)",
+    docMaxWidth: "var(--theme-layout-attachment-tile-medium-doc-max-width)",
     iconBox: "size-10",
     icon: "size-5",
   },
@@ -153,10 +156,8 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       src={previewUrl ?? undefined}
       alt={onActivate ? "" : filename}
       onError={() => setImageFailed(true)}
-      className={clsx(
-        geometry.media,
-        "rounded-[var(--theme-radius-base)] border object-cover [border-color:var(--theme-border-media)]",
-      )}
+      style={{ width: geometry.mediaSize, height: geometry.mediaSize }}
+      className="rounded-[var(--theme-radius-base)] border object-cover [border-color:var(--theme-border-media)]"
     />
   ) : (
     <div
@@ -199,9 +200,10 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
         // Media keeps its square; a document pill sizes to its name but never
         // grows to fill the row — that stretch is what makes today's chips
         // read as list rows rather than tiles.
-        isMedia ? "shrink-0" : clsx("min-w-0", geometry.docWidth),
+        isMedia ? "shrink-0" : "min-w-0",
         className,
       )}
+      style={isMedia ? undefined : { maxWidth: geometry.docMaxWidth }}
       data-filetype={fileType}
     >
       {onActivate ? (
@@ -236,10 +238,8 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
 
       {isMedia && showCaption && (
         <p
-          className={clsx(
-            geometry.mediaWidth,
-            "mt-1 truncate text-xs text-[var(--theme-fg-muted)]",
-          )}
+          className="mt-1 truncate text-xs text-[var(--theme-fg-muted)]"
+          style={{ width: geometry.mediaSize }}
           title={filename}
         >
           {filename}

--- a/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
@@ -45,9 +45,6 @@ export interface AttachmentTileListProps {
   className?: string;
 }
 
-/** Roughly three rows of compact tiles, past which the list scrolls. */
-const CAPPED_TILE_AREA = "max-h-48";
-
 export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
   items,
   size = "compact",
@@ -105,11 +102,16 @@ export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
           // overhang in padding, takes it back in margin to leave the tiles
           // where they were, and pins `overflow-x` explicitly.
           capHeight &&
-            clsx(
-              CAPPED_TILE_AREA,
-              "-mr-1 -mt-1 overflow-y-auto overflow-x-hidden pr-1 pt-1",
-            ),
+            "-mr-1 -mt-1 overflow-y-auto overflow-x-hidden pr-1 pt-1",
         )}
+        style={
+          capHeight
+            ? {
+                maxHeight:
+                  "var(--theme-layout-attachment-tile-staged-max-height)",
+              }
+            : undefined
+        }
       >
         {media.length > 0 && (
           <div className="flex flex-wrap items-start gap-2">

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -250,6 +250,15 @@ export type ThemeLayout = {
     imagePreviewMaxWidth: string;
     imagePreviewMaxHeight: string;
   };
+  /** Attachment tiles: compact stages in the composer, medium carries the transcript. */
+  attachmentTile: {
+    compactMediaSize: string;
+    compactDocMaxWidth: string;
+    mediumMediaSize: string;
+    mediumDocMaxWidth: string;
+    /** Height the staged area caps at before it scrolls. */
+    stagedMaxHeight: string;
+  };
   sidebar: {
     width: string;
     slimWidth: string;
@@ -552,6 +561,13 @@ export const defaultTheme: Theme = {
       inputMaxWidth: "56rem",
       imagePreviewMaxWidth: "24rem",
       imagePreviewMaxHeight: "24rem",
+    },
+    attachmentTile: {
+      compactMediaSize: "3.5rem",
+      compactDocMaxWidth: "15rem",
+      mediumMediaSize: "7rem",
+      mediumDocMaxWidth: "18rem",
+      stagedMaxHeight: "12rem",
     },
     sidebar: {
       width: "17.5rem",

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -263,6 +263,11 @@
   --theme-layout-chat-input-max-width: 56rem;
   --theme-layout-chat-image-preview-max-width: 24rem;
   --theme-layout-chat-image-preview-max-height: 24rem;
+  --theme-layout-attachment-tile-compact-media-size: 3.5rem;
+  --theme-layout-attachment-tile-compact-doc-max-width: 15rem;
+  --theme-layout-attachment-tile-medium-media-size: 7rem;
+  --theme-layout-attachment-tile-medium-doc-max-width: 18rem;
+  --theme-layout-attachment-tile-staged-max-height: 12rem;
   --theme-layout-sidebar-width: 17.5rem;
   --theme-layout-sidebar-slim-width: 4rem;
   --theme-layout-dropdown-min-width: 12rem;


### PR DESCRIPTION
Stacked on #1050.

Tile dimensions move from constants to `--theme-layout-attachment-tile-*` so a customer theme can retune them: compact/medium media size, compact/medium document max width, and the staged area's max height. Values are unchanged; only their source moves.

Declared in `theme.ts` (type + defaults), `globals.css` (CSS fallbacks) and `ThemeProvider` (the allowlist that lets a theme override them), matching how the existing `--theme-layout-chat-*` tokens are wired. The icon plate stays a class — it is proportional chrome, not a dimension worth overriding on its own.