### PR TITLE
Make theming fail loudly instead of silently, and hoist user attachments above the message body

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -490,7 +490,14 @@ export function ChatHistoryFilterMenu({
       onPointerLeave={handleSubmenuHoverAway}
       className={clsx(
         rowClassName,
-        openSubmenu === row.key && "bg-theme-bg-hover text-theme-fg-primary",
+        // Keyed off the `aria-expanded` already on this button rather than a
+        // `openSubmenu === row.key && "…"` branch: without tailwind-merge the
+        // conditional `text-theme-fg-primary` raced `rowClassName`'s
+        // `text-theme-fg-secondary` on stylesheet position and lost, so an open
+        // row never brightened. `aria-expanded:` compiles to
+        // `.aria-expanded\:text-…[aria-expanded="true"]` — (0,2,0) beats
+        // (0,1,0) — and applies only while this row's submenu is open.
+        "aria-expanded:bg-theme-bg-hover aria-expanded:text-theme-fg-primary",
       )}
     >
       <span className="min-w-0 flex-1 truncate">{row.label}</span>

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2744,7 +2744,7 @@ export const ChatInput = ({
                   "text-base",
                   "scrollbar-auto-hide",
                   isAnyTokenLimitExceeded &&
-                    "border-[var(--theme-error)] placeholder:text-[var(--theme-error-fg)]",
+                    "border-[var(--theme-error-border)] placeholder:text-[var(--theme-error-fg)]",
                 )}
               />
             </div>

--- a/frontend/src/components/ui/Chat/ChatMessage.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.test.tsx
@@ -59,9 +59,19 @@ vi.mock("../Message/ImageLightbox", () => ({
   ImageLightbox: () => null,
 }));
 
+// Stubbed so placement can be asserted without a query client. `null` is the
+// real component's behaviour while the file ids are still resolving.
+const attachmentsRenderMock = vi.hoisted(() => vi.fn());
+vi.mock("./MessageAttachments", () => ({
+  MessageAttachments: () => attachmentsRenderMock(),
+}));
+
 describe("ChatMessage", () => {
   beforeEach(() => {
     messageContentMock.mockClear();
+    attachmentsRenderMock.mockReturnValue(
+      <div data-testid="attachments-stub" />,
+    );
     showVerboseAssistantErrorsMock.mockReturnValue(false);
     showCopyErrorReportMock.mockReturnValue(true);
     Object.assign(navigator, {
@@ -113,7 +123,9 @@ describe("ChatMessage", () => {
     expect(messageShell.className).toContain(
       "hover:bg-[var(--theme-message-hover)]",
     );
-    expect(messageShell.firstElementChild).toHaveStyle({
+    // Located by hook, not by position: a user message carrying files puts the
+    // attachments wrapper first, so `firstElementChild` is not the body there.
+    expect(messageShell.querySelector('[data-ui="message-body"]')).toHaveStyle({
       gap: "var(--theme-spacing-message-gap)",
     });
     expect(messageContentMock).toHaveBeenCalledWith(
@@ -157,6 +169,101 @@ describe("ChatMessage", () => {
     expect(messageContentMock).toHaveBeenCalledWith(
       expect.objectContaining({ preserveSoftLineBreaks: true }),
     );
+  });
+
+  it.each([
+    ["user", ["message-attachments", "message-body"]],
+    ["assistant", ["message-body"]],
+  ] as const)(
+    "places %s attachments relative to the message body",
+    async (role, expectedHooks) => {
+      const message: UiChatMessage = {
+        id: `msg_files_${role}`,
+        content: [{ content_type: "text", text: "See attached" }],
+        role,
+        sender: role,
+        authorId: `${role}_1`,
+        createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+        status: "complete",
+        input_files_ids: ["file_1"],
+      };
+
+      const { i18n } = await import("@lingui/core");
+      i18n.load("en", enMessages as unknown as Messages);
+      i18n.activate("en");
+
+      render(
+        <I18nProvider i18n={i18n}>
+          <ChatMessage
+            message={message}
+            controls={() => null}
+            controlsContext={{
+              currentUserId: "user_1",
+              dialogOwnerId: "user_1",
+              isSharedDialog: false,
+            }}
+            onMessageAction={async () => true}
+          />
+        </I18nProvider>,
+      );
+
+      const messageShell = screen.getByTestId(`message-${role}`);
+      expect(
+        Array.from(messageShell.children).map((child) =>
+          child.getAttribute("data-ui"),
+        ),
+      ).toEqual(expectedHooks);
+
+      // A user message tints the body alone, so the attachments have to sit
+      // outside it; an assistant message keeps them inline.
+      const body = messageShell.querySelector('[data-ui="message-body"]');
+      expect(body?.contains(screen.getByTestId("attachments-stub"))).toBe(
+        role === "assistant",
+      );
+    },
+  );
+
+  it("keeps the attachments hook out of the layout until files resolve", async () => {
+    attachmentsRenderMock.mockReturnValue(null);
+
+    const message: UiChatMessage = {
+      id: "msg_files_pending",
+      content: [{ content_type: "text", text: "See attached" }],
+      role: "user",
+      sender: "user",
+      authorId: "user_1",
+      createdAt: new Date("2025-01-01T12:00:00Z").toISOString(),
+      status: "complete",
+      input_files_ids: ["file_1"],
+    };
+
+    const { i18n } = await import("@lingui/core");
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ChatMessage
+          message={message}
+          controls={() => null}
+          controlsContext={{
+            currentUserId: "user_1",
+            dialogOwnerId: "user_1",
+            isSharedDialog: false,
+          }}
+          onMessageAction={async () => true}
+        />
+      </I18nProvider>,
+    );
+
+    // The wrapper is keyed off the file ids, which are known before the files
+    // are, so it renders empty for a beat. `empty:hidden` keeps a theme from
+    // painting a bare box in that window.
+    const wrapper = screen
+      .getByTestId("message-user")
+      .querySelector('[data-ui="message-attachments"]');
+    expect(wrapper).toBeEmptyDOMElement();
+    expect(wrapper).toHaveClass("empty:hidden");
   });
 
   it("hides verbose assistant error details by default", async () => {

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -154,11 +154,25 @@ export const ChatMessage = memo(function ChatMessage({
     return null;
   }
 
+  const attachments =
+    message.input_files_ids && message.input_files_ids.length > 0 ? (
+      <MessageAttachments
+        fileIds={message.input_files_ids}
+        filesById={filesById}
+        relatedFiles={siblingFiles}
+        onFilePreview={onFilePreview}
+      />
+    ) : null;
+
   return (
     <div
       className={clsx(
         "chat-message-skin group relative flex",
         "w-full min-w-[280px] shrink-0",
+        // A user message stacks: attachments above, body below. An assistant
+        // message has only the body, so the direction is immaterial there and
+        // the row default is left alone.
+        isUser && "flex-col",
         messageStyles.hover,
         messageStyles.container[role],
         className,
@@ -171,7 +185,20 @@ export const ChatMessage = memo(function ChatMessage({
       data-ui="chat-message"
       data-role={role}
     >
-      <div className="flex w-full" style={messageContentRowStyle}>
+      {/* You attach the files, then you write the prompt — so for a user
+          message the attachments sit above the body rather than under it.
+          Hoisting them out of the body is also what lets a theme tint the
+          body alone: the attachments are a sibling of the tinted surface,
+          not a descendant of it. Assistant attachments stay inline below. */}
+      {isUser && attachments && (
+        <div data-ui="message-attachments">{attachments}</div>
+      )}
+
+      <div
+        className="flex w-full"
+        style={messageContentRowStyle}
+        data-ui="message-body"
+      >
         {showAvatar && (
           <Avatar userProfile={userProfile} userOrAssistant={!!isUser} />
         )}
@@ -277,15 +304,9 @@ export const ChatMessage = memo(function ChatMessage({
               />
             )}
 
-          {/* Display attached files if any */}
-          {message.input_files_ids && message.input_files_ids.length > 0 && (
-            <MessageAttachments
-              fileIds={message.input_files_ids}
-              filesById={filesById}
-              relatedFiles={siblingFiles}
-              onFilePreview={onFilePreview}
-            />
-          )}
+          {/* Display attached files if any — user messages render these
+              above the body instead, see the hoisted slot. */}
+          {!isUser && attachments}
 
           {message.loading && message.content.length === 0 && (
             <div className="mt-2">

--- a/frontend/src/components/ui/Chat/ChatMessage.tsx
+++ b/frontend/src/components/ui/Chat/ChatMessage.tsx
@@ -190,8 +190,14 @@ export const ChatMessage = memo(function ChatMessage({
           Hoisting them out of the body is also what lets a theme tint the
           body alone: the attachments are a sibling of the tinted surface,
           not a descendant of it. Assistant attachments stay inline below. */}
+      {/* `empty:hidden` because the element above is truthy as soon as the
+          message names a file, while MessageAttachments renders null until
+          those ids resolve — without it a theme styling this hook paints a
+          bare box while the fetch is in flight. */}
       {isUser && attachments && (
-        <div data-ui="message-attachments">{attachments}</div>
+        <div className="mb-2 empty:hidden" data-ui="message-attachments">
+          {attachments}
+        </div>
       )}
 
       <div

--- a/frontend/src/components/ui/Chat/SidebarCollapsibleSection.tsx
+++ b/frontend/src/components/ui/Chat/SidebarCollapsibleSection.tsx
@@ -84,8 +84,13 @@ export const SidebarCollapsibleSection = memo<{
                 "group-hover/toggle:text-theme-fg-primary group-focus-visible/toggle:text-theme-fg-primary",
                 "opacity-0 group-hover:opacity-100 group-focus-visible/toggle:opacity-100",
                 // Touch devices get no hover reveal, so the non-default
-                // collapsed state must stay visible on its own.
-                !isExpanded && "opacity-100",
+                // collapsed state must stay visible on its own. Keyed off the
+                // button's own `aria-expanded` rather than a `!isExpanded && …`
+                // branch: without tailwind-merge a conditional `opacity-100`
+                // only beats the base `opacity-0` if it happens to sit later in
+                // the generated stylesheet. The variant carries the group's
+                // attribute selector, so it wins on specificity instead.
+                "group-aria-[expanded=false]/toggle:opacity-100",
               )}
             />
           </button>

--- a/frontend/src/components/ui/Feedback/ChatErrorBoundary.tsx
+++ b/frontend/src/components/ui/Feedback/ChatErrorBoundary.tsx
@@ -28,7 +28,7 @@ const ChatErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
       <div className="flex size-12 items-center justify-center rounded-full bg-[var(--theme-error-bg)]">
         <ErrorIcon className="size-6 text-[var(--theme-error-fg)]" />
       </div>
-      <h3 className="text-lg font-medium text-[var(--theme-fg-strong)]">
+      <h3 className="text-lg font-medium text-[var(--theme-fg-primary)]">
         {t`Chat Error`}
       </h3>
       <p className="max-w-md text-center text-sm text-[var(--theme-fg-muted)]">

--- a/frontend/src/components/ui/FilePreview/DocxPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/DocxPreview.tsx
@@ -7,6 +7,7 @@ import docxWasmUrl from "@extend-ai/react-docx/docx_wasm_bg.wasm?url";
 import { t } from "@lingui/core/macro";
 import { useEffect, useState } from "react";
 
+import { useTheme } from "@/components/providers/ThemeProvider";
 import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
 import { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
@@ -28,7 +29,11 @@ setWasmSource(docxWasmUrl);
 
 export const DocxPreview: React.FC<DocxPreviewProps> = ({ url }) => {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
-  const [docxTheme, setDocxTheme] = useState<DocxTheme>("light");
+  // Opens in whichever mode the app is resolved to, then the toggle below owns
+  // it — reading a dark document in a light app stays possible, but the
+  // preview no longer forces a white page into a dark app.
+  const { effectiveTheme } = useTheme();
+  const [docxTheme, setDocxTheme] = useState<DocxTheme>(effectiveTheme);
   const { model, isLoading, error } = useDocxModel(
     state.kind === "ready" ? state.buffer : undefined,
   );
@@ -98,7 +103,7 @@ export const DocxPreview: React.FC<DocxPreviewProps> = ({ url }) => {
 
   return (
     <div
-      className="docx-preview-theme relative h-[75vh] overflow-hidden rounded-md border border-[var(--theme-border-muted)]"
+      className="docx-preview-theme relative h-[75vh] overflow-hidden rounded-md border border-[var(--theme-border-subtle)]"
       data-docx-theme={docxTheme}
       data-testid="file-preview-docx"
     >

--- a/frontend/src/components/ui/FilePreview/PdfPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/PdfPreview.tsx
@@ -424,7 +424,7 @@ export const PdfPreview: React.FC<PdfPreviewProps> = ({ url }) => {
 
   return (
     <div
-      className="pdf-preview-theme flex h-[75vh] flex-col overflow-hidden rounded-md border border-[var(--theme-border-muted)]"
+      className="pdf-preview-theme flex h-[75vh] flex-col overflow-hidden rounded-md border border-[var(--theme-border-subtle)]"
       data-testid="file-preview-pdf"
     >
       <EmbedPDF engine={engine} plugins={PDF_PLUGINS}>

--- a/frontend/src/components/ui/FilePreview/XlsxPreview.tsx
+++ b/frontend/src/components/ui/FilePreview/XlsxPreview.tsx
@@ -2,6 +2,7 @@ import { XlsxViewer } from "@extend-ai/react-xlsx";
 import { t } from "@lingui/core/macro";
 import { useState } from "react";
 
+import { useTheme } from "@/components/providers/ThemeProvider";
 import { Button } from "@/components/ui/Controls/Button";
 import { Alert } from "@/components/ui/Feedback/Alert";
 import { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
@@ -17,7 +18,10 @@ interface XlsxPreviewProps {
 }
 
 export const XlsxPreview: React.FC<XlsxPreviewProps> = ({ filename, url }) => {
-  const [xlsxTheme, setXlsxTheme] = useState<XlsxTheme>("light");
+  // Opens in whichever mode the app is resolved to; the toggle below then owns
+  // it, so a light sheet inside a dark app stays reachable.
+  const { effectiveTheme } = useTheme();
+  const [xlsxTheme, setXlsxTheme] = useState<XlsxTheme>(effectiveTheme);
   const isDarkXlsxTheme = xlsxTheme === "dark";
   const toggleXlsxThemeLabel = isDarkXlsxTheme
     ? t({
@@ -31,7 +35,7 @@ export const XlsxPreview: React.FC<XlsxPreviewProps> = ({ filename, url }) => {
 
   return (
     <div
-      className="xlsx-preview-theme flex h-[75vh] flex-col overflow-hidden rounded-md border border-[var(--theme-border-muted)]"
+      className="xlsx-preview-theme flex h-[75vh] flex-col overflow-hidden rounded-md border border-[var(--theme-border-subtle)]"
       data-testid="file-preview-xlsx"
       data-xlsx-theme={xlsxTheme}
     >

--- a/frontend/src/components/ui/FileUpload/FileUpload.tsx
+++ b/frontend/src/components/ui/FileUpload/FileUpload.tsx
@@ -228,7 +228,7 @@ export const FileUpload = memo<FileUploadProps>(
                   variant="ghost"
                   size="sm"
                   onClick={handleClearFiles}
-                  className="text-[var(--theme-fg-muted)] hover:text-[var(--theme-fg)]"
+                  className="text-[var(--theme-fg-muted)] hover:text-[var(--theme-fg-primary)]"
                 >
                   {t`Clear All`}
                 </Button>

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -450,10 +450,19 @@ const StatusRow: React.FC<{
   const isError = tone === "error";
   const Icon = isError ? ErrorIcon : InfoIcon;
   return (
+    // `data-tone` carries the error state into CSS so the overrides below can
+    // be `data-[tone=error]:` variants. `FILE_PREVIEW_STYLES` is shared with
+    // FilePreviewBase/FilePreviewLoading and already sets a border colour and a
+    // filename colour; without tailwind-merge an `isError && "…"` branch raced
+    // those on generated-stylesheet position, and the filename override lost —
+    // an error filename rendered in the ordinary foreground colour. The variant
+    // compiles to `.data-\[tone\=error\]\:…[data-tone="error"]`, specificity
+    // (0,2,0) against the shared constant's (0,1,0), so it wins by rule.
     <div
+      data-tone={tone}
       className={clsx(
         FILE_PREVIEW_STYLES.container,
-        isError && "border-[var(--theme-error-border)]",
+        "data-[tone=error]:border-[var(--theme-error-border)]",
       )}
       role={isError ? "alert" : "status"}
       aria-live={isError ? undefined : "polite"}
@@ -470,9 +479,10 @@ const StatusRow: React.FC<{
       </div>
       <div className="min-w-0 flex-1">
         <div
+          data-tone={tone}
           className={clsx(
             FILE_PREVIEW_STYLES.name,
-            isError && "text-[var(--theme-error-fg)]",
+            "data-[tone=error]:text-[var(--theme-error-fg)]",
           )}
           title={label}
         >

--- a/frontend/src/components/ui/Input/Input.test.tsx
+++ b/frontend/src/components/ui/Input/Input.test.tsx
@@ -89,6 +89,47 @@ describe("Input tokens", () => {
     expect(textarea.className).not.toContain("focus:ring-red-500/20");
   });
 
+  // There is no tailwind-merge in this repo, so `clsx("bg-a", disabled && "bg-b")`
+  // is decided by position in the generated stylesheet, not by argument order —
+  // and `bg-theme-bg-secondary` is emitted after `bg-theme-bg-primary`, so the
+  // disabled branch used to lose. `disabled:` variants compile to a compound
+  // selector (0,2,0) that beats the base utility (0,1,0) whatever the order.
+  it.each([
+    ["Input", () => <Input aria-label="Disabled field" disabled />],
+    ["Textarea", () => <Textarea aria-label="Disabled field" disabled />],
+  ])(
+    "expresses %s's disabled styling as disabled: variants",
+    (_name, renderField) => {
+      render(renderField());
+
+      const field = screen.getByRole("textbox", { name: "Disabled field" });
+
+      for (const cls of [
+        "disabled:bg-theme-bg-primary",
+        "disabled:text-theme-fg-muted",
+        "disabled:cursor-not-allowed",
+        "disabled:opacity-50",
+      ]) {
+        expect(field.className).toContain(cls);
+      }
+
+      // The bare forms would lose to the base utilities on stylesheet position.
+      const tokens = field.className.split(/\s+/);
+      for (const cls of [
+        "bg-theme-bg-primary",
+        "text-theme-fg-muted",
+        "cursor-not-allowed",
+        "opacity-50",
+      ]) {
+        expect(tokens).not.toContain(cls);
+      }
+
+      // The enabled-state base utilities are still present and unconditional.
+      expect(tokens).toContain("bg-theme-bg-secondary");
+      expect(tokens).toContain("text-theme-fg-primary");
+    },
+  );
+
   it("sizes textarea auto-resize from rendered row metrics", () => {
     let mockScrollHeight = 40;
 

--- a/frontend/src/components/ui/Input/Input.tsx
+++ b/frontend/src/components/ui/Input/Input.tsx
@@ -106,9 +106,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               : "border-[var(--theme-border-field)] focus:border-[var(--theme-border-field-focus)] focus:ring-theme-focus",
             // Focus styles
             "focus:outline-none focus:ring-2",
-            // Disabled styles
-            disabled &&
-              "cursor-not-allowed bg-theme-bg-primary text-theme-fg-muted opacity-50",
+            // Disabled styles. These are `disabled:` variants, not a
+            // `disabled && "..."` branch: there is no tailwind-merge in this
+            // repo, so a conditional `bg-theme-bg-primary` would race the base
+            // `bg-theme-bg-secondary` on generated-stylesheet position and lose.
+            // The variant compiles to `.disabled\:bg-…:disabled` — specificity
+            // (0,2,0) vs (0,1,0) — so it wins regardless of source order.
+            "disabled:cursor-not-allowed disabled:bg-theme-bg-primary disabled:text-theme-fg-muted disabled:opacity-50",
             // Custom classes
             className,
           )}

--- a/frontend/src/components/ui/Input/Textarea.tsx
+++ b/frontend/src/components/ui/Input/Textarea.tsx
@@ -185,9 +185,13 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               : "border-[var(--theme-border-field)] focus:border-[var(--theme-border-field-focus)] focus:ring-theme-focus",
             // Focus styles
             "focus:outline-none focus:ring-2",
-            // Disabled styles
-            disabled &&
-              "cursor-not-allowed bg-theme-bg-primary text-theme-fg-muted opacity-50",
+            // Disabled styles. These are `disabled:` variants, not a
+            // `disabled && "..."` branch: there is no tailwind-merge in this
+            // repo, so a conditional `bg-theme-bg-primary` would race the base
+            // `bg-theme-bg-secondary` on generated-stylesheet position and lose.
+            // The variant compiles to `.disabled\:bg-…:disabled` — specificity
+            // (0,2,0) vs (0,1,0) — so it wins regardless of source order.
+            "disabled:cursor-not-allowed disabled:bg-theme-bg-primary disabled:text-theme-fg-muted disabled:opacity-50",
             // Monospace font
             monospace && "font-mono text-sm",
             // Resize behavior

--- a/frontend/src/components/ui/Message/LoadMoreButton.tsx
+++ b/frontend/src/components/ui/Message/LoadMoreButton.tsx
@@ -53,7 +53,12 @@ export const LoadMoreButton = memo(
         className={clsx(
           "flex w-full justify-center p-2",
           {
-            "sticky top-0 z-10 bg-theme-bg": isSticky,
+            // The bar floats over the scrolling message list, which is painted
+            // `--theme-shell-chat-body` (.chat-body-skin), so it has to be
+            // opaque in exactly that colour. `bg-theme-bg` was a dead class —
+            // tailwind.config declares no DEFAULT under `theme.bg`, so no such
+            // utility was ever generated and the bar stayed transparent.
+            "sticky top-0 z-10 bg-[var(--theme-shell-chat-body)]": isSticky,
           },
           className,
         )}

--- a/frontend/src/components/ui/MessageList/MessageEditor.tsx
+++ b/frontend/src/components/ui/MessageList/MessageEditor.tsx
@@ -87,22 +87,11 @@ export const MessageEditor = ({
 
   return (
     <div className="w-full" data-testid="message-editor">
-      <textarea
-        ref={textareaRef}
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onKeyDown={handleKeyDown}
-        aria-label={t({
-          id: "chat.messageEditor.ariaLabel",
-          message: "Edit your message",
-        })}
-        data-testid="message-editor-input"
-        className="w-full resize-none rounded-md border border-theme-border bg-theme-bg-primary p-2 text-theme-fg-primary focus:outline-none focus:ring-2 focus:ring-theme-focus"
-        rows={1}
-      />
-
+      {/* Above the textarea, matching both the composer and the sent message.
+          Below it, switching into edit mode would move the tiles from one side
+          of the text to the other and back again on cancel. */}
       {attachedFiles.length > 0 && (
-        <div className="mt-2">
+        <div className="mb-2">
           <FileAttachmentsPreview
             attachedFiles={attachedFiles}
             maxFiles={attachedFiles.length}
@@ -116,6 +105,20 @@ export const MessageEditor = ({
           />
         </div>
       )}
+
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label={t({
+          id: "chat.messageEditor.ariaLabel",
+          message: "Edit your message",
+        })}
+        data-testid="message-editor-input"
+        className="w-full resize-none rounded-md border border-theme-border bg-theme-bg-primary p-2 text-theme-fg-primary focus:outline-none focus:ring-2 focus:ring-theme-focus"
+        rows={1}
+      />
 
       {renderTokenUsage?.(draft)}
 

--- a/frontend/src/config/__tests__/themeConfig.test.ts
+++ b/frontend/src/config/__tests__/themeConfig.test.ts
@@ -511,6 +511,7 @@ describe("themeConfig", () => {
       global.fetch = vi.fn();
       mockDebugLog.mockClear();
       vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "warn").mockImplementation(() => {});
       vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
@@ -537,7 +538,7 @@ describe("themeConfig", () => {
       expect(global.fetch).toHaveBeenCalledWith("/custom/theme.json");
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(console.log).toHaveBeenCalledWith(
-        "Custom theme loaded: Test Theme from /custom/theme.json",
+        'Custom theme loaded: Test Theme from /custom/theme.json (requested: themeConfigPath "/custom/theme.json", themePath "/themes/company")',
       );
     });
 
@@ -586,7 +587,7 @@ describe("themeConfig", () => {
       expect(global.fetch).toHaveBeenCalledWith("/themes/company/theme.json");
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(console.log).toHaveBeenCalledWith(
-        "Custom theme loaded: Test Theme from /themes/company/theme.json",
+        'Custom theme loaded: Test Theme from /themes/company/theme.json (requested: themeConfigPath "/custom/theme.json", themePath "/themes/company")',
       );
     });
 
@@ -707,6 +708,103 @@ describe("themeConfig", () => {
 
       expect(result).toEqual(mockTheme);
       expect(global.fetch).toHaveBeenCalledWith("/custom-config/theme.json");
+    });
+
+    it("should warn when a requested customer theme falls through to the generic theme", async () => {
+      mockEnv.mockReturnValue(
+        createMockEnv({ themeCustomerName: "unknown-customer" }),
+      );
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockResolvedValueOnce({ ok: true, json: async () => mockTheme });
+
+      const result = await loadResolvedThemeConfig();
+
+      expect(result?.themeConfigPath).toBe(
+        "/public/common/custom-theme/theme.json",
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        'Requested theme (customer name "unknown-customer") was not found. Loaded "Test Theme" from the fallback location /public/common/custom-theme/theme.json instead. Check the theme configuration and that the theme pack is deployed.',
+      );
+      expect(mockDebugLog).toHaveBeenCalledWith(
+        "UI",
+        "Theme not found at /public/common/custom-theme/unknown-customer/theme.json (HTTP 404), trying next location",
+      );
+    });
+
+    it("should not warn when the requested customer theme is the one that loaded", async () => {
+      mockEnv.mockReturnValue(createMockEnv({ themeCustomerName: "acme" }));
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTheme,
+      });
+
+      const result = await loadResolvedThemeConfig();
+
+      expect(result?.themeConfigPath).toBe(
+        "/public/common/custom-theme/acme/theme.json",
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(
+        'Custom theme loaded: Test Theme from /public/common/custom-theme/acme/theme.json (requested: customer name "acme")',
+      );
+    });
+
+    it("should not warn when no theme was requested at all", async () => {
+      mockEnv.mockReturnValue(createMockEnv());
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockTheme,
+      });
+
+      const result = await loadResolvedThemeConfig();
+
+      expect(result?.themeConfigPath).toBe(
+        "/public/common/custom-theme/theme.json",
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(
+        "Custom theme loaded: Test Theme from /public/common/custom-theme/theme.json (requested: none)",
+      );
+    });
+
+    it("should not warn when a lower-priority request is honoured", async () => {
+      mockEnv.mockReturnValue(
+        createMockEnv({
+          themeConfigPath: "/missing/theme.json",
+          themeCustomerName: "acme",
+        }),
+      );
+
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        .mockResolvedValueOnce({ ok: true, json: async () => mockTheme });
+
+      const result = await loadResolvedThemeConfig();
+
+      expect(result?.themeConfigPath).toBe(
+        "/public/common/custom-theme/acme/theme.json",
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it("should warn when a requested theme is not found anywhere", async () => {
+      mockEnv.mockReturnValue(createMockEnv({ themeCustomerName: "acme" }));
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await loadResolvedThemeConfig();
+
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        'Requested theme (customer name "acme") was not found at any location; falling back to the built-in default theme. Tried: /public/common/custom-theme/acme/theme.json, /public/common/custom-theme/theme.json',
+      );
     });
   });
 

--- a/frontend/src/config/themeConfig.ts
+++ b/frontend/src/config/themeConfig.ts
@@ -374,10 +374,55 @@ export interface LoadedThemeConfig {
   themeConfigPath: string;
 }
 
+/**
+ * A theme the environment explicitly asked for, plus a predicate that says
+ * whether a resolved theme.json path actually satisfies that request.
+ *
+ * `getThemePaths()` always ends with generic fall-back locations, so a
+ * misconfigured request resolves to *some* theme rather than failing. These
+ * descriptors let us tell "the requested theme loaded" apart from "we silently
+ * loaded a different one".
+ */
+interface RequestedTheme {
+  label: string;
+  matches: (path: string) => boolean;
+}
+
+const describeRequestedThemes = (): RequestedTheme[] => {
+  const { themeConfigPath, themeCustomerName, themePath } = env();
+  const requests: RequestedTheme[] = [];
+
+  if (themeConfigPath) {
+    requests.push({
+      label: `themeConfigPath "${themeConfigPath}"`,
+      matches: (path) => path === themeConfigPath,
+    });
+  }
+  if (themePath) {
+    requests.push({
+      label: `themePath "${themePath}"`,
+      matches: (path) => path === `${themePath}/theme.json`,
+    });
+  }
+  if (themeCustomerName) {
+    requests.push({
+      label: `customer name "${themeCustomerName}"`,
+      matches: (path) =>
+        path.endsWith(`/custom-theme/${themeCustomerName}/theme.json`),
+    });
+  }
+
+  return requests;
+};
+
 export async function loadResolvedThemeConfig(
   config: ThemeLocationConfig = defaultThemeConfig,
 ): Promise<LoadedThemeConfig | null> {
   try {
+    const requests = describeRequestedThemes();
+    const requestedLabel = requests.length
+      ? requests.map((request) => request.label).join(", ")
+      : "none";
     const pathsToTry = config.getThemePaths().filter(Boolean) as string[];
 
     for (const path of pathsToTry) {
@@ -385,18 +430,37 @@ export async function loadResolvedThemeConfig(
         const response = await fetch(path);
         if (response.ok) {
           const themeConfig = (await response.json()) as CustomThemeConfig;
-          console.log(`Custom theme loaded: ${themeConfig.name} from ${path}`);
+          console.log(
+            `Custom theme loaded: ${themeConfig.name} from ${path} (requested: ${requestedLabel})`,
+          );
+          if (
+            requests.length > 0 &&
+            !requests.some((request) => request.matches(path))
+          ) {
+            console.warn(
+              `Requested theme (${requestedLabel}) was not found. Loaded "${themeConfig.name}" from the fallback location ${path} instead. Check the theme configuration and that the theme pack is deployed.`,
+            );
+          }
           return {
             themeConfig,
             themeConfigPath: path,
           };
         }
+        debugLog(
+          "UI",
+          `Theme not found at ${path} (HTTP ${response.status}), trying next location`,
+        );
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (error) {
         debugLog("UI", `Theme not found at ${path}, trying next location`);
       }
     }
 
+    if (requests.length > 0) {
+      console.warn(
+        `Requested theme (${requestedLabel}) was not found at any location; falling back to the built-in default theme. Tried: ${pathsToTry.join(", ")}`,
+      );
+    }
     debugLog("UI", "No custom theme found, using default theme");
     return null;
   } catch (error) {

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -849,17 +849,23 @@ body {
   max-width: calc(100vw - 16px);
 }
 
+/* The chrome (`control-*`) aliases `--theme-*` exactly as `.pdf-preview-theme`
+   below does, so it follows the app theme and stays reachable from theme.json.
+   The document surface (`surface-*`, `page-*`) stays literal on purpose: it is
+   owned by this preview's own light/dark toggle, which is independent of the
+   app theme — a dark page in a light app is a supported state, so those cannot
+   be app tokens. */
 .docx-preview-theme {
   --docx-preview-surface-bg: #f3f4f6;
   --docx-preview-page-bg: #ffffff;
   --docx-preview-page-fg: #111827;
   --docx-preview-page-border: #d4d4d4;
   --docx-preview-page-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
-  --docx-preview-control-bg: rgba(255, 255, 255, 0.94);
-  --docx-preview-control-fg: #111827;
-  --docx-preview-control-border: rgba(17, 24, 39, 0.16);
-  --docx-preview-control-hover-bg: #ffffff;
-  --docx-preview-control-hover-fg: #111827;
+  --docx-preview-control-bg: var(--theme-bg-primary);
+  --docx-preview-control-fg: var(--theme-fg-primary);
+  --docx-preview-control-border: var(--theme-border-subtle);
+  --docx-preview-control-hover-bg: var(--theme-bg-hover);
+  --docx-preview-control-hover-fg: var(--theme-fg-primary);
   background: var(--docx-preview-surface-bg);
   color: var(--docx-preview-page-fg);
 }
@@ -870,11 +876,6 @@ body {
   --docx-preview-page-fg: #f8fafc;
   --docx-preview-page-border: #334155;
   --docx-preview-page-shadow: 0 10px 28px rgba(0, 0, 0, 0.32);
-  --docx-preview-control-bg: rgba(15, 23, 42, 0.94);
-  --docx-preview-control-fg: #f8fafc;
-  --docx-preview-control-border: rgba(226, 232, 240, 0.22);
-  --docx-preview-control-hover-bg: #1e293b;
-  --docx-preview-control-hover-fg: #ffffff;
 }
 
 .docx-preview-theme [data-testid="react-docx-viewer"] {
@@ -888,23 +889,20 @@ body {
   color: var(--docx-preview-page-fg) !important;
 }
 
+/* Same split as `.docx-preview-theme` above: the toolbar chrome aliases
+   `--theme-*`, the sheet surface behind the grid stays literal because the
+   preview's own light/dark toggle owns it. */
 .xlsx-preview-theme {
-  --xlsx-preview-control-bg: #f8fafc;
-  --xlsx-preview-button-bg: rgba(255, 255, 255, 0.94);
-  --xlsx-preview-control-fg: #111827;
-  --xlsx-preview-control-border: rgba(17, 24, 39, 0.14);
-  --xlsx-preview-control-hover-bg: #ffffff;
-  --xlsx-preview-control-hover-fg: #111827;
+  --xlsx-preview-control-bg: var(--theme-bg-primary);
+  --xlsx-preview-button-bg: var(--theme-bg-tertiary);
+  --xlsx-preview-control-fg: var(--theme-fg-primary);
+  --xlsx-preview-control-border: var(--theme-border-subtle);
+  --xlsx-preview-control-hover-bg: var(--theme-bg-hover);
+  --xlsx-preview-control-hover-fg: var(--theme-fg-primary);
   background: #ffffff;
 }
 
 .xlsx-preview-theme[data-xlsx-theme="dark"] {
-  --xlsx-preview-control-bg: #111827;
-  --xlsx-preview-button-bg: rgba(15, 23, 42, 0.94);
-  --xlsx-preview-control-fg: #f8fafc;
-  --xlsx-preview-control-border: rgba(226, 232, 240, 0.22);
-  --xlsx-preview-control-hover-bg: #1e293b;
-  --xlsx-preview-control-hover-fg: #ffffff;
   background: #0f172a;
 }
 

--- a/frontend/src/utils/themeUtils.test.ts
+++ b/frontend/src/utils/themeUtils.test.ts
@@ -132,4 +132,81 @@ describe("mergeThemeWithOverrides", () => {
       fontFamily: '"IBM Plex Mono", monospace',
     });
   });
+
+  // globals.css declares --theme-font-heading/--theme-font-semibold as aliases of
+  // --theme-font-body, and --theme-font-heading-bold as an alias of
+  // --theme-font-heading. ThemeProvider emits all of them explicitly, so the merge
+  // has to reproduce that alias chain or a brand font only half-applies.
+  it("back-fills heading, semibold and headingBold from a body-only font override", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      typography: { fontFamily: { body: "Brand Sans" } },
+    });
+
+    expect(mergedTheme.typography?.fontFamily).toMatchObject({
+      body: "Brand Sans",
+      heading: "Brand Sans",
+      semibold: "Brand Sans",
+      headingBold: "Brand Sans",
+      // mono has no alias in globals.css, so it must keep the default
+      mono: defaultTheme.typography?.fontFamily.mono,
+    });
+  });
+
+  it("resolves headingBold from an explicit heading rather than from body", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      typography: {
+        fontFamily: { body: "Brand Sans", heading: "Brand Display" },
+      },
+    });
+
+    expect(mergedTheme.typography?.fontFamily).toMatchObject({
+      body: "Brand Sans",
+      heading: "Brand Display",
+      semibold: "Brand Sans",
+      headingBold: "Brand Display",
+    });
+  });
+
+  it("back-fills headingBold from heading even when body is not overridden", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      typography: { fontFamily: { heading: "Brand Display" } },
+    });
+
+    expect(mergedTheme.typography?.fontFamily).toMatchObject({
+      body: defaultTheme.typography?.fontFamily.body,
+      heading: "Brand Display",
+      semibold: defaultTheme.typography?.fontFamily.semibold,
+      headingBold: "Brand Display",
+    });
+  });
+
+  it("preserves explicitly overridden font families over the back-filled ones", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      typography: {
+        fontFamily: {
+          body: "Brand Sans",
+          semibold: "Brand Sans Semibold",
+          headingBold: "Brand Display Bold",
+        },
+      },
+    });
+
+    expect(mergedTheme.typography?.fontFamily).toMatchObject({
+      body: "Brand Sans",
+      heading: "Brand Sans",
+      semibold: "Brand Sans Semibold",
+      headingBold: "Brand Display Bold",
+    });
+  });
+
+  it("leaves font families untouched when the override sets no font family", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      typography: { fontSize: { base: "1.125rem" } },
+    });
+
+    expect(mergedTheme.typography?.fontSize.base).toBe("1.125rem");
+    expect(mergedTheme.typography?.fontFamily).toEqual(
+      defaultTheme.typography?.fontFamily,
+    );
+  });
 });

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -118,6 +118,51 @@ const withBorderRadiusCompatibility = (
   };
 };
 
+/**
+ * Back-fills the font-family aliases the way `globals.css` declares them:
+ *
+ *   --theme-font-heading:      var(--theme-font-body);
+ *   --theme-font-semibold:     var(--theme-font-body);
+ *   --theme-font-heading-bold: var(--theme-font-heading);
+ *
+ * ThemeProvider emits every one of those custom properties explicitly, which
+ * flattens the alias chain. Without this back-fill a pack that sets only
+ * `typography.fontFamily.body` keeps the default font for headings, semibold
+ * text and bold headings. Keys the override sets explicitly always win.
+ */
+const withTypographyCompatibility = (
+  theme: Theme,
+  override?: ThemeOverride,
+): Theme => {
+  const fontFamilyOverride = override?.typography?.fontFamily;
+  const typography = theme.typography;
+  if (!fontFamilyOverride || !typography) return theme;
+
+  const fontFamily = { ...typography.fontFamily };
+
+  if (fontFamilyOverride.body) {
+    if (!fontFamilyOverride.heading) {
+      fontFamily.heading = typography.fontFamily.body;
+    }
+    if (!fontFamilyOverride.semibold) {
+      fontFamily.semibold = typography.fontFamily.body;
+    }
+  }
+
+  // headingBold aliases the *resolved* heading, which may itself come from body.
+  if (
+    (fontFamilyOverride.body || fontFamilyOverride.heading) &&
+    !fontFamilyOverride.headingBold
+  ) {
+    fontFamily.headingBold = fontFamily.heading;
+  }
+
+  return {
+    ...theme,
+    typography: { ...typography, fontFamily },
+  };
+};
+
 const withLegacyColorCompatibility = (
   theme: Theme,
   override?: ThemeOverride,
@@ -242,8 +287,11 @@ export function mergeThemeWithOverrides(
 ): Theme {
   const mergedTheme = deepMerge(baseTheme, override as Partial<Theme>);
 
-  return withLegacyColorCompatibility(
-    withBorderRadiusCompatibility(mergedTheme, override),
+  return withTypographyCompatibility(
+    withLegacyColorCompatibility(
+      withBorderRadiusCompatibility(mergedTheme, override),
+      override,
+    ),
     override,
   );
 }

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -165,12 +165,16 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="chat-input-shell"`
 - `data-ui="chat-input-controls"`
 - `data-ui="chat-message"`
+- `data-ui="message-body"`
+- `data-ui="message-attachments"`
 - `data-ui="message-controls"`
 - `data-ui="modal-overlay"`
 - `data-ui="modal-shell"`
 - `data-ui="dropdown-panel"`
 
 Messages also expose `data-role="user"` and `data-role="assistant"` on the message shell.
+
+`message-body` wraps the avatar and the message content. On a user message carrying files, `message-attachments` is a sibling rendered above it, so a fill applied to `message-body` covers the text without covering the attachments; on an assistant message the attachments stay inside `message-body` and the hook is absent. Themes that need to work against both shapes can branch on `:has([data-ui="message-body"])`.
 
 ## Custom Logos
 


### PR DESCRIPTION
Two commits. The first fixes six validated defects that make a custom theme fail *quietly*; the second adds two `data-ui` hooks and moves user attachments above the message body.

Found while building a real theme pack end-to-end against this app. Every claim below was verified against a running instance, not inferred.

## `5e2552ba` — Make theming fail loudly instead of silently

18 files, +417/−47, including **220 lines of new tests**.

**The silent fallback.** `themeConfig.ts` now logs requested-vs-resolved. Previously a misconfigured theme did not error — it loaded a *different* theme and logged `Custom theme loaded: …`, i.e. success framing for a fallback. That cost twenty minutes of hunting during validation; the file was reachable at 200 the whole time.

**Font-alias flattening.** `globals.css` declares `--theme-font-heading: var(--theme-font-body)`, so in CSS setting the body face cascades to headings. But `themeUtils.ts` had no typography handling at all — `withLegacyColorCompatibility` back-fills colours only — and `ThemeProvider` emits `--theme-font-heading` from the *default*, flattening the alias. A customer sets their brand face, body changes, **headings silently stay Geist**. Setting the brand font is usually a theme author's first move. Adds `withTypographyCompatibility`.

**Tailwind collisions.** No `tailwind-merge` in the project, and authoring order is provably irrelevant. `Input.tsx` and `Textarea.tsx` never got their disabled background *or* text colour; `GroupedFileAttachmentsPreview`'s error filename painted `fg-primary`. Fixed with variants that win on specificity (`disabled:`, `data-[tone=error]:`, `aria-expanded:`) rather than by reordering classes.

**Private namespaces.** 32 literal colours under `--docx-preview-*` / `--xlsx-preview-*` were unreachable from `theme.json`, while `--pdf-preview-*` next door was already a proper `--theme-*` alias. Now consistent.

Plus 4 token renames and `LoadMoreButton` reading `--theme-shell-chat-body`.

## `69adc35b` — Hoist user attachments above the message body

1 file, +31/−10.

Adds `data-ui="message-body"` on the content row and `data-ui="message-attachments"` on a wrapper, and renders user attachments as a **sibling above** the body instead of nested inside it.

Two reasons:

- **Order.** You attach the files, then you write the prompt. Rendering them under the text inverts that.
- **Themeability.** A theme that tints the user message needs somewhere to put the tint that is not "everything in the message". With attachments nested inside, any fill or hover on the container necessarily covered them, and no CSS could lift them out — `display: contents` destroys the avatar row, absolute positioning reserves no space.

**Assistant messages are untouched** — the hoist is behind `isUser`, so their attachments stay inline below the content.

The hook is a wrapper div in `ChatMessage` rather than a prop on `MessageAttachments`, because `AttachmentTileList` destructures its props with **no rest spread** — a `data-*` attribute passed to it is silently dropped.

## Verification

- `eslint --max-warnings=0 .` → exit 0
- `tsc --noEmit` → exit 0
- `prettier . --check` → exit 0
- `vitest run` → **1503 passed, 11 skipped**. Six files fail to *load* with `Denied ID …wasm?url` — pre-existing, all wasm/PDF-preview, and they fail identically with these changes stashed.

Rendered both roles and asserted the DOM: user container children are `["message-attachments", "message-body"]` as siblings; assistant is `["message-body"]` alone.

6 behind `main` at time of writing, merge base `b685352c`. One touched file overlaps (`ChatInput.tsx`) but `git merge-tree` reports a clean merge.

## Note on the pre-push hook

`.hooks/pre-push` drives its checks through an `fzf` menu, which needs a TTY and hangs rather than failing in a non-interactive shell. Worth knowing if this repo ever pushes from CI or an agent. The three commands it offers were run directly and all pass, as above.