### PR TITLE
Keep the picked file size on staged attachments

### DIFF
--- a/e2e-tests/tests/chat.basic.spec.ts
+++ b/e2e-tests/tests/chat.basic.spec.ts
@@ -22,7 +22,10 @@ test(
     const filePath = "test-files/sample-report-compressed.pdf";
     await fileChooser.setFiles(filePath);
 
-    await expect(page.getByText("PDF", { exact: true })).toBeVisible();
+    // Type and size share one line. Asserting the size too makes this the
+    // regression test for carrying it over from the picked file, since the
+    // API record has no size of its own.
+    await expect(page.getByText(/^PDF · \d/)).toBeVisible();
     await expect(
       page.getByText(/sample-report-compressed\.pdf/i),
     ).toBeVisible();

--- a/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
+++ b/frontend/src/hooks/files/__tests__/useFileDropzone.test.tsx
@@ -193,18 +193,19 @@ describe("useFileDropzone", () => {
       }),
     );
 
-    // Check state updates
+    // Check state updates. The server record carries no size, so each item is
+    // annotated with the byte size of the file the user actually picked.
     expect(result.current.isUploading).toBe(false);
     expect(result.current.uploadedFiles).toEqual([
-      createMockUploadedFile("file1", "test1.pdf"),
-      createMockUploadedFile("file2", "test2.jpg"),
+      { ...createMockUploadedFile("file1", "test1.pdf"), size: 12 },
+      { ...createMockUploadedFile("file2", "test2.jpg"), size: 10 },
     ]);
     expect(result.current.error).toBeNull();
 
     // Check callback
     expect(mockOnFilesUploaded).toHaveBeenCalledWith([
-      createMockUploadedFile("file1", "test1.pdf"),
-      createMockUploadedFile("file2", "test2.jpg"),
+      { ...createMockUploadedFile("file1", "test1.pdf"), size: 12 },
+      { ...createMockUploadedFile("file2", "test2.jpg"), size: 10 },
     ]);
   });
 

--- a/frontend/src/hooks/files/__tests__/withLocalSizes.test.ts
+++ b/frontend/src/hooks/files/__tests__/withLocalSizes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { withLocalSizes } from "../useFileDropzone";
+
+import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
+
+const uploaded = (id: string, filename: string): FileUploadItem =>
+  ({
+    id,
+    filename,
+    download_url: `https://example.invalid/${id}`,
+  }) as FileUploadItem;
+
+const local = (name: string, size: number) =>
+  new File(["x".repeat(size)], name);
+
+describe("withLocalSizes", () => {
+  it("carries the picked file's size onto the server record", () => {
+    const [result] = withLocalSizes(
+      [uploaded("1", "report.pdf")],
+      [local("report.pdf", 2048)],
+    );
+
+    expect(result).toMatchObject({ id: "1", size: 2048 });
+  });
+
+  it("matches by name rather than position, since response order is not contractual", () => {
+    const result = withLocalSizes(
+      [uploaded("1", "b.pdf"), uploaded("2", "a.pdf")],
+      [local("a.pdf", 10), local("b.pdf", 20)],
+    );
+
+    expect(result).toMatchObject([
+      { filename: "b.pdf", size: 20 },
+      { filename: "a.pdf", size: 10 },
+    ]);
+  });
+
+  it("leaves a duplicated name without a size rather than guessing", () => {
+    const result = withLocalSizes(
+      [uploaded("1", "shot.png"), uploaded("2", "shot.png")],
+      [local("shot.png", 10), local("shot.png", 999)],
+    );
+
+    expect(result[0]).not.toHaveProperty("size");
+    expect(result[1]).not.toHaveProperty("size");
+  });
+
+  it("passes through a record with no matching local file", () => {
+    const [result] = withLocalSizes([uploaded("1", "server-only.pdf")], []);
+
+    expect(result).not.toHaveProperty("size");
+    expect(result.filename).toBe("server-only.pdf");
+  });
+});

--- a/frontend/src/hooks/files/useFileDropzone.ts
+++ b/frontend/src/hooks/files/useFileDropzone.ts
@@ -26,6 +26,7 @@ import {
 } from "./errors";
 import { useFileUploadStore } from "./useFileUploadStore";
 
+import type { FileUploadItemWithSize } from "@/components/ui/FileUpload/FilePreviewBase";
 import type {
   FileUploadItem,
   FileUploadResponse,
@@ -134,6 +135,32 @@ interface UseFileDropzoneResult {
 /**
  * Modern hook for handling file dropzone and upload functionality
  */
+
+/**
+ * Carries each upload's byte size over from the browser `File` the user picked.
+ *
+ * The API type has no size field, so the value is otherwise lost the moment the
+ * local `File` is swapped for the server's record — even though the composer
+ * held it a line earlier. Matching is by filename rather than position, because
+ * response ordering is not part of the upload contract; a name duplicated
+ * within one batch is ambiguous, so it is dropped and that file simply shows no
+ * size.
+ */
+export function withLocalSizes(
+  uploaded: FileUploadItem[],
+  localFiles: File[],
+): FileUploadItemWithSize[] {
+  const sizeByName = new Map<string, number | null>();
+  for (const file of localFiles) {
+    sizeByName.set(file.name, sizeByName.has(file.name) ? null : file.size);
+  }
+
+  return uploaded.map((item) => {
+    const size = sizeByName.get(item.filename);
+    return typeof size === "number" ? { ...item, size } : item;
+  });
+}
+
 export function useFileDropzone({
   acceptedFileTypes = [],
   multiple = false,
@@ -286,9 +313,10 @@ export function useFileDropzone({
         }
 
         if (result.files.length > 0) {
-          addFiles(result.files);
-          onFilesUploaded?.(result.files);
-          uploadedItems = result.files; // Store the result
+          const sized = withLocalSizes(result.files, filesToUpload);
+          addFiles(sized);
+          onFilesUploaded?.(sized);
+          uploadedItems = sized; // Store the result
         }
       } catch (err) {
         logger.error("Error uploading files (outer catch):", err);


### PR DESCRIPTION
Stacked on #1051. Closes the remaining ERMAIN-691 item, without the migration the issue originally proposed.

`useFileDropzone.uploadFiles` takes browser `File[]`, so `file.size` is in hand, posts them, then replaces them with the server's `FileUploadItem[]` — which has no size field. The size was being discarded at that boundary, not missing. It is now carried across, so the web composer shows `PDF · 80 KB` exactly as the add-in already does for its locally staged files.

Matching is by filename rather than position: response ordering is not part of the upload contract. A name duplicated within one batch is ambiguous, so it is dropped and that file simply shows no size.

No backend change. `file_uploads` has no size column and does not need one for this — a column would only buy sizes in the transcript, where a rehydrated chat never saw the browser `File`, and comparable products do not show size ther