### PR TITLE
new hook useChatHistoryRowPresentation

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -81,6 +81,35 @@ const useRowStatus = (session: ChatSession): ChatAttentionStatus | null => {
   return resolveSessionRowStatus(session, storeStatus, hasPendingConfirmation);
 };
 
+/**
+ * Row title, attention status and composed aria label — the shape a component
+ * kit needs when it overrides this list. Exposed as the resolved result rather
+ * than its ingredients so kits cannot reimplement `resolveSessionRowStatus`
+ * and end up with a dot that disagrees with the session's group.
+ *
+ * `extraLabels` is folded into `ariaLabel`.
+ */
+export const useChatHistoryRowPresentation = (
+  session: ChatSession,
+  extraLabels: (string | null | undefined)[] = [],
+): {
+  title: string;
+  status: ChatAttentionStatus | null;
+  statusLabel: string | null;
+  ariaLabel: string;
+} => {
+  const title = useRowTitle(session);
+  const status = useRowStatus(session);
+  const statusLabel = status ? chatAttentionStatusLabel(status) : null;
+
+  return {
+    title,
+    status,
+    statusLabel,
+    ariaLabel: [title, ...extraLabels, statusLabel].filter(Boolean).join(", "),
+  };
+};
+
 export interface ChatHistoryListProps {
   sessions: ChatSession[];
   currentSessionId: string | null;
@@ -153,11 +182,14 @@ const ChatHistoryListItem = memo<{
     showTimestamps = true,
     disableRowLinks = false,
   }) => {
-    const generationStatus = useRowStatus(session);
-    const rowTitle = useRowTitle(session);
     // Present only for delegated runs, so it doubles as the "this row is a
     // run" test — the rows only a widened filter puts in this list.
     const runOrigin = delegatedRunOrigin(session);
+    const {
+      title: rowTitle,
+      status: generationStatus,
+      ariaLabel: rowAriaLabel,
+    } = useChatHistoryRowPresentation(session, [runOrigin?.label]);
     // A stable Date instance: an inline `new Date(...)` would defeat
     // MessageTimestamp's shallow memo on every list render.
     const updatedAtDate = useMemo(
@@ -179,13 +211,6 @@ const ChatHistoryListItem = memo<{
             id: "chat.history.menu.pin",
             message: "Pin",
           });
-    const rowAriaLabel = [
-      rowTitle,
-      runOrigin?.label,
-      generationStatus ? chatAttentionStatusLabel(generationStatus) : null,
-    ]
-      .filter(Boolean)
-      .join(", ");
     const rowBody = (
       <InteractiveContainer
         useDiv={true}

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -12,6 +12,7 @@ export type { AssistantWelcomeScreenProps } from "@/components/ui/Assistant/Assi
 export { ChatAttentionStatusDot } from "@/components/ui/Chat/ChatAttentionStatusDot";
 export { ChatHistoryList } from "@/components/ui/Chat/ChatHistoryList";
 export { ChatHistoryListSkeleton } from "@/components/ui/Chat/ChatHistoryList";
+export { useChatHistoryRowPresentation } from "@/components/ui/Chat/ChatHistoryList";
 export type { ChatHistoryListProps } from "@/components/ui/Chat/ChatHistoryList";
 export { CHAT_MESSAGE_HOST_COMPONENTS } from "@/components/ui/Chat/ChatMessage";
 export { ChatMessage } from "@/components/ui/Chat/ChatMessage";

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -65,6 +65,8 @@ export {
 } from "@/components/ui/icons/index";
 export { messageStyles } from "@/components/ui/styles/chatMessageStyles";
 export { Tooltip } from "@/components/ui/Controls/Tooltip";
+// The resolved result, not the stores behind it — kits read status, never write it.
+export { useChatHistoryRowPresentation } from "@/components/ui/Chat/ChatHistoryList";
 
 export {
   useGetFile,


### PR DESCRIPTION
This pull request introduces a new hook, `useChatHistoryRowPresentation`, to centralize and standardize the logic for presenting chat history row information (such as title, status, and ARIA label). This ensures consistency across components and prevents duplication of logic. The hook is now used in `ChatHistoryListItem`, and it is exported for use in component kits. Related redundant code in `ChatHistoryListItem` has been removed.

**New hook for row presentation:**

* Added `useChatHistoryRowPresentation` to `ChatHistoryList.tsx`, which returns the row title, attention status, status label, and a composed ARIA label for accessibility. This prevents component kits from reimplementing underlying logic and ensures consistency.

**Refactoring to use the new hook:**

* Updated `ChatHistoryListItem` to use `useChatHistoryRowPresentation` instead of manually composing row title, status, and ARIA label.
* Removed redundant ARIA label composition logic from `ChatHistoryListItem`, as this is now handled by the new hook.

**Exports for component kits:**

* Exported `useChatHistoryRowPresentation` from `component-registry.generated.ts` to make it available to component kits.
* Exported `useChatHistoryRowPresentation` from `index.ts` with a comment clarifying that only the resolved result should be read by kits.