### PR TITLE
Let images grow in place before the full preview

### DIFF
--- a/frontend/src/components/ui/Chat/MessageAttachments.test.tsx
+++ b/frontend/src/components/ui/Chat/MessageAttachments.test.tsx
@@ -1,6 +1,6 @@
 import { I18nProvider } from "@lingui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
@@ -145,6 +145,45 @@ describe("MessageAttachments", () => {
       expect.objectContaining({ id: "1" }),
       files,
     );
+  });
+
+  it("grows an image in place, between the tile and the full preview", async () => {
+    const files = [file("1", "shot.png", "https://example.invalid/preview/1")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+        onFilePreview={vi.fn()}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /Expand shot\.png/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+
+    expect(
+      screen.getByRole("button", { name: /Collapse shot\.png/ }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("offers no in-place growth for a document, which has nothing larger to show", async () => {
+    const files = [file("1", "report.pdf")];
+
+    await renderWithProviders(
+      <MessageAttachments
+        fileIds={["1"]}
+        filesById={byId(...files)}
+        relatedFiles={files}
+        onFilePreview={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Expand/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("skips ids it cannot resolve rather than rendering a broken tile", async () => {

--- a/frontend/src/components/ui/Chat/MessageAttachments.tsx
+++ b/frontend/src/components/ui/Chat/MessageAttachments.tsx
@@ -101,6 +101,7 @@ export const MessageAttachments: React.FC<MessageAttachmentsProps> = ({
     <AttachmentTileList
       items={items}
       size="medium"
+      expandable
       className="mt-2"
       onActivate={
         onFilePreview

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -12,7 +12,12 @@ import {
   splitFilenameForDisplay,
   type FileResource,
 } from "./FilePreviewBase";
-import { CloseIcon, ResolvedIcon, ZoomInIcon, ZoomOutIcon } from "../icons";
+import {
+  CloseIcon,
+  CollapseDiagonalIcon,
+  ExpandDiagonalIcon,
+  ResolvedIcon,
+} from "../icons";
 
 import type React from "react";
 
@@ -265,9 +270,9 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           )}
         >
           {expanded ? (
-            <ZoomOutIcon className="size-3" />
+            <CollapseDiagonalIcon className="size-3" />
           ) : (
-            <ZoomInIcon className="size-3" />
+            <ExpandDiagonalIcon className="size-3" />
           )}
         </button>
       )}

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -12,7 +12,7 @@ import {
   splitFilenameForDisplay,
   type FileResource,
 } from "./FilePreviewBase";
-import { CloseIcon, ResolvedIcon } from "../icons";
+import { CloseIcon, ResolvedIcon, ZoomInIcon, ZoomOutIcon } from "../icons";
 
 import type React from "react";
 
@@ -62,6 +62,12 @@ export interface AttachmentTileProps {
   labelOverride?: string;
   /** Filename under a media tile. Document tiles always carry their name inline. */
   showCaption?: boolean;
+  /**
+   * Offers a middle tier between the tile and the full preview: an image grows
+   * in place, capped at the chat image bounds. Only meaningful for media —
+   * a document tile has nothing larger to show without loading a renderer.
+   */
+  expandable?: boolean;
   disabled?: boolean;
   className?: string;
 }
@@ -108,11 +114,13 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
   activateLabel,
   labelOverride,
   showCaption = false,
+  expandable = false,
   disabled = false,
   className,
 }) => {
   const { iconMappings } = useTheme();
   const [imageFailed, setImageFailed] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   const filename = useMemo(() => getFileName(file), [file]);
   const fileType = useMemo(() => getFileType(filename), [filename]);
@@ -156,8 +164,20 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       src={previewUrl ?? undefined}
       alt={onActivate ? "" : filename}
       onError={() => setImageFailed(true)}
-      style={{ width: geometry.mediaSize, height: geometry.mediaSize }}
-      className="rounded-[var(--theme-radius-base)] border object-cover [border-color:var(--theme-border-media)]"
+      style={
+        expanded
+          ? {
+              maxWidth: "var(--theme-layout-chat-image-preview-max-width)",
+              maxHeight: "var(--theme-layout-chat-image-preview-max-height)",
+            }
+          : { width: geometry.mediaSize, height: geometry.mediaSize }
+      }
+      className={clsx(
+        "rounded-[var(--theme-radius-base)] border [border-color:var(--theme-border-media)]",
+        // Cropping is right for a thumbnail standing in for the file, wrong
+        // once the point is seeing what the image actually contains.
+        expanded ? "w-full object-contain" : "object-cover",
+      )}
     />
   ) : (
     <div
@@ -200,7 +220,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
         // Media keeps its square; a document pill sizes to its name but never
         // grows to fill the row — that stretch is what makes today's chips
         // read as list rows rather than tiles.
-        isMedia ? "shrink-0" : "min-w-0",
+        isMedia ? (expanded ? "w-full" : "shrink-0") : "min-w-0",
         className,
       )}
       style={isMedia ? undefined : { maxWidth: geometry.docMaxWidth }}
@@ -226,6 +246,30 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
         // Not interactive, so it cannot hold focus — the title serves hover and
         // the image's alt text serves assistive tech.
         <div title={filename}>{face}</div>
+      )}
+
+      {expandable && isMedia && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          aria-label={
+            expanded ? `${t`Collapse`} ${filename}` : `${t`Expand`} ${filename}`
+          }
+          className={clsx(
+            "absolute -left-1 -top-1 z-10 inline-flex size-5 items-center justify-center rounded-full",
+            "border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] text-[var(--theme-fg-muted)] shadow-sm",
+            "hover:text-[var(--theme-fg-primary)]",
+            "opacity-0 transition-opacity focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100",
+            "[@media(hover:none)]:opacity-100",
+          )}
+        >
+          {expanded ? (
+            <ZoomOutIcon className="size-3" />
+          ) : (
+            <ZoomInIcon className="size-3" />
+          )}
+        </button>
       )}
 
       {onRemove && (

--- a/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTileList.tsx
@@ -26,6 +26,8 @@ export interface AttachmentTileListProps {
   onRemoveAll?: () => void;
   onActivate?: (item: AttachmentTileItem) => void;
   showCaptions?: boolean;
+  /** Offers in-place growth on image tiles. Off in the composer, where the tile is an inventory marker rather than something to read. */
+  expandable?: boolean;
   disabled?: boolean;
   /**
    * Below this count the tiles speak for themselves, so the bulk control stays
@@ -52,6 +54,7 @@ export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
   onRemoveAll,
   onActivate,
   showCaptions = false,
+  expandable = false,
   disabled = false,
   removeAllThreshold = 3,
   capHeight = false,
@@ -85,6 +88,7 @@ export const AttachmentTileList: React.FC<AttachmentTileListProps> = ({
       size={size}
       labelOverride={item.labelOverride}
       showCaption={showCaptions}
+      expandable={expandable}
       disabled={disabled}
       onRemove={onRemove ? () => onRemove(item.id) : undefined}
       onActivate={onActivate ? () => onActivate(item) : undefined}

--- a/frontend/src/components/ui/icons/index.tsx
+++ b/frontend/src/components/ui/icons/index.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import {
   AtSign,
   Copy,
@@ -43,6 +44,8 @@ import {
   RotateCameraRight,
   ZoomIn,
   ZoomOut,
+  ArrowSeparate,
+  ArrowUnion,
   Folder,
   ShareIos,
   GridXmark,
@@ -297,6 +300,19 @@ export const ZoomInIcon = ({ className, ...props }: IconProps) => (
 
 export const ZoomOutIcon = ({ className, ...props }: IconProps) => (
   <ZoomOut className={className} {...props} />
+);
+
+/**
+ * Diagonal expand/collapse pair. Iconoir draws these arrows horizontally, so
+ * the rotation is what makes them read as "grow to the corner" rather than
+ * "widen" — the two are otherwise the same glyph.
+ */
+export const ExpandDiagonalIcon = ({ className, ...props }: IconProps) => (
+  <ArrowSeparate className={clsx("-rotate-45", className)} {...props} />
+);
+
+export const CollapseDiagonalIcon = ({ className, ...props }: IconProps) => (
+  <ArrowUnion className={clsx("-rotate-45", className)} {...props} />
 );
 
 export const RotateClockwiseIcon = ({ className, ...props }: IconProps) => (

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4434,6 +4434,10 @@ msgstr "Dialog schließen"
 msgid "Close modal overlay"
 msgstr "Dialog-Overlay schließen"
 
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Collapse"
+msgstr ""
+
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Collapse {title}"
 msgstr ""
@@ -4721,6 +4725,10 @@ msgstr "Tokennutzung wird geschätzt..."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Exit audio mode"
+msgstr ""
+
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Expand"
 msgstr ""
 
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -4434,6 +4434,10 @@ msgstr "Close modal"
 msgid "Close modal overlay"
 msgstr "Close modal overlay"
 
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Collapse"
+msgstr "Collapse"
+
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Collapse {title}"
 msgstr "Collapse {title}"
@@ -4722,6 +4726,10 @@ msgstr "Estimating token usage..."
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Exit audio mode"
 msgstr "Exit audio mode"
+
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Expand"
+msgstr "Expand"
 
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Expand {title}"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4434,6 +4434,10 @@ msgstr "Cerrar modal"
 msgid "Close modal overlay"
 msgstr "Cerrar superposición del modal"
 
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Collapse"
+msgstr ""
+
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Collapse {title}"
 msgstr ""
@@ -4721,6 +4725,10 @@ msgstr "Estimando uso de tokens..."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Exit audio mode"
+msgstr ""
+
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Expand"
 msgstr ""
 
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4434,6 +4434,10 @@ msgstr "Fermer la modal"
 msgid "Close modal overlay"
 msgstr "Fermer le fond de modal"
 
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Collapse"
+msgstr ""
+
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Collapse {title}"
 msgstr ""
@@ -4721,6 +4725,10 @@ msgstr "Estimation de l'utilisation des tokens..."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Exit audio mode"
+msgstr ""
+
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Expand"
 msgstr ""
 
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4434,6 +4434,10 @@ msgstr "Zamknij okno"
 msgid "Close modal overlay"
 msgstr "Zamknij nakładkę okna"
 
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Collapse"
+msgstr ""
+
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx
 msgid "Collapse {title}"
 msgstr ""
@@ -4721,6 +4725,10 @@ msgstr "Szacowanie użycia tokenów..."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Exit audio mode"
+msgstr ""
+
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+msgid "Expand"
 msgstr ""
 
 #: src/components/ui/Chat/SidebarCollapsibleSection.tsx

--- a/frontend/src/stories/ui/AttachmentTile.stories.tsx
+++ b/frontend/src/stories/ui/AttachmentTile.stories.tsx
@@ -169,6 +169,20 @@ export const SentMessageMedium: Story = {
   },
 };
 
+/**
+ * The middle tier: an image grows in place, capped at the chat image bounds,
+ * without leaving the transcript. The corner toggle appears on hover or focus;
+ * clicking the tile itself still opens the full preview.
+ */
+export const SentMessageExpandable: Story = {
+  args: {
+    items: fullSet,
+    size: "medium",
+    expandable: true,
+    onActivate: () => {},
+  },
+};
+
 export const SentMessageWithCaptions: Story = {
   args: {
     items: fullSet,


### PR DESCRIPTION
Stacked on #1052. First slice of ERMAIN-658, images only.

Adds the middle tier between the tile and the full preview: an image in a sent message grows in place, capped at the same `--theme-layout-chat-image-preview-*` bounds assistant images already use, and takes its own row so siblings stay put. `object-contain` while expanded — cropping is right for a thumbnail standing in for a file, wrong once the point is seeing what it contains.

The toggle sits in the corner opposite the remove button, revealed on hover or focus and always visible where there is no hover, carrying `aria-expanded` and an Expand/Collapse label. Clicking the tile itself still opens the full preview, so the existing path is unchanged — expand is a peek, the modal is for tools (zoom, page navigation, download, related files).

Off in the composer, where the tile is an inventory marker rather than something to read. Documents are out of scope for this pass: expanding one means lazy-mounting `PdfPreview` (pdfium wasm), which is the part with real cost and a visible loading state.

Note this does not use `Collapse`: that primitive toggles fully-hidden ↔ fully-shown, whereas an image grows from a capped size, so it is a size swap using the same clipping idea rather than `0fr ↔ 1fr`.