### PR TITLE
Add experience policy document as a runtime configuration source type (ERMAIN-694)

### DIFF
--- a/backend/erato/src/distribution/experience_policy.rs
+++ b/backend/erato/src/distribution/experience_policy.rs
@@ -30,13 +30,96 @@ pub struct ExperiencePolicyDocument {
     pub priority_order: Vec<String>,
 }
 
-/// One audience an admin can pin a starting assistant for.
+/// One subject an audience is composed of, in the same vocabulary a
+/// `share_grants` row uses for `subject_type` / `subject_id_type` /
+/// `subject_id` (see [`crate::models::share_grant`]).
+///
+/// Deliberately identity-provider agnostic: nothing on this path interprets an
+/// id, it only compares it to what the token carried. Turning an id into a
+/// human-readable name is the only Entra-specific step, and it happens in the
+/// admin panel against MS Graph — the last possible moment.
+///
+/// The `subject_id_type` half of the share-grant triple is not on the wire
+/// because each variant admits exactly one, so encoding it would only create
+/// illegal states to validate:
+///
+/// | variant              | share-grant `subject_type` | `subject_id_type`       |
+/// | -------------------- | -------------------------- | ----------------------- |
+/// | `organization`       | `organization`             | `organization_id`       |
+/// | `organization_group` | `organization_group`       | `organization_group_id` |
+/// | `user`               | `user`                     | `organization_user_id`  |
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
-pub struct ExperienceAudience {
+#[serde(tag = "subject_type", rename_all = "snake_case")]
+pub enum AudienceSubject {
+    /// Everyone who is authenticated — the org-wide audience. Mirrors a share
+    /// grant whose subject is
+    /// [`ORGANIZATION_SUBJECT_TYPE`](crate::models::share_grant::ORGANIZATION_SUBJECT_TYPE)
+    /// and carries no per-user identifier.
+    ///
+    /// This says "this applies to everyone", which is not the same as "everyone
+    /// not matched above": placed first in `priority_order` it shadows every
+    /// audience below it, placed last it is a catch-all default.
+    Organization,
+    /// A directory group the caller is a member of.
+    ///
     /// Matched against `MeProfile.groups` (rego `input.groups`), not the
     /// `Subject`'s `organization_group_ids` — the wrong one silently matches
     /// nothing.
-    pub entra_group_id: String,
+    OrganizationGroup {
+        /// The group's id as the identity provider writes it into the token's
+        /// `groups` claim.
+        group_id: String,
+    },
+    /// One named person, so an audience can pick up a handful of individuals
+    /// without an IT department minting a group for three people.
+    User {
+        /// The caller's directory user id — the `oid` claim, surfaced as
+        /// `MeProfile.organization_user_id`, and the id
+        /// `GET /me/organization/users` hands a people-picker.
+        ///
+        /// Not the internal `users.id`: that row only exists once the person
+        /// has logged in at least once, and an audience has to be able to name
+        /// someone before their first login.
+        organization_user_id: String,
+    },
+}
+
+impl AudienceSubject {
+    /// The wire tag for this variant, for error and log messages.
+    #[must_use]
+    pub fn subject_type(&self) -> &'static str {
+        match self {
+            Self::Organization => "organization",
+            Self::OrganizationGroup { .. } => "organization_group",
+            Self::User { .. } => "user",
+        }
+    }
+
+    /// The id this subject names, or `None` for the org-wide subject, which
+    /// names no one in particular.
+    #[must_use]
+    pub fn subject_id(&self) -> Option<&str> {
+        match self {
+            Self::Organization => None,
+            Self::OrganizationGroup { group_id } => Some(group_id),
+            Self::User {
+                organization_user_id,
+            } => Some(organization_user_id),
+        }
+    }
+}
+
+/// One audience an admin can pin a starting assistant for.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct ExperienceAudience {
+    /// The subjects this audience is composed of. A person is in the audience
+    /// if **any** subject matches them, so groups, named individuals and the
+    /// whole organization compose freely — the same way a resource can be
+    /// shared with several subjects at once.
+    ///
+    /// Required and non-empty: an audience that matches nobody is a mistake
+    /// worth failing the whole document over, not a silently inert entry.
+    pub subjects: Vec<AudienceSubject>,
     /// An `assistant_hub_assistants.id`, never an `assistants.id`:
     /// `clone_source_assistant` mints a fresh `assistants.id` on every
     /// republish, so a stored one goes stale silently. Resolved to the live
