### PR TITLE
Clamp long code blocks with a reveal control

### DIFF
--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -203,6 +203,10 @@ const getThemeVariableEntries = (theme: Theme): Array<[string, string]> => {
       theme.layout.chat.imagePreviewMaxHeight,
     ],
     [
+      "--theme-layout-code-block-collapsed-max-height",
+      theme.layout.codeBlock.collapsedMaxHeight,
+    ],
+    [
       "--theme-layout-attachment-tile-compact-media-size",
       theme.layout.attachmentTile.compactMediaSize,
     ],

--- a/frontend/src/components/ui/Message/CollapsibleCodeBlock.test.tsx
+++ b/frontend/src/components/ui/Message/CollapsibleCodeBlock.test.tsx
@@ -1,0 +1,93 @@
+import { I18nProvider } from "@lingui/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { messages as enMessages } from "@/locales/en/messages.json";
+
+import { CollapsibleCodeBlock } from "./CollapsibleCodeBlock";
+
+import type { Messages } from "@lingui/core";
+
+/**
+ * jsdom reports every layout box as zero, so overflow has to be simulated.
+ * Both properties are patched on the prototype because the component reads
+ * them off the clipper element it owns.
+ */
+function stubHeights({ content, clip }: { content: number; clip: number }) {
+  const scroll = vi
+    .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+    .mockReturnValue(content);
+  const client = vi
+    .spyOn(HTMLElement.prototype, "clientHeight", "get")
+    .mockReturnValue(clip);
+  return () => {
+    scroll.mockRestore();
+    client.mockRestore();
+  };
+}
+
+async function renderBlock(ui: React.ReactElement) {
+  const { i18n } = await import("@lingui/core");
+  i18n.load("en", enMessages as unknown as Messages);
+  i18n.activate("en");
+  return render(<I18nProvider i18n={i18n}>{ui}</I18nProvider>);
+}
+
+const LONG = <div>a long block</div>;
+
+describe("CollapsibleCodeBlock", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leaves a block that fits alone", async () => {
+    const restore = stubHeights({ content: 100, clip: 100 });
+    await renderBlock(
+      <CollapsibleCodeBlock lineCount={4}>{LONG}</CollapsibleCodeBlock>,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+  });
+
+  it("offers to reveal the rest of a block that overflows, naming how much", async () => {
+    const restore = stubHeights({ content: 900, clip: 384 });
+    await renderBlock(
+      <CollapsibleCodeBlock lineCount={120}>{LONG}</CollapsibleCodeBlock>,
+    );
+
+    const toggle = screen.getByRole("button", { name: /Show all 120 lines/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    restore();
+  });
+
+  it("reveals and re-clamps on demand", async () => {
+    const restore = stubHeights({ content: 900, clip: 384 });
+    await renderBlock(
+      <CollapsibleCodeBlock lineCount={120}>{LONG}</CollapsibleCodeBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Show all 120 lines/ }));
+    const collapse = screen.getByRole("button", { name: /Show less/ });
+    expect(collapse).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(collapse);
+    expect(
+      screen.getByRole("button", { name: /Show all 120 lines/ }),
+    ).toHaveAttribute("aria-expanded", "false");
+    restore();
+  });
+
+  it("does not clamp while the block is still streaming", async () => {
+    // The height changes on every chunk, so a cap would fight the content.
+    const restore = stubHeights({ content: 900, clip: 384 });
+    await renderBlock(
+      <CollapsibleCodeBlock lineCount={120} disabled>
+        {LONG}
+      </CollapsibleCodeBlock>,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    restore();
+  });
+});

