### PR TITLE
Pin the kit-facing shared surface

### DIFF
--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -17,6 +17,55 @@ export * from "@/providers/ProfileProvider";
 export * from "@/state/audioInputDeviceStore";
 export * from "@/state/uiStore";
 
+// Primitives the component kits actually build on.
+//
+// The generated surface above already exports all of these — but only because
+// some registry-reachable component happens to import them. That makes the
+// contract a byproduct of an unrelated import graph: a refactor elsewhere can
+// drop one without anyone noticing, and a kit is a single flat named-import,
+// so one missing name fails module linking and takes the WHOLE kit offline
+// (every override silently reverting to its default). `Tooltip` left the
+// surface exactly this way when the attachments preview was rewritten.
+//
+// Naming them here makes the dependency explicit and lets the type checker
+// enforce it: if one of these stops existing, the build fails here instead of
+// in a customer's browser. Explicit exports take precedence over the star
+// export above, so this shadows rather than duplicates.
+export { InteractiveContainer } from "@/components/ui/Container/InteractiveContainer";
+export { Button } from "@/components/ui/Controls/Button";
+export { DropdownMenu } from "@/components/ui/Controls/DropdownMenu";
+export type { DropdownMenuItem } from "@/components/ui/Controls/DropdownMenu";
+export { Alert } from "@/components/ui/Feedback/Alert";
+export { Avatar } from "@/components/ui/Feedback/Avatar";
+export { CopyErrorButton } from "@/components/ui/Feedback/CopyErrorButton";
+export { LoadingIndicator } from "@/components/ui/Feedback/LoadingIndicator";
+export { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
+export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
+export { ImageLightbox } from "@/components/ui/Message/ImageLightbox";
+export { MessageContent } from "@/components/ui/Message/MessageContent";
+export { MessageTimestamp } from "@/components/ui/Message/MessageTimestamp";
+export { ModalBase } from "@/components/ui/Modal/ModalBase";
+export { ResolvedIcon } from "@/components/ui/icons/ResolvedIcon";
+export {
+  ArchiveIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  CloseIcon,
+  DocumentIcon,
+  EditIcon,
+  ErrorIcon,
+  InfoIcon,
+  LogOutIcon,
+  MediaVideoIcon,
+  MoreVertical,
+  MultiplePagesIcon,
+  MusicNoteIcon,
+  PageIcon,
+  ShareIcon,
+} from "@/components/ui/icons/index";
+export { messageStyles } from "@/components/ui/styles/chatMessageStyles";
+export { Tooltip } from "@/components/ui/Controls/Tooltip";
+
 export {
   useGetFile,
   useGetFilePreview,


### PR DESCRIPTION
The `@erato/frontend/shared` surface is a byproduct of an import graph, not a declaration. `component-registry.generated.ts` exports every symbol of every module reachable from a registry extension point — so a component is public only because something else happens to import it.

`Tooltip` left the surface that way in #1046: it was exported solely because the old `FileAttachmentsPreview` imported it for a "Remove all files" tooltip, and the rewrite dropped that import. Nothing consumed it, so nothing broke.

The exposure is wider than that one symbol. Of the 46 names the Beckhoff kit imports from this surface, **31 are provided only by incidental reachability** — Alert, Button, Avatar, ModalBase, MessageContent, ResolvedIcon, InteractiveContainer, the icon set, and so on. Any refactor that changes an unrelated component's imports can drop one.

That matters because of how the failure presents. A kit is one flat named-import resolved through the browser import map, so a missing export fails module linking with `SyntaxError: does not provide an export named 'X'` — killing the **entire kit** at load, with every override silently reverting to its default. `ERATO_SHARED_SURFACE_VERSION` cannot warn, because it is imported in that same statement.

This names those 31 (plus `Tooltip`) explicitly, so the contract is declared rather than inferred and the type checker enforces it. Verified by falsification: renaming `Tooltip`'s export now fails the build at `shared/index.ts` rather than in a customer's browser.

No runtime change — explicit exports shadow the star export, and the generated file is untouched.