@@ -48,6 +131,11 @@ pub struct ExperienceAudience {
 ///
 /// A typo'd audience name in `priority_order` would otherwise silently never
 /// match. Audiences absent from `priority_order` are allowed (staged rollout).
+///
+/// An unknown `subject_type` and a subject missing its id are rejected by the
+/// derived `Deserialize` for [`AudienceSubject`]; what is left for this
+/// function is the structure serde cannot express — an audience matching
+/// nobody, and an id that is present but blank.
 pub fn parse_experience_policy(contents: &str) -> Result<ExperiencePolicyDocument, Report> {
     let document: ExperiencePolicyDocument = serde_json::from_str(contents)?;
 
@@ -64,8 +152,16 @@ pub fn parse_experience_policy(contents: &str) -> Result<ExperiencePolicyDocumen
     }
 
     for (name, audience) in &document.audiences {
-        if audience.entra_group_id.trim().is_empty() {
-            return Err(eyre!("audience \"{name}\" has an empty entra_group_id"));
+        if audience.subjects.is_empty() {
+            return Err(eyre!("audience \"{name}\" has no subjects"));
+        }
+        for subject in &audience.subjects {
+            if subject.subject_id().is_some_and(|id| id.trim().is_empty()) {
+                return Err(eyre!(
+                    "audience \"{name}\" has a {} subject with an empty id",
+                    subject.subject_type()
+                ));
+            }
         }
     }
 
@@ -142,31 +238,51 @@ mod tests {
             r#"{
                 "audiences": {
                     "engineering": {
-                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "subjects": [
+                            {"subject_type": "organization_group", "group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"},
+                            {"subject_type": "organization_group", "group_id": "2c4e6a80-1111-4222-8333-444455556666"},
+                            {"subject_type": "user", "organization_user_id": "9d8c7b6a-5f4e-4d3c-8b2a-1f0e9d8c7b6a"}
+                        ],
                         "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                     },
-                    "sales": {
-                        "entra_group_id": "1f2e3d4c-5b6a-4978-8899-aabbccddeeff",
+                    "everyone": {
+                        "subjects": [{"subject_type": "organization"}],
                         "pinned_assistant_hub_assistant_id": "0b1c2d3e-4f50-4161-8273-8495a6b7c8d9"
                     }
                 },
-                "priority_order": ["sales", "engineering"]
+                "priority_order": ["engineering", "everyone"]
             }"#,
         )
         .unwrap();
 
-        assert_eq!(document.priority_order, vec!["sales", "engineering"]);
+        assert_eq!(document.priority_order, vec!["engineering", "everyone"]);
         assert_eq!(document.audiences.len(), 2);
+
         let engineering = &document.audiences["engineering"];
         assert_eq!(
-            engineering.entra_group_id,
-            "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"
+            engineering.subjects,
+            vec![
+                AudienceSubject::OrganizationGroup {
+                    group_id: "8f7cb1f3-5c92-4e0f-9c39-89f65a852101".to_string(),
+                },
+                AudienceSubject::OrganizationGroup {
+                    group_id: "2c4e6a80-1111-4222-8333-444455556666".to_string(),
+                },
+                AudienceSubject::User {
+                    organization_user_id: "9d8c7b6a-5f4e-4d3c-8b2a-1f0e9d8c7b6a".to_string(),
+                },
+            ]
         );
         assert_eq!(
             engineering.pinned_assistant_hub_assistant_id,
             "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                 .parse::<Uuid>()
                 .unwrap()
+        );
+
+        assert_eq!(
+            document.audiences["everyone"].subjects,
+            vec![AudienceSubject::Organization]
         );
     }
 
@@ -176,7 +292,7 @@ mod tests {
             r#"{
                 "audiences": {
                     "engineering": {
-                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "subjects": [{"subject_type": "organization_group", "group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"}],
                         "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                     }
                 },
@@ -193,7 +309,7 @@ mod tests {
             r#"{
                 "audiences": {
                     "engineering": {
-                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "subjects": [{"subject_type": "organization_group", "group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"}],
                         "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                     }
                 },
@@ -205,19 +321,98 @@ mod tests {
     }
 
     #[test]
-    fn rejects_an_empty_entra_group_id() {
+    fn rejects_an_audience_with_no_subjects() {
         let error = parse_experience_policy(
             r#"{
                 "audiences": {
                     "engineering": {
-                        "entra_group_id": "   ",
+                        "subjects": [],
                         "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                     }
                 }
             }"#,
         )
         .unwrap_err();
-        assert!(error.to_string().contains("empty entra_group_id"));
+        assert!(error.to_string().contains("has no subjects"));
+    }
+
+    #[test]
+    fn rejects_a_subject_with_a_blank_id() {
+        for (subject, expected) in [
+            (
+                r#"{"subject_type": "organization_group", "group_id": "   "}"#,
+                "organization_group subject with an empty id",
+            ),
+            (
+                r#"{"subject_type": "user", "organization_user_id": ""}"#,
+                "user subject with an empty id",
+            ),
+        ] {
+            let error = parse_experience_policy(&format!(
+                r#"{{
+                    "audiences": {{
+                        "engineering": {{
+                            "subjects": [{subject}],
+                            "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                        }}
+                    }}
+                }}"#
+            ))
+            .unwrap_err();
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?} in {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_an_unknown_or_malformed_subject() {
+        // An unknown `subject_type`, and a known one missing its id, are both
+        // rejected by the derived Deserialize rather than reaching the
+        // resolver as a subject that can never match.
+        for subject in [
+            r#"{"subject_type": "entra_group", "group_id": "g"}"#,
+            r#"{"subject_type": "organization_group"}"#,
+            r#"{"subject_type": "user", "group_id": "g"}"#,
+            r#"{"group_id": "g"}"#,
+        ] {
+            assert!(
+                parse_experience_policy(&format!(
+                    r#"{{
+                        "audiences": {{
+                            "engineering": {{
+                                "subjects": [{subject}],
+                                "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                            }}
+                        }}
+                    }}"#
+                ))
+                .is_err(),
+                "expected {subject} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_the_superseded_single_group_audience_shape() {
+        // The pre-review shape carried one `entra_group_id` per audience. It is
+        // a clean break, not an alias: `subjects` is required, so a stale
+        // document fails loudly in `ReloadableAppState::load` (which keeps the
+        // previous policy and logs) rather than silently matching nobody.
+        let error = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    }
+                },
+                "priority_order": ["engineering"]
+            }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("subjects"));
     }
 
     #[test]
@@ -226,7 +421,11 @@ mod tests {
             r#"{
                 "audiences": {
                     "engineering": {
-                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "subjects": [{
+                            "subject_type": "organization_group",
+                            "group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                            "future_subject_field": "display name"
+                        }],
                         "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01",
                         "future_audience_field": true
                     }

--- a/backend/erato/src/distribution/experience_policy.rs
+++ b/backend/erato/src/distribution/experience_policy.rs
@@ -1,0 +1,247 @@
+//! Org-wide experience policy document, written by the admin panel as a
+//! `runtime_configuration` row (source type `experience_policy`) and read back
+//! on every reload. This is the policy document only; resolving it for a user
+//! happens in `server::api::v1beta::starting_assistant`.
+
+use eyre::{Report, eyre};
+use serde::Deserialize;
+use sqlx::types::Uuid;
+use std::collections::{HashMap, HashSet};
+
+/// The slug of the single live policy document. Other valid slugs are reserved
+/// for future drafts and are deliberately not loaded.
+pub const EXPERIENCE_POLICY_SLUG: &str = "policy";
+
+/// The org-wide experience policy: which audiences exist and in which order
+/// they are resolved for a user.
+///
+/// Deliberately not `deny_unknown_fields`, so a newer admin panel writing an
+/// unknown field does not wedge the backend into keep-previous forever during
+/// a mixed-version deployment.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize)]
+pub struct ExperiencePolicyDocument {
+    #[serde(default)]
+    pub audiences: HashMap<String, ExperienceAudience>,
+    /// Precedence lives in this separate ordered key, like
+    /// `chat_providers.priority_order` and `language_detection_priority` —
+    /// never in the map above, whose `HashMap` iteration order is arbitrary.
+    /// An audience absent from here can never win.
+    #[serde(default)]
+    pub priority_order: Vec<String>,
+}
+
+/// One audience an admin can pin a starting assistant for.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct ExperienceAudience {
+    /// Matched against `MeProfile.groups` (rego `input.groups`), not the
+    /// `Subject`'s `organization_group_ids` — the wrong one silently matches
+    /// nothing.
+    pub entra_group_id: String,
+    /// An `assistant_hub_assistants.id`, never an `assistants.id`:
+    /// `clone_source_assistant` mints a fresh `assistants.id` on every
+    /// republish, so a stored one goes stale silently. Resolved to the live
+    /// id at read time via `get_published_current_version`.
+    pub pinned_assistant_hub_assistant_id: Uuid,
+}
+
+/// Parse and structurally validate an experience policy document.
+///
+/// A typo'd audience name in `priority_order` would otherwise silently never
+/// match. Audiences absent from `priority_order` are allowed (staged rollout).
+pub fn parse_experience_policy(contents: &str) -> Result<ExperiencePolicyDocument, Report> {
+    let document: ExperiencePolicyDocument = serde_json::from_str(contents)?;
+
+    let mut seen = HashSet::new();
+    for name in &document.priority_order {
+        if !document.audiences.contains_key(name) {
+            return Err(eyre!("priority_order names unknown audience \"{name}\""));
+        }
+        if !seen.insert(name.as_str()) {
+            return Err(eyre!(
+                "priority_order lists audience \"{name}\" more than once"
+            ));
+        }
+    }
+
+    for (name, audience) in &document.audiences {
+        if audience.entra_group_id.trim().is_empty() {
+            return Err(eyre!("audience \"{name}\" has an empty entra_group_id"));
+        }
+    }
+
+    Ok(document)
+}
+
+/// Return the slug encoded by an admin-panel experience policy filename.
+///
+/// Experience policy files intentionally have a narrow name contract:
+/// `experience/<slug>.json`. Rejecting all other paths keeps loading
+/// independent of filesystem path handling, as `translation_locale` does.
+#[must_use]
+pub fn experience_policy_slug(filename: &str) -> Option<&str> {
+    let slug = filename
+        .strip_prefix("experience/")?
+        .strip_suffix(".json")?;
+    if slug.is_empty()
+        || slug.contains('/')
+        || !slug
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return None;
+    }
+    Some(slug)
+}
+
+/// Build the filename for a policy slug, validating by round-tripping through
+/// [`experience_policy_slug`] so parser and writer cannot drift.
+pub fn experience_policy_filename(slug: &str) -> Result<String, Report> {
+    if experience_policy_slug(&format!("experience/{slug}.json")) != Some(slug) {
+        return Err(eyre!("invalid experience policy slug"));
+    }
+    Ok(format!("experience/{slug}.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_experience_policy_filenames() {
+        assert_eq!(
+            experience_policy_slug("experience/policy.json"),
+            Some("policy")
+        );
+        assert_eq!(
+            experience_policy_slug("experience/draft-v2.json"),
+            Some("draft-v2")
+        );
+        assert_eq!(experience_policy_slug("experience/policy.toml"), None);
+        assert_eq!(experience_policy_slug("experience/nested/x.json"), None);
+        assert_eq!(experience_policy_slug("../experience/policy.json"), None);
+        assert_eq!(experience_policy_slug("experience/.json"), None);
+    }
+
+    #[test]
+    fn filename_round_trips_through_the_slug_parser() {
+        let filename = experience_policy_filename(EXPERIENCE_POLICY_SLUG).unwrap();
+        assert_eq!(filename, "experience/policy.json");
+        assert_eq!(
+            experience_policy_slug(&filename),
+            Some(EXPERIENCE_POLICY_SLUG)
+        );
+
+        assert!(experience_policy_filename("").is_err());
+        assert!(experience_policy_filename("nested/slug").is_err());
+        assert!(experience_policy_filename("dotted.slug").is_err());
+    }
+
+    #[test]
+    fn parses_a_full_document() {
+        let document = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    },
+                    "sales": {
+                        "entra_group_id": "1f2e3d4c-5b6a-4978-8899-aabbccddeeff",
+                        "pinned_assistant_hub_assistant_id": "0b1c2d3e-4f50-4161-8273-8495a6b7c8d9"
+                    }
+                },
+                "priority_order": ["sales", "engineering"]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(document.priority_order, vec!["sales", "engineering"]);
+        assert_eq!(document.audiences.len(), 2);
+        let engineering = &document.audiences["engineering"];
+        assert_eq!(
+            engineering.entra_group_id,
+            "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"
+        );
+        assert_eq!(
+            engineering.pinned_assistant_hub_assistant_id,
+            "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                .parse::<Uuid>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn rejects_priority_order_naming_an_unknown_audience() {
+        let error = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    }
+                },
+                "priority_order": ["enginering"]
+            }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown audience"));
+    }
+
+    #[test]
+    fn rejects_duplicate_priority_order_entries() {
+        let error = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    }
+                },
+                "priority_order": ["engineering", "engineering"]
+            }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("more than once"));
+    }
+
+    #[test]
+    fn rejects_an_empty_entra_group_id() {
+        let error = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "   ",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    }
+                }
+            }"#,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("empty entra_group_id"));
+    }
+
+    #[test]
+    fn accepts_unknown_fields_from_newer_writers() {
+        let document = parse_experience_policy(
+            r#"{
+                "audiences": {
+                    "engineering": {
+                        "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+                        "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01",
+                        "future_audience_field": true
+                    }
+                },
+                "priority_order": ["engineering"],
+                "future_top_level_field": {"nested": 1}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(document.priority_order, vec!["engineering"]);
+    }
+
+    #[test]
+    fn parses_an_empty_document_to_defaults() {
+        let document = parse_experience_policy("{}").unwrap();
+        assert_eq!(document, ExperiencePolicyDocument::default());
+    }
+}

