### PR TITLE
Improve frontend bundle spliting; Bucket icon catalogs

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,4 +1,10 @@
+import { fileURLToPath, URL } from "node:url";
+
 import type { StorybookConfig } from "@storybook/react-vite";
+
+import { iconCatalogPlugin } from "../vite.icon-catalogs";
+
+const frontendRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
@@ -21,5 +27,12 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript",
     check: false,
   },
+  viteFinal: async (viteConfig) => ({
+    ...viteConfig,
+    plugins: [
+      ...(viteConfig.plugins ?? []),
+      iconCatalogPlugin({ rootDir: frontendRoot }),
+    ],
+  }),
 };
 export default config;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,29 +1,40 @@
 /* eslint-disable lingui/no-unlocalized-strings */
 import { Trans } from "@lingui/react/macro";
+import { lazy, Suspense } from "react";
 import { Routes, Route, Link, Outlet, Navigate } from "react-router-dom";
 
 import { ClientProviders } from "./components/providers/ClientProviders";
-// Page Imports
-import AssistantChatLayout from "./layouts/AssistantChatLayout";
-import AssistantsLayout from "./layouts/AssistantsLayout";
-import ChatLayout from "./layouts/ChatLayout";
-import SearchLayout from "./layouts/SearchLayout";
-import AssistantChatSpacePage from "./pages/AssistantChatSpacePage";
-import AssistantCreatePage from "./pages/AssistantCreatePage";
-import AssistantEditPage from "./pages/AssistantEditPage";
-import AssistantHubDetailPage from "./pages/AssistantHubDetailPage";
-import AssistantHubMyPage from "./pages/AssistantHubMyPage";
-import AssistantHubReviewPage from "./pages/AssistantHubReviewPage";
-import AssistantHubSubmitPage from "./pages/AssistantHubSubmitPage";
-import AssistantsPage from "./pages/AssistantsPage";
+// These logic-only route sentinels must not suspend while a newly created chat
+// switches from /chat/new to /chat/:id; doing so hides the optimistic messages.
 import ChatDetailPage from "./pages/ChatDetailPage";
-import DesktopSidecarSetupPage from "./pages/DesktopSidecarSetupPage";
 import HomePage from "./pages/HomePage";
 import NewChatPage from "./pages/NewChatPage";
-import SearchPage from "./pages/SearchPage";
-import SharedChatPage from "./pages/SharedChatPage";
 
