### PR TITLE
Pin FilePreviewButton and ChatAttentionStatusDot to the kit-facing shared surface

### DIFF
--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -39,6 +39,7 @@ export { Alert } from "@/components/ui/Feedback/Alert";
 export { Avatar } from "@/components/ui/Feedback/Avatar";
 export { CopyErrorButton } from "@/components/ui/Feedback/CopyErrorButton";
 export { LoadingIndicator } from "@/components/ui/Feedback/LoadingIndicator";
+export { FilePreviewButton } from "@/components/ui/FileUpload/FilePreviewButton";
 export { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
 export { DefaultMessageControls } from "@/components/ui/Message/DefaultMessageControls";
 export { ImageLightbox } from "@/components/ui/Message/ImageLightbox";

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -68,6 +68,10 @@ export { messageStyles } from "@/components/ui/styles/chatMessageStyles";
 export { Tooltip } from "@/components/ui/Controls/Tooltip";
 // The resolved result, not the stores behind it — kits read status, never write it.
 export { useChatHistoryRowPresentation } from "@/components/ui/Chat/ChatHistoryList";
+// Pinned alongside the hook that feeds it: only two registry-reachable
+// importers keep it on the generated surface, and a kit rendering its own
+// rows needs both halves or neither.
+export { ChatAttentionStatusDot } from "@/components/ui/Chat/ChatAttentionStatusDot";
 
 export {
   useGetFile,


### PR DESCRIPTION
Two names that component kits import reach `@erato/frontend/shared` only through the generated half, where they survive on whichever registry-reachable component happens to import them. Both are one refactor away from vanishing — and one already has.

## `FilePreviewButton` — already broken

`#1050` switched `GroupedFileAttachmentsPreview` from `FilePreviewButton` to `AttachmentTile`. That was the last registry-reachable importer, so the name left the surface. `FileUpload.tsx:8` still imports it but is not registry-reachable, so it did not keep it alive.

This is verbatim the failure this file's own comment describes:

> *"a refactor elsewhere can drop one without anyone noticing, and a kit is a single flat named-import, so one missing name fails module linking and takes the WHOLE kit offline (every override silently reverting to its default). `Tooltip` left the surface exactly this way when the attachments preview was rewritten."*

`#1055` was the corrective pass for that class and pinned `Tooltip` and `FilePreviewLoading` — it missed `FilePreviewButton`.

A first-party kit imports it (`hostLibrary.tsx:24`, rendered at `OpenWebUIChatMessageRenderer.tsx:700`) and is broken three ways today:

| Path | Result |
|---|---|
| `pnpm build` (`tsc && vite build`) | dies at `tsc` — absent from `dist-library/shared/index.d.ts` |
| a build that skips `tsc` | emits a bare import (`@erato/frontend/shared` is rollup-external) → linking fails at load |
| deploying a host built from current `main` | the **already-built** kit fails linking — no rebuild involved |

## `ChatAttentionStatusDot` — same shape, not yet broken

Kept alive by exactly two importers: `ChatHistoryList.tsx` and `DelegatedRunsSection.tsx`.

`#1066` pinned `useChatHistoryRowPresentation` so kits could resolve a row's attention status the one canonical way. The component that *renders* that status was left on the generated half — so half the contract is protected. A kit drawing its own history rows needs both or neither. Pinning it now rather than after it breaks.

## Notes

Both additive, so no `ERATO_SHARED_SURFACE_VERSION` bump — its comment scopes bumps to breaking changes. `FilePreviewButton` is presentational (`Button`, `CloseIcon`, `FilePreviewBase` — the last already surfaced), so this adds no new host coupling. The generator writes and `--check`s only `component-registry.generated.ts`, so hand edits to `index.ts` cannot trip the drift gate.

Verified: `tsc --noEmit` clean · `check:component-registry-shared` passes · `ChatHistoryList` 21/21 · rebuilt `dist-library` exports both names.