--- a/backend/erato/src/distribution/mod.rs
+++ b/backend/erato/src/distribution/mod.rs
@@ -10,6 +10,7 @@ use crate::config::AppConfig;
 
 pub mod component_kits;
 pub mod desktop_sidecar;
+pub mod experience_policy;
 pub mod frontend_bundles;
 pub mod runtime;
 pub mod translations;

--- a/backend/erato/src/distribution/runtime.rs
+++ b/backend/erato/src/distribution/runtime.rs
@@ -2,11 +2,13 @@
 
 use crate::db::entity::prelude::RuntimeConfiguration;
 use crate::db::entity::runtime_configuration;
+use crate::distribution::experience_policy;
+use crate::models::runtime_configuration::EXPERIENCE_POLICY_SOURCE_TYPE;
 use crate::state::AppState;
 use eyre::{Report, eyre};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
 
-const ADMIN_PANEL_SOURCE_SERVICE: &str = "erato_admin_panel";
+pub const ADMIN_PANEL_SOURCE_SERVICE: &str = "erato_admin_panel";
 const TRANSLATION_PO_SOURCE_TYPE: &str = "translation_po";
 
 /// A file that is made available by a runtime distribution producer.
@@ -43,10 +45,18 @@ impl DistributionBundle {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ReloadableAppState {
     pub distribution_bundle: DistributionBundle,
+    /// `None` means no policy row exists — a valid complete state, distinct
+    /// from a failed load, which keeps the previous policy. Kept out of the
+    /// bundle above, whose files are served unauthenticated.
+    pub experience_policy: Option<experience_policy::ExperiencePolicyDocument>,
 }
 
 impl ReloadableAppState {
     pub async fn load(app_state: &AppState) -> Result<Self, Report> {
+        // Scoped so the read guard drops here: callers assign the result into
+        // a `write()` on the same lock.
+        let previous_policy = { app_state.reloadable.read().await.experience_policy.clone() };
+
         let rows = RuntimeConfiguration::find()
             .filter(runtime_configuration::Column::SourceService.eq(ADMIN_PANEL_SOURCE_SERVICE))
             .filter(runtime_configuration::Column::SourceType.eq(TRANSLATION_PO_SOURCE_TYPE))
@@ -71,10 +81,72 @@ impl ReloadableAppState {
             });
         }
 
+        // A malformed policy must not take the translation bundle down: carry
+        // the previous policy forward so the swap stays one complete write. On
+        // a cold start that previous policy is `None`.
+        let experience_policy = match load_experience_policy(app_state).await {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::error!(%error, "Failed to load experience policy; keeping the previous policy");
+                previous_policy
+            }
+        };
+
         Ok(Self {
             distribution_bundle: DistributionBundle { files },
+            experience_policy,
         })
     }
