### PR TITLE
Keep the composer upload button usable after a file error (ERMAIN-163)

### DIFF
--- a/e2e-tests/tests/chat.basic.spec.ts
+++ b/e2e-tests/tests/chat.basic.spec.ts
@@ -141,15 +141,17 @@ test.describe("Can submit a message and get a response with slow routes", () => 
 });
 
 test(
-  "Uploading a file that is too large shows an error",
+  "A too-large file shows a dismissable error and leaves the upload button usable",
   { tag: TAG_CI },
   async ({ page }) => {
     await page.goto("/");
     await chatIsReadyToChat(page);
 
+    const uploadButton = page.getByRole("button", { name: "Upload Files" });
+
     // Start waiting for file chooser before clicking the button
     const fileChooserPromise = page.waitForEvent("filechooser");
-    await page.getByRole("button", { name: "Upload Files" }).click();
+    await uploadButton.click();
     const fileChooser = await fileChooserPromise;
 
     const filePath = "test-files/big-file-60mb.pdf";
@@ -166,6 +168,23 @@ test(
       "File is too large",
       { timeout: 30000 },
     );
+
+    await page
+      .getByTestId("file-upload-error")
+      .getByRole("button", { name: "Dismiss" })
+      .click();
+    await expect(page.getByTestId("file-upload-error")).toHaveCount(0);
+
+    await expect(uploadButton).toBeEnabled();
+    const retryChooserPromise = page.waitForEvent("filechooser");
+    await uploadButton.click();
+    const retryChooser = await retryChooserPromise;
+    await retryChooser.setFiles("test-files/sample-report-compressed.pdf");
+
+    await expect(
+      page.getByText(/sample-report-compressed\.pdf/i),
+    ).toBeVisible();
+    await expect(page.getByTestId("file-upload-error")).toHaveCount(0);
   },
 );
 

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -4,7 +4,13 @@ import {
   QueryClientProvider,
   skipToken,
 } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +18,8 @@ import { componentRegistry } from "@/config/componentRegistry";
 import { useComposeSessionStore } from "@/hooks/chat/store/composeSessionStore";
 import { useConfirmationRegistryStore } from "@/hooks/chat/store/confirmationRegistryStore";
 import { useMessageQueueStore } from "@/hooks/chat/store/messageQueueStore";
+import { UploadTooLargeError } from "@/hooks/files/errors";
+import { useFileUploadStore } from "@/hooks/files/useFileUploadStore";
 import { messages as enMessages } from "@/locales/en/messages.json";
 
 import { ChatInput } from "./ChatInput";