--- a/frontend/src/components/ui/Message/CollapsibleCodeBlock.tsx
+++ b/frontend/src/components/ui/Message/CollapsibleCodeBlock.tsx
@@ -1,0 +1,100 @@
+import { t } from "@lingui/core/macro";
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { DisclosureChevron } from "../Controls/DisclosureChevron";
+
+import type React from "react";
+
+export interface CollapsibleCodeBlockProps {
+  /** Total lines in the block, used to say how much is hidden. */
+  lineCount: number;
+  /**
+   * Suppresses clamping. Set while the block is still streaming: the height
+   * changes on every chunk, so a cap would fight the content instead of
+   * settling it.
+   */
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Caps a long code block and offers to reveal the rest.
+ *
+ * The opposite default to an image, which is too small and grows: code arrives
+ * too tall and shrinks. Deliberately not `Collapse` — that toggles fully
+ * hidden against fully shown, whereas this clamps to a readable height and
+ * keeps the first lines visible.
+ *
+ * There is no gradient fade: the block's background comes from the Prism
+ * theme, so a fade would have to guess at a colour it does not own. The footer
+ * states the hidden line count instead, which also says how much is missing
+ * rather than merely that something is.
+ */
+export const CollapsibleCodeBlock: React.FC<CollapsibleCodeBlockProps> = ({
+  lineCount,
+  disabled = false,
+  children,
+}) => {
+  const clipperRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+
+  useLayoutEffect(() => {
+    const clipper = clipperRef.current;
+    if (!clipper || disabled) {
+      setOverflows(false);
+      return;
+    }
+
+    // Only meaningful while clamped — once expanded the element is exactly as
+    // tall as its content, so the last collapsed measurement stands.
+    if (expanded) {
+      return;
+    }
+
+    const measure = () => {
+      setOverflows(clipper.scrollHeight > clipper.clientHeight + 1);
+    };
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(clipper);
+    return () => observer.disconnect();
+  }, [disabled, expanded, children]);
+
+  // The cap applies whenever collapsed, not only once overflow is known —
+  // otherwise the measurement is circular, since an uncapped element can never
+  // report that it exceeds the cap. A block shorter than the cap is unaffected;
+  // it simply never reports overflow and never grows a toggle.
+  const clamped = !expanded && !disabled;
+
+  return (
+    <>
+      <div
+        ref={clipperRef}
+        className={clamped ? "overflow-hidden" : undefined}
+        style={
+          clamped
+            ? {
+                maxHeight:
+                  "var(--theme-layout-code-block-collapsed-max-height)",
+              }
+            : undefined
+        }
+      >
+        {children}
+      </div>
+      {overflows && (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          className="flex w-full items-center justify-center gap-1 border-t border-theme-border py-1.5 text-xs text-theme-fg-muted hover:text-theme-fg-primary"
+        >
+          <DisclosureChevron open={expanded} />
+          {expanded ? t`Show less` : t`Show all ${lineCount} lines`}
+        </button>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/ui/Message/MessageContent.tsx
+++ b/frontend/src/components/ui/Message/MessageContent.tsx
@@ -18,6 +18,7 @@ import { useTraceFeature } from "@/providers/FeatureConfigProvider";
 import { findMentionRanges } from "@/utils/chat/assistantMentions";
 import { FileTypeUtil } from "@/utils/fileTypes";
 
+import { CollapsibleCodeBlock } from "./CollapsibleCodeBlock";
 import { EratoAppointmentBlock } from "./EratoAppointmentBlock";
 import { EratoEmailSuggestion } from "./EratoEmailSuggestion";
 import { ImageContentDisplay } from "./ImageContentDisplay";
@@ -262,16 +263,21 @@ function MarkdownPre({
 
   return (
     <div className="group relative my-4">
-      <pre
-        className={["message-content-code-block", className]
-          .filter(Boolean)
-          .join(" ")}
-        {...props}
+      <CollapsibleCodeBlock
+        lineCount={codeContent === "" ? 0 : codeContent.split("\n").length}
+        disabled={isStreaming}
       >
-        <BlockCodeContext.Provider value={{ isBlockCode: true, isStreaming }}>
-          {children}
-        </BlockCodeContext.Provider>
-      </pre>
+        <pre
+          className={["message-content-code-block", className]
+            .filter(Boolean)
+            .join(" ")}
+          {...props}
+        >
+          <BlockCodeContext.Provider value={{ isBlockCode: true, isStreaming }}>
+            {children}
+          </BlockCodeContext.Provider>
+        </pre>
+      </CollapsibleCodeBlock>
       <button
         type="button"
         onClick={handleCopy}

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -250,6 +250,10 @@ export type ThemeLayout = {
     imagePreviewMaxWidth: string;
     imagePreviewMaxHeight: string;
   };
+  /** Height a long code block clamps to before offering to reveal the rest. */
+  codeBlock: {
+    collapsedMaxHeight: string;
+  };
   /** Attachment tiles: compact stages in the composer, medium carries the transcript. */
   attachmentTile: {
     compactMediaSize: string;
@@ -561,6 +565,9 @@ export const defaultTheme: Theme = {
       inputMaxWidth: "56rem",
       imagePreviewMaxWidth: "24rem",
       imagePreviewMaxHeight: "24rem",
+    },
+    codeBlock: {
+      collapsedMaxHeight: "24rem",
     },
     attachmentTile: {
       compactMediaSize: "3.5rem",

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1729,6 +1729,16 @@ msgid "chat.message.code.copy"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showAll"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showLess"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "chat.message.email.copied"
 msgstr ""
@@ -5283,11 +5293,16 @@ msgstr "{hiddenCount} weitere Elemente anzeigen"
 msgid "Show 1 more item"
 msgstr "1 weiteres Element anzeigen"
 
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+msgid "Show all {lineCount} lines"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Show details"
 msgstr "Details anzeigen"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Weniger anzeigen"
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1729,6 +1729,16 @@ msgid "chat.message.code.copy"
 msgstr "Copy code"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showAll"
+#~ msgstr "Show all {lineCount} lines"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showLess"
+#~ msgstr "Show less"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "chat.message.email.copied"
 msgstr "Copied!"
@@ -5283,11 +5293,16 @@ msgstr "Show {hiddenCount} more items"
 msgid "Show 1 more item"
 msgstr "Show 1 more item"
 
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+msgid "Show all {lineCount} lines"
+msgstr "Show all {lineCount} lines"
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Show details"
 msgstr "Show details"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Show less"
 

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1729,6 +1729,16 @@ msgid "chat.message.code.copy"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showAll"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showLess"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "chat.message.email.copied"
 msgstr ""
@@ -5283,11 +5293,16 @@ msgstr "Mostrar {hiddenCount} elementos más"
 msgid "Show 1 more item"
 msgstr "Mostrar 1 elemento más"
 
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+msgid "Show all {lineCount} lines"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Show details"
 msgstr "Mostrar detalles"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Mostrar menos"
 

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1729,6 +1729,16 @@ msgid "chat.message.code.copy"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showAll"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showLess"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "chat.message.email.copied"
 msgstr ""
@@ -5283,11 +5293,16 @@ msgstr "Afficher {hiddenCount} éléments de plus"
 msgid "Show 1 more item"
 msgstr "Afficher 1 élément de plus"
 
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+msgid "Show all {lineCount} lines"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Show details"
 msgstr "Afficher les détails"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Afficher moins"
 

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1729,6 +1729,16 @@ msgid "chat.message.code.copy"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showAll"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+#~ msgid "chat.message.code.showLess"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/components/ui/Message/EratoEmailSuggestion.tsx
 msgid "chat.message.email.copied"
 msgstr ""
@@ -5283,11 +5293,16 @@ msgstr "Pokaż jeszcze {hiddenCount} elementów"
 msgid "Show 1 more item"
 msgstr "Pokaż jeszcze 1 element"
 
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
+msgid "Show all {lineCount} lines"
+msgstr ""
+
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Show details"
 msgstr "Pokaż szczegóły"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Pokaż mniej"
 

--- a/frontend/src/stories/ui/MessageContent.codeblock.stories.tsx
+++ b/frontend/src/stories/ui/MessageContent.codeblock.stories.tsx
@@ -1,0 +1,45 @@
+import { MessageContent } from "../../components/ui/Message/MessageContent";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const shortCode = ["const a = 1;", "const b = 2;", "console.log(a + b);"].join(
+  "\n",
+);
+
+const longCode = Array.from(
+  { length: 120 },
+  (_, index) =>
+    `const line${index} = compute(${index}); // a reasonably long line of code`,
+).join("\n");
+
+const meta = {
+  title: "UI/MessageContent/CodeBlock",
+  component: MessageContent,
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <div className="bg-theme-bg-primary p-6">
+        <div className="mx-auto max-w-[46rem]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MessageContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Short enough to need no affordance at all. */
+export const ShortCode: Story = {
+  args: {
+    content: [{ content_type: "text", text: "```ts\n" + shortCode + "\n```" }],
+  },
+};
+
+/** Clamps at the themed height and says how much it is hiding. */
+export const LongCodeClamped: Story = {
+  args: {
+    content: [{ content_type: "text", text: "```ts\n" + longCode + "\n```" }],
+  },
+};

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -263,6 +263,7 @@
   --theme-layout-chat-input-max-width: 56rem;
   --theme-layout-chat-image-preview-max-width: 24rem;
   --theme-layout-chat-image-preview-max-height: 24rem;
+  --theme-layout-code-block-collapsed-max-height: 24rem;
   --theme-layout-attachment-tile-compact-media-size: 3.5rem;
   --theme-layout-attachment-tile-compact-doc-max-width: 15rem;
   --theme-layout-attachment-tile-medium-media-size: 7rem;


### PR DESCRIPTION
Completes the code half of ERMAIN-658. Independent of the tile stack — branches off main.

A long code block now clamps to a themed height and offers to reveal the rest. This is the opposite default to an image: code arrives too tall and shrinks, an image arrives too small and grows. Deliberately not `Collapse`, which toggles fully hidden against fully shown — this clamps to a readable height and keeps the first lines visible.

No gradient fade. The block's background comes from the Prism theme, so a fade would have to guess at a colour it does not own; the footer states the hidden line count instead, which says how much is missing rather than merely that something is.

Clamping is suppressed while the block is still streaming — the height changes on every chunk, so a cap would fight the content instead of settling it.

`--theme-layout-code-block-collapsed-max-height` (24rem) follows the tile-geometry precedent, wired through `theme.ts`, `globals.css` and the `ThemeProvider` allowlist.

Worth knowing for review: the clamp applies whenever collapsed, not only once overflow is detected. Measuring the other way round is circular — an uncapped element can never report that it exceeds the cap. A block shorter than the cap is unaffected and grows no toggle