+}
+
+/// Load the org-wide experience policy from the runtime configuration table.
+///
+/// Zero rows is `Ok(None)`: the admin panel unpins by deleting the row, so
+/// absence must clear the policy rather than trigger keep-previous. Rows that
+/// exist but none named for the live slug is an `Err`, so a defective write
+/// keeps the previous policy instead of silently unpinning the whole org.
+async fn load_experience_policy(
+    app_state: &AppState,
+) -> Result<Option<experience_policy::ExperiencePolicyDocument>, Report> {
+    let rows = RuntimeConfiguration::find()
+        .filter(runtime_configuration::Column::SourceService.eq(ADMIN_PANEL_SOURCE_SERVICE))
+        .filter(runtime_configuration::Column::SourceType.eq(EXPERIENCE_POLICY_SOURCE_TYPE))
+        .order_by_asc(runtime_configuration::Column::SourceFilename)
+        .all(&app_state.db)
+        .await?;
+
+    if rows.is_empty() {
+        return Ok(None);
+    }
+
+    let live_filename =
+        experience_policy::experience_policy_filename(experience_policy::EXPERIENCE_POLICY_SLUG)?;
+    let mut matching = rows
+        .iter()
+        .filter(|row| row.source_filename.as_deref() == Some(live_filename.as_str()));
+    let Some(row) = matching.next() else {
+        let seen = rows
+            .iter()
+            .map(|row| row.source_filename.as_deref().unwrap_or("<none>"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(eyre!(
+            "experience policy rows exist but none is named {live_filename}; saw: {seen}"
+        ));
+    };
+    // The table has no uniqueness on (source_service, source_type,
+    // source_filename), so first-match keeps the load deterministic — but a
+    // duplicate points at a buggy writer.
+    if matching.next().is_some() {
+        tracing::warn!(
+            source_filename = %live_filename,
+            "Multiple experience policy rows share the live filename; using the first"
+        );
+    }
+
+    let contents = app_state.decrypt(&row.config)?;
+    let document = experience_policy::parse_experience_policy(&contents)?;
+    Ok(Some(document))
 }
 
 /// Return the locale encoded by an admin-panel translation filename.

--- a/backend/erato/src/models/runtime_configuration.rs
+++ b/backend/erato/src/models/runtime_configuration.rs
@@ -11,6 +11,7 @@ use sea_orm::{
 pub const ERATO_BACKEND_SOURCE_SERVICE: &str = "erato_backend";
 pub const ERATO_TOML_SOURCE_TYPE: &str = "erato_toml";
 pub const TRANSLATION_PO_SOURCE_TYPE: &str = "translation_po";
+pub const EXPERIENCE_POLICY_SOURCE_TYPE: &str = "experience_policy";
 
 // ASCII "erato-rc", used only to serialize replacement transactions.
 const RUNTIME_CONFIGURATION_ADVISORY_LOCK_KEY: i64 = 7_310_012_297_885_086_307;

--- a/backend/erato/tests/integration_tests/db/mod.rs
+++ b/backend/erato/tests/integration_tests/db/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod migrations;
 pub mod runtime_configuration;
+pub mod runtime_distribution;
 pub mod users;

--- a/backend/erato/tests/integration_tests/db/runtime_distribution.rs
+++ b/backend/erato/tests/integration_tests/db/runtime_distribution.rs
@@ -5,7 +5,9 @@ use crate::test_utils::hermetic_app_config;
 use crate::{MIGRATOR, test_app_state};
 use erato::db::entity::prelude::RuntimeConfiguration;
 use erato::db::entity::runtime_configuration;
-use erato::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use erato::distribution::experience_policy::{
+    AudienceSubject, ExperienceAudience, ExperiencePolicyDocument,
+};
 use erato::distribution::runtime::{ADMIN_PANEL_SOURCE_SERVICE, ReloadableAppState};
 use erato::models::runtime_configuration::{
     EXPERIENCE_POLICY_SOURCE_TYPE, TRANSLATION_PO_SOURCE_TYPE,
@@ -20,7 +22,10 @@ const TEST_ENCRYPTION_KEY: &str = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
 const VALID_POLICY_JSON: &str = r#"{
     "audiences": {
         "engineering": {
-            "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+            "subjects": [
+                {"subject_type": "organization_group", "group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101"},
+                {"subject_type": "user", "organization_user_id": "9d8c7b6a-5f4e-4d3c-8b2a-1f0e9d8c7b6a"}
+            ],
             "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
         }
     },
@@ -38,7 +43,14 @@ fn expected_policy_document() -> ExperiencePolicyDocument {
         audiences: HashMap::from([(
             "engineering".to_string(),
             ExperienceAudience {
-                entra_group_id: "8f7cb1f3-5c92-4e0f-9c39-89f65a852101".to_string(),
+                subjects: vec![
+                    AudienceSubject::OrganizationGroup {
+                        group_id: "8f7cb1f3-5c92-4e0f-9c39-89f65a852101".to_string(),
+                    },
+                    AudienceSubject::User {
+                        organization_user_id: "9d8c7b6a-5f4e-4d3c-8b2a-1f0e9d8c7b6a".to_string(),
+                    },
+                ],
                 pinned_assistant_hub_assistant_id: "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
                     .parse::<Uuid>()
                     .unwrap(),

--- a/backend/erato/tests/integration_tests/db/runtime_distribution.rs
+++ b/backend/erato/tests/integration_tests/db/runtime_distribution.rs
@@ -1,0 +1,263 @@
+//! Integration tests for `ReloadableAppState::load` covering the experience
+//! policy source type beside runtime translations.
+
+use crate::test_utils::hermetic_app_config;
+use crate::{MIGRATOR, test_app_state};
+use erato::db::entity::prelude::RuntimeConfiguration;
+use erato::db::entity::runtime_configuration;
+use erato::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use erato::distribution::runtime::{ADMIN_PANEL_SOURCE_SERVICE, ReloadableAppState};
+use erato::models::runtime_configuration::{
+    EXPERIENCE_POLICY_SOURCE_TYPE, TRANSLATION_PO_SOURCE_TYPE,
+};
+use sea_orm::{ActiveValue::Set, ColumnTrait, EntityTrait, QueryFilter};
+use sqlx::types::Uuid;
+use sqlx::{Pool, Postgres};
+use std::collections::HashMap;
+
+const TEST_ENCRYPTION_KEY: &str = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+const VALID_POLICY_JSON: &str = r#"{
+    "audiences": {
+        "engineering": {
+            "entra_group_id": "8f7cb1f3-5c92-4e0f-9c39-89f65a852101",
+            "pinned_assistant_hub_assistant_id": "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+        }
+    },
+    "priority_order": ["engineering"]
+}"#;
+
+async fn app_state_with_encryption(pool: Pool<Postgres>) -> erato::state::AppState {
+    let mut app_config = hermetic_app_config(None, None);
+    app_config.server.encryption_key = Some(TEST_ENCRYPTION_KEY.into());
+    test_app_state(app_config, pool).await
+}
+
+fn expected_policy_document() -> ExperiencePolicyDocument {
+    ExperiencePolicyDocument {
+        audiences: HashMap::from([(
+            "engineering".to_string(),
+            ExperienceAudience {
+                entra_group_id: "8f7cb1f3-5c92-4e0f-9c39-89f65a852101".to_string(),
+                pinned_assistant_hub_assistant_id: "6a3d2c76-2f6e-4e6f-8ad0-1f8f8f4f2a01"
+                    .parse::<Uuid>()
+                    .unwrap(),
+            },
+        )]),
+        priority_order: vec!["engineering".to_string()],
+    }
+}
+
+fn admin_panel_row(
+    source_type: &str,
+    source_filename: Option<&str>,
+    config: String,
+) -> runtime_configuration::ActiveModel {
+    runtime_configuration::ActiveModel {
+        source_service: Set(ADMIN_PANEL_SOURCE_SERVICE.to_string()),
+        source_type: Set(source_type.to_string()),
+        source_filename: Set(source_filename.map(str::to_string)),
+        config: Set(config),
+        ..Default::default()
+    }
+}
+
+async fn insert_rows(
+    app_state: &erato::state::AppState,
+    rows: impl IntoIterator<Item = runtime_configuration::ActiveModel>,
+) {
+    RuntimeConfiguration::insert_many(rows)
+        .exec(&app_state.db)
+        .await
+        .unwrap();
+}
+
+async fn delete_policy_rows(app_state: &erato::state::AppState) {
+    RuntimeConfiguration::delete_many()
+        .filter(runtime_configuration::Column::SourceType.eq(EXPERIENCE_POLICY_SOURCE_TYPE))
+        .exec(&app_state.db)
+        .await
+        .unwrap();
+}
+
+async fn replace_translation_row(app_state: &erato::state::AppState, contents: &str) {
+    RuntimeConfiguration::delete_many()
+        .filter(runtime_configuration::Column::SourceType.eq(TRANSLATION_PO_SOURCE_TYPE))
+        .filter(runtime_configuration::Column::SourceService.eq(ADMIN_PANEL_SOURCE_SERVICE))
+        .exec(&app_state.db)
+        .await
+        .unwrap();
+    insert_rows(
+        app_state,
+        [admin_panel_row(
+            TRANSLATION_PO_SOURCE_TYPE,
+            Some("overrides/de.po"),
+            app_state.encrypt(contents).unwrap(),
+        )],
+    )
+    .await;
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn load_includes_experience_policy_beside_translations(pool: Pool<Postgres>) {
+    let app_state = app_state_with_encryption(pool).await;
+    insert_rows(
+        &app_state,
+        [admin_panel_row(
+            EXPERIENCE_POLICY_SOURCE_TYPE,
+            Some("experience/policy.json"),
+            app_state.encrypt(VALID_POLICY_JSON).unwrap(),
+        )],
+    )
+    .await;
+    replace_translation_row(&app_state, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").await;
+
+    let loaded = ReloadableAppState::load(&app_state).await.unwrap();
+    assert_eq!(loaded.experience_policy, Some(expected_policy_document()));
+    let translation = loaded
+        .distribution_bundle
+        .file("overrides/de.po")
+        .expect("translation file should load beside the policy");
+    assert_eq!(translation.contents, "msgid \"Hello\"\nmsgstr \"Hallo\"\n");
+
+    // Deleting the row is the admin panel's unpin operation: absence must
+    // clear the policy, not survive as a ghost via keep-previous.
+    delete_policy_rows(&app_state).await;
+    *app_state.reloadable.write().await = loaded;
+    let reloaded = ReloadableAppState::load(&app_state).await.unwrap();
+    assert_eq!(reloaded.experience_policy, None);
+    assert!(
+        reloaded
+            .distribution_bundle
+            .file("overrides/de.po")
+            .is_some()
+    );
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn malformed_experience_policy_keeps_previous_policy_and_reloads_translations(
+    pool: Pool<Postgres>,
+) {
+    let app_state = app_state_with_encryption(pool).await;
+    insert_rows(
+        &app_state,
+        [admin_panel_row(
+            EXPERIENCE_POLICY_SOURCE_TYPE,
+            Some("experience/policy.json"),
+            app_state.encrypt(VALID_POLICY_JSON).unwrap(),
+        )],
+    )
+    .await;
+    replace_translation_row(&app_state, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").await;
+
+    let good_state = ReloadableAppState::load(&app_state).await.unwrap();
+    assert_eq!(
+        good_state.experience_policy,
+        Some(expected_policy_document())
+    );
+    *app_state.reloadable.write().await = good_state;
+
+    let unknown_audience_json = r#"{
+        "audiences": {},
+        "priority_order": ["missing"]
+    }"#;
+    let malformed_configs = [
+        // Non-JSON garbage that still decrypts.
+        app_state.encrypt("this is not json").unwrap(),
+        // Valid JSON that fails structural validation.
+        app_state.encrypt(unknown_audience_json).unwrap(),
+        // Well-formed enc-v1 envelope whose ciphertext cannot decrypt.
+        "enc-v1:AAAAAAAAAAAAAAAA:AAAA".to_string(),
+    ];
+
+    for (index, malformed_config) in malformed_configs.into_iter().enumerate() {
+        delete_policy_rows(&app_state).await;
+        insert_rows(
+            &app_state,
+            [admin_panel_row(
+                EXPERIENCE_POLICY_SOURCE_TYPE,
+                Some("experience/policy.json"),
+                malformed_config,
+            )],
+        )
+        .await;
+        let translation_contents = format!("msgid \"Hello\"\nmsgstr \"Hallo {index}\"\n");
+        replace_translation_row(&app_state, &translation_contents).await;
+
+        let loaded = ReloadableAppState::load(&app_state).await.unwrap();
+        // The changed translation proves the load actually ran end to end.
+        assert_eq!(
+            loaded
+                .distribution_bundle
+                .file("overrides/de.po")
+                .unwrap()
+                .contents,
+            translation_contents
+        );
+        assert_eq!(
+            loaded.experience_policy,
+            Some(expected_policy_document()),
+            "variant {index} must keep the previous policy"
+        );
+    }
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn malformed_policy_at_cold_start_loads_translations_without_policy(pool: Pool<Postgres>) {
+    let app_state = app_state_with_encryption(pool).await;
+    insert_rows(
+        &app_state,
+        [admin_panel_row(
+            EXPERIENCE_POLICY_SOURCE_TYPE,
+            Some("experience/policy.json"),
+            app_state.encrypt("this is not json").unwrap(),
+        )],
+    )
+    .await;
+    replace_translation_row(&app_state, "msgid \"Hello\"\nmsgstr \"Hallo\"\n").await;
+
+    // The harness seeds `reloadable` as Default, so the previous policy is
+    // None — the malformed row degrades to "no policy", never to a failed load
+    // that would take the translation bundle down.
+    let loaded = ReloadableAppState::load(&app_state).await.unwrap();
+    assert_eq!(loaded.experience_policy, None);
+    assert!(loaded.distribution_bundle.file("overrides/de.po").is_some());
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn foreign_filenames_never_silently_unpin(pool: Pool<Postgres>) {
+    let app_state = app_state_with_encryption(pool).await;
+    insert_rows(
+        &app_state,
+        [
+            admin_panel_row(
+                EXPERIENCE_POLICY_SOURCE_TYPE,
+                Some("experience/draft.json"),
+                app_state.encrypt(VALID_POLICY_JSON).unwrap(),
+            ),
+            admin_panel_row(
+                EXPERIENCE_POLICY_SOURCE_TYPE,
+                None,
+                app_state.encrypt(VALID_POLICY_JSON).unwrap(),
+            ),
+            admin_panel_row(
+                EXPERIENCE_POLICY_SOURCE_TYPE,
+                Some("experience/policy.toml"),
+                app_state.encrypt(VALID_POLICY_JSON).unwrap(),
+            ),
+        ],
+    )
+    .await;
+
+    let previous = ReloadableAppState {
+        experience_policy: Some(expected_policy_document()),
+        ..Default::default()
+    };
+    *app_state.reloadable.write().await = previous;
+
+    // Rows exist but none carries the live filename: a defective or
+    // newer-admin-panel write must keep the previous policy, never silently
+    // unpin the whole org.
+    let loaded = ReloadableAppState::load(&app_state).await.unwrap();
+    assert_eq!(loaded.experience_policy, Some(expected_policy_document()));
+}


### PR DESCRIPTION
Stack 1/3 for the audience-resolved start screen. Base: `main`.

An admin picks a starting assistant for an Entra group in the admin panel; people in that group land in it instead of the welcome screen. This PR carries the policy document into the running backend and does nothing else — nothing reads it yet.

Linear: ERMAIN-694 (parent: ERMAIN-693)

## What this adds

A third `source_type` in `runtime_configuration`, beside `erato_toml` and `translation_po`. **No migration** — the table already has `(source_service, source_type, source_filename, config)`.

- `distribution/experience_policy.rs` — the document type and a validating parser. JSON, at the fixed filename `experience/policy.json`, encrypted with the shared key.
- `ReloadableAppState` grows a field; `load()` still returns one complete value so the swap stays a single `RwLock` write.
- The existing `pg_notify('configuration_changed')` listener needed **no change** — it already reloads the whole bundle.

Shape: `audiences` keyed by an admin-owned name, each with `entra_group_id` and `pinned_assistant_hub_assistant_id`, plus an **ordered** `priority_order`.

## Two design points worth a reviewer's attention

**Why `priority_order` is a separate ordered key rather than a field on a rule.** A person matches many groups and exactly one pin must win. This follows the existing two-stage composition — `determine_chat_provider` over `chat_providers.priority_order`, and `language_detection_priority`. Ordering deliberately does *not* live inside a rule map: `rules` maps are `HashMap`s whose iteration order reaches rego directly, so "first match wins" over that data would be non-deterministic across restarts.

**The pin is an `assistant_hub_assistants.id`, never an `assistants.id`.** `clone_source_assistant` mints a fresh UUID on every republish, so a pin stored as the route id goes stale silently. Resolution to the live id happens at read time (PR 2/3).

## Load-path semantics — please bless or push back

Two behaviours depart from what the ticket text said. Both are deliberate, commented and tested, but a human should agree:

- A row whose filename is foreign returns `Err` and keeps the previous policy, rather than skip-and-warn.
- A decrypt failure logs and keeps the previous policy, rather than being fatal at startup — so a cold start degrades to no-policy instead of refusing to boot.

A malformed policy must never take the translation bundle down with it; that is tested.