### PR TITLE
Serve the per-user starting assistant on GET /me/starting-assistant (ERMAIN-695)

### DIFF
--- a/backend/erato/src/models/share_grant.rs
+++ b/backend/erato/src/models/share_grant.rs
@@ -395,38 +395,106 @@ pub async fn get_resources_shared_with_subject_and_groups(
     Ok(grants)
 }
 
-/// Whether a resource is shared with a specific organization group. An
-/// organization-wide grant counts, since it covers every group.
+/// A share-grant subject to test a resource against: the
+/// `(subject_type, subject_id_type, subject_id)` triple a `share_grants` row
+/// stores, borrowed rather than owned so callers can build one per candidate
+/// without allocating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShareSubject<'a> {
+    pub subject_type: &'a str,
+    pub subject_id_type: &'a str,
+    pub subject_id: &'a str,
+}
+
+impl<'a> ShareSubject<'a> {
+    /// The organization-wide subject, which every authenticated user is part of.
+    #[must_use]
+    pub fn organization() -> Self {
+        Self {
+            subject_type: ORGANIZATION_SUBJECT_TYPE,
+            subject_id_type: ORGANIZATION_SUBJECT_ID_TYPE,
+            subject_id: ORGANIZATION_SUBJECT_ID,
+        }
+    }
+
+    /// A directory group, by the id the identity provider puts in the token.
+    #[must_use]
+    pub fn organization_group(organization_group_id: &'a str) -> Self {
+        Self {
+            subject_type: "organization_group",
+            subject_id_type: "organization_group_id",
+            subject_id: organization_group_id,
+        }
+    }
+
+    /// One person by their directory user id (the `oid` claim).
+    #[must_use]
+    pub fn organization_user(organization_user_id: &'a str) -> Self {
+        Self {
+            subject_type: "user",
+            subject_id_type: "organization_user_id",
+            subject_id: organization_user_id,
+        }
+    }
+
+    /// One person by their internal `users.id`.
+    #[must_use]
+    pub fn user(user_id: &'a str) -> Self {
+        Self {
+            subject_type: "user",
+            subject_id_type: "id",
+            subject_id: user_id,
+        }
+    }
+}
+
+/// Whether a resource is shared with ANY of `subjects`. An organization-wide
+/// grant always counts, since it covers every subject.
 ///
-/// This asks about the GROUP's access, not any particular user's — a caller
-/// may hold a direct grant to a resource its group cannot see.
-pub async fn is_resource_shared_with_organization_group(
+/// This asks about the given SUBJECTS' access, not the caller's — a caller may
+/// hold a direct grant to a resource the audience it matched cannot see, and
+/// an audience pin must not survive on that.
+///
+/// NOTE (see PR #1072 review): this is grant interpretation living in Rust,
+/// duplicating what `backend.rego` already knows about `share_grants`, and the
+/// two can drift. The intended destination is the `PolicyEngine` — but the
+/// question "does subject S reach resource R" cannot be asked of it today:
+/// `SubjectKind` has only `User`, and every rego rule gates on
+/// `input.subject_kind == subject_kind_user`, so a group or organization
+/// subject has no way in. Closing that means either a `group` subject kind or
+/// a dedicated non-`allow` query entrypoint. Deliberately not built here; do
+/// not add a second predicate of this shape without doing it.
+pub async fn is_resource_shared_with_any_subject(
     conn: &DatabaseConnection,
     resource_type: &str,
     resource_id: &str,
-    organization_group_id: &str,
+    subjects: &[ShareSubject<'_>],
 ) -> Result<bool, Report> {
-    let condition = Condition::any()
-        .add(
-            Condition::all()
-                .add(share_grants::Column::SubjectType.eq("organization_group"))
-                .add(share_grants::Column::SubjectIdType.eq("organization_group_id"))
-                .add(share_grants::Column::SubjectId.eq(organization_group_id))
-                .add(share_grants::Column::ResourceType.eq(resource_type))
-                .add(share_grants::Column::ResourceId.eq(resource_id)),
-        )
-        .add(
-            Condition::all()
-                .add(share_grants::Column::SubjectType.eq(ORGANIZATION_SUBJECT_TYPE))
-                .add(share_grants::Column::SubjectIdType.eq(ORGANIZATION_SUBJECT_ID_TYPE))
-                .add(share_grants::Column::SubjectId.eq(ORGANIZATION_SUBJECT_ID))
-                .add(share_grants::Column::ResourceType.eq(resource_type))
-                .add(share_grants::Column::ResourceId.eq(resource_id)),
-        );
+    let mut condition = Condition::any().add(subject_condition(
+        resource_type,
+        resource_id,
+        ShareSubject::organization(),
+    ));
+    for subject in subjects {
+        condition = condition.add(subject_condition(resource_type, resource_id, *subject));
+    }
 
     Ok(ShareGrants::find()
         .filter(condition)
         .one(conn)
         .await?
         .is_some())
+}
+
+fn subject_condition(
+    resource_type: &str,
+    resource_id: &str,
+    subject: ShareSubject<'_>,
+) -> Condition {
+    Condition::all()
+        .add(share_grants::Column::SubjectType.eq(subject.subject_type))
+        .add(share_grants::Column::SubjectIdType.eq(subject.subject_id_type))
+        .add(share_grants::Column::SubjectId.eq(subject.subject_id))
+        .add(share_grants::Column::ResourceType.eq(resource_type))
+        .add(share_grants::Column::ResourceId.eq(resource_id))
 }

--- a/backend/erato/src/models/share_grant.rs
+++ b/backend/erato/src/models/share_grant.rs
@@ -394,3 +394,39 @@ pub async fn get_resources_shared_with_subject_and_groups(
 
     Ok(grants)
 }
+
+/// Whether a resource is shared with a specific organization group. An
+/// organization-wide grant counts, since it covers every group.
+///
+/// This asks about the GROUP's access, not any particular user's — a caller
+/// may hold a direct grant to a resource its group cannot see.
+pub async fn is_resource_shared_with_organization_group(
+    conn: &DatabaseConnection,
+    resource_type: &str,
+    resource_id: &str,
+    organization_group_id: &str,
+) -> Result<bool, Report> {
+    let condition = Condition::any()
+        .add(
+            Condition::all()
+                .add(share_grants::Column::SubjectType.eq("organization_group"))
+                .add(share_grants::Column::SubjectIdType.eq("organization_group_id"))
+                .add(share_grants::Column::SubjectId.eq(organization_group_id))
+                .add(share_grants::Column::ResourceType.eq(resource_type))
+                .add(share_grants::Column::ResourceId.eq(resource_id)),
+        )
+        .add(
+            Condition::all()
+                .add(share_grants::Column::SubjectType.eq(ORGANIZATION_SUBJECT_TYPE))
+                .add(share_grants::Column::SubjectIdType.eq(ORGANIZATION_SUBJECT_ID_TYPE))
+                .add(share_grants::Column::SubjectId.eq(ORGANIZATION_SUBJECT_ID))
+                .add(share_grants::Column::ResourceType.eq(resource_type))
+                .add(share_grants::Column::ResourceId.eq(resource_id)),
+        );
+
+    Ok(ShareGrants::find()
+        .filter(condition)
+        .one(conn)
+        .await?
+        .is_some())
+}

--- a/backend/erato/src/server/api/v1beta/mod.rs
+++ b/backend/erato/src/server/api/v1beta/mod.rs
@@ -15,6 +15,7 @@ pub mod policy_engine_middleware;
 pub mod share_grants;
 pub mod share_links;
 pub mod sharepoint;
+pub mod starting_assistant;
 pub mod token_usage;
 pub mod user_tool_approval_settings;
 
@@ -140,6 +141,10 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         .route("/profile/preferences", put(update_profile_preferences))
         .route("/facets", get(facets))
         .route("/starter-prompts", get(starter_prompts))
+        .route(
+            "/starting-assistant",
+            get(starting_assistant::starting_assistant),
+        )
         .route("/messages/submitstream", post(message_submit_sse))
         .route("/messages/regeneratestream", post(regenerate_message_sse))
         .route("/messages/editstream", post(edit_message_sse))
@@ -443,7 +448,8 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         sharepoint::get_drive_item,
         sharepoint::get_drive_item_children,
         entra_id::list_organization_users,
-        entra_id::list_organization_groups
+        entra_id::list_organization_groups,
+        starting_assistant::starting_assistant
     ),
     components(schemas(
         Message,
@@ -556,7 +562,9 @@ pub fn router(app_state: AppState) -> OpenApiRouter<AppState> {
         entra_id::OrganizationUser,
         entra_id::OrganizationUsersResponse,
         entra_id::OrganizationGroup,
-        entra_id::OrganizationGroupsResponse
+        entra_id::OrganizationGroupsResponse,
+        starting_assistant::StartingAssistantResponse,
+        starting_assistant::StartingAssistantInfo
     ))
 )]
 pub struct ApiV1ApiDoc;

