### PR TITLE
Share the growth control between attached and generated images

### DIFF
--- a/frontend/src/components/ui/Controls/ExpandMediaButton.tsx
+++ b/frontend/src/components/ui/Controls/ExpandMediaButton.tsx
@@ -1,0 +1,55 @@
+import { t } from "@lingui/core/macro";
+import clsx from "clsx";
+
+import { CollapseDiagonalIcon, ExpandDiagonalIcon } from "../icons";
+
+import type React from "react";
+
+export interface ExpandMediaButtonProps {
+  expanded: boolean;
+  onToggle: () => void;
+  /** Names the thing being expanded, e.g. a filename. */
+  label: string;
+  className?: string;
+}
+
+/**
+ * Corner control offering the middle tier between a sized-down image and the
+ * full preview: grow it in place, no chrome, reversible.
+ *
+ * Shared so an attached image and a generated one behave identically — the two
+ * differ only in what they collapse back to. Revealed on hover or focus, and
+ * pinned visible where there is no hover to reveal it with.
+ */
+export const ExpandMediaButton: React.FC<ExpandMediaButtonProps> = ({
+  expanded,
+  onToggle,
+  label,
+  className,
+}) => (
+  <button
+    type="button"
+    onClick={(event) => {
+      // The image itself usually opens the full preview; growing it in place
+      // must not also trigger that.
+      event.stopPropagation();
+      onToggle();
+    }}
+    aria-expanded={expanded}
+    aria-label={expanded ? `${t`Collapse`} ${label}` : `${t`Expand`} ${label}`}
+    className={clsx(
+      "absolute -left-1 -top-1 z-10 inline-flex size-5 items-center justify-center rounded-full",
+      "border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] text-[var(--theme-fg-muted)] shadow-sm",
+      "hover:text-[var(--theme-fg-primary)]",
+      "opacity-0 transition-opacity focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100",
+      "[@media(hover:none)]:opacity-100",
+      className,
+    )}
+  >
+    {expanded ? (
+      <CollapseDiagonalIcon className="size-3" />
+    ) : (
+      <ExpandDiagonalIcon className="size-3" />
+    )}
+  </button>
+);

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -12,12 +12,8 @@ import {
   splitFilenameForDisplay,
   type FileResource,
 } from "./FilePreviewBase";
-import {
-  CloseIcon,
-  CollapseDiagonalIcon,
-  ExpandDiagonalIcon,
-  ResolvedIcon,
-} from "../icons";
+import { ExpandMediaButton } from "../Controls/ExpandMediaButton";
+import { CloseIcon, ResolvedIcon } from "../icons";
 
 import type React from "react";
 