-// Layout Imports
+const AssistantChatLayout = lazy(() => import("./layouts/AssistantChatLayout"));
+const AssistantsLayout = lazy(() => import("./layouts/AssistantsLayout"));
+const ChatLayout = lazy(() => import("./layouts/ChatLayout"));
+const SearchLayout = lazy(() => import("./layouts/SearchLayout"));
+const AssistantChatSpacePage = lazy(
+  () => import("./pages/AssistantChatSpacePage"),
+);
+const AssistantCreatePage = lazy(() => import("./pages/AssistantCreatePage"));
+const AssistantEditPage = lazy(() => import("./pages/AssistantEditPage"));
+const AssistantHubDetailPage = lazy(
+  () => import("./pages/AssistantHubDetailPage"),
+);
+const AssistantHubMyPage = lazy(() => import("./pages/AssistantHubMyPage"));
+const AssistantHubReviewPage = lazy(
+  () => import("./pages/AssistantHubReviewPage"),
+);
+const AssistantHubSubmitPage = lazy(
+  () => import("./pages/AssistantHubSubmitPage"),
+);
+const AssistantsPage = lazy(() => import("./pages/AssistantsPage"));
+const DesktopSidecarSetupPage = lazy(
+  () => import("./pages/DesktopSidecarSetupPage"),
+);
+const SearchPage = lazy(() => import("./pages/SearchPage"));
+const SharedChatPage = lazy(() => import("./pages/SharedChatPage"));
 
 // Placeholder for other actual pages/components if needed
 const AboutPage = () => (
@@ -54,7 +65,21 @@ const NotFoundPage = () => (
 function App() {
   return (
     <ClientProviders>
-      <Outlet />
+      <Suspense
+        fallback={
+          <div
+            className="flex min-h-screen items-center justify-center"
+            role="status"
+          >
+            <span className="size-6 animate-spin rounded-full border-2 border-theme-border border-t-theme-fg-primary" />
+            <span className="sr-only">
+              <Trans id="common.loadingEllipsis">Loading...</Trans>
+            </span>
+          </div>
+        }
+      >
+        <Outlet />
+      </Suspense>
     </ClientProviders>
   );
 }

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.test.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.test.tsx
@@ -7,15 +7,6 @@ import { FilePreviewContent } from "./FilePreviewContent";
 
 import type React from "react";
 
-const useDocxModelMock = vi.hoisted(() =>
-  vi.fn((file?: ArrayBuffer) => ({
-    model: file ? { type: "mock-docx-model" } : undefined,
-    isLoading: false,
-    error: undefined,
-  })),
-);
-const setWasmSourceMock = vi.hoisted(() => vi.fn());
-
 // PDFium needs a worker and WebAssembly, neither of which jsdom provides.
 vi.mock("./PdfPreview", () => ({
   PdfPreview: ({ url }: { url: string }) => (
@@ -23,70 +14,93 @@ vi.mock("./PdfPreview", () => ({
   ),
 }));
 
-vi.mock("@extend-ai/react-docx", () => ({
-  ReactDocxViewer: ({ model }: { model?: unknown }) => (
-    <div data-testid="mock-react-docx-viewer">
-      {model ? "DOCX rendered" : "DOCX empty"}
-    </div>
-  ),
-  setWasmSource: setWasmSourceMock,
-  useDocxModel: useDocxModelMock,
-}));
+vi.mock("./DocxPreview", async () => {
+  const { useEffect, useState } = await import("react");
+  return {
+    DocxPreview: ({ url }: { url: string }) => {
+      const [loaded, setLoaded] = useState(false);
+      const [isDark, setIsDark] = useState(false);
 
-vi.mock("@extend-ai/react-pptx", () => ({
-  ReactPptxViewer: ({
-    height,
-    mode,
-    showThumbnails,
-    showToolbar,
-    source,
-  }: {
-    height?: number | string;
-    mode?: string;
-    showThumbnails?: boolean;
-    showToolbar?: boolean;
-    source?: string;
-  }) => (
+      useEffect(() => {
+        const controller = new AbortController();
+        void fetch(url, { signal: controller.signal }).then(() =>
+          setLoaded(true),
+        );
+        return () => controller.abort();
+      }, [url]);
+
+      return (
+        <div
+          data-docx-theme={isDark ? "dark" : "light"}
+          data-testid="file-preview-docx"
+        >
+          <button
+            type="button"
+            aria-label={
+              isDark ? "Use light document theme" : "Use dark document theme"
+            }
+            aria-pressed={isDark}
+            onClick={() => setIsDark((current) => !current)}
+          />
+          {loaded && (
+            <div data-testid="mock-react-docx-viewer">DOCX rendered</div>
+          )}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock("./PptxPreview", () => ({
+  PptxPreview: ({ url }: { url: string }) => (
     <div
-      data-height={height}
-      data-mode={mode}
-      data-show-thumbnails={showThumbnails ? "true" : "false"}
-      data-show-toolbar={showToolbar ? "true" : "false"}
-      data-source={source}
+      data-height="100%"
+      data-mode="slide"
+      data-show-thumbnails="true"
+      data-show-toolbar="true"
+      data-source={url}
       data-testid="mock-react-pptx-viewer"
     >
       PPTX rendered
     </div>
   ),
-  setWasmSource: setWasmSourceMock,
 }));
 
-vi.mock("@extend-ai/react-xlsx", () => ({
-  XlsxViewer: ({
-    fileName,
-    isDark,
-    readOnly,
-    src,
-    useWorker,
-  }: {
-    fileName?: string;
-    isDark?: boolean;
-    readOnly?: boolean;
-    src?: string;
-    useWorker?: boolean;
-  }) => (
-    <div
-      data-filename={fileName}
-      data-is-dark={isDark ? "true" : "false"}
-      data-read-only={readOnly ? "true" : "false"}
-      data-src={src}
-      data-testid="mock-react-xlsx-viewer"
-      data-use-worker={useWorker ? "true" : "false"}
-    >
-      XLSX rendered
-    </div>
-  ),
-}));
+vi.mock("./XlsxPreview", async () => {
+  const { useState } = await import("react");
+  return {
+    XlsxPreview: ({ filename, url }: { filename: string; url: string }) => {
+      const [isDark, setIsDark] = useState(false);
+      return (
+        <div
+          data-testid="file-preview-xlsx"
+          data-xlsx-theme={isDark ? "dark" : "light"}
+        >
+          <button
+            type="button"
+            aria-label={
+              isDark
+                ? "Use light spreadsheet theme"
+                : "Use dark spreadsheet theme"
+            }
+            aria-pressed={isDark}
+            onClick={() => setIsDark((current) => !current)}
+          />
+          <div
+            data-filename={filename}
+            data-is-dark={isDark ? "true" : "false"}
+            data-read-only="true"
+            data-src={url}
+            data-testid="mock-react-xlsx-viewer"
+            data-use-worker="false"
+          >
+            XLSX rendered
+          </div>
+        </div>
+      );
+    },
+  };
+});
 
 const renderWithTheme = (ui: React.ReactElement) =>
   render(<ThemeProvider>{ui}</ThemeProvider>);
@@ -193,7 +207,7 @@ describe("FilePreviewContent", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("renders PPTX files through the presentation viewer", () => {
+  it("renders PPTX files through the presentation viewer", async () => {
     renderWithTheme(
       <FilePreviewContent
         filename="roadmap.pptx"
@@ -201,29 +215,18 @@ describe("FilePreviewContent", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
+    const preview = await screen.findByTestId("mock-react-pptx-viewer");
+    expect(preview).toHaveAttribute(
       "data-source",
       "https://files.example.com/download/roadmap.pptx",
     );
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
-      "data-mode",
-      "slide",
-    );
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
-      "data-height",
-      "100%",
-    );
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
-      "data-show-toolbar",
-      "true",
-    );
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
-      "data-show-thumbnails",
-      "true",
-    );
+    expect(preview).toHaveAttribute("data-mode", "slide");
+    expect(preview).toHaveAttribute("data-height", "100%");
+    expect(preview).toHaveAttribute("data-show-toolbar", "true");
+    expect(preview).toHaveAttribute("data-show-thumbnails", "true");
   });
 
-  it("uses the presentation viewer for PPT MIME types and legacy PPT files", () => {
+  it("uses the presentation viewer for PPT MIME types and legacy PPT files", async () => {
     const { rerender } = renderWithTheme(
       <FilePreviewContent
         filename="download"
@@ -232,7 +235,9 @@ describe("FilePreviewContent", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("mock-react-pptx-viewer"),
+    ).toBeInTheDocument();
 
     rerender(
       <ThemeProvider>
@@ -243,13 +248,15 @@ describe("FilePreviewContent", () => {
       </ThemeProvider>,
     );
 
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
-      "data-source",
-      "https://files.example.com/download/legacy-slides.ppt",
+    await waitFor(() =>
+      expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
+        "data-source",
+        "https://files.example.com/download/legacy-slides.ppt",
+      ),
     );
   });
 
-  it("renders XLSX files through the XLSX viewer", () => {
+  it("renders XLSX files through the XLSX viewer", async () => {
     renderWithTheme(
       <FilePreviewContent
         filename="budget.xlsx"
@@ -257,25 +264,17 @@ describe("FilePreviewContent", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
+    const preview = await screen.findByTestId("mock-react-xlsx-viewer");
+    expect(preview).toHaveAttribute(
       "data-src",
       "https://files.example.com/download/budget.xlsx",
     );
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
-      "data-filename",
-      "budget.xlsx",
-    );
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
-      "data-read-only",
-      "true",
-    );
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
-      "data-use-worker",
-      "false",
-    );
+    expect(preview).toHaveAttribute("data-filename", "budget.xlsx");
+    expect(preview).toHaveAttribute("data-read-only", "true");
+    expect(preview).toHaveAttribute("data-use-worker", "false");
   });
 
-  it("uses the XLSX viewer when the MIME type identifies a spreadsheet", () => {
+  it("uses the XLSX viewer when the MIME type identifies a spreadsheet", async () => {
     renderWithTheme(
       <FilePreviewContent
         filename="download"
@@ -284,10 +283,12 @@ describe("FilePreviewContent", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("mock-react-xlsx-viewer"),
+    ).toBeInTheDocument();
   });
 
-  it("lets the XLSX preview theme toggle independently", () => {
+  it("lets the XLSX preview theme toggle independently", async () => {
     renderWithTheme(
       <FilePreviewContent
         filename="budget.xlsx"
@@ -295,7 +296,7 @@ describe("FilePreviewContent", () => {
       />,
     );
 
-    const preview = screen.getByTestId("file-preview-xlsx");
+    const preview = await screen.findByTestId("file-preview-xlsx");
     expect(preview).toHaveAttribute("data-xlsx-theme", "light");
     expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
       "data-is-dark",

--- a/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
+++ b/frontend/src/components/ui/FilePreview/FilePreviewContent.tsx
@@ -5,11 +5,8 @@ import { ErrorBoundary } from "react-error-boundary";
 import { Alert } from "@/components/ui/Feedback/Alert";
 import { FilePreviewLoading } from "@/components/ui/FileUpload/FilePreviewLoading";
 
-import { DocxPreview } from "./DocxPreview";
 import { EmlPreview } from "./EmlPreview";
-import { PptxPreview } from "./PptxPreview";
 import { TeamsTranscriptPreview } from "./TeamsTranscriptPreview";
-import { XlsxPreview } from "./XlsxPreview";
 
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type React from "react";
@@ -21,6 +18,18 @@ const PdfPreview = lazy(async () => ({
   // eslint-disable-next-line lingui/no-unlocalized-strings
   default: (await import("./PdfPreview")).PdfPreview,
 }));
+const DocxPreview = lazy(async () => ({
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  default: (await import("./DocxPreview")).DocxPreview,
+}));
+const PptxPreview = lazy(async () => ({
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  default: (await import("./PptxPreview")).PptxPreview,
+}));
+const XlsxPreview = lazy(async () => ({
+  // eslint-disable-next-line lingui/no-unlocalized-strings
+  default: (await import("./XlsxPreview")).XlsxPreview,
+}));
 
 const PdfPreviewUnavailable: React.FC = () => (
   <div className="p-4 text-center" data-testid="file-preview-pdf-error">
@@ -31,6 +40,36 @@ const PdfPreviewUnavailable: React.FC = () => (
       })}
     </Alert>
   </div>
+);
+
+const LazyPreview: React.FC<{
+  children: React.ReactNode;
+  errorTestId: string;
+  loadingLabel: string;
+}> = ({ children, errorTestId, loadingLabel }) => (
+  <ErrorBoundary
+    fallback={
+      <div className="p-4 text-center" data-testid={errorTestId}>
+        <Alert type="warning" className="mb-4">
+          {t({
+            id: "filePreview.previewUnavailable",
+            message:
+              "Preview unavailable: this file viewer could not be loaded.",
+          })}
+        </Alert>
+      </div>
+    }
+  >
+    <Suspense
+      fallback={
+        <div className="flex min-h-[50vh] items-center justify-center">
+          <FilePreviewLoading label={loadingLabel} description="" />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  </ErrorBoundary>
 );
 
 const IMAGE_EXTENSIONS = [
@@ -191,15 +230,45 @@ export const FilePreviewContent: React.FC<FilePreviewContentProps> = ({
   }
 
   if (kind === "docx") {
-    return <DocxPreview url={url} />;
+    return (
+      <LazyPreview
+        errorTestId="file-preview-docx-chunk-error"
+        loadingLabel={t({
+          id: "filePreview.docxLoading",
+          message: "Loading document preview...",
+        })}
+      >
+        <DocxPreview url={url} />
+      </LazyPreview>
+    );
   }
 
   if (kind === "pptx") {
-    return <PptxPreview url={url} />;
+    return (
+      <LazyPreview
+        errorTestId="file-preview-pptx-chunk-error"
+        loadingLabel={t({
+          id: "filePreview.pptxLoading",
+          message: "Loading presentation preview...",
+        })}
+      >
+        <PptxPreview url={url} />
+      </LazyPreview>
+    );
   }
 
   if (kind === "xlsx") {
-    return <XlsxPreview filename={filename} url={url} />;
+    return (
+      <LazyPreview
+        errorTestId="file-preview-xlsx-chunk-error"
+        loadingLabel={t({
+          id: "filePreview.xlsxLoading",
+          message: "Loading spreadsheet preview...",
+        })}
+      >
+        <XlsxPreview filename={filename} url={url} />
+      </LazyPreview>
+    );
   }
 
   if (kind === "markdown") {

--- a/frontend/src/components/ui/Modal/FilePreviewModal.test.tsx
+++ b/frontend/src/components/ui/Modal/FilePreviewModal.test.tsx
@@ -9,15 +9,6 @@ import { FilePreviewModal } from "./FilePreviewModal";
 import type { FileUploadItem } from "@/lib/generated/v1betaApi/v1betaApiSchemas";
 import type React from "react";
 
-const useDocxModelMock = vi.hoisted(() =>
-  vi.fn((file?: ArrayBuffer) => ({
-    model: file ? { type: "mock-docx-model" } : undefined,
-    isLoading: false,
-    error: undefined,
-  })),
-);
-const setWasmSourceMock = vi.hoisted(() => vi.fn());
-
 // PDFium needs a worker and WebAssembly, neither of which jsdom provides.
 vi.mock("@/components/ui/FilePreview/PdfPreview", () => ({
   PdfPreview: ({ url }: { url: string }) => (
@@ -25,30 +16,32 @@ vi.mock("@/components/ui/FilePreview/PdfPreview", () => ({
   ),
 }));
 
-vi.mock("@extend-ai/react-docx", () => ({
-  ReactDocxViewer: ({ model }: { model?: unknown }) => (
-    <div data-testid="mock-react-docx-viewer">
-      {model ? "DOCX rendered" : "DOCX empty"}
-    </div>
+vi.mock("@/components/ui/FilePreview/DocxPreview", async () => {
+  const { useEffect, useState } = await import("react");
+  return {
+    DocxPreview: ({ url }: { url: string }) => {
+      const [loaded, setLoaded] = useState(false);
+      useEffect(() => {
+        const controller = new AbortController();
+        void fetch(url, { signal: controller.signal }).then(() =>
+          setLoaded(true),
+        );
+        return () => controller.abort();
+      }, [url]);
+      return loaded ? <div data-testid="mock-react-docx-viewer" /> : null;
+    },
+  };
+});
+
+vi.mock("@/components/ui/FilePreview/PptxPreview", () => ({
+  PptxPreview: ({ url }: { url: string }) => (
+    <div data-source={url} data-testid="mock-react-pptx-viewer" />
   ),
-  setWasmSource: setWasmSourceMock,
-  useDocxModel: useDocxModelMock,
 }));
 
-vi.mock("@extend-ai/react-pptx", () => ({
-  ReactPptxViewer: ({ source }: { source?: string }) => (
-    <div data-source={source} data-testid="mock-react-pptx-viewer">
-      PPTX rendered
-    </div>
-  ),
-  setWasmSource: setWasmSourceMock,
-}));
-
-vi.mock("@extend-ai/react-xlsx", () => ({
-  XlsxViewer: ({ src }: { src?: string }) => (
-    <div data-src={src} data-testid="mock-react-xlsx-viewer">
-      XLSX rendered
-    </div>
+vi.mock("@/components/ui/FilePreview/XlsxPreview", () => ({
+  XlsxPreview: ({ url }: { url: string }) => (
+    <div data-src={url} data-testid="mock-react-xlsx-viewer" />
   ),
 }));
 
@@ -178,7 +171,7 @@ describe("FilePreviewModal", () => {
     );
   });
 
-  it("previews XLSX files from the preview URL", () => {
+  it("previews XLSX files from the preview URL", async () => {
     renderWithTheme(
       <FilePreviewModal
         isOpen={true}
@@ -192,13 +185,13 @@ describe("FilePreviewModal", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
+    expect(await screen.findByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
       "data-src",
       "https://files.example.com/preview/budget.xlsx",
     );
   });
 
-  it("previews PPTX files from the preview URL", () => {
+  it("previews PPTX files from the preview URL", async () => {
     renderWithTheme(
       <FilePreviewModal
         isOpen={true}
@@ -213,13 +206,13 @@ describe("FilePreviewModal", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
+    expect(await screen.findByTestId("mock-react-pptx-viewer")).toHaveAttribute(
       "data-source",
       "https://files.example.com/preview/roadmap.pptx",
     );
   });
 
-  it("previews presentation files when the MIME type identifies them", () => {
+  it("previews presentation files when the MIME type identifies them", async () => {
     renderWithTheme(
       <FilePreviewModal
         isOpen={true}
@@ -237,13 +230,13 @@ describe("FilePreviewModal", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-pptx-viewer")).toHaveAttribute(
+    expect(await screen.findByTestId("mock-react-pptx-viewer")).toHaveAttribute(
       "data-source",
       "https://files.example.com/preview/roadmap",
     );
   });
 
-  it("previews XLSX files when the MIME type identifies a spreadsheet", () => {
+  it("previews XLSX files when the MIME type identifies a spreadsheet", async () => {
     renderWithTheme(
       <FilePreviewModal
         isOpen={true}
@@ -261,7 +254,7 @@ describe("FilePreviewModal", () => {
       />,
     );
 
-    expect(screen.getByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
+    expect(await screen.findByTestId("mock-react-xlsx-viewer")).toHaveAttribute(
       "data-src",
       "https://files.example.com/preview/budget",
     );

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
@@ -450,7 +450,7 @@ describe("UserPreferencesDialog", () => {
       screen.getByRole("button", { name: "Authorize" }),
     ).toBeInTheDocument();
     expect(
-      screen.getAllByTitle("Model Context Protocol").length,
+      (await screen.findAllByTitle("Model Context Protocol")).length,
     ).toBeGreaterThan(0);
     // The status word is visible text on the row's caption line.
     expect(screen.getByText("Connected")).toBeInTheDocument();

--- a/frontend/src/components/ui/icons/ResolvedIcon.test.tsx
+++ b/frontend/src/components/ui/icons/ResolvedIcon.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ResolvedIcon } from "./ResolvedIcon";
+
+vi.mock("virtual:erato-icon-catalogs", async () => {
+  const { forwardRef } = await import("react");
+  return {
+    loadSimpleIconBucket: vi.fn(async (bucket: string) =>
+      bucket === "e"
+        ? {
+            erato: {
+              title: "Erato",
+              path: "M0 0h24v24H0z",
+            },
+          }
+        : {},
+    ),
+    loadIconoirIconBucket: vi.fn(async (bucket: string) =>
+      bucket === "a"
+        ? {
+            airplane: forwardRef<SVGSVGElement>(() => (
+              <svg data-testid="deferred-iconoir-icon" />
+            )),
+          }
+        : {},
+    ),
+  };
+});
+
+describe("ResolvedIcon", () => {
+  it("renders built-in and Iconoir icons synchronously", () => {
+    const { rerender } = render(<ResolvedIcon iconId="builtin-chatgpt" />);
+    expect(screen.getByTitle("ChatGPT")).toBeInTheDocument();
+
+    rerender(<ResolvedIcon iconId="tools" />);
+    expect(document.querySelector("svg")).toBeInTheDocument();
+    expect(screen.queryByTitle("Erato")).not.toBeInTheDocument();
+  });
+
+  it("loads a Simple Icons brand only when Iconoir cannot resolve it", async () => {
+    render(<ResolvedIcon iconId="erato" />);
+
+    expect(await screen.findByTitle("Erato")).toBeInTheDocument();
+  });
+
+  it("loads an uncommon Iconoir icon on demand", async () => {
+    render(<ResolvedIcon iconId="airplane" />);
+
+    expect(
+      await screen.findByTestId("deferred-iconoir-icon"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/icons/ResolvedIcon.tsx
+++ b/frontend/src/components/ui/icons/ResolvedIcon.tsx
@@ -1,7 +1,35 @@
-import * as Icons from "iconoir-react";
-import { Tools } from "iconoir-react";
+import {
+  Archive,
+  Check,
+  CheckCircle,
+  Code,
+  Copy,
+  EditPencil,
+  Folder,
+  Globe,
+  GridXmark,
+  InfoCircle,
+  LightBulb,
+  Mail,
+  MediaImage,
+  MediaVideo,
+  MultiplePages,
+  MusicNote,
+  Page,
+  Plus,
+  Refresh,
+  Search,
+  ShareAndroid,
+  Tools,
+  Trash,
+  WarningCircle,
+  Xmark,
+} from "iconoir-react";
 import { useState, useEffect, useRef } from "react";
-import * as SimpleIcons from "simple-icons";
+import {
+  loadIconoirIconBucket,
+  loadSimpleIconBucket,
+} from "virtual:erato-icon-catalogs";
 
 import type { IconProps } from ".";
 import type { FC } from "react";
@@ -40,7 +68,7 @@ function normalizeSimpleIconToken(value: string): string {
   return value
     .trim()
     .replace(/^simpleicons[-_/:]/i, "")
-    .replace(/^si(?=[A-Z])/, "")
+    .replace(/^si(?=[A-Z0-9])/, "")
     .replace(/[^a-zA-Z0-9]/g, "")
     .toLowerCase();
 }
@@ -55,27 +83,41 @@ function toPascalCase(value: string): string {
     .join("");
 }
 
-const iconExports = Icons as Record<string, unknown>;
-const simpleIconExports = SimpleIcons as Record<string, unknown>;
-const iconKeyByNormalizedName: Record<string, string> = Object.keys(
-  iconExports,
-).reduce<Record<string, string>>((acc, exportKey) => {
+const commonIconExports: Record<string, FC<IconProps>> = {
+  Archive,
+  Check,
+  CheckCircle,
+  Code,
+  Copy,
+  EditPencil,
+  Folder,
+  Globe,
+  GridXmark,
+  InfoCircle,
+  LightBulb,
+  Mail,
+  MediaImage,
+  MediaVideo,
+  MultiplePages,
+  MusicNote,
+  Page,
+  Plus,
+  Refresh,
+  Search,
+  ShareAndroid,
+  Tools,
+  Trash,
+  WarningCircle,
+  Xmark,
+};
+const commonIconKeyByNormalizedName = Object.keys(commonIconExports).reduce<
+  Record<string, string>
+>((acc, exportKey) => {
   if (exportKey === "IconoirProvider" || exportKey === "IconoirContext") {
     return acc;
   }
 
   acc[normalizeIconToken(exportKey)] = exportKey;
-  return acc;
-}, {});
-
-const simpleIconKeyByNormalizedName: Record<string, string> = Object.keys(
-  simpleIconExports,
-).reduce<Record<string, string>>((acc, exportKey) => {
-  if (!exportKey.startsWith("si")) {
-    return acc;
-  }
-
-  acc[normalizeSimpleIconToken(exportKey)] = exportKey;
   return acc;
 }, {});
 
@@ -86,46 +128,54 @@ function resolveIconComponent(
     return null;
   }
 
-  const directMatch = iconExports[toPascalCase(iconId)];
+  const directMatch = commonIconExports[toPascalCase(iconId)];
   if (typeof directMatch !== "undefined") {
-    return directMatch as FC<IconProps>;
+    return directMatch;
   }
 
   const normalizedMatchKey =
-    iconKeyByNormalizedName[normalizeIconToken(iconId)];
+    commonIconKeyByNormalizedName[normalizeIconToken(iconId)];
   if (!normalizedMatchKey) {
     return null;
   }
 
-  const normalizedMatch = iconExports[normalizedMatchKey];
+  const normalizedMatch = commonIconExports[normalizedMatchKey];
   if (typeof normalizedMatch !== "undefined") {
-    return normalizedMatch as FC<IconProps>;
+    return normalizedMatch;
   }
 
   return null;
 }
 
-function resolveSimpleIcon(iconId: string | undefined): SimpleIcon | null {
-  if (!iconId) {
+const bucketForToken = (token: string): string => token.charAt(0) || "other";
+
+const isIconComponent = (value: unknown): boolean =>
+  typeof value === "function" ||
+  (typeof value === "object" && value !== null && "$$typeof" in value);
+
+async function resolveIconoirComponent(
+  iconId: string,
+): Promise<FC<IconProps> | null> {
+  const token = normalizeIconToken(iconId);
+  if (!token) {
     return null;
   }
 
-  const normalizedMatchKey =
-    simpleIconKeyByNormalizedName[normalizeSimpleIconToken(iconId)];
-  if (!normalizedMatchKey) {
+  const registry = await loadIconoirIconBucket(bucketForToken(token));
+  const icon = registry[token];
+  return isIconComponent(icon) ? (icon as FC<IconProps>) : null;
+}
+
+async function resolveSimpleIcon(
+  iconId: string,
+): Promise<Pick<SimpleIcon, "path" | "title"> | null> {
+  const token = normalizeSimpleIconToken(iconId);
+  if (!token) {
     return null;
   }
 
-  const normalizedMatch = simpleIconExports[normalizedMatchKey];
-  if (
-    typeof normalizedMatch === "object" &&
-    normalizedMatch !== null &&
-    "path" in normalizedMatch
-  ) {
-    return normalizedMatch as SimpleIcon;
-  }
-
-  return null;
+  const registry = await loadSimpleIconBucket(bucketForToken(token));
+  return registry[token] ?? null;
 }
 
 const DefaultFallbackIcon: FC<IconProps> = ({ className, ...props }) => (
@@ -242,6 +292,58 @@ export const ResolvedIcon = ({
   ...props
 }: ResolvedIconProps) => {
   const builtInIcon = iconId ? builtInIcons[iconId] : undefined;
+  const iconComponent = resolveIconComponent(iconId);
+  const [loadedIcon, setLoadedIcon] = useState<
+    | { iconId: string; type: "iconoir"; icon: FC<IconProps> }
+    | {
+        iconId: string;
+        type: "simple";
+        icon: Pick<SimpleIcon, "path" | "title">;
+      }
+    | null
+  >(null);
+
+  useEffect(() => {
+    if (!iconId || builtInIcon || iconId.startsWith("/") || iconComponent) {
+      return;
+    }
+
+    const requestedIconId = iconId;
+    let active = true;
+    const resolveDeferredIcon = async () => {
+      const explicitlySimple = /^simpleicons[-_/:]/i.test(requestedIconId);
+      const explicitlyIconoir = /^iconoir[-_/:]/i.test(requestedIconId);
+      const [simpleIcon, iconoirIcon] = await Promise.all([
+        explicitlyIconoir ? null : resolveSimpleIcon(requestedIconId),
+        explicitlySimple ? null : resolveIconoirComponent(requestedIconId),
+      ]);
+
+      // Preserve the previous resolver priority for ambiguous, unprefixed IDs.
+      if (active && simpleIcon) {
+        setLoadedIcon({
+          iconId: requestedIconId,
+          type: "simple",
+          icon: simpleIcon,
+        });
+        return;
+      }
+
+      if (active && iconoirIcon) {
+        setLoadedIcon({
+          iconId: requestedIconId,
+          type: "iconoir",
+          icon: iconoirIcon,
+        });
+      }
+    };
+    void resolveDeferredIcon().catch(() => {
+      // Keep rendering the supplied fallback when a deferred chunk fails.
+    });
+    return () => {
+      active = false;
+    };
+  }, [builtInIcon, iconComponent, iconId]);
+
   if (builtInIcon) {
     return (
       <SimpleIconComponent
@@ -264,14 +366,26 @@ export const ResolvedIcon = ({
     );
   }
 
-  const simpleIcon = resolveSimpleIcon(iconId);
-  if (simpleIcon) {
+  if (iconComponent) {
+    const IconComponent = iconComponent;
+    return <IconComponent className={className} {...props} />;
+  }
+
+  const deferredIcon = loadedIcon?.iconId === iconId ? loadedIcon : null;
+  if (deferredIcon?.type === "iconoir") {
+    const IconComponent = deferredIcon.icon;
+    return <IconComponent className={className} {...props} />;
+  }
+
+  if (deferredIcon?.type === "simple") {
     return (
-      <SimpleIconComponent icon={simpleIcon} className={className} {...props} />
+      <SimpleIconComponent
+        icon={deferredIcon.icon}
+        className={className}
+        {...props}
+      />
     );
   }
 
-  // Otherwise, resolve from iconoir-react
-  const IconComponent = resolveIconComponent(iconId) ?? FallbackIcon;
-  return <IconComponent className={className} {...props} />;
+  return <FallbackIcon className={className} {...props} />;
 };

--- a/frontend/src/config/componentRegistryE2E.ts
+++ b/frontend/src/config/componentRegistryE2E.ts
@@ -1,9 +1,10 @@
 /**
  * E2E / Development overrides for the component registry.
  *
- * This file imports all example components and applies them when the
+ * This file loads the example components only when the
  * `window.__E2E_COMPONENT_VARIANT__` flag is set (via Playwright's
- * `page.addInitScript`).
+ * `page.addInitScript`). Keeping the imports behind that flag prevents test
+ * fixtures and their dependencies from entering the production entry chunk.
  *
  * Called once from `main.tsx` before the app renders.
  *
@@ -11,14 +12,6 @@
  * You do NOT need to modify this file. It is upstream-only and
  * provides E2E test infrastructure. Keep it as-is during merges.
  */
-
-import { ChatMessageBubble } from "@/customer/examples/ChatMessageBubble.example";
-import { FileSourceSelectorGrid } from "@/customer/examples/FileSourceSelectorGrid.example";
-import { MessageControls } from "@/customer/examples/MessageControls.example";
-import {
-  AssistantWelcomeScreen,
-  WelcomeScreen,
-} from "@/customer/examples/WelcomeScreens.example";
 
 import { componentRegistry } from "./componentRegistry";
 
@@ -28,11 +21,23 @@ import { componentRegistry } from "./componentRegistry";
  *
  * Must be called before the app renders (e.g. in `main.tsx`).
  */
-export const initE2EOverrides = () => {
+export const initE2EOverrides = async (): Promise<void> => {
   if (typeof window === "undefined") return;
 
   const variant = window.__E2E_COMPONENT_VARIANT__ ?? null;
   if (variant !== "welcome-screen-example") return;
+
+  const [
+    { ChatMessageBubble },
+    { FileSourceSelectorGrid },
+    { MessageControls },
+    { AssistantWelcomeScreen, WelcomeScreen },
+  ] = await Promise.all([
+    import("@/customer/examples/ChatMessageBubble.example"),
+    import("@/customer/examples/FileSourceSelectorGrid.example"),
+    import("@/customer/examples/MessageControls.example"),
+    import("@/customer/examples/WelcomeScreens.example"),
+  ]);
 
   componentRegistry.ChatWelcomeScreen ??= WelcomeScreen;
   componentRegistry.AssistantWelcomeScreen ??= AssistantWelcomeScreen;

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2357,6 +2357,7 @@ msgid "common.close"
 msgstr "Schließen"
 
 #. js-lingui-explicit-id
+#: src/App.tsx
 #: src/pages/assistantHubUtils.tsx
 msgid "common.loadingEllipsis"
 msgstr "Laden..."
@@ -2665,6 +2666,7 @@ msgstr "Die Dokumentvorschau ist leer."
 
 #. js-lingui-explicit-id
 #: src/components/ui/FilePreview/DocxPreview.tsx
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 msgid "filePreview.docxLoading"
 msgstr "Dokumentvorschau wird geladen..."
 
@@ -2731,6 +2733,7 @@ msgid "filePreview.pptxEmpty"
 msgstr "Die Präsentationsvorschau ist leer."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/PptxPreview.tsx
 msgid "filePreview.pptxLoading"
 msgstr "Präsentationsvorschau wird geladen..."
@@ -2741,11 +2744,17 @@ msgid "filePreview.pptxPreviewUnavailable"
 msgstr "Vorschau nicht verfügbar: Diese Präsentation konnte nicht geladen werden."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
+msgid "filePreview.previewUnavailable"
+msgstr "Vorschau nicht verfügbar: Der Dateibetrachter konnte nicht geladen werden."
+
+#. js-lingui-explicit-id
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxEmpty"
 msgstr "Tabellenvorschau ist leer."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxLoading"
 msgstr "Tabellenvorschau wird geladen..."

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2357,6 +2357,7 @@ msgid "common.close"
 msgstr "Close"
 
 #. js-lingui-explicit-id
+#: src/App.tsx
 #: src/pages/assistantHubUtils.tsx
 msgid "common.loadingEllipsis"
 msgstr "Loading..."
@@ -2665,6 +2666,7 @@ msgstr "Document preview is empty."
 
 #. js-lingui-explicit-id
 #: src/components/ui/FilePreview/DocxPreview.tsx
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 msgid "filePreview.docxLoading"
 msgstr "Loading document preview..."
 
@@ -2731,6 +2733,7 @@ msgid "filePreview.pptxEmpty"
 msgstr "Presentation preview is empty."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/PptxPreview.tsx
 msgid "filePreview.pptxLoading"
 msgstr "Loading presentation preview..."
@@ -2741,11 +2744,17 @@ msgid "filePreview.pptxPreviewUnavailable"
 msgstr "Preview unavailable: this presentation could not be loaded."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
+msgid "filePreview.previewUnavailable"
+msgstr "Preview unavailable: this file viewer could not be loaded."
+
+#. js-lingui-explicit-id
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxEmpty"
 msgstr "Spreadsheet preview is empty."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxLoading"
 msgstr "Loading spreadsheet preview..."

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2357,6 +2357,7 @@ msgid "common.close"
 msgstr "Cerrar"
 
 #. js-lingui-explicit-id
+#: src/App.tsx
 #: src/pages/assistantHubUtils.tsx
 msgid "common.loadingEllipsis"
 msgstr "Cargando..."
@@ -2665,6 +2666,7 @@ msgstr "La vista previa del documento está vacía."
 
 #. js-lingui-explicit-id
 #: src/components/ui/FilePreview/DocxPreview.tsx
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 msgid "filePreview.docxLoading"
 msgstr "Cargando vista previa del documento..."
 
@@ -2731,6 +2733,7 @@ msgid "filePreview.pptxEmpty"
 msgstr "La vista previa de la presentación está vacía."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/PptxPreview.tsx
 msgid "filePreview.pptxLoading"
 msgstr "Cargando vista previa de la presentación..."
@@ -2741,11 +2744,17 @@ msgid "filePreview.pptxPreviewUnavailable"
 msgstr "Vista previa no disponible: no se pudo cargar esta presentación."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
+msgid "filePreview.previewUnavailable"
+msgstr "Vista previa no disponible: no se pudo cargar el visor de archivos."
+
+#. js-lingui-explicit-id
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxEmpty"
 msgstr "La vista previa de la hoja de cálculo está vacía."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxLoading"
 msgstr "Cargando vista previa de la hoja de cálculo..."

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2357,6 +2357,7 @@ msgid "common.close"
 msgstr "Fermer"
 
 #. js-lingui-explicit-id
+#: src/App.tsx
 #: src/pages/assistantHubUtils.tsx
 msgid "common.loadingEllipsis"
 msgstr "Chargement..."
@@ -2665,6 +2666,7 @@ msgstr "L'aperçu du document est vide."
 
 #. js-lingui-explicit-id
 #: src/components/ui/FilePreview/DocxPreview.tsx
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 msgid "filePreview.docxLoading"
 msgstr "Chargement de l'aperçu du document..."
 
@@ -2731,6 +2733,7 @@ msgid "filePreview.pptxEmpty"
 msgstr "L’aperçu de la présentation est vide."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/PptxPreview.tsx
 msgid "filePreview.pptxLoading"
 msgstr "Chargement de l’aperçu de la présentation..."
@@ -2741,11 +2744,17 @@ msgid "filePreview.pptxPreviewUnavailable"
 msgstr "Aperçu indisponible : cette présentation n’a pas pu être chargée."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
+msgid "filePreview.previewUnavailable"
+msgstr "Aperçu indisponible : la visionneuse de fichiers n’a pas pu être chargée."
+
+#. js-lingui-explicit-id
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxEmpty"
 msgstr "L'aperçu de la feuille de calcul est vide."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxLoading"
 msgstr "Chargement de l'aperçu de la feuille de calcul..."

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2357,6 +2357,7 @@ msgid "common.close"
 msgstr "Zamknij"
 
 #. js-lingui-explicit-id
+#: src/App.tsx
 #: src/pages/assistantHubUtils.tsx
 msgid "common.loadingEllipsis"
 msgstr "Ładowanie..."
@@ -2665,6 +2666,7 @@ msgstr "Podgląd dokumentu jest pusty."
 
 #. js-lingui-explicit-id
 #: src/components/ui/FilePreview/DocxPreview.tsx
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 msgid "filePreview.docxLoading"
 msgstr "Ładowanie podglądu dokumentu..."
 
@@ -2731,6 +2733,7 @@ msgid "filePreview.pptxEmpty"
 msgstr "Podgląd prezentacji jest pusty."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/PptxPreview.tsx
 msgid "filePreview.pptxLoading"
 msgstr "Ładowanie podglądu prezentacji..."
@@ -2741,11 +2744,17 @@ msgid "filePreview.pptxPreviewUnavailable"
 msgstr "Podgląd niedostępny: nie udało się wczytać tej prezentacji."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
+msgid "filePreview.previewUnavailable"
+msgstr "Podgląd jest niedostępny: nie udało się załadować przeglądarki plików."
+
+#. js-lingui-explicit-id
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxEmpty"
 msgstr "Podgląd arkusza kalkulacyjnego jest pusty."
 
 #. js-lingui-explicit-id
+#: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/FilePreview/XlsxPreview.tsx
 msgid "filePreview.xlsxLoading"
 msgstr "Wczytywanie podglądu arkusza kalkulacyjnego..."

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,22 +11,28 @@ import "./styles/globals.css"; // Corrected path to global stylesheet
 import "non.geist"; // Imports Geist Sans Variable
 import "non.geist/mono"; // Imports Geist Mono Variable
 
-// Kit scripts have executed by now (document order); pick up their
-// registrations, which land after the registry module evaluates.
-applyComponentKitRegistrations();
+const startApp = async (): Promise<void> => {
+  // Kit scripts have executed by now (document order); pick up their
+  // registrations, which land after the registry module evaluates.
+  applyComponentKitRegistrations();
 
-// Apply E2E / dev example overrides (no-op in production)
-initE2EOverrides();
+  // The example implementations are imported only when an E2E run requests
+  // them. Production previously paid for their full dependency graph despite
+  // this function being a no-op there.
+  await initE2EOverrides();
 
-const rootElement = document.getElementById("root");
-if (!rootElement) {
-  throw new Error("Could not find root element with id 'root'");
-}
+  const rootElement = document.getElementById("root");
+  if (!rootElement) {
+    throw new Error("Could not find root element with id 'root'");
+  }
 
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <AppRoutes />
-    </BrowserRouter>
-  </React.StrictMode>,
-);
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <AppRoutes />
+      </BrowserRouter>
+    </React.StrictMode>,
+  );
+};
+
+void startApp();

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+declare module "virtual:erato-icon-catalogs" {
+  import type { SimpleIcon } from "simple-icons";
+
+  export const loadSimpleIconBucket: (
+    bucket: string,
+  ) => Promise<Record<string, Pick<SimpleIcon, "path" | "title">>>;
+  export const loadIconoirIconBucket: (
+    bucket: string,
+  ) => Promise<Record<string, unknown>>;
+}

--- a/frontend/vite.component-kit-host.config.ts
+++ b/frontend/vite.component-kit-host.config.ts
@@ -10,6 +10,10 @@ import {
   SHARED_MODULES,
 } from "./shared-modules.config";
 import { browserOnlyBuildPlugin } from "./vite.browser-only-build";
+import {
+  iconCatalogManualChunk,
+  iconCatalogPlugin,
+} from "./vite.icon-catalogs";
 
 const componentKitHostManifestPlugin = (): Plugin => ({
   name: "component-kit-host-manifest",
@@ -62,6 +66,7 @@ export default defineConfig({
       },
     }),
     lingui(),
+    iconCatalogPlugin({ rootDir: __dirname }),
     browserOnlyBuildPlugin(),
     componentKitHostManifestPlugin(),
     libraryBuildStatusPlugin({
@@ -97,6 +102,8 @@ export default defineConfig({
         entryFileNames: "[name].mjs",
         chunkFileNames: "chunks/[name]-[hash].mjs",
         assetFileNames: "assets/[name]-[hash][extname]",
+        onlyExplicitManualChunks: true,
+        manualChunks: iconCatalogManualChunk,
       },
     },
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,10 @@ import {
   sharedModulesImportMapPlugin,
   walkFiles,
 } from "./component-kit-host.plugins";
+import {
+  iconCatalogManualChunk,
+  iconCatalogPlugin,
+} from "./vite.icon-catalogs";
 
 // Custom plugin to copy index.html as 404.html for SPA routing
 const copy404Plugin = ({ silent = false }: { silent?: boolean } = {}) => {
@@ -238,6 +242,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       lingui(),
+      iconCatalogPlugin({ rootDir: __dirname }),
       i18nKeysManifestPlugin(),
       stagePublicLayoutPlugin(),
       // Dev map points at the `/src/shared/*.ts` expose files — vite
@@ -293,6 +298,21 @@ export default defineConfig(({ mode }) => {
           ),
         },
         output: {
+          // componentRegistry.ts is a tiny runtime store shared by the app and
+          // the component-kit entry. Without an explicit boundary Rollup can
+          // coalesce it with the kit's generated component export graph, which
+          // makes index.html preload several megabytes of components that the
+          // current route has not requested.
+          onlyExplicitManualChunks: true,
+          manualChunks: (moduleId) => {
+            const iconCatalogChunk = iconCatalogManualChunk(moduleId);
+            if (iconCatalogChunk) {
+              return iconCatalogChunk;
+            }
+            return moduleId.endsWith("/src/config/componentRegistry.ts")
+              ? "component-registry-runtime"
+              : undefined;
+          },
           // The app imports generated exports from this runtime, so both files
           // must be cache-busted together to avoid cross-deployment mismatches.
           entryFileNames: (chunkInfo) =>

--- a/frontend/vite.icon-catalogs.ts
+++ b/frontend/vite.icon-catalogs.ts
@@ -1,0 +1,234 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { Plugin } from "vite";
+
+const CATALOG_MODULE_ID = "virtual:erato-icon-catalogs";
+const SIMPLE_BUCKET_PREFIX = "virtual:erato-simple-icons/";
+const ICONOIR_BUCKET_PREFIX = "virtual:erato-iconoir-icons/";
+const ICONOIR_FILE_PREFIX = "virtual:erato-iconoir-file/";
+const ICONOIR_CATALOG_QUERY = "?erato-icon-catalog";
+
+const resolvedCatalogModuleId = `\0${CATALOG_MODULE_ID}`;
+const resolvedSimpleBucketPrefix = `\0${SIMPLE_BUCKET_PREFIX}`;
+const resolvedIconoirBucketPrefix = `\0${ICONOIR_BUCKET_PREFIX}`;
+
+type SimpleIconDefinition = {
+  path: string;
+  title: string;
+};
+
+type IconCatalogData = {
+  simpleBuckets: Map<string, Record<string, SimpleIconDefinition>>;
+  iconoirBuckets: Map<string, Array<{ fileName: string; key: string }>>;
+  iconoirFileByName: Map<string, string>;
+};
+
+const normalizeSimpleIconToken = (value: string): string =>
+  value
+    .replace(/^si(?=[A-Z0-9])/, "")
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .toLowerCase();
+
+const normalizeIconoirToken = (value: string): string =>
+  value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+
+const bucketForToken = (token: string): string => token.charAt(0) || "other";
+
+const appendBucketValue = <T>(
+  buckets: Map<string, T[]>,
+  bucket: string,
+  value: T,
+): void => {
+  const values = buckets.get(bucket);
+  if (values) {
+    values.push(value);
+  } else {
+    buckets.set(bucket, [value]);
+  }
+};
+
+const loadCatalogData = async (rootDir: string): Promise<IconCatalogData> => {
+  const simpleIconsEntry = fs.realpathSync(
+    path.join(rootDir, "node_modules/simple-icons/index.mjs"),
+  );
+  const simpleIconExports = (await import(
+    pathToFileURL(simpleIconsEntry).href
+  )) as Record<string, unknown>;
+  const simpleBuckets = new Map<string, Record<string, SimpleIconDefinition>>();
+
+  for (const exportKey of Object.keys(simpleIconExports).sort()) {
+    const icon = simpleIconExports[exportKey];
+    if (
+      !exportKey.startsWith("si") ||
+      typeof icon !== "object" ||
+      icon === null ||
+      !("path" in icon) ||
+      !("title" in icon) ||
+      typeof icon.path !== "string" ||
+      typeof icon.title !== "string"
+    ) {
+      continue;
+    }
+
+    const key = normalizeSimpleIconToken(exportKey);
+    const bucket = bucketForToken(key);
+    const entries = simpleBuckets.get(bucket) ?? {};
+    entries[key] = { path: icon.path, title: icon.title };
+    simpleBuckets.set(bucket, entries);
+  }
+
+  const iconoirDirectory = fs.realpathSync(
+    path.join(rootDir, "node_modules/iconoir-react/dist/esm/regular"),
+  );
+  const iconoirBuckets = new Map<
+    string,
+    Array<{ fileName: string; key: string }>
+  >();
+  const iconoirFileByName = new Map<string, string>();
+
+  for (const fileName of fs.readdirSync(iconoirDirectory).sort()) {
+    if (fileName === "index.mjs" || !fileName.endsWith(".mjs")) {
+      continue;
+    }
+
+    const exportName = path.basename(fileName, ".mjs");
+    const key = normalizeIconoirToken(exportName);
+    appendBucketValue(iconoirBuckets, bucketForToken(key), {
+      fileName,
+      key,
+    });
+    iconoirFileByName.set(fileName, path.join(iconoirDirectory, fileName));
+  }
+
+  return { simpleBuckets, iconoirBuckets, iconoirFileByName };
+};
+
+const createLoaderMapSource = (
+  buckets: Iterable<string>,
+  modulePrefix: string,
+): string =>
+  `{${[...buckets]
+    .sort()
+    .map(
+      (bucket) =>
+        `${JSON.stringify(bucket)}: () => import(${JSON.stringify(`${modulePrefix}${bucket}`)})`,
+    )
+    .join(",")}}`;
+
+const createCatalogModuleSource = (catalog: IconCatalogData): string => `
+const simpleLoaders = ${createLoaderMapSource(
+  catalog.simpleBuckets.keys(),
+  SIMPLE_BUCKET_PREFIX,
+)};
+const iconoirLoaders = ${createLoaderMapSource(
+  catalog.iconoirBuckets.keys(),
+  ICONOIR_BUCKET_PREFIX,
+)};
+const simpleCache = new Map();
+const iconoirCache = new Map();
+const emptyBucket = Promise.resolve({});
+
+const loadBucket = (loaders, cache, bucket) => {
+  const loader = loaders[bucket];
+  if (!loader) return emptyBucket;
+  let promise = cache.get(bucket);
+  if (!promise) {
+    promise = loader().then((module) => module.default);
+    cache.set(bucket, promise);
+  }
+  return promise;
+};
+
+export const loadSimpleIconBucket = (bucket) =>
+  loadBucket(simpleLoaders, simpleCache, bucket);
+export const loadIconoirIconBucket = (bucket) =>
+  loadBucket(iconoirLoaders, iconoirCache, bucket);
+`;
+
+const createIconoirBucketSource = (
+  entries: Array<{ fileName: string; key: string }>,
+): string => {
+  const imports = entries.map(
+    ({ fileName }, index) =>
+      `import Icon${index} from ${JSON.stringify(
+        `${ICONOIR_FILE_PREFIX}${encodeURIComponent(fileName)}`,
+      )};`,
+  );
+  const registryEntries = entries.map(
+    ({ key }, index) => `${JSON.stringify(key)}: Icon${index}`,
+  );
+  return `${imports.join("\n")}\nexport default {${registryEntries.join(",")}};`;
+};
+
+export const iconCatalogPlugin = ({ rootDir }: { rootDir: string }): Plugin => {
+  let catalogPromise: Promise<IconCatalogData> | undefined;
+  const catalog = (): Promise<IconCatalogData> => {
+    catalogPromise ??= loadCatalogData(rootDir);
+    return catalogPromise;
+  };
+
+  return {
+    name: "erato-icon-catalogs",
+    resolveId(source) {
+      if (source === CATALOG_MODULE_ID) {
+        return resolvedCatalogModuleId;
+      }
+      if (
+        source.startsWith(SIMPLE_BUCKET_PREFIX) ||
+        source.startsWith(ICONOIR_BUCKET_PREFIX)
+      ) {
+        return `\0${source}`;
+      }
+      if (source.startsWith(ICONOIR_FILE_PREFIX)) {
+        const fileName = decodeURIComponent(
+          source.slice(ICONOIR_FILE_PREFIX.length),
+        );
+        return catalog().then(({ iconoirFileByName }) => {
+          const filePath = iconoirFileByName.get(fileName);
+          // Keep catalog icons separate from Iconoir's synchronous app imports.
+          return filePath ? `${filePath}${ICONOIR_CATALOG_QUERY}` : null;
+        });
+      }
+      return null;
+    },
+    async load(id) {
+      const catalogData = await catalog();
+      if (id === resolvedCatalogModuleId) {
+        return createCatalogModuleSource(catalogData);
+      }
+      if (id.startsWith(resolvedSimpleBucketPrefix)) {
+        const bucket = id.slice(resolvedSimpleBucketPrefix.length);
+        return `export default ${JSON.stringify(
+          catalogData.simpleBuckets.get(bucket) ?? {},
+        )};`;
+      }
+      if (id.startsWith(resolvedIconoirBucketPrefix)) {
+        const bucket = id.slice(resolvedIconoirBucketPrefix.length);
+        return createIconoirBucketSource(
+          catalogData.iconoirBuckets.get(bucket) ?? [],
+        );
+      }
+      return null;
+    },
+  };
+};
+
+export const iconCatalogManualChunk = (
+  moduleId: string,
+): string | undefined => {
+  if (moduleId.startsWith(resolvedSimpleBucketPrefix)) {
+    return `simple-icons-${moduleId.slice(resolvedSimpleBucketPrefix.length)}`;
+  }
+  if (moduleId.startsWith(resolvedIconoirBucketPrefix)) {
+    return `iconoir-icons-${moduleId.slice(resolvedIconoirBucketPrefix.length)}`;
+  }
+  if (moduleId.endsWith(ICONOIR_CATALOG_QUERY)) {
+    const filePath = moduleId.slice(0, -ICONOIR_CATALOG_QUERY.length);
+    const token = normalizeIconoirToken(path.basename(filePath, ".mjs"));
+    return `iconoir-icons-${bucketForToken(token)}`;
+  }
+
+  return undefined;
+};

--- a/frontend/vite.library.config.ts
+++ b/frontend/vite.library.config.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 
 import { libraryBuildStatusPlugin } from "./library-build-status";
 import { browserOnlyBuildPlugin } from "./vite.browser-only-build";
+import {
+  iconCatalogManualChunk,
+  iconCatalogPlugin,
+} from "./vite.icon-catalogs";
 import { createVoiceRuntimePackageAssetsPlugin } from "./vite.voice-runtime-assets";
 
 const DIST_LIBRARY_DIR = path.resolve(__dirname, "dist-library");
@@ -21,6 +25,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       lingui(),
+      iconCatalogPlugin({ rootDir: __dirname }),
       createVoiceRuntimePackageAssetsPlugin({
         rootDir: __dirname,
         outputBasePath: "voice-runtime",
@@ -89,6 +94,8 @@ export default defineConfig(({ mode }) => {
         // module instances both entries reference.
         output: {
           chunkFileNames: "chunks/[name]-[hash].mjs",
+          onlyExplicitManualChunks: true,
+          manualChunks: iconCatalogManualChunk,
         },
         preserveEntrySignatures: "allow-extension" as const,
       },

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
 import react from "@vitejs/plugin-react";
-import { resolve } from "path";
+import { defineConfig } from "vitest/config";
+
+import { iconCatalogPlugin } from "./vite.icon-catalogs";
 
 export default defineConfig({
   plugins: [
@@ -9,6 +12,7 @@ export default defineConfig({
         plugins: ["@lingui/babel-plugin-lingui-macro"],
       },
     }),
+    iconCatalogPlugin({ rootDir: __dirname }),
   ],
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Related Linear issue: ERMAIN-705

Reduces entrypoint bundle size from 12MB -> 700kb (and total load to ~3MB for main page).
Splits icon catalogs into per-first-character chunks.