### PR TITLE
Resolve dropdown and media borders through the merged theme

### DIFF
--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -474,8 +474,8 @@ describe("ThemeProvider", () => {
     expect(varsCss).toContain("--theme-border-subtle: #cfddd1;");
     expect(varsCss).toContain("--theme-border-field: #cfddd1;");
     expect(varsCss).toContain("--theme-border-chat-input: #cfddd1;");
-    expect(varsCss).toContain("--theme-border-dropdown: #d1d5db;");
-    expect(varsCss).toContain("--theme-border-media: #d1d5db;");
+    expect(varsCss).toContain("--theme-border-dropdown: #cfddd1;");
+    expect(varsCss).toContain("--theme-border-media: #cfddd1;");
     expect(varsCss).toContain("--theme-border-attachment: #cfddd1;");
     expect(varsCss).toContain("--theme-border-field-focus: #6b7280;");
     expect(varsCss).toContain("--theme-border-chat-input-focus: #6b7280;");

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -134,6 +134,15 @@
   }
 }
 
+/* ThemeProvider emits a `<style data-theme-vars>` into <head> after this file
+   and writes every token it knows about as a literal value. For those tokens
+   the declarations below are the pre-hydration fallback only — a `var()` alias
+   here does NOT survive into a running app, and a custom theme changing the
+   source will not move the alias. Anything derived has to be re-derived in
+   `themeUtils.ts`; that is what the `with*Compatibility` helpers are for.
+
+   A token the provider does not emit keeps its alias live — see
+   `--theme-bg-hover-strong` below, which is why it still tracks its source. */
 :root {
   /* Base theme - Light Mode */
 
@@ -164,6 +173,10 @@
   /* Border colors */
   --theme-border: #d1d5db;
   --theme-border-primary: var(--theme-border);
+  /* Fallback only, and deliberately NOT what runtime does: the provider
+     derives subtle from `border.default`, not from the accent background.
+     Re-pointing this at the accent would tint every subtle border with the
+     pack's brand colour — several packs set a saturated `background.accent`. */
   --theme-border-subtle: var(--theme-bg-accent);
   --theme-border-strong: #9ca3af;
   --theme-border-divider: var(--theme-border);
@@ -180,6 +193,9 @@
   --theme-shell-app: var(--theme-bg-primary);
   --theme-shell-page: var(--theme-bg-secondary);
   --theme-shell-sidebar: var(--theme-bg-sidebar);
+  /* Overridden at runtime: the provider emits a static value here, so this
+     mix does not track a custom sidebar/chat-body colour. Packs that want a
+     matching hover set `background.hover` (or `shell.sidebarHover`) today. */
   --theme-shell-sidebar-hover: color-mix(
     in srgb,
     var(--theme-shell-sidebar),
@@ -194,6 +210,9 @@
   --theme-overlay-modal: rgba(17, 24, 39, 0.6);
   --theme-message-user: var(--theme-bg-primary);
   --theme-message-assistant: var(--theme-bg-secondary);
+  /* Overridden at runtime: the provider emits a static value here, so this
+     mix does not track a custom sidebar/chat-body colour. Packs that want a
+     matching hover set `background.hover` (or `shell.sidebarHover`) today. */
   --theme-message-hover: color-mix(
     in srgb,
     var(--theme-shell-chat-body),
@@ -374,6 +393,10 @@
     /* Border colors */
     --theme-border: #4b5563;
     --theme-border-primary: var(--theme-border);
+    /* Fallback only, and deliberately NOT what runtime does: the provider
+     derives subtle from `border.default`, not from the accent background.
+     Re-pointing this at the accent would tint every subtle border with the
+     pack's brand colour — several packs set a saturated `background.accent`. */
     --theme-border-subtle: var(--theme-bg-accent);
     --theme-border-strong: #6b7280;
     --theme-border-divider: var(--theme-border);
@@ -390,6 +413,9 @@
     --theme-shell-app: var(--theme-bg-primary);
     --theme-shell-page: var(--theme-bg-secondary);
     --theme-shell-sidebar: var(--theme-bg-sidebar);
+    /* Overridden at runtime: the provider emits a static value here, so this
+     mix does not track a custom sidebar/chat-body colour. Packs that want a
+     matching hover set `background.hover` (or `shell.sidebarHover`) today. */
     --theme-shell-sidebar-hover: color-mix(
       in srgb,
       var(--theme-shell-sidebar),
@@ -404,6 +430,9 @@
     --theme-overlay-modal: rgba(0, 0, 0, 0.7);
     --theme-message-user: var(--theme-bg-primary);
     --theme-message-assistant: var(--theme-bg-secondary);
+    /* Overridden at runtime: the provider emits a static value here, so this
+     mix does not track a custom sidebar/chat-body colour. Packs that want a
+     matching hover set `background.hover` (or `shell.sidebarHover`) today. */
     --theme-message-hover: color-mix(
       in srgb,
       var(--theme-shell-chat-body),

--- a/frontend/src/utils/themeUtils.test.ts
+++ b/frontend/src/utils/themeUtils.test.ts
@@ -65,9 +65,45 @@ describe("mergeThemeWithOverrides", () => {
     expect(mergedTheme.colors.border.divider).toBe("#ea580c");
     expect(mergedTheme.colors.border.field).toBe("#ea580c");
     expect(mergedTheme.colors.border.chatInput).toBe("#ea580c");
-    expect(mergedTheme.colors.border.dropdown).toBe("#d1d5db");
-    expect(mergedTheme.colors.border.media).toBe("#d1d5db");
+    // These two alias divider/primary, which follow border.default, so they
+    // land on the override like every other border. They previously read the
+    // pre-merge theme and kept the built-in grey.
+    expect(mergedTheme.colors.border.dropdown).toBe("#ea580c");
+    expect(mergedTheme.colors.border.media).toBe("#ea580c");
     expect(mergedTheme.colors.border.attachment).toBe("#ea580c");
+  });
+
+  it("still lets an explicit dropdown or media border win over the alias", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      colors: {
+        border: {
+          default: "#ea580c",
+          dropdown: "#123456",
+          media: "#654321",
+        },
+      },
+    });
+
+    expect(mergedTheme.colors.border.dropdown).toBe("#123456");
+    expect(mergedTheme.colors.border.media).toBe("#654321");
+    expect(mergedTheme.colors.border.divider).toBe("#ea580c");
+  });
+
+  it("resolves dropdown and media through an explicitly overridden alias source", () => {
+    const mergedTheme = mergeThemeWithOverrides(defaultTheme, {
+      colors: {
+        border: {
+          default: "#ea580c",
+          divider: "#00ff00",
+          primary: "#0000ff",
+        },
+      },
+    });
+
+    // dropdown aliases divider and media aliases primary, so an explicit value
+    // for those sources has to carry through rather than being bypassed.
+    expect(mergedTheme.colors.border.dropdown).toBe("#00ff00");
+    expect(mergedTheme.colors.border.media).toBe("#0000ff");
   });
 
   it("preserves explicit new token overrides over legacy-derived values", () => {
@@ -108,8 +144,8 @@ describe("mergeThemeWithOverrides", () => {
 
     expect(mergedTheme.colors.border.field).toBe("#94a3b8");
     expect(mergedTheme.colors.border.chatInput).toBe("#94a3b8");
-    expect(mergedTheme.colors.border.dropdown).toBe("#d1d5db");
-    expect(mergedTheme.colors.border.media).toBe("#d1d5db");
+    expect(mergedTheme.colors.border.dropdown).toBe("#94a3b8");
+    expect(mergedTheme.colors.border.media).toBe("#94a3b8");
     expect(mergedTheme.colors.border.attachment).toBe("#94a3b8");
     expect(mergedTheme.colors.border.fieldFocus).toBe("#64748b");
     expect(mergedTheme.colors.border.chatInputFocus).toBe("#64748b");

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -258,11 +258,16 @@ const withLegacyColorCompatibility = (
     if (!colorsOverride.border.chatInput) {
       nextTheme.colors.border.chatInput = theme.colors.border.default;
     }
+    // These two alias a token that this same block may have just re-pointed,
+    // so they read `nextTheme` where the others read `theme`: globals.css has
+    // them aliasing divider/primary, and those follow `border.default`. Reading
+    // the pre-merge value left them on the built-in grey while every other
+    // border followed the pack.
     if (!colorsOverride.border.dropdown) {
-      nextTheme.colors.border.dropdown = theme.colors.border.divider;
+      nextTheme.colors.border.dropdown = nextTheme.colors.border.divider;
     }
     if (!colorsOverride.border.media) {
-      nextTheme.colors.border.media = theme.colors.border.primary;
+      nextTheme.colors.border.media = nextTheme.colors.border.primary;
     }
     if (!colorsOverride.border.attachment) {
       nextTheme.colors.border.attachment = theme.colors.border.default;


### PR DESCRIPTION
Follow-up to #1068. That PR fixed the *typography* instance of a general bug: `ThemeProvider` emits every token as a literal, which flattens the `var()` aliases `globals.css` declares, so any derived token has to be re-derived in `themeUtils.ts`. This fixes one colour instance of the same class, and documents two others that turned out **not** to be bugs.

## The fix

`withLegacyColorCompatibility` re-points eight border tokens when a pack sets `border.default`. Six read the value it just wrote; two read the pre-merge object:

```js
nextTheme.colors.border.dropdown = theme.colors.border.divider;  // ← theme, not nextTheme
nextTheme.colors.border.media    = theme.colors.border.primary;  // ← same
```

So a pack setting only `border.default` got every border in its brand colour **except dropdown and media**, which stayed on the built-in `#d1d5db`.

Affects `novoferm`, `trilux`, `trilux-test`, `modern-theme` — they set only `border.default`. `erato` and `open-webui-like` set `dropdown`/`media` explicitly, so the back-fill was already skipped for them and nothing changes.

**Two existing tests were pinning the buggy value** (`themeUtils.test.ts`, `ThemeProvider.test.tsx`), each sitting next to six assertions that all follow the override. Both updated, plus two new tests covering explicit-override precedence and resolution through an explicitly overridden alias source.

## Two things that are *not* bugs

Both looked like the same defect and are not. Documented in place so the next reader doesn't re-derive the wrong conclusion:

- **`--theme-border-subtle: var(--theme-bg-accent)`** — the CSS and the JS disagree, but the JS is right. `novoferm`/`trilux` set `background.accent: #cf0000` and `modern-theme` sets `#0f766e`; making the JS match the CSS would tint every subtle border with the brand colour, including the docx/xlsx/pdf preview borders that #1068 just pointed at this token.
- **`--theme-shell-sidebar-hover` / `--theme-message-hover`** — declared as `color-mix()` derivations that the provider overrides with static values. Real, but inert: every current pack sets `background.hover` or `messageItem.hover`, which the existing back-fill already handles. Restoring the derivation needs a precedence decision, so it is only described here.

`--theme-bg-hover-strong` is the control case — not emitted by the provider, so its alias stays live