### PR TITLE
Make the info tooltip reachable by keyboard

### DIFF
--- a/frontend/src/components/ui/Controls/Tooltip.tsx
+++ b/frontend/src/components/ui/Controls/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import type { ReactNode } from "react";
@@ -17,7 +17,7 @@ interface TooltipProps {
 }
 
 /**
- * A simple tooltip component that shows on hover
+ * A simple tooltip that shows on hover or when the trigger receives focus.
  */
 export const Tooltip: React.FC<TooltipProps> = ({
   content,
@@ -30,9 +30,21 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
+  const tooltipId = useId();
 
-  // Handle mouse enter to show tooltip
-  const handleMouseEnter = () => {
+  // Drop a pending show-timer if the trigger unmounts while it is queued.
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  // Queue the tooltip. Used for both pointer hover and keyboard focus, so the
+  // help text is reachable without a mouse.
+  const showTooltip = () => {
     // Clear any existing timeout
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
@@ -73,13 +85,35 @@ export const Tooltip: React.FC<TooltipProps> = ({
     }, delay);
   };
 
-  // Handle mouse leave to hide tooltip
-  const handleMouseLeave = () => {
+  // Hide the tooltip and drop any timer that has not fired yet.
+  const hideTooltip = () => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
     setIsVisible(false);
   };
+
+  // WCAG 1.4.13: a tooltip must be dismissable without moving the pointer or
+  // focus. A document listener (not an onKeyDown on the wrapper) is required
+  // because a hover-shown tooltip leaves focus somewhere else entirely.
+  // Capture phase + stopPropagation so the Escape that dismisses the tooltip
+  // does not also reach ModalBase/AnchoredPopover and close the surrounding
+  // dialog. Registered only while visible, so Escape is untouched otherwise.
+  useEffect(() => {
+    if (!isVisible) {
+      return;
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        setIsVisible(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape, true);
+    return () => document.removeEventListener("keydown", handleEscape, true);
+  }, [isVisible]);
 
   // Position classes based on position prop
   const positionClasses = {
@@ -93,20 +127,29 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const positionClass = positionClasses[position];
 
   return (
+    // React focus events bubble, so the wrapper sees focus/blur from whatever
+    // the child renders without any per-child wiring.
     <div
       ref={triggerRef}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      onFocus={showTooltip}
+      onBlur={hideTooltip}
       className="relative inline-flex"
     >
-      {/* Clone the child element */}
-      {React.cloneElement(children)}
+      {/* Point the trigger at the tooltip while it is showing. */}
+      {React.cloneElement(
+        children as React.ReactElement<{ "aria-describedby"?: string }>,
+        { "aria-describedby": isVisible ? tooltipId : undefined },
+      )}
 
       {/* Render tooltip using portal if visible */}
       {isVisible &&
         typeof document !== "undefined" &&
         createPortal(
           <div
+            id={tooltipId}
+            role="tooltip"
             className={`pointer-events-none fixed z-50 ${positionClass} ${className}`}
             style={{
               top: `${tooltipPosition.top}px`,

--- a/frontend/src/components/ui/Controls/__tests__/InfoTooltip.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/InfoTooltip.test.tsx
@@ -105,7 +105,7 @@ describe("InfoTooltip", () => {
     expect(svg).toHaveClass("h-4", "w-4");
   });
 
-  it("should have cursor-help class for accessibility indication", () => {
+  it("should have cursor-help class as the hover affordance", () => {
     // Add a test translation
     i18n.load("en", {
       ...(enMessages as unknown as Messages),

--- a/frontend/src/components/ui/Controls/__tests__/Tooltip.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/Tooltip.test.tsx
@@ -1,0 +1,137 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { Tooltip } from "../Tooltip";
+
+const renderTooltip = () => {
+  render(
+    <Tooltip content="Helpful hint" delay={0}>
+      <button type="button">Trigger</button>
+    </Tooltip>,
+  );
+
+  return screen.getByRole("button", { name: "Trigger" });
+};
+
+describe("Tooltip", () => {
+  it("should show the tooltip when the trigger receives focus", async () => {
+    const trigger = renderTooltip();
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    act(() => {
+      trigger.focus();
+    });
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Helpful hint");
+  });
+
+  it("should hide the tooltip when the trigger loses focus", async () => {
+    const trigger = renderTooltip();
+
+    act(() => {
+      trigger.focus();
+    });
+    await screen.findByRole("tooltip");
+
+    act(() => {
+      trigger.blur();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should still show the tooltip on hover", async () => {
+    const trigger = renderTooltip();
+
+    fireEvent.mouseEnter(trigger);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Helpful hint",
+    );
+
+    fireEvent.mouseLeave(trigger);
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should point the trigger at the tooltip with aria-describedby only while visible", async () => {
+    const trigger = renderTooltip();
+
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+
+    act(() => {
+      trigger.focus();
+    });
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveAttribute("id");
+    expect(trigger).toHaveAttribute("aria-describedby", tooltip.id);
+
+    act(() => {
+      trigger.blur();
+    });
+
+    await waitFor(() => {
+      expect(trigger).not.toHaveAttribute("aria-describedby");
+    });
+  });
+
+  // WCAG 1.4.13: hover-shown content must be dismissable without moving the
+  // pointer or focus, which is why this is a document listener rather than a
+  // key handler on the trigger.
+  it("should dismiss a hover-shown tooltip when Escape is pressed", async () => {
+    const trigger = renderTooltip();
+
+    fireEvent.mouseEnter(trigger);
+    await screen.findByRole("tooltip");
+    expect(document.activeElement).not.toBe(trigger);
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should only swallow Escape while the tooltip is visible", async () => {
+    const onEscape = vi.fn();
+    // Mirrors ModalBase: a bubble-phase document listener that closes the
+    // surrounding dialog.
+    document.addEventListener("keydown", onEscape);
+
+    try {
+      const trigger = renderTooltip();
+
+      // Hidden: Escape must reach the dialog as usual.
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(onEscape).toHaveBeenCalledTimes(1);
+
+      // Visible: Escape dismisses the tooltip and stops there.
+      fireEvent.mouseEnter(trigger);
+      await screen.findByRole("tooltip");
+
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(onEscape).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      });
+
+      // Hidden again: the listener is gone, so Escape is untouched.
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(onEscape).toHaveBeenCalledTimes(2);
+    } finally {
+      document.removeEventListener("keydown", onEscape);
+    }
+  });
+});


### PR DESCRIPTION
`Tooltip` had `onMouseEnter`/`onMouseLeave` and nothing else — no focus handling, no `role="tooltip"`, no `id`, no way to dismiss it. Its content is the customer-configurable help text `InfoTooltip` pulls out of the locale files, so **the one thing the component exists to deliver was unreachable without a pointer**, and invisible to a screen reader even with one.

## What changed

- The wrapper handles `onFocus`/`onBlur` alongside the mouse handlers. React focus events bubble, so the existing wrapper sees them from whatever the child renders — no per-child wiring.
- The portal node gets a `useId` and `role="tooltip"`; the already-present no-op `React.cloneElement(children)` gains an `aria-describedby` pointing at it while visible.
- Escape dismisses the tooltip, via a **capture-phase `document` keydown listener registered only while visible**, with `stopPropagation()`.
- The pending show-timer is cleared on unmount.

## Why Escape is not an `onKeyDown` on the wrapper

The obvious form is wrong twice over. It trips `jsx-a11y/no-static-element-interactions` as an eslint error, and — the substantive problem — **a hover-shown tooltip leaves focus somewhere else entirely**, so no key event ever reaches the wrapper and WCAG 1.4.13 stays failed for exactly the case this PR is about.

The capture listener plus `stopPropagation` keeps that Escape from also reaching `ModalBase`'s document listener and closing the surrounding dialog. The `isVisible` guard is load-bearing — without it the component would swallow every Escape in the app. Two-stage Escape handling has precedent in `ChatHistoryFilterMenu`.

Covered by a test that asserts a ModalBase-shaped listener fires when the tooltip is hidden, does **not** while it is visible, and fires again after dismissal.

## Deliberate: showing on focus also shows on click

On browsers that focus a button when you click it, mouseenter → focus → click leaves the tooltip visible, and a later mouseleave hides it while the button still holds focus, dropping `aria-describedby` with focus on the trigger. That is a real, visible behaviour change and a deliberate trade.

Gating on `:focus-visible` would avoid it, but **jsdom returns `false` for `matches(":focus-visible")` on a focused button**, so that would silently disable the tooltip in every jsdom test that exercises it.

## Public kit surface caveat

`Tooltip` is exported from `frontend/src/shared/index.ts`, which names it explicitly as a contract kits build on. `cloneElement` silently no-ops for components that swallow unknown props and for Fragments, and it **clobbers any `aria-describedby` the child already had** — worth knowing before anyone relies on it. (The throws on string/array children already happen today with the argument-less `cloneElement`, so those are not a regression.)

No `ERATO_SHARED_SURFACE_VERSION` bump — no exported type changed.

## Timer cleanup is tidiness, not a leak fix

Measured: the surviving timer does nothing. React nulls `triggerRef.current` before it fires and the existing guard swallows the callback — zero layout reads, zero errors either way. Clearing it is hygiene.

## Out of scope

The `fixed` positioning combined with the `bottom-full`/`right-full` classes is over-constrained for the `"top"` and `"left"` placements. Real, but unverifiable by unit test (jsdom does no layout), and belongs in its own change.