### PR TITLE
Fail CI when the kit shared surface drifts

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -167,6 +167,11 @@ jobs:
         if: success() || failure()
         run: node scripts/generate-served-routes.mjs --check
 
+      - name: "Component-kit shared surface is up-to-date"
+        working-directory: ./frontend
+        if: success() || failure()
+        run: pnpm run check:component-registry-shared
+
       # Lint run section
       # Every step here should be conditional on "success() || failure()",
       # in order to prevent failing fast, so that we can run all linting steps in one run.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
     "codegen": "pnpm codegen:generate && pnpm codegen:fix-types",
     "generate:component-registry-shared": "node scripts/generate-component-registry-shared-exports.mjs",
     "generate:served-routes": "node ../scripts/generate-served-routes.mjs --target frontend",
+    "check:component-registry-shared": "node scripts/generate-component-registry-shared-exports.mjs --check",
     "check:served-routes": "node ../scripts/generate-served-routes.mjs --check --target frontend",
     "typecheck": "tsc --noEmit",
     "check": "pnpm lint:strict && pnpm typecheck",

--- a/frontend/scripts/generate-component-registry-shared-exports.mjs
+++ b/frontend/scripts/generate-component-registry-shared-exports.mjs
@@ -17,6 +17,13 @@ const outputPath = path.join(
   "component-registry.generated.ts",
 );
 const watchMode = process.argv.includes("--watch");
+// The build regenerates this file anyway, so a stale commit never reaches a
+// deployed surface. It does two other kinds of harm: local type-checking
+// disagrees with the build, and — the reason this exists — a component
+// silently *leaving* the surface never appears in a diff. A kit is one flat
+// named import, so a dropped export is a load-time failure that takes the
+// whole kit down.
+const checkMode = process.argv.includes("--check");
 const sourceExtensions = [".ts", ".tsx"];
 
 const isWithin = (parentPath, childPath) => {
@@ -375,20 +382,56 @@ const generatedSource = () => {
   ].join("\n");
 };
 
+/**
+ * Names what changed rather than telling the reader to go diff it. Removals
+ * lead: they are the ones that break a kit at load time.
+ */
+const reportDrift = (currentSource, nextSource) => {
+  const exportsOf = (source) =>
+    new Set(
+      source === null
+        ? []
+        : [...source.matchAll(/^export (?:type )?\{ (\w+)/gm)].map((m) => m[1]),
+    );
+  const before = exportsOf(currentSource);
+  const after = exportsOf(nextSource);
+  const removed = [...before].filter((name) => !after.has(name));
+  const added = [...after].filter((name) => !before.has(name));
+
+  return [
+    removed.length > 0 ? `  removed: ${removed.join(", ")}` : null,
+    added.length > 0 ? `  added:   ${added.join(", ")}` : null,
+    removed.length === 0 && added.length === 0
+      ? "  the exported names are unchanged; only their order or source paths moved"
+      : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+};
+
 const generate = () => {
   const nextSource = generatedSource();
   const currentSource = fs.existsSync(outputPath)
     ? fs.readFileSync(outputPath, "utf8")
     : null;
+  const relativeOutput = path.relative(rootDir, outputPath);
 
   if (currentSource === nextSource) {
+    if (checkMode) {
+      console.log(`✓ ${relativeOutput} is up-to-date`);
+    }
     return;
   }
 
+  if (checkMode) {
+    console.error(`✖ ${relativeOutput} is out of date.`);
+    console.error(reportDrift(currentSource, nextSource));
+    console.error("Run `pnpm generate:component-registry-shared` to update.");
+    process.exit(1);
+  }
+
   fs.writeFileSync(outputPath, nextSource);
-  console.log(
-    `[component-registry-shared] wrote ${path.relative(rootDir, outputPath)}`,
-  );
+  console.log(`[component-registry-shared] wrote ${relativeOutput}`);
 };
 
 generate();

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -41,6 +41,8 @@ export type { DisclosureChevronSize } from "@/components/ui/Controls/DisclosureC
 export { DropdownMenu } from "@/components/ui/Controls/DropdownMenu";
 export type { DropdownMenuItem } from "@/components/ui/Controls/DropdownMenu";
 export type { DropdownMenuProps } from "@/components/ui/Controls/DropdownMenu";
+export { ExpandMediaButton } from "@/components/ui/Controls/ExpandMediaButton";
+export type { ExpandMediaButtonProps } from "@/components/ui/Controls/ExpandMediaButton";
 export { SegmentedControl } from "@/components/ui/Controls/SegmentedControl";
 export type { SegmentedControlAttention } from "@/components/ui/Controls/SegmentedControl";
 export type { SegmentedControlOption } from "@/components/ui/Controls/SegmentedControl";


### PR DESCRIPTION
`component-registry.generated.ts` is the `@erato/frontend/shared` surface kits import from, and it is a byproduct of an import graph: it exports every symbol of every module reachable from a registry extension point. A refactor to an unrelated component can add or drop whole modules from a public API, and the committed file drifts silently because it is only regenerated as a side effect of `build:app` / `build:lib`.

It drifted three times in a day. `Tooltip` left the surface when the attachments preview stopped importing it; the two diagonal icons and `ExpandMediaButton` never arrived. This regenerates the file and adds a check so the next one fails loudly.

**Scope, honestly:** this is not a production fix. Both builds run the generator first, so a deployed surface always includes everything reachable. What drift actually costs is that local type-checking disagrees with the build, and — the reason this is worth doing — a component *leaving* the surface never appears in a diff. A kit is one flat named import, so a dropped export fails module linking and takes the whole kit down, every override silently reverting to its default. `ERATO_SHARED_SURFACE_VERSION` cannot warn about it, because it is imported in that same statement.

The generator gains `--check`, mirroring `generate-served-routes.mjs --check`, which is already run in CI one step above the new one. The failure names what moved rather than telling the reader to go diff a generated file, and leads with removals:

```
✖ src/shared/component-registry.generated.ts is out of date.
  removed: GhostComponent
  added:   ExpandMediaButton, ExpandMediaButtonProps
Run `pnpm generate:component-registry-shared` to update.
```