@@ -254,27 +250,11 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       )}
 
       {expandable && isMedia && (
-        <button
-          type="button"
-          onClick={() => setExpanded((value) => !value)}
-          aria-expanded={expanded}
-          aria-label={
-            expanded ? `${t`Collapse`} ${filename}` : `${t`Expand`} ${filename}`
-          }
-          className={clsx(
-            "absolute -left-1 -top-1 z-10 inline-flex size-5 items-center justify-center rounded-full",
-            "border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] text-[var(--theme-fg-muted)] shadow-sm",
-            "hover:text-[var(--theme-fg-primary)]",
-            "opacity-0 transition-opacity focus-visible:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100",
-            "[@media(hover:none)]:opacity-100",
-          )}
-        >
-          {expanded ? (
-            <CollapseDiagonalIcon className="size-3" />
-          ) : (
-            <ExpandDiagonalIcon className="size-3" />
-          )}
-        </button>
+        <ExpandMediaButton
+          expanded={expanded}
+          onToggle={() => setExpanded((value) => !value)}
+          label={filename}
+        />
       )}
 
       {onRemove && (

--- a/frontend/src/components/ui/Message/ImageContentDisplay.test.tsx
+++ b/frontend/src/components/ui/Message/ImageContentDisplay.test.tsx
@@ -43,7 +43,10 @@ describe("ImageContentDisplay", () => {
       <ImageContentDisplay images={images} onImageClick={onImageClick} />,
     );
 
-    const imageButton = screen.getByRole("button");
+    // The frame now also carries a growth toggle, so target the image itself.
+    const imageButton = screen.getByRole("button", {
+      name: "Message attachment",
+    });
     fireEvent.click(imageButton);
 
     expect(imageButton.tagName).toBe("BUTTON");
@@ -59,6 +62,36 @@ describe("ImageContentDisplay", () => {
     expect(screen.queryByRole("button")).toBeNull();
     expect(image).not.toHaveClass("cursor-pointer");
     expect(image).not.toHaveClass("hover:scale-105");
+  });
+
+  it("offers in-place growth on an interactive preview, and re-collapses", () => {
+    renderWithTheme(
+      <ImageContentDisplay images={images} onImageClick={vi.fn()} />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /Expand/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+    const collapse = screen.getByRole("button", { name: /Collapse/ });
+    expect(collapse).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(collapse);
+    expect(screen.getByRole("button", { name: /Expand/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("does not open the full preview when growing in place", () => {
+    const onImageClick = vi.fn();
+    renderWithTheme(
+      <ImageContentDisplay images={images} onImageClick={onImageClick} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Expand/ }));
+
+    expect(onImageClick).not.toHaveBeenCalled();
   });
 
   it("uses the same theme height hook for the error fallback", () => {

--- a/frontend/src/components/ui/Message/ImageContentDisplay.tsx
+++ b/frontend/src/components/ui/Message/ImageContentDisplay.tsx
@@ -2,6 +2,7 @@ import { t, msg } from "@lingui/core/macro";
 import { useState, memo } from "react";
 
 import { InteractiveContainer } from "@/components/ui/Container/InteractiveContainer";
+import { ExpandMediaButton } from "@/components/ui/Controls/ExpandMediaButton";
 
 import type { UiImagePart } from "@/utils/adapters/contentPartAdapter";
 
@@ -35,6 +36,17 @@ const STATIC_IMAGE_CLASS_NAME = "w-full object-contain";
 export const ImageContentDisplay = memo<ImageContentDisplayProps>(
   ({ images, onImageClick, className = "" }) => {
     const [loadErrors, setLoadErrors] = useState<Set<string>>(new Set());
+    // Independent per image: growing one says nothing about the others.
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+    const toggleExpanded = (imageId: string) =>
+      setExpandedIds((previous) => {
+        const next = new Set(previous);
+        if (!next.delete(imageId)) {
+          next.add(imageId);
+        }
+        return next;
+      });
 
     if (images.length === 0) return null;
 
@@ -55,6 +67,21 @@ export const ImageContentDisplay = memo<ImageContentDisplayProps>(
       <div className={`my-4 flex flex-wrap gap-2 ${className}`}>
         {images.map((image) => {
           const hasError = loadErrors.has(image.id);
+          const expanded = expandedIds.has(image.id);
+          const imageLabel = t(
+            msg({
+              id: "ui.image.messageAttachment",
+              message: "Message attachment",
+            }),
+          );
+          // Collapsed sits at the chat image bounds; expanded gives the image
+          // the full message width, which is the point — a generated chart at
+          // 24rem is often too small to read, and the lightbox is a heavier
+          // interaction than the question deserves.
+          const frameStyle = expanded
+            ? { maxWidth: "100%" }
+            : IMAGE_PREVIEW_CONTAINER_STYLE;
+          const pictureStyle = expanded ? undefined : IMAGE_PREVIEW_STYLE;
           const imageElement = hasError ? (
             <div
               className="flex w-full items-center justify-center bg-theme-bg-tertiary p-4 text-center"
@@ -83,18 +110,21 @@ export const ImageContentDisplay = memo<ImageContentDisplayProps>(
                   ? INTERACTIVE_IMAGE_CLASS_NAME
                   : STATIC_IMAGE_CLASS_NAME
               }
-              style={IMAGE_PREVIEW_STYLE}
+              style={pictureStyle}
               onError={(e) => handleImageError(image.id, e)}
               loading="lazy"
             />
           );
 
+          // A static preview stays wholly non-interactive by contract, so it
+          // gets no growth affordance either — only the already-clickable
+          // variant below offers the middle tier.
           if (!onImageClick) {
             return (
               <div
                 key={image.id}
-                className={IMAGE_PREVIEW_FRAME_CLASS_NAME}
-                style={IMAGE_PREVIEW_CONTAINER_STYLE}
+                className={`group ${IMAGE_PREVIEW_FRAME_CLASS_NAME}`}
+                style={frameStyle}
               >
                 {imageElement}
               </div>
@@ -102,15 +132,22 @@ export const ImageContentDisplay = memo<ImageContentDisplayProps>(
           }
 
           return (
-            <InteractiveContainer
-              key={image.id}
-              onClick={() => onImageClick(image)}
-              fullWidth={false}
-              className={IMAGE_PREVIEW_FRAME_CLASS_NAME}
-              style={IMAGE_PREVIEW_CONTAINER_STYLE}
-            >
-              {imageElement}
-            </InteractiveContainer>
+            <div key={image.id} className="group relative" style={frameStyle}>
+              <InteractiveContainer
+                onClick={() => onImageClick(image)}
+                fullWidth={false}
+                className={IMAGE_PREVIEW_FRAME_CLASS_NAME}
+              >
+                {imageElement}
+              </InteractiveContainer>
+              {!hasError && (
+                <ExpandMediaButton
+                  expanded={expanded}
+                  onToggle={() => toggleExpanded(image.id)}
+                  label={imageLabel}
+                />
+              )}
+            </div>
           );
         })}
       </div>

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4434,7 +4434,7 @@ msgstr "Dialog schließen"
 msgid "Close modal overlay"
 msgstr "Dialog-Overlay schließen"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Collapse"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr "Tokennutzung wird geschätzt..."
 msgid "Exit audio mode"
 msgstr ""
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Expand"
 msgstr ""
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -4434,7 +4434,7 @@ msgstr "Close modal"
 msgid "Close modal overlay"
 msgstr "Close modal overlay"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Collapse"
 msgstr "Collapse"
 
@@ -4727,7 +4727,7 @@ msgstr "Estimating token usage..."
 msgid "Exit audio mode"
 msgstr "Exit audio mode"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Expand"
 msgstr "Expand"
 

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4434,7 +4434,7 @@ msgstr "Cerrar modal"
 msgid "Close modal overlay"
 msgstr "Cerrar superposición del modal"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Collapse"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr "Estimando uso de tokens..."
 msgid "Exit audio mode"
 msgstr ""
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Expand"
 msgstr ""
 

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4434,7 +4434,7 @@ msgstr "Fermer la modal"
 msgid "Close modal overlay"
 msgstr "Fermer le fond de modal"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Collapse"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr "Estimation de l'utilisation des tokens..."
 msgid "Exit audio mode"
 msgstr ""
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Expand"
 msgstr ""
 

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4434,7 +4434,7 @@ msgstr "Zamknij okno"
 msgid "Close modal overlay"
 msgstr "Zamknij nakładkę okna"
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Collapse"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr "Szacowanie użycia tokenów..."
 msgid "Exit audio mode"
 msgstr ""
 
-#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/Controls/ExpandMediaButton.tsx
 msgid "Expand"
 msgstr ""
 


### PR DESCRIPTION
Stacked on #1053. Closes the loose end ERMAIN-690 named: `ImageContentDisplay` and the attachment tile each hand-rolled their own sizing, and should share one wrapper with different defaults.

Extracts the corner growth control into `ExpandMediaButton` and uses it in both, so an attached image and a generated one behave identically — they differ only in what they collapse back to. The tile's behaviour is unchanged; this is a straight extraction.

Generated images gain the middle tier they lacked. They were capped at the chat image bounds with only the lightbox beyond, so a generated chart at 24rem was often too small to read and the only way to see it was a modal. It can now grow to the full message width in place.

Two deliberate limits:

- **A static preview stays wholly inert.** `ImageContentDisplay` without `onImageClick` is non-interactive by contract, asserted by an existing test, so it gets no growth affordance either. Only the already-clickable variant offers the tier.
- **Growing never opens the lightbox.** The toggle stops propagation and sits as a sibling of the click target rather than inside it, covered by a test