--- a/backend/erato/src/server/api/v1beta/starting_assistant.rs
+++ b/backend/erato/src/server/api/v1beta/starting_assistant.rs
@@ -1,0 +1,269 @@
+//! Per-user resolution of the admin-pinned "starting assistant". An admin pins
+//! an assistant-hub assistant for an audience (an Entra group) in the org-wide
+//! experience policy document ([`crate::distribution::experience_policy`]); a
+//! user in that audience lands there instead of on the welcome screen.
+//!
+//! This lives on the authenticated `/me` tree rather than the public bundle
+//! route because the document is org-wide but its resolution depends on the
+//! caller's group memberships.
+//!
+//! The response is always `200 OK`: every failure mode — no policy, no matching
+//! audience, a stale or revoked pin, an infrastructure error — degrades to an
+//! absent `starting_assistant` field, so a pin can never turn into an error
+//! page for the very users it targets.
+
+use crate::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use crate::models::{assistant_hub, share_grant};
+use crate::server::api::v1beta::me_profile_middleware::MeProfile;
+use crate::state::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// The resolved starting assistant for the calling user.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StartingAssistantInfo {
+    /// The live `assistants.id` of the current published version. Resolved at
+    /// read time from the pinned hub id, so it is always the id a client can
+    /// open a chat with — even right after a republish minted a fresh clone.
+    pub assistant_id: String,
+    /// The stable `assistant_hub_assistants.id` the admin pinned.
+    pub assistant_hub_assistant_id: String,
+    /// The name of the audience (policy key) whose pin won for this user.
+    pub audience: String,
+}
+
+/// Response for `GET /me/starting-assistant`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StartingAssistantResponse {
+    /// Absent when no pin applies to the calling user; the client shows the
+    /// ordinary welcome screen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(nullable = false)]
+    pub starting_assistant: Option<StartingAssistantInfo>,
+}
+
+/// Pick the winning audience for a user: the first entry of `priority_order`
+/// naming an audience whose Entra group the user is a member of.
+///
+/// Precedence comes from `priority_order` alone, as `determine_chat_provider`
+/// does for `chat_providers.priority_order`; the `audiences` map's iteration
+/// order is arbitrary and must never decide the winner.
+pub fn match_winning_audience<'a>(
+    policy: &'a ExperiencePolicyDocument,
+    user_groups: &[String],
+) -> Option<(&'a str, &'a ExperienceAudience)> {
+    policy.priority_order.iter().find_map(|audience_name| {
+        policy
+            .audiences
+            .get_key_value(audience_name)
+            .filter(|(_, audience)| {
+                user_groups
+                    .iter()
+                    .any(|group| group == &audience.entra_group_id)
+            })
+            .map(|(name, audience)| (name.as_str(), audience))
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/me/starting-assistant",
+    responses(
+        (status = OK, body = StartingAssistantResponse),
+        (status = UNAUTHORIZED, description = "When no valid JWT token is provided")
+    ),
+    security(
+        ("bearer_auth" = [])
+    )
+)]
+pub async fn starting_assistant(
+    State(app_state): State<AppState>,
+    Extension(me_user): Extension<MeProfile>,
+) -> Result<Json<StartingAssistantResponse>, StatusCode> {
+    let no_pin = || {
+        Ok(Json(StartingAssistantResponse {
+            starting_assistant: None,
+        }))
+    };
+
+    // Clone out of the read guard so a slow DB await below never holds the
+    // reload lock.
+    let policy = { app_state.reloadable.read().await.experience_policy.clone() };
+    let Some(policy) = policy else {
+        return no_pin();
+    };
+    if !app_state.config.assistant_hub.enabled {
+        return no_pin();
+    }
+
+    // Exactly one winner: if its pin fails to resolve below we degrade to the
+    // welcome screen rather than falling through to the next matching audience.
+    let Some((audience_name, audience)) = match_winning_audience(&policy, &me_user.groups) else {
+        return no_pin();
+    };
+
+    // Resolves the stable hub id to the current published clone's
+    // `assistants.id`, and enforces that the caller can access it.
+    let record = match assistant_hub::get_published_current_version(
+        &app_state.db,
+        &app_state.config.assistant_hub,
+        &me_user.to_subject(),
+        audience.pinned_assistant_hub_assistant_id,
+    )
+    .await
+    {
+        Ok(record) => record,
+        Err(report) => {
+            tracing::warn!(
+                hub_assistant_id = %audience.pinned_assistant_hub_assistant_id,
+                audience = %audience_name,
+                error = ?report,
+                "Pinned starting assistant did not resolve; serving welcome screen"
+            );
+            return no_pin();
+        }
+    };
+
+    // Check the AUDIENCE's own access, not the caller's: revoking the audience
+    // grant must stop the pin even for users who keep personal access through
+    // a direct grant.
+    let assistant_id = record.assistant.id.to_string();
+    match share_grant::is_resource_shared_with_organization_group(
+        &app_state.db,
+        "assistant",
+        &assistant_id,
+        &audience.entra_group_id,
+    )
+    .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                hub_assistant_id = %audience.pinned_assistant_hub_assistant_id,
+                audience = %audience_name,
+                "Pinned starting assistant is no longer shared with its audience; serving welcome screen"
+            );
+            return no_pin();
+        }
+        Err(report) => {
+            tracing::error!(
+                hub_assistant_id = %audience.pinned_assistant_hub_assistant_id,
+                audience = %audience_name,
+                error = ?report,
+                "Failed to check audience share for pinned starting assistant; serving welcome screen"
+            );
+            return no_pin();
+        }
+    }
+
+    Ok(Json(StartingAssistantResponse {
+        starting_assistant: Some(StartingAssistantInfo {
+            assistant_id,
+            assistant_hub_assistant_id: audience.pinned_assistant_hub_assistant_id.to_string(),
+            audience: audience_name.to_string(),
+        }),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::types::Uuid;
+    use std::collections::HashMap;
+
+    fn audience(entra_group_id: &str) -> ExperienceAudience {
+        ExperienceAudience {
+            entra_group_id: entra_group_id.to_string(),
+            pinned_assistant_hub_assistant_id: Uuid::new_v4(),
+        }
+    }
+
+    fn policy_with(
+        entries: Vec<(&str, ExperienceAudience)>,
+        priority_order: Vec<&str>,
+    ) -> ExperiencePolicyDocument {
+        let mut audiences = HashMap::new();
+        for (name, audience) in entries {
+            audiences.insert(name.to_string(), audience);
+        }
+        ExperiencePolicyDocument {
+            audiences,
+            priority_order: priority_order
+                .into_iter()
+                .map(|name| name.to_string())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn first_priority_order_entry_wins_regardless_of_map_insert_order() {
+        let user_groups = vec!["group-a".to_string(), "group-b".to_string()];
+
+        // Insert the audiences in both orders: the winner must come from
+        // priority_order, never from HashMap iteration/insertion order.
+        for entries in [
+            vec![
+                ("alpha", audience("group-a")),
+                ("beta", audience("group-b")),
+            ],
+            vec![
+                ("beta", audience("group-b")),
+                ("alpha", audience("group-a")),
+            ],
+        ] {
+            let policy = policy_with(entries.clone(), vec!["beta", "alpha"]);
+            let (winner, matched) = match_winning_audience(&policy, &user_groups).unwrap();
+            assert_eq!(winner, "beta");
+            assert_eq!(matched.entra_group_id, "group-b");
+
+            // Reversing priority_order must flip the winner: the ordered key
+            // is load-bearing.
+            let policy = policy_with(entries, vec!["alpha", "beta"]);
+            let (winner, matched) = match_winning_audience(&policy, &user_groups).unwrap();
+            assert_eq!(winner, "alpha");
+            assert_eq!(matched.entra_group_id, "group-a");
+        }
+    }
+
+    #[test]
+    fn skips_priority_order_entries_the_user_is_not_a_member_of() {
+        let policy = policy_with(
+            vec![
+                ("alpha", audience("group-a")),
+                ("beta", audience("group-b")),
+            ],
+            vec!["alpha", "beta"],
+        );
+        let user_groups = vec!["group-b".to_string()];
+        let (winner, _) = match_winning_audience(&policy, &user_groups).unwrap();
+        assert_eq!(winner, "beta");
+    }
+
+    #[test]
+    fn skips_unknown_priority_order_entries() {
+        // The parser rejects these, but the resolver must stay total anyway.
+        let policy = policy_with(vec![("beta", audience("group-b"))], vec!["ghost", "beta"]);
+        let user_groups = vec!["group-b".to_string()];
+        let (winner, _) = match_winning_audience(&policy, &user_groups).unwrap();
+        assert_eq!(winner, "beta");
+    }
+
+    #[test]
+    fn audience_absent_from_priority_order_never_wins() {
+        let policy = policy_with(vec![("alpha", audience("group-a"))], vec![]);
+        let user_groups = vec!["group-a".to_string()];
+        assert!(match_winning_audience(&policy, &user_groups).is_none());
+    }
+
+    #[test]
+    fn no_winner_for_empty_groups_or_empty_policy() {
+        let policy = policy_with(vec![("alpha", audience("group-a"))], vec!["alpha"]);
+        assert!(match_winning_audience(&policy, &[]).is_none());
+
+        let empty = ExperiencePolicyDocument::default();
+        assert!(match_winning_audience(&empty, &["group-a".to_string()]).is_none());
+    }
+}

--- a/backend/erato/src/server/api/v1beta/starting_assistant.rs
+++ b/backend/erato/src/server/api/v1beta/starting_assistant.rs
@@ -1,18 +1,23 @@
 //! Per-user resolution of the admin-pinned "starting assistant". An admin pins
-//! an assistant-hub assistant for an audience (an Entra group) in the org-wide
+//! an assistant-hub assistant for an audience — a list of subjects: directory
+//! groups, named individuals, or the whole organization — in the org-wide
 //! experience policy document ([`crate::distribution::experience_policy`]); a
-//! user in that audience lands there instead of on the welcome screen.
+//! user any of those subjects matches lands there instead of on the welcome
+//! screen.
 //!
 //! This lives on the authenticated `/me` tree rather than the public bundle
-//! route because the document is org-wide but its resolution depends on the
-//! caller's group memberships.
+//! route because the document is org-wide but its resolution depends on who
+//! the caller is and which groups they are in.
 //!
 //! The response is always `200 OK`: every failure mode — no policy, no matching
 //! audience, a stale or revoked pin, an infrastructure error — degrades to an
 //! absent `starting_assistant` field, so a pin can never turn into an error
 //! page for the very users it targets.
 
-use crate::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use crate::distribution::experience_policy::{
+    AudienceSubject, ExperienceAudience, ExperiencePolicyDocument,
+};
+use crate::models::share_grant::ShareSubject;
 use crate::models::{assistant_hub, share_grant};
 use crate::server::api::v1beta::me_profile_middleware::MeProfile;
 use crate::state::AppState;
@@ -45,24 +50,85 @@ pub struct StartingAssistantResponse {
     pub starting_assistant: Option<StartingAssistantInfo>,
 }
 
+/// Who an audience's subjects are matched against.
+///
+/// Built from the caller's token, not from the database: an audience is
+/// evaluated against the identity the request arrived with.
+#[derive(Debug, Clone, Copy)]
+pub struct AudienceIdentity<'a> {
+    /// The token's `groups` claim, i.e. `MeProfile.groups` (rego
+    /// `input.groups`) — not `Subject::organization_group_ids`, which is empty
+    /// for the plain `Subject::User` variant and would silently match nothing.
+    pub groups: &'a [String],
+    /// The caller's directory user id from the `oid` claim. `None` for identity
+    /// providers that emit none, in which case `user` subjects simply never
+    /// match — the same way `groups` subjects never match without a `groups`
+    /// claim.
+    pub organization_user_id: Option<&'a str>,
+}
+
+impl<'a> AudienceIdentity<'a> {
+    #[must_use]
+    pub fn from_profile(profile: &'a MeProfile) -> Self {
+        Self {
+            groups: &profile.groups,
+            organization_user_id: profile.organization_user_id.as_deref(),
+        }
+    }
+}
+
+/// Whether one audience subject matches the caller.
+#[must_use]
+pub fn subject_matches(subject: &AudienceSubject, identity: AudienceIdentity<'_>) -> bool {
+    match subject {
+        // Everyone who got this far is authenticated.
+        AudienceSubject::Organization => true,
+        AudienceSubject::OrganizationGroup { group_id } => {
+            identity.groups.iter().any(|group| group == group_id)
+        }
+        AudienceSubject::User {
+            organization_user_id,
+        } => identity.organization_user_id == Some(organization_user_id.as_str()),
+    }
+}
+
+/// The subjects of `audience` that match the caller — usually one, but a person
+/// can be in two of an audience's groups at once, and each match is a separate
+/// reason the pin might still be granted.
+#[must_use]
+pub fn matching_subjects<'a>(
+    audience: &'a ExperienceAudience,
+    identity: AudienceIdentity<'_>,
+) -> Vec<&'a AudienceSubject> {
+    audience
+        .subjects
+        .iter()
+        .filter(|subject| subject_matches(subject, identity))
+        .collect()
+}
+
 /// Pick the winning audience for a user: the first entry of `priority_order`
-/// naming an audience whose Entra group the user is a member of.
+/// naming an audience any of whose subjects matches the caller.
 ///
 /// Precedence comes from `priority_order` alone, as `determine_chat_provider`
 /// does for `chat_providers.priority_order`; the `audiences` map's iteration
-/// order is arbitrary and must never decide the winner.
+/// order is arbitrary and must never decide the winner. An audience whose
+/// subjects include the whole organization therefore shadows everything below
+/// it and defaults everything above it, depending only on where the admin put
+/// it in the order.
 pub fn match_winning_audience<'a>(
     policy: &'a ExperiencePolicyDocument,
-    user_groups: &[String],
+    identity: AudienceIdentity<'_>,
 ) -> Option<(&'a str, &'a ExperienceAudience)> {
     policy.priority_order.iter().find_map(|audience_name| {
         policy
             .audiences
             .get_key_value(audience_name)
             .filter(|(_, audience)| {
-                user_groups
+                audience
+                    .subjects
                     .iter()
-                    .any(|group| group == &audience.entra_group_id)
+                    .any(|subject| subject_matches(subject, identity))
             })
             .map(|(name, audience)| (name.as_str(), audience))
     })
@@ -101,7 +167,8 @@ pub async fn starting_assistant(
 
     // Exactly one winner: if its pin fails to resolve below we degrade to the
     // welcome screen rather than falling through to the next matching audience.
-    let Some((audience_name, audience)) = match_winning_audience(&policy, &me_user.groups) else {
+    let identity = AudienceIdentity::from_profile(&me_user);
+    let Some((audience_name, audience)) = match_winning_audience(&policy, identity) else {
         return no_pin();
     };
 
@@ -127,15 +194,44 @@ pub async fn starting_assistant(
         }
     };
 
-    // Check the AUDIENCE's own access, not the caller's: revoking the audience
-    // grant must stop the pin even for users who keep personal access through
-    // a direct grant.
+    // Check the access of the SUBJECTS the caller matched on, not the caller's
+    // own: revoking the audience grant must stop the pin even for users who
+    // keep personal access through an unrelated direct grant. Any one matched
+    // subject being granted is enough — a person in two of the audience's
+    // groups is reached if either group can see the assistant.
+    //
+    // This is the last possible moment: the audience vocabulary is translated
+    // into share-grant subjects only here, at the edge where grants are read.
+    // A `user` subject is checked under both id types share grants recognise,
+    // because a grant to that person is a grant to that person however the
+    // sharer addressed them.
+    //
+    // NOTE (see PR #1072 review): the predicate below is grant interpretation
+    // in Rust that arguably belongs in the PolicyEngine; see
+    // `share_grant::is_resource_shared_with_any_subject` for why it cannot
+    // move there yet and what it would take.
+    let mut share_subjects: Vec<ShareSubject<'_>> = Vec::new();
+    for subject in matching_subjects(audience, identity) {
+        match subject {
+            AudienceSubject::Organization => share_subjects.push(ShareSubject::organization()),
+            AudienceSubject::OrganizationGroup { group_id } => {
+                share_subjects.push(ShareSubject::organization_group(group_id));
+            }
+            AudienceSubject::User {
+                organization_user_id,
+            } => {
+                share_subjects.push(ShareSubject::organization_user(organization_user_id));
+                share_subjects.push(ShareSubject::user(&me_user.id));
+            }
+        }
+    }
+
     let assistant_id = record.assistant.id.to_string();
-    match share_grant::is_resource_shared_with_organization_group(
+    match share_grant::is_resource_shared_with_any_subject(
         &app_state.db,
         "assistant",
         &assistant_id,
-        &audience.entra_group_id,
+        &share_subjects,
     )
     .await
     {
@@ -174,10 +270,39 @@ mod tests {
     use sqlx::types::Uuid;
     use std::collections::HashMap;
 
-    fn audience(entra_group_id: &str) -> ExperienceAudience {
+    fn group(group_id: &str) -> AudienceSubject {
+        AudienceSubject::OrganizationGroup {
+            group_id: group_id.to_string(),
+        }
+    }
+
+    fn person(organization_user_id: &str) -> AudienceSubject {
+        AudienceSubject::User {
+            organization_user_id: organization_user_id.to_string(),
+        }
+    }
+
+    fn audience_of(subjects: Vec<AudienceSubject>) -> ExperienceAudience {
         ExperienceAudience {
-            entra_group_id: entra_group_id.to_string(),
+            subjects,
             pinned_assistant_hub_assistant_id: Uuid::new_v4(),
+        }
+    }
+
+    /// The common single-group audience, still the shape most audiences take.
+    fn audience(group_id: &str) -> ExperienceAudience {
+        audience_of(vec![group(group_id)])
+    }
+
+    fn member_of(groups: &[&str]) -> Vec<String> {
+        groups.iter().map(|group| (*group).to_string()).collect()
+    }
+
+    /// A caller in `groups` whose identity provider issued no `oid`.
+    fn identity_of(groups: &[String]) -> AudienceIdentity<'_> {
+        AudienceIdentity {
+            groups,
+            organization_user_id: None,
         }
     }
 
@@ -200,7 +325,8 @@ mod tests {
 
     #[test]
     fn first_priority_order_entry_wins_regardless_of_map_insert_order() {
-        let user_groups = vec!["group-a".to_string(), "group-b".to_string()];
+        let user_groups = member_of(&["group-a", "group-b"]);
+        let identity = identity_of(&user_groups);
 
         // Insert the audiences in both orders: the winner must come from
         // priority_order, never from HashMap iteration/insertion order.
@@ -215,16 +341,16 @@ mod tests {
             ],
         ] {
             let policy = policy_with(entries.clone(), vec!["beta", "alpha"]);
-            let (winner, matched) = match_winning_audience(&policy, &user_groups).unwrap();
+            let (winner, matched) = match_winning_audience(&policy, identity).unwrap();
             assert_eq!(winner, "beta");
-            assert_eq!(matched.entra_group_id, "group-b");
+            assert_eq!(matched.subjects, vec![group("group-b")]);
 
             // Reversing priority_order must flip the winner: the ordered key
             // is load-bearing.
             let policy = policy_with(entries, vec!["alpha", "beta"]);
-            let (winner, matched) = match_winning_audience(&policy, &user_groups).unwrap();
+            let (winner, matched) = match_winning_audience(&policy, identity).unwrap();
             assert_eq!(winner, "alpha");
-            assert_eq!(matched.entra_group_id, "group-a");
+            assert_eq!(matched.subjects, vec![group("group-a")]);
         }
     }
 
@@ -237,8 +363,8 @@ mod tests {
             ],
             vec!["alpha", "beta"],
         );
-        let user_groups = vec!["group-b".to_string()];
-        let (winner, _) = match_winning_audience(&policy, &user_groups).unwrap();
+        let user_groups = member_of(&["group-b"]);
+        let (winner, _) = match_winning_audience(&policy, identity_of(&user_groups)).unwrap();
         assert_eq!(winner, "beta");
     }
 
@@ -246,24 +372,152 @@ mod tests {
     fn skips_unknown_priority_order_entries() {
         // The parser rejects these, but the resolver must stay total anyway.
         let policy = policy_with(vec![("beta", audience("group-b"))], vec!["ghost", "beta"]);
-        let user_groups = vec!["group-b".to_string()];
-        let (winner, _) = match_winning_audience(&policy, &user_groups).unwrap();
+        let user_groups = member_of(&["group-b"]);
+        let (winner, _) = match_winning_audience(&policy, identity_of(&user_groups)).unwrap();
         assert_eq!(winner, "beta");
     }
 
     #[test]
     fn audience_absent_from_priority_order_never_wins() {
         let policy = policy_with(vec![("alpha", audience("group-a"))], vec![]);
-        let user_groups = vec!["group-a".to_string()];
-        assert!(match_winning_audience(&policy, &user_groups).is_none());
+        let user_groups = member_of(&["group-a"]);
+        assert!(match_winning_audience(&policy, identity_of(&user_groups)).is_none());
     }
 
     #[test]
     fn no_winner_for_empty_groups_or_empty_policy() {
         let policy = policy_with(vec![("alpha", audience("group-a"))], vec!["alpha"]);
-        assert!(match_winning_audience(&policy, &[]).is_none());
+        assert!(match_winning_audience(&policy, identity_of(&[])).is_none());
 
         let empty = ExperiencePolicyDocument::default();
-        assert!(match_winning_audience(&empty, &["group-a".to_string()]).is_none());
+        let user_groups = member_of(&["group-a"]);
+        assert!(match_winning_audience(&empty, identity_of(&user_groups)).is_none());
+    }
+
+    #[test]
+    fn any_subject_of_a_multi_subject_audience_is_enough() {
+        // One audience spanning two groups and one named person: each of the
+        // three ways in reaches it on its own, and nobody else gets in.
+        let policy = policy_with(
+            vec![(
+                "rollout",
+                audience_of(vec![
+                    group("group-a"),
+                    group("group-b"),
+                    person("oid-carol"),
+                ]),
+            )],
+            vec!["rollout"],
+        );
+
+        for groups in [member_of(&["group-a"]), member_of(&["group-b"])] {
+            let (winner, _) = match_winning_audience(&policy, identity_of(&groups)).unwrap();
+            assert_eq!(winner, "rollout");
+        }
+
+        let carol = AudienceIdentity {
+            groups: &[],
+            organization_user_id: Some("oid-carol"),
+        };
+        let (winner, _) = match_winning_audience(&policy, carol).unwrap();
+        assert_eq!(winner, "rollout");
+
+        let stranger = AudienceIdentity {
+            groups: &member_of(&["group-z"]),
+            organization_user_id: Some("oid-dave"),
+        };
+        assert!(match_winning_audience(&policy, stranger).is_none());
+    }
+
+    #[test]
+    fn a_user_subject_matches_only_that_user() {
+        let policy = policy_with(
+            vec![("named", audience_of(vec![person("oid-alice")]))],
+            vec!["named"],
+        );
+
+        let alice = AudienceIdentity {
+            groups: &[],
+            organization_user_id: Some("oid-alice"),
+        };
+        assert_eq!(
+            match_winning_audience(&policy, alice).map(|(name, _)| name),
+            Some("named")
+        );
+
+        let bob = AudienceIdentity {
+            groups: &[],
+            organization_user_id: Some("oid-bob"),
+        };
+        assert!(match_winning_audience(&policy, bob).is_none());
+
+        // An identity provider that issues no `oid` cannot match a user
+        // subject — the id it would be compared against was never asserted.
+        let groups = member_of(&["oid-alice"]);
+        assert!(match_winning_audience(&policy, identity_of(&groups)).is_none());
+    }
+
+    #[test]
+    fn an_organization_audience_matches_a_user_with_no_groups() {
+        let policy = policy_with(
+            vec![("everyone", audience_of(vec![AudienceSubject::Organization]))],
+            vec!["everyone"],
+        );
+
+        let (winner, _) = match_winning_audience(&policy, identity_of(&[])).unwrap();
+        assert_eq!(winner, "everyone");
+    }
+
+    #[test]
+    fn an_organization_audience_shadows_or_defaults_by_its_place_in_the_order() {
+        let entries = vec![
+            ("everyone", audience_of(vec![AudienceSubject::Organization])),
+            ("engineering", audience("group-a")),
+        ];
+        let engineer = member_of(&["group-a"]);
+
+        // Listed last it is a catch-all: the specific audience still wins for
+        // the people it names, and everyone else falls through to it.
+        let policy = policy_with(entries.clone(), vec!["engineering", "everyone"]);
+        assert_eq!(
+            match_winning_audience(&policy, identity_of(&engineer)).map(|(name, _)| name),
+            Some("engineering")
+        );
+        assert_eq!(
+            match_winning_audience(&policy, identity_of(&[])).map(|(name, _)| name),
+            Some("everyone")
+        );
+
+        // Listed first it shadows everything below it — an org-wide rollout,
+        // deliberately, and visibly, from one ordered key.
+        let policy = policy_with(entries, vec!["everyone", "engineering"]);
+        assert_eq!(
+            match_winning_audience(&policy, identity_of(&engineer)).map(|(name, _)| name),
+            Some("everyone")
+        );
+    }
+
+    #[test]
+    fn matching_subjects_returns_every_reason_the_user_is_in_the_audience() {
+        // The eligibility check downstream needs all of them: a person in two
+        // of the audience's groups keeps the pin if either group is granted.
+        let audience = audience_of(vec![
+            group("group-a"),
+            group("group-b"),
+            group("group-c"),
+            person("oid-alice"),
+        ]);
+        let groups = member_of(&["group-a", "group-c"]);
+        let identity = AudienceIdentity {
+            groups: &groups,
+            organization_user_id: Some("oid-alice"),
+        };
+
+        assert_eq!(
+            matching_subjects(&audience, identity),
+            vec![&group("group-a"), &group("group-c"), &person("oid-alice")]
+        );
+
+        assert!(matching_subjects(&audience, identity_of(&[])).is_empty());
     }
 }

--- a/backend/erato/tests/integration_tests/api/mod.rs
+++ b/backend/erato/tests/integration_tests/api/mod.rs
@@ -15,3 +15,4 @@ pub mod messages;
 pub mod sharepoint;
 pub mod sharing;
 pub mod starter_prompts;
+pub mod starting_assistant;

--- a/backend/erato/tests/integration_tests/api/starting_assistant.rs
+++ b/backend/erato/tests/integration_tests/api/starting_assistant.rs
@@ -7,7 +7,9 @@ use erato::config::{
 };
 use erato::db::entity::prelude::ShareGrants;
 use erato::db::entity::share_grants;
-use erato::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use erato::distribution::experience_policy::{
+    AudienceSubject, ExperienceAudience, ExperiencePolicyDocument,
+};
 use erato::policy::engine::PolicyEngine;
 use erato::state::AppState;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -49,21 +51,47 @@ fn starting_assistant_app_config() -> erato::config::AppConfig {
     app_config
 }
 
+fn group_subject(group_id: &str) -> AudienceSubject {
+    AudienceSubject::OrganizationGroup {
+        group_id: group_id.to_string(),
+    }
+}
+
+fn user_subject(organization_user_id: &str) -> AudienceSubject {
+    AudienceSubject::User {
+        organization_user_id: organization_user_id.to_string(),
+    }
+}
+
 /// Install an experience policy on the running app state, replacing any
-/// previous one. Entries are `(audience_name, entra_group_id, pinned_hub_id)`;
-/// their order controls `HashMap` insertion order, deliberately independent of
-/// `priority_order`.
+/// previous one. Entries are `(audience_name, group_id, pinned_hub_id)` — the
+/// single-group audience, still the common case. Their order controls `HashMap`
+/// insertion order, deliberately independent of `priority_order`.
 async fn install_policy(
     app_state: &AppState,
     entries: Vec<(&str, &str, Uuid)>,
     priority_order: Vec<&str>,
 ) {
+    let entries = entries
+        .into_iter()
+        .map(|(name, group_id, hub_id)| (name, vec![group_subject(group_id)], hub_id))
+        .collect();
+    install_policy_with_subjects(app_state, entries, priority_order).await;
+}
+
+/// [`install_policy`] for audiences composed of several subjects — groups,
+/// named individuals, the whole organization, in any mix.
+async fn install_policy_with_subjects(
+    app_state: &AppState,
+    entries: Vec<(&str, Vec<AudienceSubject>, Uuid)>,
+    priority_order: Vec<&str>,
+) {
     let mut audiences = HashMap::new();
-    for (name, entra_group_id, pinned_assistant_hub_assistant_id) in entries {
+    for (name, subjects, pinned_assistant_hub_assistant_id) in entries {
         audiences.insert(
             name.to_string(),
             ExperienceAudience {
-                entra_group_id: entra_group_id.to_string(),
+                subjects,
                 pinned_assistant_hub_assistant_id,
             },
         );
@@ -96,6 +124,26 @@ async fn create_source_assistant(
     .expect("failed to create source assistant")
 }
 
+/// A viewer `audience_grants` entry for a directory group.
+fn group_grant(group_id: &str) -> Value {
+    json!({
+        "subject_type": "organization_group",
+        "subject_id_type": "organization_group_id",
+        "subject_id": group_id,
+        "role": "viewer"
+    })
+}
+
+/// A viewer `audience_grants` entry covering the whole organization.
+fn organization_grant() -> Value {
+    json!({
+        "subject_type": "organization",
+        "subject_id_type": "organization_id",
+        "subject_id": "__organization__",
+        "role": "viewer"
+    })
+}
+
 /// Submit, review-accept, publish and mark current a hub version for the
 /// given source assistant, granting the audience group viewer access. Returns
 /// the submitted version JSON (including `hub_assistant_id` and the clone
@@ -108,6 +156,28 @@ async fn publish_hub_version(
     version_number: &str,
     audience_group_id: &str,
 ) -> Value {
+    publish_hub_version_with_grants(
+        server,
+        owner_token,
+        reviewer_token,
+        source_assistant_id,
+        version_number,
+        vec![group_grant(audience_group_id)],
+    )
+    .await
+}
+
+/// [`publish_hub_version`] with arbitrary audience grants, so a published
+/// assistant can be reachable by a group, a named person, or the whole
+/// organization — whatever the audience being tested is composed of.
+async fn publish_hub_version_with_grants(
+    server: &TestServer,
+    owner_token: &str,
+    reviewer_token: &str,
+    source_assistant_id: &str,
+    version_number: &str,
+    audience_grants: Vec<Value>,
+) -> Value {
     let submission_response = server
         .post(&format!(
             "/api/v1beta/assistant-hub/assistants/{source_assistant_id}/versions"
@@ -119,12 +189,7 @@ async fn publish_hub_version(
             "version_number": version_number,
             "version_comment": "Submission for starting-assistant tests",
             "creator_review_comment": "Ready for review",
-            "audience_grants": [{
-                "subject_type": "organization_group",
-                "subject_id_type": "organization_group_id",
-                "subject_id": audience_group_id,
-                "role": "viewer"
-            }]
+            "audience_grants": audience_grants
         }))
         .with_bearer_token(owner_token)
         .await;
@@ -591,6 +656,258 @@ async fn test_starting_assistant_absent_without_policy_or_membership(pool: Pool<
     .await;
     let body = get_starting_assistant(&server, &outsider_token).await;
     assert!(body.get("starting_assistant").is_none());
+}
+
+/// An audience whose only subject is the whole organization applies to every
+/// authenticated caller, including one carrying no `groups` claim at all —
+/// "this applies to everyone", not "everyone not matched above".
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_organization_audience_matches_a_user_with_no_groups(
+    pool: Pool<Postgres>,
+) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("org-audience-owner")
+        .email("org-audience-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("org-audience-reviewer")
+        .email("org-audience-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    // No `.groups(..)` at all: the claim is absent, not merely empty.
+    let grouplessviewer_token = JwtTokenBuilder::new()
+        .subject("org-audience-groupless")
+        .email("org-audience-groupless@example.com")
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "org-audience-owner",
+        Some("org-audience-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+    let source_assistant =
+        create_source_assistant(&app_state, &owner.id.to_string(), "Org Wide Assistant").await;
+
+    let version = publish_hub_version_with_grants(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "1.0.0",
+        vec![organization_grant()],
+    )
+    .await;
+    let hub_assistant_id: Uuid = version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let assistant_id = version["assistant_id"].as_str().unwrap().to_string();
+
+    install_policy_with_subjects(
+        &app_state,
+        vec![(
+            "everyone",
+            vec![AudienceSubject::Organization],
+            hub_assistant_id,
+        )],
+        vec!["everyone"],
+    )
+    .await;
+
+    let body = get_starting_assistant(&server, &grouplessviewer_token).await;
+    let pinned = body["starting_assistant"]
+        .as_object()
+        .expect("an organization audience should reach a caller with no groups");
+    assert_eq!(pinned["audience"], "everyone");
+    assert_eq!(pinned["assistant_id"], assistant_id.as_str());
+}
+
+/// A `user` subject names exactly one person, by the directory id the token
+/// carries in `oid` — so a colleague with no matching claim gets nothing, and
+/// no group has to be created for a one-person audience.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_user_subject_matches_only_that_user(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    const ALICE_OID: &str = "5f0b6a7c-1111-4222-8333-alice0000001";
+    const BOB_OID: &str = "5f0b6a7c-1111-4222-8333-bob000000002";
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("user-subject-owner")
+        .email("user-subject-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("user-subject-reviewer")
+        .email("user-subject-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    let alice_token = JwtTokenBuilder::new()
+        .subject("user-subject-alice")
+        .email("user-subject-alice@example.com")
+        .organization_user_id(ALICE_OID)
+        .build();
+    let bob_token = JwtTokenBuilder::new()
+        .subject("user-subject-bob")
+        .email("user-subject-bob@example.com")
+        .organization_user_id(BOB_OID)
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "user-subject-owner",
+        Some("user-subject-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+    let source_assistant =
+        create_source_assistant(&app_state, &owner.id.to_string(), "Named Person Assistant").await;
+
+    // Granted org-wide, so reachability is identical for both callers and the
+    // only thing under test is whether the audience matched them.
+    let version = publish_hub_version_with_grants(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "1.0.0",
+        vec![organization_grant()],
+    )
+    .await;
+    let hub_assistant_id: Uuid = version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    install_policy_with_subjects(
+        &app_state,
+        vec![(
+            "alice-only",
+            vec![user_subject(ALICE_OID)],
+            hub_assistant_id,
+        )],
+        vec!["alice-only"],
+    )
+    .await;
+
+    let body = get_starting_assistant(&server, &alice_token).await;
+    assert_eq!(
+        body["starting_assistant"]["audience"], "alice-only",
+        "the named person should get the pin"
+    );
+
+    let body = get_starting_assistant(&server, &bob_token).await;
+    assert!(
+        body.get("starting_assistant").is_none(),
+        "a user subject must not spill over to anyone else"
+    );
+}
+
+/// An audience spanning several groups reaches a member of any of them, and the
+/// eligibility check follows the subject that actually matched: being in a
+/// second group of the same audience is no help when that group was never
+/// granted the assistant.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_multi_group_audience_checks_the_matched_subject(
+    pool: Pool<Postgres>,
+) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("multi-subject-owner")
+        .email("multi-subject-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("multi-subject-reviewer")
+        .email("multi-subject-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    let granted_member_token = JwtTokenBuilder::new()
+        .subject("multi-subject-granted")
+        .email("multi-subject-granted@example.com")
+        .groups(vec![AUDIENCE_GROUP_ID.to_string()])
+        .build();
+    let ungranted_member_token = JwtTokenBuilder::new()
+        .subject("multi-subject-ungranted")
+        .email("multi-subject-ungranted@example.com")
+        .groups(vec![SECOND_AUDIENCE_GROUP_ID.to_string()])
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "multi-subject-owner",
+        Some("multi-subject-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+    let source_assistant =
+        create_source_assistant(&app_state, &owner.id.to_string(), "Multi Group Assistant").await;
+
+    // Only the FIRST group is granted the assistant, though both are in the
+    // audience.
+    let version = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "1.0.0",
+        AUDIENCE_GROUP_ID,
+    )
+    .await;
+    let hub_assistant_id: Uuid = version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    install_policy_with_subjects(
+        &app_state,
+        vec![(
+            "rollout",
+            vec![
+                group_subject(AUDIENCE_GROUP_ID),
+                group_subject(SECOND_AUDIENCE_GROUP_ID),
+            ],
+            hub_assistant_id,
+        )],
+        vec!["rollout"],
+    )
+    .await;
+
+    let body = get_starting_assistant(&server, &granted_member_token).await;
+    assert_eq!(
+        body["starting_assistant"]["audience"], "rollout",
+        "a member of the granted group should get the pin"
+    );
+
+    let body = get_starting_assistant(&server, &ungranted_member_token).await;
+    assert!(
+        body.get("starting_assistant").is_none(),
+        "matching the audience through a group that cannot see the assistant must not pin it"
+    );
 }
 
 /// The endpoint sits behind the `/me` authentication middleware.

--- a/backend/erato/tests/integration_tests/api/starting_assistant.rs
+++ b/backend/erato/tests/integration_tests/api/starting_assistant.rs
@@ -1,0 +1,608 @@
+//! Starting assistant (audience pin) API endpoint integration tests.
+
+use axum::http;
+use axum_test::TestServer;
+use erato::config::{
+    AssistantHubCategoryConfig, AssistantHubReviewerPermissionsConfig, AssistantHubReviewerRule,
+};
+use erato::db::entity::prelude::ShareGrants;
+use erato::db::entity::share_grants;
+use erato::distribution::experience_policy::{ExperienceAudience, ExperiencePolicyDocument};
+use erato::policy::engine::PolicyEngine;
+use erato::state::AppState;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde_json::{Value, json};
+use sqlx::Pool;
+use sqlx::postgres::Postgres;
+use sqlx::types::Uuid;
+use std::collections::HashMap;
+
+use crate::test_app_state;
+use crate::test_utils::{
+    JwtTokenBuilder, TEST_USER_ISSUER, TestRequestAuthExt, create_test_server, hermetic_app_config,
+};
+
+const REVIEWER_GROUP_ID: &str = "starting-assistant-reviewers";
+const AUDIENCE_GROUP_ID: &str = "starting-assistant-audience";
+const SECOND_AUDIENCE_GROUP_ID: &str = "starting-assistant-second-audience";
+const STORE_CATEGORY_ID: &str = "productivity";
+
+fn starting_assistant_app_config() -> erato::config::AppConfig {
+    let mut app_config = hermetic_app_config(None, None);
+    app_config.assistant_hub.enabled = true;
+    app_config.assistant_hub.reviewers = AssistantHubReviewerPermissionsConfig {
+        rules: [(
+            "test-reviewers".to_string(),
+            AssistantHubReviewerRule::AllowForGroupMembers {
+                groups: vec![REVIEWER_GROUP_ID.to_string()],
+            },
+        )]
+        .into(),
+    };
+    app_config.assistant_hub.categories.insert(
+        STORE_CATEGORY_ID.to_string(),
+        AssistantHubCategoryConfig {
+            display_name: "Productivity".to_string(),
+            icon: "Bot".to_string(),
+        },
+    );
+    app_config
+}
+
+/// Install an experience policy on the running app state, replacing any
+/// previous one. Entries are `(audience_name, entra_group_id, pinned_hub_id)`;
+/// their order controls `HashMap` insertion order, deliberately independent of
+/// `priority_order`.
+async fn install_policy(
+    app_state: &AppState,
+    entries: Vec<(&str, &str, Uuid)>,
+    priority_order: Vec<&str>,
+) {
+    let mut audiences = HashMap::new();
+    for (name, entra_group_id, pinned_assistant_hub_assistant_id) in entries {
+        audiences.insert(
+            name.to_string(),
+            ExperienceAudience {
+                entra_group_id: entra_group_id.to_string(),
+                pinned_assistant_hub_assistant_id,
+            },
+        );
+    }
+    let document = ExperiencePolicyDocument {
+        audiences,
+        priority_order: priority_order.into_iter().map(String::from).collect(),
+    };
+    app_state.reloadable.write().await.experience_policy = Some(document);
+}
+
+async fn create_source_assistant(
+    app_state: &AppState,
+    owner_id: &str,
+    name: &str,
+) -> erato::db::entity::assistants::Model {
+    erato::models::assistant::create_assistant(
+        &app_state.db,
+        &PolicyEngine::new(),
+        &erato::policy::types::Subject::User(owner_id.to_string()),
+        name.to_string(),
+        Some("Source draft description".to_string()),
+        "You are a starting-assistant test fixture.".to_string(),
+        None,
+        None,
+        Some("mock-llm".to_string()),
+        false,
+    )
+    .await
+    .expect("failed to create source assistant")
+}
+
+/// Submit, review-accept, publish and mark current a hub version for the
+/// given source assistant, granting the audience group viewer access. Returns
+/// the submitted version JSON (including `hub_assistant_id` and the clone
+/// `assistant_id`).
+async fn publish_hub_version(
+    server: &TestServer,
+    owner_token: &str,
+    reviewer_token: &str,
+    source_assistant_id: &str,
+    version_number: &str,
+    audience_group_id: &str,
+) -> Value {
+    let submission_response = server
+        .post(&format!(
+            "/api/v1beta/assistant-hub/assistants/{source_assistant_id}/versions"
+        ))
+        .json(&json!({
+            "long_description": "A reviewed assistant pinned for an audience.",
+            "category_ids": [STORE_CATEGORY_ID],
+            "keywords": ["starting", "assistant"],
+            "version_number": version_number,
+            "version_comment": "Submission for starting-assistant tests",
+            "creator_review_comment": "Ready for review",
+            "audience_grants": [{
+                "subject_type": "organization_group",
+                "subject_id_type": "organization_group_id",
+                "subject_id": audience_group_id,
+                "role": "viewer"
+            }]
+        }))
+        .with_bearer_token(owner_token)
+        .await;
+    assert_eq!(submission_response.status_code(), http::StatusCode::CREATED);
+    let submitted: Value = submission_response.json();
+    let version_id = submitted["version"]["version_id"]
+        .as_str()
+        .expect("submitted version should include version_id")
+        .to_string();
+
+    let review_response = server
+        .post(&format!(
+            "/api/v1beta/assistant-hub/versions/{version_id}/review"
+        ))
+        .json(&json!({
+            "accepted": true,
+            "reviewer_review_comment": "Accepted"
+        }))
+        .with_bearer_token(reviewer_token)
+        .await;
+    assert_eq!(review_response.status_code(), http::StatusCode::OK);
+
+    let publish_response = server
+        .put(&format!(
+            "/api/v1beta/assistant-hub/versions/{version_id}/published"
+        ))
+        .json(&json!({ "is_published": true }))
+        .with_bearer_token(owner_token)
+        .await;
+    assert_eq!(publish_response.status_code(), http::StatusCode::OK);
+
+    let current_response = server
+        .put(&format!(
+            "/api/v1beta/assistant-hub/versions/{version_id}/current"
+        ))
+        .with_bearer_token(owner_token)
+        .await;
+    assert_eq!(current_response.status_code(), http::StatusCode::OK);
+
+    submitted["version"].clone()
+}
+
+async fn get_starting_assistant(server: &TestServer, token: &str) -> Value {
+    let response = server
+        .get("/api/v1beta/me/starting-assistant")
+        .with_bearer_token(token)
+        .await;
+    response.assert_status_ok();
+    response.json()
+}
+
+/// The pin stores the stable hub id, so after a republish the endpoint must
+/// serve the new clone's `assistants.id` without any change to the policy
+/// document.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_tracks_current_published_version_across_republish(
+    pool: Pool<Postgres>,
+) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-owner")
+        .email("starting-assistant-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-reviewer")
+        .email("starting-assistant-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    let viewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-viewer")
+        .email("starting-assistant-viewer@example.com")
+        .groups(vec![AUDIENCE_GROUP_ID.to_string()])
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "starting-assistant-owner",
+        Some("starting-assistant-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+    let source_assistant = create_source_assistant(
+        &app_state,
+        &owner.id.to_string(),
+        "Pinned Starting Assistant",
+    )
+    .await;
+
+    let v1 = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "1.0.0",
+        AUDIENCE_GROUP_ID,
+    )
+    .await;
+    let hub_assistant_id = v1["hub_assistant_id"]
+        .as_str()
+        .expect("version should include hub_assistant_id")
+        .to_string();
+    let v1_assistant_id = v1["assistant_id"].as_str().unwrap().to_string();
+
+    install_policy(
+        &app_state,
+        vec![(
+            "pilot",
+            AUDIENCE_GROUP_ID,
+            hub_assistant_id.parse().unwrap(),
+        )],
+        vec!["pilot"],
+    )
+    .await;
+
+    let body = get_starting_assistant(&server, &viewer_token).await;
+    let pinned = body["starting_assistant"]
+        .as_object()
+        .expect("starting_assistant should be present for the audience member");
+    assert_eq!(pinned["assistant_id"], v1_assistant_id.as_str());
+    assert_eq!(pinned["assistant_hub_assistant_id"], hub_assistant_id);
+    assert_eq!(pinned["audience"], "pilot");
+
+    // Republish: v2 mints a fresh clone `assistants.id` under the SAME hub id.
+    let v2 = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "2.0.0",
+        AUDIENCE_GROUP_ID,
+    )
+    .await;
+    assert_eq!(v2["hub_assistant_id"], hub_assistant_id);
+    let v2_assistant_id = v2["assistant_id"].as_str().unwrap().to_string();
+    assert_ne!(
+        v1_assistant_id, v2_assistant_id,
+        "republish should mint a fresh clone assistants.id"
+    );
+
+    // The policy document was NOT touched — the endpoint must now serve the
+    // v2 clone id because the pin stores the stable hub id.
+    let body = get_starting_assistant(&server, &viewer_token).await;
+    let pinned = body["starting_assistant"]
+        .as_object()
+        .expect("starting_assistant should still be present after republish");
+    assert_eq!(pinned["assistant_id"], v2_assistant_id.as_str());
+    assert_eq!(pinned["assistant_hub_assistant_id"], hub_assistant_id);
+}
+
+/// Revoking the AUDIENCE's share grant must clear the pin even for a user who
+/// retains personal access to the pinned assistant.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_absent_when_audience_grant_revoked(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-revoke-owner")
+        .email("starting-assistant-revoke-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-revoke-reviewer")
+        .email("starting-assistant-revoke-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    let viewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-revoke-viewer")
+        .email("starting-assistant-revoke-viewer@example.com")
+        .groups(vec![AUDIENCE_GROUP_ID.to_string()])
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "starting-assistant-revoke-owner",
+        Some("starting-assistant-revoke-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+    let viewer = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "starting-assistant-revoke-viewer",
+        Some("starting-assistant-revoke-viewer@example.com"),
+    )
+    .await
+    .expect("failed to create viewer");
+
+    let source_assistant = create_source_assistant(
+        &app_state,
+        &owner.id.to_string(),
+        "Revocable Starting Assistant",
+    )
+    .await;
+
+    let version = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &source_assistant.id.to_string(),
+        "1.0.0",
+        AUDIENCE_GROUP_ID,
+    )
+    .await;
+    let hub_assistant_id: Uuid = version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let clone_assistant_id = version["assistant_id"].as_str().unwrap().to_string();
+    let group_grant = ShareGrants::find()
+        .filter(share_grants::Column::ResourceType.eq("assistant"))
+        .filter(share_grants::Column::ResourceId.eq(clone_assistant_id.clone()))
+        .filter(share_grants::Column::SubjectType.eq("organization_group"))
+        .filter(share_grants::Column::SubjectId.eq(AUDIENCE_GROUP_ID))
+        .one(&app_state.db)
+        .await
+        .expect("failed to query the audience grant")
+        .expect("publishing should have created the audience grant");
+    let group_grant_id = group_grant.id.to_string();
+
+    install_policy(
+        &app_state,
+        vec![("pilot", AUDIENCE_GROUP_ID, hub_assistant_id)],
+        vec!["pilot"],
+    )
+    .await;
+
+    // Sanity: the pin applies before the revocation.
+    let body = get_starting_assistant(&server, &viewer_token).await;
+    assert!(
+        body["starting_assistant"].is_object(),
+        "pin should apply before the audience grant is revoked"
+    );
+
+    // Grant the viewer PERSONAL access to the clone assistant, then revoke
+    // the audience grant. The personal grant must not keep the pin alive.
+    let personal_grant_response = server
+        .post("/api/v1beta/share-grants")
+        .json(&json!({
+            "resource_type": "assistant",
+            "resource_id": clone_assistant_id,
+            "subject_type": "user",
+            "subject_id_type": "id",
+            "subject_id": viewer.id.to_string(),
+            "role": "viewer"
+        }))
+        .with_bearer_token(&owner_token)
+        .await;
+    assert_eq!(
+        personal_grant_response.status_code(),
+        http::StatusCode::CREATED
+    );
+
+    let delete_response = server
+        .delete(&format!("/api/v1beta/share-grants/{group_grant_id}"))
+        .with_bearer_token(&owner_token)
+        .await;
+    assert_eq!(delete_response.status_code(), http::StatusCode::NO_CONTENT);
+
+    // The viewer still sees the assistant in the hub through the personal
+    // grant — proving the absent pin below comes from the audience check,
+    // not from lost access.
+    let hub_response = server
+        .get("/api/v1beta/assistant-hub/assistants")
+        .with_bearer_token(&viewer_token)
+        .await;
+    hub_response.assert_status_ok();
+    let hub_body: Value = hub_response.json();
+    assert_eq!(hub_body["versions"].as_array().unwrap().len(), 1);
+
+    let body = get_starting_assistant(&server, &viewer_token).await;
+    assert!(
+        body.get("starting_assistant").is_none(),
+        "revoking the audience grant must clear the pin despite personal access"
+    );
+}
+
+/// A pin naming a hub assistant that does not exist (or is not published)
+/// degrades to the welcome screen with status 200.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_absent_for_stale_hub_id(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let viewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-stale-viewer")
+        .email("starting-assistant-stale-viewer@example.com")
+        .groups(vec![AUDIENCE_GROUP_ID.to_string()])
+        .build();
+
+    install_policy(
+        &app_state,
+        vec![("pilot", AUDIENCE_GROUP_ID, Uuid::new_v4())],
+        vec!["pilot"],
+    )
+    .await;
+
+    let body = get_starting_assistant(&server, &viewer_token).await;
+    assert!(
+        body.get("starting_assistant").is_none(),
+        "an unresolvable hub id must degrade to no pin, not an error"
+    );
+}
+
+/// A user in two audiences gets the one earlier in `priority_order`, stable
+/// across repeated requests and across `HashMap` insertion orders; reversing
+/// `priority_order` flips the winner.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_two_audiences_priority_order_decides(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let owner_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-order-owner")
+        .email("starting-assistant-order-owner@example.com")
+        .build();
+    let reviewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-order-reviewer")
+        .email("starting-assistant-order-reviewer@example.com")
+        .groups(vec![REVIEWER_GROUP_ID.to_string()])
+        .build();
+    // The viewer belongs to BOTH audiences.
+    let viewer_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-order-viewer")
+        .email("starting-assistant-order-viewer@example.com")
+        .groups(vec![
+            AUDIENCE_GROUP_ID.to_string(),
+            SECOND_AUDIENCE_GROUP_ID.to_string(),
+        ])
+        .build();
+
+    let owner = erato::models::user::get_or_create_user(
+        &app_state.db,
+        TEST_USER_ISSUER,
+        "starting-assistant-order-owner",
+        Some("starting-assistant-order-owner@example.com"),
+    )
+    .await
+    .expect("failed to create owner");
+
+    let first_source = create_source_assistant(
+        &app_state,
+        &owner.id.to_string(),
+        "First Audience Assistant",
+    )
+    .await;
+    let second_source = create_source_assistant(
+        &app_state,
+        &owner.id.to_string(),
+        "Second Audience Assistant",
+    )
+    .await;
+
+    let first_version = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &first_source.id.to_string(),
+        "1.0.0",
+        AUDIENCE_GROUP_ID,
+    )
+    .await;
+    let second_version = publish_hub_version(
+        &server,
+        &owner_token,
+        &reviewer_token,
+        &second_source.id.to_string(),
+        "1.0.0",
+        SECOND_AUDIENCE_GROUP_ID,
+    )
+    .await;
+
+    let first_hub_id: Uuid = first_version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let second_hub_id: Uuid = second_version["hub_assistant_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let first_assistant_id = first_version["assistant_id"].as_str().unwrap().to_string();
+    let second_assistant_id = second_version["assistant_id"].as_str().unwrap().to_string();
+
+    // Rebuild the policy with the audiences inserted into the HashMap in both
+    // orders: the winner must always be the first entry of priority_order.
+    for entries in [
+        vec![
+            ("alpha", AUDIENCE_GROUP_ID, first_hub_id),
+            ("beta", SECOND_AUDIENCE_GROUP_ID, second_hub_id),
+        ],
+        vec![
+            ("beta", SECOND_AUDIENCE_GROUP_ID, second_hub_id),
+            ("alpha", AUDIENCE_GROUP_ID, first_hub_id),
+        ],
+    ] {
+        install_policy(&app_state, entries.clone(), vec!["alpha", "beta"]).await;
+        // Repeat the request: the winner must be stable run over run.
+        for _ in 0..3 {
+            let body = get_starting_assistant(&server, &viewer_token).await;
+            let pinned = &body["starting_assistant"];
+            assert_eq!(pinned["audience"], "alpha");
+            assert_eq!(pinned["assistant_id"], first_assistant_id.as_str());
+        }
+
+        // Reversing priority_order must flip the winner: precedence lives in
+        // the ordered key alone, never in map iteration order.
+        install_policy(&app_state, entries, vec!["beta", "alpha"]).await;
+        let body = get_starting_assistant(&server, &viewer_token).await;
+        let pinned = &body["starting_assistant"];
+        assert_eq!(pinned["audience"], "beta");
+        assert_eq!(pinned["assistant_id"], second_assistant_id.as_str());
+    }
+}
+
+/// No policy, and policy without a matching audience, both yield an absent
+/// pin with status 200.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_absent_without_policy_or_membership(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let outsider_token = JwtTokenBuilder::new()
+        .subject("starting-assistant-outsider")
+        .email("starting-assistant-outsider@example.com")
+        .groups(vec!["some-unrelated-group".to_string()])
+        .build();
+
+    // No policy loaded at all (reloadable default).
+    let body = get_starting_assistant(&server, &outsider_token).await;
+    assert!(body.get("starting_assistant").is_none());
+
+    // A policy exists but the user is in none of its audiences.
+    install_policy(
+        &app_state,
+        vec![("pilot", AUDIENCE_GROUP_ID, Uuid::new_v4())],
+        vec!["pilot"],
+    )
+    .await;
+    let body = get_starting_assistant(&server, &outsider_token).await;
+    assert!(body.get("starting_assistant").is_none());
+}
+
+/// The endpoint sits behind the `/me` authentication middleware.
+///
+/// # Test Categories
+/// - `uses-db`
+/// - `auth-required`
+#[sqlx::test(migrator = "crate::MIGRATOR")]
+async fn test_starting_assistant_requires_authentication(pool: Pool<Postgres>) {
+    let app_state = test_app_state(starting_assistant_app_config(), pool).await;
+    let server = create_test_server(app_state.clone());
+
+    let response = server.get("/api/v1beta/me/starting-assistant").await;
+    assert_eq!(response.status_code(), http::StatusCode::UNAUTHORIZED);
+}

--- a/backend/generated/openapi.json
+++ b/backend/generated/openapi.json
@@ -2921,6 +2921,34 @@
         ]
       }
     },