@@ -208,9 +216,22 @@ vi.mock("../Controls/Button", () => ({
 vi.mock("../Feedback/Alert", () => ({
   Alert: ({
     children,
+    dismissible,
+    onDismiss,
     ...props
-  }: { children: ReactNode } & HTMLAttributes<HTMLDivElement>) => (
-    <div {...props}>{children}</div>
+  }: {
+    children: ReactNode;
+    dismissible?: boolean;
+    onDismiss?: () => void;
+  } & HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>
+      {children}
+      {dismissible && onDismiss && (
+        <button type="button" aria-label="Dismiss" onClick={onDismiss}>
+          dismiss
+        </button>
+      )}
+    </div>
   ),
 }));
 
@@ -326,6 +347,48 @@ describe("ChatInput", () => {
       hasRecordedAudioFile: () => false,
       toggleAudioRecording: vi.fn(),
     });
+  });
+
+  it("clears the shared upload error when the file error alert is dismissed", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const setFileError = vi.fn();
+    const uploadError = new UploadTooLargeError("50 MB");
+    mockUseChatInputHandlers.mockReturnValue({
+      attachedFiles: [],
+      fileError: uploadError.message,
+      setFileError,
+      handleFilesUploaded: vi.fn(),
+      handleRemoveFile: vi.fn(),
+      handleRemoveAllFiles: vi.fn(),
+      setAttachedFiles: vi.fn(),
+      createSubmitHandler: () => (event: FormEvent) => event.preventDefault(),
+    });
+    useFileUploadStore.getState().setError(uploadError);
+
+    const { i18n } = await import("@lingui/core");
+    render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput onSendMessage={vi.fn()} uploadError={uploadError} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("file-upload-error")).toBeInTheDocument();
+
+    fireEvent.click(
+      within(screen.getByTestId("file-upload-error")).getByRole("button", {
+        name: "Dismiss",
+      }),
+    );
+
+    expect(setFileError).toHaveBeenCalledWith(null);
+    expect(useFileUploadStore.getState().error).toBeNull();
   });
 
   it("re-focuses the chat textarea when a response finishes streaming", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -451,6 +451,7 @@ export const ChatInput = ({
   const silentChatId = useFileUploadStore((state) => state.silentChatId);
   const uploadedFiles = useFileUploadStore((state) => state.uploadedFiles);
   const setSilentChatId = useFileUploadStore((state) => state.setSilentChatId);
+  const setUploadStoreError = useFileUploadStore((state) => state.setError);
   const sendErrorText = useMemo(
     () => resolveChatSendErrorMessage(messagingError),
     [messagingError],
@@ -2369,6 +2370,13 @@ export const ChatInput = ({
     return fileError;
   }, [externalUploadError, fileError]);
 
+  // The banner mirrors the upload store, so dismissing has to clear both — the
+  // local copy alone leaves the store error to outlive its own message.
+  const handleDismissFileError = useCallback(() => {
+    setFileError(null);
+    setUploadStoreError(null);
+  }, [setFileError, setUploadStoreError]);
+
   const ChatInputAttachmentPreview =
     componentRegistry.ChatInputAttachmentPreview;
   const hasTopLeftAccessoryOverride =
@@ -2491,7 +2499,7 @@ export const ChatInput = ({
             type="error"
             geometryVariant="message"
             dismissible
-            onDismiss={() => setFileError(null)}
+            onDismiss={handleDismissFileError}
             className="mb-2"
             data-testid="file-upload-error"
           >
@@ -2768,10 +2776,6 @@ export const ChatInput = ({
                       onFilesUploaded: handleFilesUploaded,
                       onTokenLimitExceeded: handleFileTokenLimitExceeded,
                       performFileUpload: uploadFiles,
-                      uploadError:
-                        externalUploadError instanceof Error
-                          ? externalUploadError
-                          : null,
                       onProcessingChange: handleFileButtonProcessingChange,
                       acceptedFileTypes,
                       multiple: maxFiles > 1,
@@ -2798,12 +2802,6 @@ export const ChatInput = ({
                         onFilesUploaded={handleFilesUploaded}
                         onTokenLimitExceeded={handleFileTokenLimitExceeded}
                         performFileUpload={uploadFiles}
-                        uploadError={
-                          externalUploadError instanceof Error
-                            ? externalUploadError
-                            : null
-                        }
-                        // Pass the callback for processing state
                         onProcessingChange={handleFileButtonProcessingChange}
                         acceptedFileTypes={acceptedFileTypes}
                         multiple={maxFiles > 1}

--- a/frontend/src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx
+++ b/frontend/src/components/ui/FileUpload/FileUploadWithTokenCheck.tsx
@@ -34,8 +34,6 @@ interface FileUploadWithTokenCheckProps {
   onTokenLimitExceeded?: (isExceeded: boolean) => void;
   /** Optional upload function supplied by a parent so drag/drop and buttons share one path */
   performFileUpload?: (files: File[]) => Promise<FileUploadItem[] | undefined>;
-  /** Optional upload error supplied by a parent */
-  uploadError?: Error | null;
   /** Array of accepted file types */
   acceptedFileTypes?: FileType[];
   /** Whether multiple files can be selected */
@@ -67,7 +65,6 @@ export function FileUploadWithTokenCheck({
   onFilesUploaded,
   onTokenLimitExceeded,
   performFileUpload: externalPerformFileUpload,
-  uploadError: externalUploadError = null,
   acceptedFileTypes = [],
   multiple = false,
   label = t({ id: "fileUpload.uploadFiles", message: "Upload Files" }),
@@ -84,7 +81,6 @@ export function FileUploadWithTokenCheck({
     hasCloudProviders,
     isProcessing,
     performDiskUpload,
-    resolvedUploadError,
     onSelectDisk,
     onSelectCloud,
     onSelectFiles,
@@ -100,7 +96,6 @@ export function FileUploadWithTokenCheck({
     onFilesUploaded,
     onTokenLimitExceeded,
     performFileUpload: externalPerformFileUpload,
-    uploadError: externalUploadError,
     acceptedFileTypes,
     multiple,
     maxFiles,
@@ -152,6 +147,8 @@ export function FileUploadWithTokenCheck({
           )}
         </>
       ) : (
+        // No `uploadError` here on purpose: the composer's dismissible alert owns
+        // upload errors, and the button's error state would swallow its picker.
         <FileUploadButton
           acceptedFileTypes={acceptedFileTypes}
           multiple={multiple}
@@ -161,7 +158,6 @@ export function FileUploadWithTokenCheck({
           disabled={disabled || isProcessing}
           performFileUpload={performDiskUpload}
           isUploading={isProcessing}
-          uploadError={resolvedUploadError}
         />
       )}
 

--- a/frontend/src/components/ui/FileUpload/__tests__/FileUploadWithTokenCheck.test.tsx
+++ b/frontend/src/components/ui/FileUpload/__tests__/FileUploadWithTokenCheck.test.tsx
@@ -1,0 +1,65 @@
+import { I18nProvider } from "@lingui/react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UploadTooLargeError } from "@/hooks/files/errors";
+import { useFileUploadStore } from "@/hooks/files/useFileUploadStore";
+import { messages as enMessages } from "@/locales/en/messages.json";
+
+import { FileUploadWithTokenCheck } from "../FileUploadWithTokenCheck";
+
+import type { Messages } from "@lingui/core";
+
+const uploadError = new UploadTooLargeError("50 MB");
+
+vi.mock("@/providers/FeatureConfigProvider", () => ({
+  useCloudProvidersFeature: () => ({ availableProviders: [] }),
+  useUploadFeature: () => ({
+    maxSizeBytes: 50 * 1024 * 1024,
+    maxSizeFormatted: "50 MB",
+  }),
+  useErrorReportFeature: () => ({
+    showVerboseAssistantErrors: false,
+    showCopyErrorReport: false,
+    errorReportTemplate: "",
+    environment: "test",
+    platform: "web",
+  }),
+}));
+
+vi.mock("@/lib/generated/v1betaApi/v1betaApiComponents", () => ({
+  useCreateChat: () => ({ mutateAsync: vi.fn() }),
+  useLinkFile: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/hooks/files/useFileUploadWithTokenCheck", () => ({
+  useFileUploadWithTokenCheck: () => ({
+    uploadFiles: vi.fn(),
+    isUploading: false,
+    isEstimating: false,
+    uploadError,
+    exceedsTokenLimit: false,
+  }),
+}));
+
+describe("FileUploadWithTokenCheck", () => {
+  beforeEach(() => {
+    useFileUploadStore.getState().setError(uploadError);
+  });
+
+  it("keeps the file picker usable while an upload error is pending", async () => {
+    const { i18n } = await import("@lingui/core");
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+
+    const { container } = render(
+      <I18nProvider i18n={i18n}>
+        <FileUploadWithTokenCheck message="" />
+      </I18nProvider>,
+    );
+
+    expect(container.querySelector('input[type="file"]')).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Upload Files" })).toBeEnabled();
+    expect(screen.queryByText(uploadError.message)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/files/useChatFileSources.tsx
+++ b/frontend/src/hooks/files/useChatFileSources.tsx
@@ -21,7 +21,7 @@ import {
 } from "react";
 import { useDropzone } from "react-dropzone";
 
-import { UploadTooLargeError } from "@/hooks/files/errors";
+import { CloudLinkError, UploadTooLargeError } from "@/hooks/files/errors";
 import { useFileUploadStore } from "@/hooks/files/useFileUploadStore";
 import { useFileUploadWithTokenCheck } from "@/hooks/files/useFileUploadWithTokenCheck";
 import {
@@ -57,7 +57,6 @@ export interface UseChatFileSourcesParams {
   onFilesUploaded?: (files: FileUploadItem[]) => void;
   onTokenLimitExceeded?: (isExceeded: boolean) => void;
   performFileUpload?: (files: File[]) => Promise<FileUploadItem[] | undefined>;
-  uploadError?: Error | null;
   acceptedFileTypes?: FileType[];
   multiple?: boolean;
   maxFiles?: number;
@@ -74,8 +73,6 @@ export interface UseChatFileSourcesResult {
   isProcessing: boolean;
   /** The disk upload path, resolving the external override when supplied. */
   performDiskUpload: (files: File[]) => Promise<FileUploadItem[] | undefined>;
-  /** Aggregated upload error (external, cloud-link, or disk). */
-  resolvedUploadError: Error | null;
   /** Open the OS disk file picker. */
   onSelectDisk: () => void;
   /** Begin selecting from a cloud provider (opens the cloud modal). */
@@ -101,7 +98,6 @@ export function useChatFileSources({
   onFilesUploaded,
   onTokenLimitExceeded,
   performFileUpload: externalPerformFileUpload,
-  uploadError: externalUploadError = null,
   acceptedFileTypes = [],
   multiple = false,
   maxFiles = DEFAULT_MAX_FILES_PER_MESSAGE,
@@ -115,7 +111,6 @@ export function useChatFileSources({
 
   const [selectedCloudProvider, setSelectedCloudProvider] =
     useState<CloudProvider | null>(null);
-  const [cloudLinkError, setCloudLinkError] = useState<Error | null>(null);
   // Linking runs as a React 19 Action: `isLinkingFiles` is the transition's
   // pending flag, so there is no manual setIsLinkingFiles bookkeeping. The
   // cloud picker's open state is derived from it (see cloudPickerProps below).
@@ -125,29 +120,20 @@ export function useChatFileSources({
   const createChatMutation = useCreateChat();
   const linkFileMutation = useLinkFile();
 
-  const {
-    uploadFiles,
-    isUploading,
-    isEstimating,
-    uploadError,
-    exceedsTokenLimit,
-  } = useFileUploadWithTokenCheck({
-    message,
-    chatId,
-    assistantId,
-    previousMessageId,
-    chatProviderId,
-    acceptedFileTypes,
-    multiple,
-    maxFiles,
-    disabled,
-  });
+  const { uploadFiles, isUploading, isEstimating, exceedsTokenLimit } =
+    useFileUploadWithTokenCheck({
+      message,
+      chatId,
+      assistantId,
+      previousMessageId,
+      chatProviderId,
+      acceptedFileTypes,
+      multiple,
+      maxFiles,
+      disabled,
+    });
 
   const performDiskUpload = externalPerformFileUpload ?? uploadFiles;
-  const resolvedUploadError =
-    externalUploadError ??
-    cloudLinkError ??
-    (uploadError instanceof Error ? uploadError : null);
 
   const handleSelectedFiles = useCallback(
     async (files: File[]) => {
@@ -219,7 +205,7 @@ export function useChatFileSources({
       }
 
       const provider = selectedCloudProvider;
-      setCloudLinkError(null);
+      setError(null);
 
       startLinkTransition(async () => {
         const allLinkedFiles: FileUploadItem[] = [];
@@ -278,11 +264,7 @@ export function useChatFileSources({
           }
         } catch (error) {
           console.error("Error linking cloud files:", error);
-          setCloudLinkError(
-            error instanceof Error
-              ? error
-              : new Error("Failed to link selected cloud files."),
-          );
+          setError(new CloudLinkError());
         } finally {
           setSelectedCloudProvider(null);
         }
@@ -297,6 +279,7 @@ export function useChatFileSources({
       createChatMutation,
       linkFileMutation,
       setSilentChatId,
+      setError,
     ],
   );
 
@@ -365,7 +348,6 @@ export function useChatFileSources({
     availableProviders,
     isProcessing,
     performDiskUpload,
-    resolvedUploadError,
     onSelectDisk: handleSelectDisk,
     onSelectCloud: handleSelectCloud,
     onSelectFiles: handleSelectedFiles,


### PR DESCRIPTION
Closes ERMAIN-163.

## The bug

A too-large (or otherwise rejected) upload put the composer in a dead end: `FileUploadButton` replaced its whole subtree — dropzone root and file input included — with a **disabled** danger button carrying the error text, so no further file could be picked from that button. The error banner above the input was already dismissible, but dismissing it only cleared `ChatInput`'s local mirror of the error; the shared upload store kept its copy, so the button stayed swapped out. Recovery required drag-and-drop, a chat switch, or a reload.

Affected the default desktop web path (no cloud providers, no host-registered selector). Mobile/add-in (the unified "+" menu) and cloud-provider deployments render `FileSourceSelector`, which never consumed the error.

## The fix

- The composer's dismissible alert is now the single surface for upload errors; the upload button keeps its picker in every state. The now-dead error plumbing (`useChatFileSources`' `uploadError` param and `resolvedUploadError` result, `FileUploadWithTokenCheck`'s `uploadError` prop and its two `ChatInput` pass-sites) goes with it.
- Dismissing the alert clears the shared upload store too, so a dismissed error does not outlive its own message.
- Cloud-link failures now go into that same store (as the localized `CloudLinkError`) instead of local hook state. They previously had no surface at all: the only renderer of `resolvedUploadError` was the plain button, which is never mounted when cloud providers exist.

`FileUploadButton`'s own error state is untouched — it is exported and still used by `FileUpload` in `buttonOnly` mode.

## Tests

- `FileUploadWithTokenCheck`: the file picker stays mounted and enabled while an upload error is pending (verified to fail when the error is re-plumbed into the button).
- `ChatInput`: dismissing the file-error alert clears the shared upload-store error.
- e2e (`chat.basic`): after the 60 MB upload error, dismiss the alert, then upload a valid file through the same button and see it attach.

Full frontend vitest suite, `lint:strict`, `typecheck`, prettier and the kit shared-surface check pass locally. The e2e spec was not run locally — the local stack is currently on Entra auth, which the headless setup cannot log into.
