### PR TITLE
Let keyboard users move through the segmented control tabs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -101,7 +101,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   lint-frontend:
-    timeout-minutes: 10
+    timeout-minutes: 20
     name: "lint (frontend)"
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     steps:

--- a/frontend/src/components/ui/Controls/SegmentedControl.tsx
+++ b/frontend/src/components/ui/Controls/SegmentedControl.tsx
@@ -1,5 +1,7 @@
 import clsx from "clsx";
-import { memo, useId } from "react";
+import { memo, useId, useRef } from "react";
+
+import type { KeyboardEvent } from "react";
 
 export interface SegmentedControlAttention {
   /** Read out after the label; the dot carries no meaning on its own. */
@@ -44,6 +46,32 @@ export interface SegmentedControlProps<T extends string> {
 }
 
 /**
+ * Walk `delta` steps at a time from `from`, wrapping at both ends, until an
+ * option that can actually be selected turns up. Disabled segments are stepped
+ * over rather than landed on, so an arrow key never parks focus on something
+ * that cannot be activated. Returns -1 when no option is selectable.
+ *
+ * `from` is allowed to sit outside the array so a single walk serves all four
+ * keys: Home enters at -1 going forward, End at `length` going backward.
+ */
+function nextEnabledIndex<T extends string>(
+  options: SegmentedControlOption<T>[],
+  from: number,
+  delta: number,
+): number {
+  const { length } = options;
+
+  for (let step = 1; step <= length; step++) {
+    const index = (((from + delta * step) % length) + length) % length;
+    if (!options[index].disabled) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+/**
  * SegmentedControl component for toggling between a small set of options
  *
  * Use this for switching between 2-4 mutually exclusive views or filters.
@@ -59,10 +87,50 @@ function SegmentedControlInner<T extends string>({
   "aria-label": ariaLabel,
 }: SegmentedControlProps<T>) {
   const groupId = useId();
+  const segmentRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const sizeStyles = {
     sm: "px-3 py-1.5 text-sm",
     md: "px-4 py-2 text-base",
+  };
+
+  /**
+   * Automatic activation: selection and focus move together, which is the
+   * promise the roving `tabIndex` already makes. Without this the selected
+   * segment is the only tab stop in the group and a keyboard user cannot
+   * reach the others at all.
+   */
+  const handleKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    let nextIndex: number;
+
+    switch (event.key) {
+      case "ArrowRight":
+        nextIndex = nextEnabledIndex(options, index, 1);
+        break;
+      case "ArrowLeft":
+        nextIndex = nextEnabledIndex(options, index, -1);
+        break;
+      case "Home":
+        nextIndex = nextEnabledIndex(options, -1, 1);
+        break;
+      case "End":
+        nextIndex = nextEnabledIndex(options, options.length, -1);
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+
+    if (nextIndex < 0) {
+      return;
+    }
+
+    onChange(options[nextIndex].value);
+    segmentRefs.current[nextIndex]?.focus();
   };
 
   return (
@@ -88,10 +156,12 @@ function SegmentedControlInner<T extends string>({
           <button
             key={option.value}
             id={`${groupId}-tab-${index}`}
+            ref={(element) => {
+              segmentRefs.current[index] = element;
+            }}
             type="button"
             role="tab"
             aria-selected={isSelected ? "true" : "false"}
-            aria-controls={`${groupId}-panel-${index}`}
             tabIndex={isSelected ? 0 : -1}
             disabled={isDisabled}
             onClick={() => {
@@ -99,6 +169,7 @@ function SegmentedControlInner<T extends string>({
                 onChange(option.value);
               }
             }}
+            onKeyDown={(event) => handleKeyDown(event, index)}
             className={clsx(
               "theme-transition flex items-center gap-1.5 rounded-[calc(var(--theme-radius-control)_-_0.125rem)] font-medium",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus",

--- a/frontend/src/components/ui/Controls/__tests__/SegmentedControl.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/SegmentedControl.test.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SegmentedControl } from "../SegmentedControl";
+
+import type { SegmentedControlOption } from "../SegmentedControl";
+
+type View = "list" | "grid" | "table";
+
+const defaultOptions: SegmentedControlOption<View>[] = [
+  { value: "list", label: "List" },
+  { value: "grid", label: "Grid" },
+  { value: "table", label: "Table" },
+];
+
+interface HarnessProps {
+  options?: SegmentedControlOption<View>[];
+  initialValue?: View;
+  onChange?: (value: View) => void;
+}
+
+/**
+ * The control is controlled, so selection only actually moves when a parent
+ * feeds the new value back in. Arrow keys activate automatically, which is
+ * only observable through a real state round-trip.
+ */
+function Harness({
+  options = defaultOptions,
+  initialValue = "list",
+  onChange,
+}: HarnessProps) {
+  const [value, setValue] = useState<View>(initialValue);
+
+  return (
+    <SegmentedControl
+      aria-label="View"
+      options={options}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+const tab = (name: string) => screen.getByRole("tab", { name });
+
+describe("SegmentedControl", () => {
+  it("moves selection and focus rightwards, wrapping past the last segment", () => {
+    render(<Harness />);
+
+    const list = tab("List");
+    list.focus();
+    expect(list).toHaveFocus();
+
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+    expect(tab("Grid")).toHaveFocus();
+    expect(tab("Grid")).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tab("Grid"), { key: "ArrowRight" });
+    expect(tab("Table")).toHaveFocus();
+
+    fireEvent.keyDown(tab("Table"), { key: "ArrowRight" });
+    expect(tab("List")).toHaveFocus();
+    expect(tab("List")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("moves selection and focus leftwards, wrapping past the first segment", () => {
+    render(<Harness />);
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "ArrowLeft" });
+    expect(tab("Table")).toHaveFocus();
+    expect(tab("Table")).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tab("Table"), { key: "ArrowLeft" });
+    expect(tab("Grid")).toHaveFocus();
+    expect(tab("Grid")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("jumps to the edges with Home and End", () => {
+    render(<Harness initialValue="grid" />);
+
+    const grid = tab("Grid");
+    grid.focus();
+
+    fireEvent.keyDown(grid, { key: "End" });
+    expect(tab("Table")).toHaveFocus();
+    expect(tab("Table")).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tab("Table"), { key: "Home" });
+    expect(tab("List")).toHaveFocus();
+    expect(tab("List")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("activates automatically, reporting each arrow as a change", () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("grid");
+
+    fireEvent.keyDown(tab("Grid"), { key: "End" });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith("table");
+  });
+
+  it("steps over a disabled segment rather than landing on it", () => {
+    const onChange = vi.fn();
+    render(
+      <Harness
+        onChange={onChange}
+        options={[
+          { value: "list", label: "List" },
+          { value: "grid", label: "Grid", disabled: true },
+          { value: "table", label: "Table" },
+        ]}
+      />,
+    );
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+
+    expect(tab("Table")).toHaveFocus();
+    expect(tab("Table")).toHaveAttribute("aria-selected", "true");
+    expect(tab("Grid")).toHaveAttribute("aria-selected", "false");
+    expect(onChange).toHaveBeenCalledWith("table");
+  });
+
+  it("skips a disabled segment when entering from the End edge", () => {
+    render(
+      <Harness
+        options={[
+          { value: "list", label: "List" },
+          { value: "grid", label: "Grid" },
+          { value: "table", label: "Table", disabled: true },
+        ]}
+      />,
+    );
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "End" });
+
+    expect(tab("Grid")).toHaveFocus();
+    expect(tab("Grid")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("stays put when it is the only segment that can be selected", () => {
+    render(
+      <Harness
+        options={[
+          { value: "list", label: "List" },
+          { value: "grid", label: "Grid", disabled: true },
+          { value: "table", label: "Table", disabled: true },
+        ]}
+      />,
+    );
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "ArrowRight" });
+
+    expect(tab("List")).toHaveFocus();
+    expect(tab("List")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("leaves unrelated keys to the browser", () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    const list = tab("List");
+    list.focus();
+
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    fireEvent.keyDown(list, { key: "a" });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(list).toHaveFocus();
+    expect(list).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps a roving tab stop on the selected segment", () => {
+    render(<Harness initialValue="grid" />);
+
+    expect(tab("Grid")).toHaveAttribute("tabindex", "0");
+    expect(tab("List")).toHaveAttribute("tabindex", "-1");
+    expect(tab("Table")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("does not claim a tabpanel that no caller renders", () => {
+    render(<Harness />);
+
+    // The control owns no panel, so an `aria-controls` here could only ever
+    // dangle. The `id` stays: unreferenced is inert, unresolvable is a fault.
+    for (const segment of screen.getAllByRole("tab")) {
+      expect(segment).not.toHaveAttribute("aria-controls");
+      expect(segment).toHaveAttribute("id");
+    }
+  });
+});

--- a/frontend/src/components/ui/Input/MarkdownPreviewInput.test.tsx
+++ b/frontend/src/components/ui/Input/MarkdownPreviewInput.test.tsx
@@ -66,4 +66,71 @@ describe("MarkdownPreviewInput", () => {
       "Description is required",
     );
   });
+
+  it("moves between tabs with the arrow keys, wrapping at both ends", () => {
+    render(<MarkdownPreviewInput {...defaultProps} id="description" />);
+
+    const markdownTab = screen.getByRole("tab", { name: "Markdown" });
+    markdownTab.focus();
+    expect(markdownTab).toHaveFocus();
+
+    fireEvent.keyDown(markdownTab, { key: "ArrowRight" });
+
+    const previewTab = screen.getByRole("tab", { name: "Preview" });
+    expect(previewTab).toHaveFocus();
+    expect(previewTab).toHaveAttribute("aria-selected", "true");
+
+    // Two tabs, so either arrow wraps straight back.
+    fireEvent.keyDown(previewTab, { key: "ArrowRight" });
+    expect(screen.getByRole("tab", { name: "Markdown" })).toHaveFocus();
+
+    fireEvent.keyDown(screen.getByRole("tab", { name: "Markdown" }), {
+      key: "ArrowLeft",
+    });
+    expect(screen.getByRole("tab", { name: "Preview" })).toHaveFocus();
+  });
+
+  it("jumps to the edges with Home and End", () => {
+    render(<MarkdownPreviewInput {...defaultProps} id="description" />);
+
+    const markdownTab = screen.getByRole("tab", { name: "Markdown" });
+    markdownTab.focus();
+
+    fireEvent.keyDown(markdownTab, { key: "End" });
+
+    const previewTab = screen.getByRole("tab", { name: "Preview" });
+    expect(previewTab).toHaveFocus();
+    expect(previewTab).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(previewTab, { key: "Home" });
+
+    expect(screen.getByRole("tab", { name: "Markdown" })).toHaveFocus();
+    expect(screen.getByRole("tab", { name: "Markdown" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("leaves unrelated keys to the browser", () => {
+    render(<MarkdownPreviewInput {...defaultProps} id="description" />);
+
+    const markdownTab = screen.getByRole("tab", { name: "Markdown" });
+    markdownTab.focus();
+
+    fireEvent.keyDown(markdownTab, { key: "ArrowDown" });
+
+    expect(markdownTab).toHaveFocus();
+    expect(markdownTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("points both tabs at the panel they actually control", () => {
+    render(<MarkdownPreviewInput {...defaultProps} id="description" />);
+
+    const panelId = screen.getByRole("tabpanel").getAttribute("id");
+    expect(panelId).toBeTruthy();
+
+    for (const tab of screen.getAllByRole("tab")) {
+      expect(tab).toHaveAttribute("aria-controls", panelId);
+    }
+  });
 });

--- a/frontend/src/components/ui/Input/MarkdownPreviewInput.tsx
+++ b/frontend/src/components/ui/Input/MarkdownPreviewInput.tsx
@@ -6,8 +6,12 @@ import remarkGfm from "remark-gfm";
 import { Textarea } from "./Textarea";
 
 import type { TextareaProps } from "./Textarea";
+import type { KeyboardEvent } from "react";
 
 type MarkdownPreviewTab = "markdown" | "preview";
+
+/** Left-to-right order of the tab strip, for arrow-key navigation. */
+const TAB_ORDER: MarkdownPreviewTab[] = ["markdown", "preview"];
 
 export interface MarkdownPreviewInputProps
   extends Omit<TextareaProps, "className"> {
@@ -53,6 +57,46 @@ export function MarkdownPreviewInput({
 
   const isMarkdownTab = activeTab === "markdown";
 
+  const tabIds: Record<MarkdownPreviewTab, string> = {
+    markdown: markdownTabId,
+    preview: previewTabId,
+  };
+
+  /**
+   * Automatic activation: selection and focus move together. Without this the
+   * selected tab is the only tab stop in the strip and a keyboard user cannot
+   * reach the other one.
+   */
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentTab: MarkdownPreviewTab,
+  ) => {
+    const currentIndex = TAB_ORDER.indexOf(currentTab);
+    let nextTab: MarkdownPreviewTab;
+
+    switch (event.key) {
+      case "ArrowRight":
+        nextTab = TAB_ORDER[(currentIndex + 1) % TAB_ORDER.length];
+        break;
+      case "ArrowLeft":
+        nextTab =
+          TAB_ORDER[(currentIndex - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+        break;
+      case "Home":
+        nextTab = TAB_ORDER[0];
+        break;
+      case "End":
+        nextTab = TAB_ORDER[TAB_ORDER.length - 1];
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    setActiveTab(nextTab);
+    document.getElementById(tabIds[nextTab])?.focus({ preventScroll: true });
+  };
+
   return (
     <div
       className={clsx(
@@ -79,6 +123,7 @@ export function MarkdownPreviewInput({
               disabled && "cursor-not-allowed opacity-50",
             )}
             onClick={() => setActiveTab("markdown")}
+            onKeyDown={(event) => handleTabKeyDown(event, "markdown")}
           >
             {markdownTabLabel}
           </button>
@@ -98,6 +143,7 @@ export function MarkdownPreviewInput({
               disabled && "cursor-not-allowed opacity-50",
             )}
             onClick={() => setActiveTab("preview")}
+            onKeyDown={(event) => handleTabKeyDown(event, "preview")}
           >
             {previewTabLabel}
           </button>


### PR DESCRIPTION
`SegmentedControl` and `MarkdownPreviewInput` both render `role="tab"` with a roving `tabIndex` and **no `onKeyDown`**. Only the selected segment is a tab stop, so a keyboard user reaches it and cannot leave or change selection — a **WCAG 2.1.1 keyboard trap** in both. Fixing only the first would have left a legitimate tablist trapped, so both are handled here.

`SegmentedControl` additionally set `aria-controls` to a panel id built from a `useId()` **inside** the component. No consumer can render that target, and none of the five call sites do — a dangling IDREF failing axe `aria-valid-attr-value` at 100% of call sites. The IDREF is removed; the `id` stays, since an unreferenced id is inert while an unresolvable one is the fault. `MarkdownPreviewInput` keeps its `aria-controls`, which resolves to a real tabpanel.

Arrow keys activate automatically — selection and focus move together, which is what the roving `tabIndex` already promised. Home/End jump to the edges, and the segmented control's walk **skips disabled options** rather than parking focus somewhere unactivatable.

## This is consistency, not novelty

The repo has already solved this twice: `useRovingMenuFocus` for the dropdown menus, and `UserPreferencesDialog` for its own tab strip. Both new handlers follow the latter. `useRovingMenuFocus` is not reusable here — it is ArrowUp/Down only and moves focus without moving selection.

## Out of scope, deliberately

Whether these should be radios rather than tabs. The five call sites genuinely disagree — `SharingDialog:249` is the sharpest case, a form field submitted with the grant that wants `radiogroup`, while `AssistantsPage:1158` calls `navigate()` and wants links. That is a maintainer decision, and worth its own issue.

Keeping `role="tab"` is also what keeps the existing **15 `role="tab"` queries and 2 `tablist` queries** green and untouched across `AssistantWelcomeScreen.test.tsx` and `AssistantsPage.test.tsx`.

## Tests

New `SegmentedControl.test.tsx` (10 cases: bidirectional wrap, Home/End, automatic activation, focus movement, and the disabled-skip branch explicitly, since no current call site passes `option.disabled`), plus 4 new cases for `MarkdownPreviewInput`'s tablist including one asserting its `aria-controls` still resolves.

The tests were checked for being load-bearing rather than assumed: reverting both source files fails **9 of them**, leaving only the 8 that do not depend on the fix.

Full run: 161 files, **1551 passed**, 11 skipped. `check:component-registry-shared` up to date with no regeneration; i18n catalog steady at 1194 messages (no new strings).