+    "/api/v1beta/me/starting-assistant": {
+      "get": {
+        "tags": [
+          "starting_assistant"
+        ],
+        "operationId": "starting_assistant",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartingAssistantResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "When no valid JWT token is provided"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/v1beta/messages": {
       "get": {
         "tags": [],
@@ -8275,6 +8303,39 @@
             "items": {
               "$ref": "#/components/schemas/StarterPromptInfo"
             }
+          }
+        }
+      },
+      "StartingAssistantInfo": {
+        "type": "object",
+        "description": "The resolved starting assistant for the calling user.",
+        "required": [
+          "assistant_id",
+          "assistant_hub_assistant_id",
+          "audience"
+        ],
+        "properties": {
+          "assistant_hub_assistant_id": {
+            "type": "string",
+            "description": "The stable `assistant_hub_assistants.id` the admin pinned."
+          },
+          "assistant_id": {
+            "type": "string",
+            "description": "The live `assistants.id` of the current published version. Resolved at\nread time from the pinned hub id, so it is always the id a client can\nopen a chat with — even right after a republish minted a fresh clone."
+          },
+          "audience": {
+            "type": "string",
+            "description": "The name of the audience (policy key) whose pin won for this user."
+          }
+        }
+      },
+      "StartingAssistantResponse": {
+        "type": "object",
+        "description": "Response for `GET /me/starting-assistant`.",
+        "properties": {
+          "starting_assistant": {
+            "$ref": "#/components/schemas/StartingAssistantInfo",
+            "description": "Absent when no pin applies to the calling user; the client shows the\nordinary welcome screen."
           }
         }
       },

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiComponents.ts
@@ -5600,6 +5600,115 @@ export const useStarterPrompts = <TData = Schemas.StarterPromptsResponse,>(
   });
 };
 
+export type StartingAssistantError = Fetcher.ErrorWrapper<undefined>;
+
+export type StartingAssistantVariables = V1betaApiContext["fetcherOptions"];
+
+export const fetchStartingAssistant = (
+  variables: StartingAssistantVariables,
+  signal?: AbortSignal,
+) =>
+  v1betaApiFetch<
+    Schemas.StartingAssistantResponse,
+    StartingAssistantError,
+    undefined,
+    {},
+    {},
+    {}
+  >({
+    url: "/api/v1beta/me/starting-assistant",
+    method: "get",
+    ...variables,
+    signal,
+  });
+
+export function startingAssistantQuery(variables: StartingAssistantVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (
+    options: QueryFnOptions,
+  ) => Promise<Schemas.StartingAssistantResponse>;
+};
+
+export function startingAssistantQuery(
+  variables: StartingAssistantVariables | reactQuery.SkipToken,
+): {
+  queryKey: reactQuery.QueryKey;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.StartingAssistantResponse>)
+    | reactQuery.SkipToken;
+};
+
+export function startingAssistantQuery(
+  variables: StartingAssistantVariables | reactQuery.SkipToken,
+) {
+  return {
+    queryKey: queryKeyFn({
+      path: "/api/v1beta/me/starting-assistant",
+      operationId: "startingAssistant",
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({ signal }: QueryFnOptions) =>
+            fetchStartingAssistant(variables, signal),
+  };
+}
+
+export const useSuspenseStartingAssistant = <
+  TData = Schemas.StartingAssistantResponse,
+>(
+  variables: StartingAssistantVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.StartingAssistantResponse,
+      StartingAssistantError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useV1betaApiContext(options);
+  return reactQuery.useSuspenseQuery<
+    Schemas.StartingAssistantResponse,
+    StartingAssistantError,
+    TData
+  >({
+    ...startingAssistantQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export const useStartingAssistant = <
+  TData = Schemas.StartingAssistantResponse,
+>(
+  variables: StartingAssistantVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<
+      Schemas.StartingAssistantResponse,
+      StartingAssistantError,
+      TData
+    >,
+    "queryKey" | "queryFn" | "initialData"
+  >,
+) => {
+  const { queryOptions, fetcherOptions } = useV1betaApiContext(options);
+  return reactQuery.useQuery<
+    Schemas.StartingAssistantResponse,
+    StartingAssistantError,
+    TData
+  >({
+    ...startingAssistantQuery(
+      variables === reactQuery.skipToken
+        ? variables
+        : deepMerge(fetcherOptions, variables),
+    ),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type MessagesError = Fetcher.ErrorWrapper<undefined>;
 
 export type MessagesResponse = Schemas.Message[];
@@ -6966,6 +7075,11 @@ export type QueryOperation =
       path: "/api/v1beta/me/starter-prompts";
       operationId: "starterPrompts";
       variables: StarterPromptsVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: "/api/v1beta/me/starting-assistant";
+      operationId: "startingAssistant";
+      variables: StartingAssistantVariables | reactQuery.SkipToken;
     }
   | {
       path: "/api/v1beta/messages";

--- a/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
+++ b/frontend/src/lib/generated/v1betaApi/v1betaApiSchemas.ts
@@ -2348,6 +2348,33 @@ export type StarterPromptsResponse = {
   starter_prompts: StarterPromptInfo[];
 };
 
+/**
+ * The resolved starting assistant for the calling user.
+ */
+export type StartingAssistantInfo = {
+  /**
+   * The stable `assistant_hub_assistants.id` the admin pinned.
+   */
+  assistant_hub_assistant_id: string;
+  /**
+   * The live `assistants.id` of the current published version. Resolved at
+   * read time from the pinned hub id, so it is always the id a client can
+   * open a chat with — even right after a republish minted a fresh clone.
+   */
+  assistant_id: string;
+  /**
+   * The name of the audience (policy key) whose pin won for this user.
+   */
+  audience: string;
+};
+
+/**
+ * Response for `GET /me/starting-assistant`.
+ */
+export type StartingAssistantResponse = {
+  starting_assistant?: StartingAssistantInfo;
+};
+
 export type TokenUsageFileInput = {
   /**
    * File upload IDs to include in estimation.


### PR DESCRIPTION
Stack 2/3. Base: `feature/ermain-694-experience-policy-source-type` — review that one first.

Turns the org-wide policy document into **one answer for one person**, on an authenticated endpoint.

Linear: ERMAIN-695 (parent: ERMAIN-693)

## `GET /api/v1beta/me/starting-assistant`

Resolution, in order:

1. audiences matched = policy audiences whose `entra_group_id` is in `MeProfile.groups`
2. winner = `priority_order.iter().find_map(...)`
3. eligibility = the pinned hub assistant is *still* shared with that audience
4. resolve to the live `assistants.id` via `get_published_current_version`
5. any step yielding `None` degrades to no pin — **always 200, never an error**

## Three things that were easy to get wrong

**It is on `/me`, not `/public/common`.** The runtime-translation routes sit on the root router next to `/health`, outside the authenticated tree, with no `MeProfile` in scope. That is right for translations — identical for every user — and wrong for a landing directive. `distribution/mod.rs` states the rule: nothing user-scoped belongs in a `DistributionBundle`. So the *document* is org-wide (the bundle is fine) and the *resolution* is per-user.

**It matches `MeProfile.groups`, not the subject's `organization_group_ids`.** Those are distinct rego inputs; passing the wrong one yields a silent empty match rather than an error. (The share-eligibility check separately and correctly uses the group id as an `organization_group_id` subject — that is the share-grant subject type, not the audience match.)

**Eligibility is a real check.** A grant can be revoked in Erato with no knowledge of the panel, and hub grants are recreated per version against the cloned assistant — so a pin valid at write time can dangle at read time. Degrading to the welcome screen is explicit, not emergent; the alternative is a redirect loop into a 403.

New helper `is_resource_shared_with_organization_group` in `models/share_grant.rs`.

## Wire contract note (cross-repo)

Key names settled during implementation and differ from the original ticket sketch: `priority_order` (not `resolution_order`), `entra_group_id`, `pinned_assistant_hub_assistant_id`. The authority is `parse_experience_policy`. The admin panel codes against this; the Linear issues have been updated to match.