### PR TITLE
Make the centered new-chat composer layout the default (ERMAIN-736)

### DIFF
--- a/backend/erato.template.toml
+++ b/backend/erato.template.toml
@@ -211,8 +211,8 @@ chat_provider_ids = ["test-token-limit"]
 # # Whether to disable automatic focusing of the chat input field (default: false)
 # # This prevents unwanted scrolling behavior when navigating to pages with embedded chat
 # disable_chat_input_autofocus = true
-# # Layout of the chat input before a conversation starts: "bottom" (default) or "centered"
-# chat_input_empty_state_layout = "centered"
+# # Layout of the chat input before a conversation starts: "centered" (default) or "bottom"
+# chat_input_empty_state_layout = "bottom"
 # # Whether to hide logout functionality from the UI (default: false)
 # disable_logout = true
 # # Whether to enable message feedback functionality in the UI (default: false)

--- a/backend/erato/src/frontend_environment.rs
+++ b/backend/erato/src/frontend_environment.rs
@@ -1184,6 +1184,28 @@ mod tests {
     }
 
     #[test]
+    fn chat_input_empty_state_layout_is_exposed_to_the_frontend() {
+        let default_environment =
+            build_frontend_environment(&AppConfig::default(), FrontendKind::Web);
+        assert_eq!(
+            default_environment
+                .additional_environment
+                .get(FRONTEND_ENV_KEY_CHAT_INPUT_EMPTY_STATE_LAYOUT),
+            Some(&Value::String("centered".to_string()))
+        );
+
+        let mut config = AppConfig::default();
+        config.frontend.chat_input_empty_state_layout = "bottom".to_string();
+        let environment = build_frontend_environment(&config, FrontendKind::Web);
+        assert_eq!(
+            environment
+                .additional_environment
+                .get(FRONTEND_ENV_KEY_CHAT_INPUT_EMPTY_STATE_LAYOUT),
+            Some(&Value::String("bottom".to_string()))
+        );
+    }
+
+    #[test]
     fn assistants_delegation_enabled_is_injected_for_both_frontends() {
         let mut config = AppConfig::default();
         config.assistants.enabled = true;

--- a/backend/erato_config/src/config.rs
+++ b/backend/erato_config/src/config.rs
@@ -2575,8 +2575,8 @@ pub struct FrontendConfig {
     #[serde(default)]
     pub disable_chat_input_autofocus: bool,
 
-    // Layout of the chat input before a conversation has started: "bottom" (default)
-    // or "centered".
+    // Layout of the chat input before a conversation has started: "centered" (default)
+    // or "bottom".
     #[serde(default = "default_chat_input_empty_state_layout")]
     pub chat_input_empty_state_layout: String,
 
@@ -2676,6 +2676,33 @@ impl Default for FrontendConfig {
             extra_frame_ancestors: Vec::new(),
             allow_any_frame_ancestor: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod frontend_config_tests {
+    use super::FrontendConfig;
+
+    #[test]
+    fn chat_input_empty_state_layout_defaults_to_centered() {
+        let config: FrontendConfig =
+            serde_json::from_value(serde_json::json!({})).expect("config should deserialize");
+
+        assert_eq!(config.chat_input_empty_state_layout, "centered");
+        assert_eq!(
+            FrontendConfig::default().chat_input_empty_state_layout,
+            "centered"
+        );
+    }
+
+    #[test]
+    fn chat_input_empty_state_layout_can_be_set_to_bottom() {
+        let config: FrontendConfig = serde_json::from_value(serde_json::json!({
+            "chat_input_empty_state_layout": "bottom"
+        }))
+        .expect("config should deserialize");
+
+        assert_eq!(config.chat_input_empty_state_layout, "bottom");
     }
 }
 
@@ -2784,7 +2811,7 @@ fn default_web_frontend_bundle_path() -> String {
 }
 
 fn default_chat_input_empty_state_layout() -> String {
-    "bottom".to_string()
+    "centered".to_string()
 }
 
 fn default_sidebar_chat_history_show_metadata() -> bool {

--- a/e2e-tests/storybook-welcome-layout/README.md
+++ b/e2e-tests/storybook-welcome-layout/README.md
@@ -1,0 +1,19 @@
+# Welcome layout geometry harness
+
+Measures the `Chat/EmptyStateLayout` stories in a real browser: composer
+shell on the pane midline, independent scrolling of the upper and lower
+halves, composer growth, and the bottom-aligned variant.
+
+Start Storybook from `frontend/`:
+
+```bash
+VITE_API_ROOT_URL=http://localhost:4180/api/ pnpm exec storybook dev -p 6136 --no-open --ci
+```
+
+Run the harness from `e2e-tests/`:
+
+```bash
+pnpm exec playwright test -c storybook-welcome-layout/playwright.config.ts
+```
+
+Set `STORYBOOK_URL` to point at a Storybook on another port.

--- a/e2e-tests/storybook-welcome-layout/playwright.config.ts
+++ b/e2e-tests/storybook-welcome-layout/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Standalone geometry harness against a running Storybook; deliberately
+// outside `tests/` so the scenario projects in ../playwright.config.ts never
+// pick it up.
+export default defineConfig({
+  testDir: ".",
+  outputDir: "../test-results/storybook-welcome-layout",
+  reporter: "list",
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: process.env.STORYBOOK_URL ?? "http://localhost:6136",
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/e2e-tests/storybook-welcome-layout/welcome-layout.spec.ts
+++ b/e2e-tests/storybook-welcome-layout/welcome-layout.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const SHELL = '[data-ui="chat-input-shell"]';
+const PANE = '[data-ui="story-pane"]';
+const ABOVE = '[data-ui="welcome-above"]';
+const BELOW = '[data-ui="welcome-below"]';
+const WELCOME_HEADING = "Welcome to AI Assistant";
+
+const storyUrl = (story: string) =>
+  `/iframe.html?id=chat-emptystatelayout--${story}&viewMode=story`;
+
+const openStory = async (
+  page: Page,
+  story: string,
+  viewport: { width: number; height: number },
+) => {
+  await page.setViewportSize(viewport);
+  await page.goto(storyUrl(story));
+  // The first request compiles the story bundle; later ones are instant.
+  await expect(page.locator(PANE)).toBeVisible({ timeout: 60_000 });
+};
+
+const box = async (locator: Locator) => {
+  const rect = await locator.boundingBox();
+  if (!rect) {
+    throw new Error("element has no bounding box");
+  }
+  return {
+    ...rect,
+    centerY: rect.y + rect.height / 2,
+    bottom: rect.y + rect.height,
+    right: rect.x + rect.width,
+  };
+};
+
+const expectShellOnMidline = async (page: Page, label: string) => {
+  const shell = await box(page.locator(SHELL));
+  const pane = await box(page.locator(PANE));
+  const delta = shell.centerY - pane.centerY;
+  console.log(
+    `${label}: shell center ${shell.centerY.toFixed(1)}, pane center ${pane.centerY.toFixed(1)}, delta ${delta.toFixed(1)}px`,
+  );
+  expect(Math.abs(delta)).toBeLessThanOrEqual(2);
+  return { shell, pane };
+};
+
+const expectInsidePane = async (page: Page) => {
+  const shell = await box(page.locator(SHELL));
+  const pane = await box(page.locator(PANE));
+  expect(shell.y).toBeGreaterThanOrEqual(pane.y);
+  expect(shell.bottom).toBeLessThanOrEqual(pane.bottom);
+  expect(shell.x).toBeGreaterThanOrEqual(pane.x);
+  expect(shell.right).toBeLessThanOrEqual(pane.right);
+};
+
+const scrollMetrics = (locator: Locator) =>
+  locator.evaluate((element) => ({
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    scrollTop: element.scrollTop,
+  }));
+
+test.describe("centered layout", () => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 1280, height: 600 },
+  ]) {
+    test(`shell sits on the pane midline at ${viewport.width}x${viewport.height}`, async ({
+      page,
+    }) => {
+      await openStory(page, "centered-default", viewport);
+      await expect(page.locator(SHELL)).toBeVisible();
+      await expectShellOnMidline(
+        page,
+        `centered-default ${viewport.width}x${viewport.height}`,
+      );
+    });
+  }
+
+  test("composer and welcome heading stay reachable on a phone viewport", async ({
+    page,
+  }) => {
+    await openStory(page, "centered-default", { width: 390, height: 700 });
+    await expect(page.locator(SHELL)).toBeVisible();
+    await expectInsidePane(page);
+    const shell = await box(page.locator(SHELL));
+    console.log(
+      `centered-default 390x700: shell y ${shell.y.toFixed(1)}..${shell.bottom.toFixed(1)}, x ${shell.x.toFixed(1)}..${shell.right.toFixed(1)}`,
+    );
+    await expect(
+      page.getByRole("heading", { level: 1, name: WELCOME_HEADING }),
+    ).toBeInViewport();
+  });
+
+  test("each half scrolls on its own without moving the shell", async ({
+    page,
+  }) => {
+    await openStory(page, "centered-long-content", {
+      width: 1280,
+      height: 800,
+    });
+    await expect(page.locator(SHELL)).toBeVisible();
+    const { shell: before } = await expectShellOnMidline(
+      page,
+      "centered-long-content 1280x800",
+    );
+    // A flex row that overflows shrinks fixed-height children unless they
+    // opt out, which would fold the advisory to zero height.
+    const advisory = await box(page.locator('[data-ui="chat-usage-advisory"]'));
+    console.log(
+      `advisory: top ${advisory.y.toFixed(1)}, height ${advisory.height.toFixed(1)}`,
+    );
+    expect(advisory.height).toBeGreaterThan(0);
+    expect(advisory.y).toBeGreaterThanOrEqual(before.bottom);
+
+    for (const [label, selector] of [
+      ["above", ABOVE],
+      ["below", BELOW],
+    ] as const) {
+      const row = page.locator(selector);
+      const initial = await scrollMetrics(row);
+      expect(initial.scrollHeight).toBeGreaterThan(initial.clientHeight);
+      await row.evaluate((element) => {
+        element.scrollTop = 200;
+      });
+      const scrolled = await scrollMetrics(row);
+      console.log(
+        `${label} row: scrollHeight ${initial.scrollHeight}, clientHeight ${initial.clientHeight}, scrollTop ${initial.scrollTop} -> ${scrolled.scrollTop}`,
+      );
+      expect(scrolled.scrollTop).not.toBe(initial.scrollTop);
+      const after = await box(page.locator(SHELL));
+      expect(Math.abs(after.centerY - before.centerY)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("a tall draft grows the composer around the midline", async ({
+    page,
+  }) => {
+    await openStory(page, "centered-default", { width: 1280, height: 800 });
+    const textbox = page.locator(`${SHELL} textarea`);
+    await expect(textbox).toBeVisible();
+    const before = await box(page.locator(SHELL));
+
+    await textbox.fill(
+      Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n"),
+    );
+    await expect
+      .poll(async () => (await box(page.locator(SHELL))).height)
+      .toBeGreaterThan(before.height);
+
+    const { shell } = await expectShellOnMidline(
+      page,
+      "centered-default after 12 lines",
+    );
+    console.log(
+      `shell height ${before.height.toFixed(1)} -> ${shell.height.toFixed(1)}`,
+    );
+    await expectInsidePane(page);
+  });
+
+  test("read-only story renders the message and no composer", async ({
+    page,
+  }) => {
+    await openStory(page, "centered-read-only", { width: 1280, height: 800 });
+    await expect(page.getByText("Loading shared chat...")).toBeVisible();
+    await expect(page.getByRole("textbox")).toHaveCount(0);
+    await expect(page.locator(SHELL)).toHaveCount(0);
+  });
+});
+
+test.describe("bottom layout", () => {
+  test("shell hugs the pane bottom with the welcome above it", async ({
+    page,
+  }) => {
+    await openStory(page, "bottom-default", { width: 1280, height: 800 });
+    await expect(page.locator(SHELL)).toBeVisible();
+    const shell = await box(page.locator(SHELL));
+    const pane = await box(page.locator(PANE));
+    const gap = pane.bottom - shell.bottom;
+    console.log(
+      `bottom-default 1280x800: shell bottom ${shell.bottom.toFixed(1)}, pane bottom ${pane.bottom.toFixed(1)}, gap ${gap.toFixed(1)}px`,
+    );
+    expect(gap).toBeGreaterThanOrEqual(0);
+    expect(gap).toBeLessThanOrEqual(80);
+
+    const heading = page.getByRole("heading", {
+      level: 1,
+      name: WELCOME_HEADING,
+    });
+    await expect(heading).toBeInViewport();
+    const headingBox = await box(heading);
+    expect(headingBox.bottom).toBeLessThanOrEqual(shell.y);
+  });
+});

--- a/frontend/src/app/__tests__/env.test.ts
+++ b/frontend/src/app/__tests__/env.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { env } from "@/app/env";
+
+describe("env chatInputEmptyStateLayout", () => {
+  afterEach(() => {
+    delete window.CHAT_INPUT_EMPTY_STATE_LAYOUT;
+  });
+
+  it("defaults to centered", () => {
+    expect(env().chatInputEmptyStateLayout).toBe("centered");
+  });
+
+  it("keeps an explicit bottom override", () => {
+    window.CHAT_INPUT_EMPTY_STATE_LAYOUT = "bottom";
+    expect(env().chatInputEmptyStateLayout).toBe("bottom");
+  });
+
+  it("falls back to centered for unknown values", () => {
+    window.CHAT_INPUT_EMPTY_STATE_LAYOUT = "sideways";
+    expect(env().chatInputEmptyStateLayout).toBe("centered");
+  });
+});

--- a/frontend/src/app/chat/__tests__/ChatPage.test.tsx
+++ b/frontend/src/app/chat/__tests__/ChatPage.test.tsx
@@ -524,7 +524,7 @@ describe("ChatPage", () => {
     expect(screen.getByTestId("chat-input")).toBeInTheDocument();
   });
 
-  it("centers the welcome state and hides the message list when configured", () => {
+  const mockEmptyChat = (overrides: Record<string, unknown> = {}) => {
     (useChatContext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       () => ({
         chats: [],
@@ -557,10 +557,36 @@ describe("ChatPage", () => {
         silentChatId: null,
         newChatCounter: 0,
         mountKey: "test-mount-key",
+        ...overrides,
       }),
     );
+  };
 
-    render(
+  it("centers the welcome state and hides the message list by default", () => {
+    mockEmptyChat();
+
+    const { container } = render(
+      <TestWrapper>
+        <StaticFeatureConfigProvider>
+          <ChatPageStructure>
+            <div />
+          </ChatPageStructure>
+        </StaticFeatureConfigProvider>
+      </TestWrapper>,
+    );
+
+    expect(
+      container.querySelector('[data-ui="chat-empty-state-centered-shell"]'),
+    ).not.toBeNull();
+    expect(screen.getByTestId("welcome-screen")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("centers the welcome state when configured explicitly", () => {
+    mockEmptyChat();
+
+    const { container } = render(
       <TestWrapper>
         <StaticFeatureConfigProvider
           config={{
@@ -578,46 +604,47 @@ describe("ChatPage", () => {
       </TestWrapper>,
     );
 
+    expect(
+      container.querySelector('[data-ui="chat-empty-state-centered-shell"]'),
+    ).not.toBeNull();
+    expect(screen.getByTestId("welcome-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
+  });
+
+  it("bottom-aligns the welcome state when configured", () => {
+    mockEmptyChat();
+
+    const { container } = render(
+      <TestWrapper>
+        <StaticFeatureConfigProvider
+          config={{
+            chatInput: {
+              autofocus: true,
+              emptyStateLayout: "bottom",
+              showUsageAdvisory: true,
+            },
+          }}
+        >
+          <ChatPageStructure>
+            <div />
+          </ChatPageStructure>
+        </StaticFeatureConfigProvider>
+      </TestWrapper>,
+    );
+
+    expect(
+      container.querySelector('[data-ui="chat-empty-state-bottom-shell"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-ui="chat-empty-state-centered-shell"]'),
+    ).toBeNull();
     expect(screen.getByTestId("welcome-screen")).toBeInTheDocument();
     expect(screen.getByTestId("chat-input")).toBeInTheDocument();
     expect(screen.queryByTestId("message-list")).not.toBeInTheDocument();
   });
 
   it("falls back to the message list once a first send is pending", () => {
-    (useChatContext as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      () => ({
-        chats: [],
-        currentChatId: "test-chat-id",
-        isHistoryLoading: false,
-        historyError: null,
-        createNewChat: vi.fn(),
-        archiveChat: vi.fn(),
-        navigateToChat: vi.fn(),
-        refetchHistory: vi.fn(),
-        pinnedChats: [],
-        pinChat: vi.fn(),
-        messages: {},
-        messageOrder: [],
-        isStreaming: false,
-        isPendingResponse: true,
-        streamingContent: null,
-        isMessagingLoading: false,
-        messagingError: null,
-        sendMessage: vi.fn(),
-        cancelMessage: vi.fn(),
-        refetchMessages: vi.fn(),
-        uploadFiles: vi.fn(),
-        isUploading: false,
-        uploadError: null,
-        uploadedFiles: [],
-        clearUploadedFiles: vi.fn(),
-        isLoading: false,
-        error: null,
-        silentChatId: null,
-        newChatCounter: 0,
-        mountKey: "test-mount-key",
-      }),
-    );
+    mockEmptyChat({ isPendingResponse: true });
 
     render(
       <TestWrapper>

--- a/frontend/src/app/env.ts
+++ b/frontend/src/app/env.ts
@@ -145,7 +145,7 @@ const OFFICE_ADDIN_PUBLIC_BASE_PATH = "/public/platform-office-addin";
 function normalizeChatInputEmptyStateLayout(
   value: string | null | undefined,
 ): "bottom" | "centered" {
-  return value === "centered" ? "centered" : "bottom";
+  return value === "bottom" ? "bottom" : "centered";
 }
 
 export const env = (): Env => {
@@ -218,7 +218,7 @@ export const env = (): Env => {
   const chatInputEmptyStateLayout = normalizeChatInputEmptyStateLayout(
     import.meta.env.VITE_CHAT_INPUT_EMPTY_STATE_LAYOUT ??
       window.CHAT_INPUT_EMPTY_STATE_LAYOUT ??
-      "bottom",
+      "centered",
   );
   const disableLogout =
     import.meta.env.VITE_DISABLE_LOGOUT === "true"

--- a/frontend/src/components/ui/Chat/Chat.test.tsx
+++ b/frontend/src/components/ui/Chat/Chat.test.tsx
@@ -1,7 +1,7 @@
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
@@ -27,12 +27,28 @@ const chatLists = vi.hoisted(() => ({
 vi.mock("./ChatHistorySidebar", () => ({
   ChatHistorySidebar: () => <div data-testid="sidebar-stub" />,
 }));
+// Mutable so a test can rerender the same tree under a different chat
+// state or layout mode without swapping the mocks.
+const testState = vi.hoisted(
+  (): {
+    chatContext: Record<string, unknown>;
+    emptyStateLayout: "bottom" | "centered";
+    showUsageAdvisory: boolean;
+  } => ({
+    chatContext: {},
+    emptyStateLayout: "bottom",
+    showUsageAdvisory: true,
+  }),
+);
+
+// An uncontrolled textarea: its draft survives only if Chat keeps the node
+// mounted, which is what the continuity tests check.
 vi.mock("./ChatInput", () => ({
   ChatInput: (props: {
     disabled?: boolean;
     initialSelectedFacetIds?: string[];
   }) => (
-    <div
+    <textarea
       data-testid="chat-input-stub"
       data-disabled={String(Boolean(props.disabled))}
       data-facets={JSON.stringify(props.initialSelectedFacetIds)}
@@ -73,28 +89,33 @@ vi.mock("@/components/ui/Modal/FilePreviewModal", () => ({
 
 vi.mock("@/providers/ChatProvider", () => ({
   useChatContext: () => ({
-    sendMessage: vi.fn(),
-    editMessage: vi.fn(),
-    regenerateMessage: vi.fn(),
-    isMessagingLoading: false,
-    isPendingResponse: false,
+    ...baseChatContext,
     chats: chatLists.chats,
-    currentChatId: "origin-1",
-    navigateToChat: vi.fn(),
-    archiveChat: vi.fn(),
-    updateChatTitle: vi.fn(),
-    pinChat: vi.fn(),
     pinnedChats: chatLists.pinnedChats,
-    createNewChat: vi.fn(),
-    isHistoryLoading: false,
-    historyError: null,
-    refetchHistory: vi.fn(),
-    fetchNextHistoryPage: vi.fn(),
-    hasNextHistoryPage: false,
-    isFetchingNextHistoryPage: false,
-    currentChatLastModel: null,
+    ...testState.chatContext,
   }),
 }));
+
+const baseChatContext = {
+  sendMessage: vi.fn(),
+  editMessage: vi.fn(),
+  regenerateMessage: vi.fn(),
+  isMessagingLoading: false,
+  isPendingResponse: false,
+  currentChatId: "origin-1",
+  navigateToChat: vi.fn(),
+  archiveChat: vi.fn(),
+  updateChatTitle: vi.fn(),
+  pinChat: vi.fn(),
+  createNewChat: vi.fn(),
+  isHistoryLoading: false,
+  historyError: null,
+  refetchHistory: vi.fn(),
+  fetchNextHistoryPage: vi.fn(),
+  hasNextHistoryPage: false,
+  isFetchingNextHistoryPage: false,
+  currentChatLastModel: null,
+};
 
 vi.mock("@/hooks/chat", () => ({
   useActiveModelSelection: () => ({
@@ -169,7 +190,11 @@ vi.mock("@/hooks/useProfile", () => ({
 }));
 
 vi.mock("@/providers/FeatureConfigProvider", () => ({
-  useChatInputFeature: () => ({ emptyStateLayout: "bottom", maxFiles: 5 }),
+  useChatInputFeature: () => ({
+    emptyStateLayout: testState.emptyStateLayout,
+    showUsageAdvisory: testState.showUsageAdvisory,
+    maxFiles: 5,
+  }),
   useChatSharingFeature: () => ({ enabled: true }),
   usePinnedChatsFeature: () => ({ enabled: true, maxItems: 5 }),
   useSidebarFeature: () => ({ chatHistoryShowMetadata: false }),
@@ -211,31 +236,61 @@ const mockRuns = (chats: RecentChat[]) => {
   });
 };
 
-const renderChat = (props: Partial<Parameters<typeof Chat>[0]> = {}) =>
-  render(
-    <QueryClientProvider
-      client={
-        new QueryClient({ defaultOptions: { queries: { retry: false } } })
-      }
-    >
-      <I18nProvider i18n={i18n}>
-        <MemoryRouter>
-          <Chat
-            messages={{}}
-            messageOrder={[]}
-            controlsContext={{}}
-            {...props}
-          />
-        </MemoryRouter>
-      </I18nProvider>
+const chatTree = (props: Partial<Parameters<typeof Chat>[0]> = {}) => (
+  <I18nProvider i18n={i18n}>
+    <MemoryRouter>
+      <Chat messages={{}} messageOrder={[]} controlsContext={{}} {...props} />
+    </MemoryRouter>
+  </I18nProvider>
+);
+
+const renderChat = (props: Partial<Parameters<typeof Chat>[0]> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      {chatTree(props)}
     </QueryClientProvider>,
   );
+  return {
+    ...result,
+    rerenderChat: (nextProps: Partial<Parameters<typeof Chat>[0]> = {}) => {
+      result.rerender(
+        <QueryClientProvider client={queryClient}>
+          {chatTree(nextProps)}
+        </QueryClientProvider>,
+      );
+    },
+  };
+};
+
+const welcome = <div data-testid="welcome-stub">Welcome</div>;
+const supplementary = <div data-testid="below-stub">More</div>;
+const firstMessage = {
+  messages: {
+    "user-1": {
+      id: "user-1",
+      content: [],
+      role: "user" as const,
+      sender: "user" as const,
+      authorId: "user-1",
+      createdAt: "2026-08-25T12:00:00.000Z",
+      status: "complete" as const,
+    },
+  },
+  messageOrder: ["user-1"],
+};
+const layoutModes = ["centered", "bottom"] as const;
 
 describe("Chat surface composition", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     chatLists.chats = [];
     chatLists.pinnedChats = [];
+    testState.chatContext = {};
+    testState.emptyStateLayout = "bottom";
+    testState.showUsageAdvisory = true;
     useGenerationStatusStore.getState().reset();
     (useRecentChats as Mock).mockReturnValue({
       data: undefined,
@@ -388,5 +443,155 @@ describe("Chat surface composition", () => {
       container.querySelector('[data-ui="delegated-runs-section"]'),
     ).toBeNull();
     expect(screen.queryByTestId("chat-input-stub")).toBeNull();
+  });
+});
+
+describe("Chat empty-state shell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chatLists.chats = [];
+    chatLists.pinnedChats = [];
+    testState.chatContext = {};
+    testState.emptyStateLayout = "centered";
+    testState.showUsageAdvisory = true;
+    useGenerationStatusStore.getState().reset();
+    mockRuns([]);
+    i18n.load("en", enMessages as unknown as Messages);
+    i18n.activate("en");
+  });
+
+  const shell = (container: HTMLElement, hook: string) =>
+    container.querySelector(`[data-ui="${hook}"]`);
+
+  it("centers the welcome by default and swaps to the bottom shell when configured", () => {
+    const { container, rerenderChat } = renderChat({
+      emptyStateComponent: welcome,
+    });
+
+    expect(shell(container, "chat-empty-state-centered-shell")).not.toBeNull();
+    expect(screen.getByTestId("welcome-stub")).toBeInTheDocument();
+    expect(screen.queryByTestId("message-list-stub")).toBeNull();
+
+    testState.emptyStateLayout = "bottom";
+    rerenderChat({ emptyStateComponent: welcome });
+
+    expect(shell(container, "chat-empty-state-bottom-shell")).not.toBeNull();
+    expect(shell(container, "chat-empty-state-centered-shell")).toBeNull();
+    expect(screen.getByTestId("welcome-stub")).toBeInTheDocument();
+    expect(screen.queryByTestId("message-list-stub")).toBeNull();
+  });
+
+  it.each(layoutModes)(
+    "keeps the same composer node and draft through pending and first message (%s)",
+    (mode) => {
+      testState.emptyStateLayout = mode;
+      const { container, rerenderChat } = renderChat({
+        emptyStateComponent: welcome,
+      });
+      const textbox = screen.getByTestId("chat-input-stub");
+      fireEvent.change(textbox, { target: { value: "draft in progress" } });
+
+      testState.chatContext = { isPendingResponse: true };
+      rerenderChat({ emptyStateComponent: welcome });
+      expect(screen.queryByTestId("welcome-stub")).toBeNull();
+      expect(screen.getByTestId("message-list-stub")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-stub")).toBe(textbox);
+
+      testState.chatContext = {};
+      rerenderChat({ emptyStateComponent: welcome, ...firstMessage });
+      expect(shell(container, "chat-conversation-shell")).not.toBeNull();
+      expect(screen.getByTestId("message-list-stub")).toBeInTheDocument();
+      expect(screen.getByTestId("chat-input-stub")).toBe(textbox);
+      expect((textbox as HTMLTextAreaElement).value).toBe("draft in progress");
+    },
+  );
+
+  it.each(layoutModes)(
+    "renders the usage advisory once, in the row below the composer (%s)",
+    (mode) => {
+      testState.emptyStateLayout = mode;
+      const { container } = renderChat({ emptyStateComponent: welcome });
+
+      const advisories = container.querySelectorAll(
+        '[data-ui="chat-usage-advisory"]',
+      );
+      expect(advisories).toHaveLength(1);
+      expect(advisories[0].closest('[data-ui="welcome-below"]')).not.toBeNull();
+      expect(
+        screen
+          .getByTestId("chat-input-stub")
+          .closest('[data-ui="composer-cluster"]'),
+      ).not.toBeNull();
+    },
+  );
+
+  it("omits the advisory when the feature is off", () => {
+    testState.showUsageAdvisory = false;
+    const { container } = renderChat({ emptyStateComponent: welcome });
+
+    expect(
+      container.querySelector('[data-ui="chat-usage-advisory"]'),
+    ).toBeNull();
+  });
+
+  it("places supplementary content after the advisory in centered mode", () => {
+    const { container } = renderChat({
+      emptyStateComponent: welcome,
+      emptyStateBelowComponent: supplementary,
+    });
+
+    const below = shell(container, "welcome-below")!;
+    const advisory = below.querySelector('[data-ui="chat-usage-advisory"]')!;
+    const extra = screen.getByTestId("below-stub");
+    expect(below.contains(extra)).toBe(true);
+    expect(
+      advisory.compareDocumentPosition(extra) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(shell(container, "welcome-above")!.contains(extra)).toBe(false);
+  });
+
+  it("places supplementary content after the welcome, above the composer, in bottom mode", () => {
+    testState.emptyStateLayout = "bottom";
+    const { container } = renderChat({
+      emptyStateComponent: welcome,
+      emptyStateBelowComponent: supplementary,
+    });
+
+    const above = shell(container, "welcome-above")!;
+    const extra = screen.getByTestId("below-stub");
+    expect(above.contains(extra)).toBe(true);
+    expect(
+      screen.getByTestId("welcome-stub").compareDocumentPosition(extra) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(shell(container, "welcome-below")!.contains(extra)).toBe(false);
+  });
+
+  it("drops supplementary content once messages exist", () => {
+    renderChat({
+      emptyStateComponent: welcome,
+      emptyStateBelowComponent: supplementary,
+      ...firstMessage,
+    });
+
+    expect(screen.queryByTestId("below-stub")).toBeNull();
+    expect(screen.queryByTestId("welcome-stub")).toBeNull();
+  });
+
+  it("renders a read-only forced-centered state without composer or advisory", () => {
+    testState.emptyStateLayout = "bottom";
+    const { container } = renderChat({
+      emptyStateComponent: welcome,
+      forceCenteredEmptyState: true,
+      readOnly: true,
+    });
+
+    expect(shell(container, "chat-empty-state-centered-shell")).not.toBeNull();
+    expect(screen.getByTestId("welcome-stub")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-input-stub")).toBeNull();
+    expect(
+      container.querySelector('[data-ui="chat-usage-advisory"]'),
+    ).toBeNull();
   });
 });

--- a/frontend/src/components/ui/Chat/Chat.test.tsx
+++ b/frontend/src/components/ui/Chat/Chat.test.tsx
@@ -47,11 +47,13 @@ vi.mock("./ChatInput", () => ({
   ChatInput: (props: {
     disabled?: boolean;
     initialSelectedFacetIds?: string[];
+    renderUsageAdvisory?: boolean;
   }) => (
     <textarea
       data-testid="chat-input-stub"
       data-disabled={String(Boolean(props.disabled))}
       data-facets={JSON.stringify(props.initialSelectedFacetIds)}
+      data-render-advisory={String(props.renderUsageAdvisory ?? true)}
     />
   ),
 }));
@@ -517,11 +519,11 @@ describe("Chat empty-state shell", () => {
       );
       expect(advisories).toHaveLength(1);
       expect(advisories[0].closest('[data-ui="welcome-below"]')).not.toBeNull();
+      const composerStub = screen.getByTestId("chat-input-stub");
       expect(
-        screen
-          .getByTestId("chat-input-stub")
-          .closest('[data-ui="composer-cluster"]'),
+        composerStub.closest('[data-ui="composer-cluster"]'),
       ).not.toBeNull();
+      expect(composerStub).toHaveAttribute("data-render-advisory", "false");
     },
   );
 

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -489,8 +489,6 @@ export const Chat = ({
     null,
   );
   const [isUpdatingChatTitle, setIsUpdatingChatTitle] = useState(false);
-  // ChatInput's audio-mode is hoisted so it survives the empty-state ↔
-  // messages layout flip below.
   const [isAudioMode, setIsAudioMode] = useState(false);
 
   const handleEditTitleSession = useCallback((sessionId: string) => {

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -1,15 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
-import {
-  cloneElement,
-  isValidElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { FilePreviewModal } from "@/components/ui/Modal/FilePreviewModal";
 import {
@@ -40,6 +32,7 @@ import { isPromptInjectionFilterDetails } from "@/types/chat";
 import { mapRecentChatToSession } from "@/utils/chat/recentChatSession";
 import { createLogger } from "@/utils/debugLogger";
 
+import { ChatEmptyStateLayout } from "./ChatEmptyStateLayout";
 import { ChatHistorySidebar } from "./ChatHistorySidebar";
 import { ChatInput } from "./ChatInput";
 import {
@@ -48,6 +41,7 @@ import {
 } from "./ChatInputControlsContext";
 import { ChatMessage as ChatMessageComponent } from "./ChatMessage";
 import { ChatShareDialog } from "./ChatShareDialog";
+import { ChatUsageAdvisory } from "./ChatUsageAdvisory";
 import { DelegatedRunsSection } from "./DelegatedRunsSection";
 import { EditChatTitleDialog } from "./EditChatTitleDialog";
 import { Button } from "../Controls/Button";
@@ -122,6 +116,8 @@ export interface ChatProps {
   customSessionSelect?: (sessionId: string) => void;
   /** Optional custom component to show when there are no messages */
   emptyStateComponent?: React.ReactNode;
+  /** Optional supplementary empty-state content rendered on the composer's far side from `emptyStateComponent` */
+  emptyStateBelowComponent?: React.ReactNode;
   /** Force the centered empty-state layout regardless of feature config */
   forceCenteredEmptyState?: boolean;
   /** Optional content rendered at the top of the conversation area */
@@ -174,6 +170,7 @@ export const Chat = ({
   acceptedFileTypes,
   customSessionSelect,
   emptyStateComponent,
+  emptyStateBelowComponent,
   forceCenteredEmptyState = false,
   topContent,
   composerDisabled = false,
@@ -492,9 +489,8 @@ export const Chat = ({
     null,
   );
   const [isUpdatingChatTitle, setIsUpdatingChatTitle] = useState(false);
-  // ChatInput's audio-mode lives here so it survives the empty-state ↔
-  // messages layout flip below, which renders ChatInput in two different
-  // JSX positions and would otherwise unmount it on the first send.
+  // ChatInput's audio-mode is hoisted so it survives the empty-state ↔
+  // messages layout flip below.
   const [isAudioMode, setIsAudioMode] = useState(false);
 
   const handleEditTitleSession = useCallback((sessionId: string) => {
@@ -650,24 +646,21 @@ export const Chat = ({
     );
   }
 
-  const shouldRenderCenteredEmptyState =
-    (forceCenteredEmptyState || emptyStateLayout === "centered") &&
+  const showEmptyState =
     !!emptyStateComponent &&
     messageOrder.length === 0 &&
     !chatLoading &&
     !isPendingResponse &&
     editingMessageId === null;
-
-  const centeredEmptyStateContent =
-    shouldRenderCenteredEmptyState &&
-    isValidElement<{ className?: string }>(emptyStateComponent)
-      ? cloneElement(emptyStateComponent, {
-          className: clsx(
-            emptyStateComponent.props.className,
-            "!translate-y-0",
-          ),
-        })
-      : emptyStateComponent;
+  const centeredEmpty =
+    (forceCenteredEmptyState || emptyStateLayout === "centered") &&
+    showEmptyState;
+  const bottomEmpty = !centeredEmpty && showEmptyState;
+  const layoutMode = centeredEmpty
+    ? "centered"
+    : bottomEmpty
+      ? "bottom"
+      : "conversation";
   const canShareCurrentChat =
     chatSharingEnabled &&
     !!currentChatId &&
@@ -711,7 +704,93 @@ export const Chat = ({
       uploadError={uploadError}
       controlledIsAudioMode={isAudioMode}
       onControlledIsAudioModeChange={setIsAudioMode}
+      renderUsageAdvisory={false}
     />
+  );
+
+  const aboveComposerContent = (
+    <>
+      {!centeredEmpty && topContent ? (
+        <div
+          className={clsx(
+            "relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 sm:px-4",
+            // The share button floats over this strip's corner.
+            canShareCurrentChat && "pr-28 sm:pr-32",
+          )}
+        >
+          {topContent}
+        </div>
+      ) : null}
+      {!centeredEmpty && canShareCurrentChat ? (
+        <div className="absolute right-3 top-3 z-10 sm:right-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<ShareIcon className="size-4" />}
+            onClick={() => {
+              handleOpenShareDialog(currentChatId);
+            }}
+          >
+            {currentShareButtonLabel}
+          </Button>
+        </div>
+      ) : null}
+      {showEmptyState ? (
+        <>
+          {emptyStateComponent}
+          {bottomEmpty ? emptyStateBelowComponent : null}
+        </>
+      ) : (
+        <MessageEditProvider value={messageEditValue}>
+          <MessageList
+            messages={messages}
+            messageOrder={messageOrder}
+            loadOlderMessages={loadOlderMessages}
+            hasOlderMessages={hasOlderMessages}
+            isPending={chatLoading}
+            currentSessionId={currentChatId ?? ""}
+            pageSize={6}
+            maxWidth={maxWidth}
+            showTimestamps={showTimestamps}
+            showAvatars={showAvatars}
+            userProfile={userMessageProfile ?? profile}
+            userDisplayNameOverride={userMessageDisplayName}
+            controls={resolvedMessageControls}
+            messageRenderer={resolvedMessageRenderer}
+            controlsContext={{
+              ...controlsContext,
+              canEdit: canEditForCurrentChat,
+            }}
+            onMessageAction={standardMessageActionHandler}
+            className={clsx(layout, canShareCurrentChat && "pt-12 sm:pt-14")}
+            useVirtualization={messageOrder.length > 30}
+            virtualizationThreshold={30}
+            onScrollToBottomRef={handleMessageListRef}
+            onFilePreview={openPreviewModal}
+            onViewFeedback={openFeedbackViewDialog}
+            assistantFiles={assistantFiles}
+            modelSwitches={modelSwitches}
+          />
+        </MessageEditProvider>
+      )}
+    </>
+  );
+
+  // Background runs launched from this chat sit right above the composer —
+  // in view even on small screens, where the sidebar is hidden. Renders
+  // nothing while the chat has none.
+  const composerContent = readOnly ? null : (
+    <>
+      <DelegatedRunsSection chatId={currentChatId} />
+      {chatInputElement}
+    </>
+  );
+
+  const belowComposerContent = readOnly ? null : (
+    <>
+      <ChatUsageAdvisory />
+      {centeredEmpty ? emptyStateBelowComponent : null}
+    </>
   );
 
   return (
@@ -822,89 +901,12 @@ export const Chat = ({
                 />
               </div>
             ) : null}
-            {shouldRenderCenteredEmptyState ? (
-              <div
-                className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-2 py-4 sm:px-4 sm:py-6"
-                data-ui="chat-empty-state-centered-shell"
-              >
-                <div className="flex w-full flex-col items-center justify-center gap-4">
-                  {centeredEmptyStateContent}
-                </div>
-              </div>
-            ) : (
-              <>
-                {topContent ? (
-                  <div
-                    className={clsx(
-                      "relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 sm:px-4",
-                      // The share button floats over this strip's corner.
-                      canShareCurrentChat && "pr-28 sm:pr-32",
-                    )}
-                  >
-                    {topContent}
-                  </div>
-                ) : null}
-                {canShareCurrentChat ? (
-                  <div className="absolute right-3 top-3 z-10 sm:right-4">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      icon={<ShareIcon className="size-4" />}
-                      onClick={() => {
-                        handleOpenShareDialog(currentChatId);
-                      }}
-                    >
-                      {currentShareButtonLabel}
-                    </Button>
-                  </div>
-                ) : null}
-                {/* Use the MessageList component */}
-                <MessageEditProvider value={messageEditValue}>
-                  <MessageList
-                    messages={messages}
-                    messageOrder={messageOrder}
-                    loadOlderMessages={loadOlderMessages}
-                    hasOlderMessages={hasOlderMessages}
-                    isPending={chatLoading}
-                    currentSessionId={currentChatId ?? ""}
-                    pageSize={6}
-                    maxWidth={maxWidth}
-                    showTimestamps={showTimestamps}
-                    showAvatars={showAvatars}
-                    userProfile={userMessageProfile ?? profile}
-                    userDisplayNameOverride={userMessageDisplayName}
-                    controls={resolvedMessageControls}
-                    messageRenderer={resolvedMessageRenderer}
-                    controlsContext={{
-                      ...controlsContext,
-                      canEdit: canEditForCurrentChat,
-                    }}
-                    onMessageAction={standardMessageActionHandler}
-                    className={clsx(
-                      layout,
-                      canShareCurrentChat && "pt-12 sm:pt-14",
-                    )}
-                    useVirtualization={messageOrder.length > 30}
-                    virtualizationThreshold={30}
-                    onScrollToBottomRef={handleMessageListRef}
-                    onFilePreview={openPreviewModal}
-                    onViewFeedback={openFeedbackViewDialog}
-                    emptyStateComponent={emptyStateComponent}
-                    assistantFiles={assistantFiles}
-                    modelSwitches={modelSwitches}
-                  />
-                </MessageEditProvider>
-              </>
-            )}
-            {/* Background runs launched from this chat sit right above the
-                composer — in view even on small screens, where the sidebar
-                is hidden. Renders nothing while the chat has none. */}
-            {!readOnly ? <DelegatedRunsSection chatId={currentChatId} /> : null}
-            {/* ChatInput lives in a stable JSX position so React doesn't
-                unmount it during the empty-state ↔ messages layout flip.
-                Anything previously hoisted to survive that unmount (audio
-                mode, voice-session refs) can stay where it naturally lives. */}
-            {!readOnly ? chatInputElement : null}
+            <ChatEmptyStateLayout
+              mode={layoutMode}
+              above={aboveComposerContent}
+              composer={composerContent}
+              below={belowComposerContent}
+            />
           </div>
         </ChatErrorBoundary>
 

--- a/frontend/src/components/ui/Chat/ChatEmptyStateLayout.tsx
+++ b/frontend/src/components/ui/Chat/ChatEmptyStateLayout.tsx
@@ -52,9 +52,8 @@ export function ChatEmptyStateLayout({
         data-ui="welcome-above"
       >
         {centered ? (
-          // `mt-auto` bottom-aligns short content but collapses to zero once
-          // the content overflows, so the row still scrolls from its top;
-          // `justify-end` would push the overflow above the scrollable area.
+          // `mt-auto`, not `justify-end`: overflowing content must scroll from
+          // its top instead of being pushed above the scrollable area.
           <div className="mt-auto flex w-full flex-col items-center pb-6">
             {above}
           </div>

--- a/frontend/src/components/ui/Chat/ChatEmptyStateLayout.tsx
+++ b/frontend/src/components/ui/Chat/ChatEmptyStateLayout.tsx
@@ -1,0 +1,80 @@
+import clsx from "clsx";
+
+import type { ReactNode } from "react";
+
+export type ChatEmptyStateLayoutMode = "centered" | "bottom" | "conversation";
+
+export interface ChatEmptyStateLayoutProps {
+  mode: ChatEmptyStateLayoutMode;
+  above: ReactNode;
+  composer: ReactNode;
+  below: ReactNode;
+  className?: string;
+}
+
+const shellHooks: Record<ChatEmptyStateLayoutMode, string> = {
+  centered: "chat-empty-state-centered-shell",
+  bottom: "chat-empty-state-bottom-shell",
+  conversation: "chat-conversation-shell",
+};
+
+/**
+ * The three-row frame around the composer. All three rows exist in every
+ * mode so the composer keeps one DOM position while the surrounding
+ * content changes; only the row classes differ.
+ */
+export function ChatEmptyStateLayout({
+  mode,
+  above,
+  composer,
+  below,
+  className,
+}: ChatEmptyStateLayoutProps) {
+  const centered = mode === "centered";
+
+  return (
+    <div
+      className={clsx(
+        centered
+          ? "grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)] py-4 sm:py-6"
+          : "flex min-h-0 flex-1 flex-col",
+        className,
+      )}
+      data-ui={shellHooks[mode]}
+    >
+      <div
+        className={clsx(
+          centered && "flex min-h-0 flex-col overflow-y-auto px-2 sm:px-4",
+          mode === "bottom" &&
+            "flex min-h-0 flex-1 flex-col items-center overflow-y-auto pb-6 pt-10 sm:pt-16",
+          mode === "conversation" && "relative flex min-h-0 flex-1 flex-col",
+        )}
+        data-ui="welcome-above"
+      >
+        {centered ? (
+          // `mt-auto` bottom-aligns short content but collapses to zero once
+          // the content overflows, so the row still scrolls from its top;
+          // `justify-end` would push the overflow above the scrollable area.
+          <div className="mt-auto flex w-full flex-col items-center pb-6">
+            {above}
+          </div>
+        ) : (
+          above
+        )}
+      </div>
+      <div className="w-full shrink-0" data-ui="composer-cluster">
+        {composer}
+      </div>
+      <div
+        className={
+          centered
+            ? "flex min-h-0 flex-col items-center overflow-y-auto px-2 sm:px-4"
+            : "shrink-0"
+        }
+        data-ui="welcome-below"
+      >
+        {below}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Chat/ChatInput.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.test.tsx
@@ -749,7 +749,7 @@ describe("ChatInput", () => {
     mockUseOptionalTranslation.mockReturnValue(advisory);
 
     const { i18n } = await import("@lingui/core");
-    render(
+    const { container } = render(
       <QueryClientProvider client={queryClient}>
         <I18nProvider i18n={i18n}>
           <ChatInput onSendMessage={onSendMessage} />
@@ -758,6 +758,7 @@ describe("ChatInput", () => {
     );
 
     expect(screen.getByText(advisory)).toBeInTheDocument();
+    expect(container.querySelector("form")).toHaveClass("pb-0");
   });
 
   it("hides the AI usage advisory when disabled by feature config", async () => {
@@ -787,6 +788,37 @@ describe("ChatInput", () => {
     );
 
     expect(screen.queryByText(advisory)).not.toBeInTheDocument();
+  });
+
+  it("leaves the advisory and the form padding to the parent when renderUsageAdvisory is false", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const advisory =
+      "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use.";
+
+    mockUseOptionalTranslation.mockReturnValue(advisory);
+
+    const { i18n } = await import("@lingui/core");
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <I18nProvider i18n={i18n}>
+          <ChatInput
+            onSendMessage={vi.fn()}
+            className="p-2 sm:p-4"
+            renderUsageAdvisory={false}
+          />
+        </I18nProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByText(advisory)).not.toBeInTheDocument();
+    const form = container.querySelector("form");
+    expect(form).toHaveClass("p-2", "sm:p-4");
+    expect(form).not.toHaveClass("pb-0");
   });
 
   it("uses externally controlled model selection when provided", async () => {

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -79,6 +79,7 @@ import { AssistantMentionPopover } from "./AssistantMentionPopover";
 import { ChatInputAddControls } from "./ChatInputAddControls";
 import { ChatInputAudioModeButton } from "./ChatInputAudioModeButton";
 import { ChatInputTokenUsage } from "./ChatInputTokenUsage";
+import { ChatUsageAdvisory } from "./ChatUsageAdvisory";
 import { DelegationRunModePopover } from "./DelegationRunModePopover";
 import { FacetSelector } from "./FacetSelector";
 import { ModelSelector } from "./ModelSelector";
@@ -289,6 +290,12 @@ interface ChatInputProps {
    */
   controlledIsAudioMode?: boolean;
   onControlledIsAudioModeChange?: (isAudioMode: boolean) => void;
+  /**
+   * Pass `false` when the parent renders `ChatUsageAdvisory` itself; the
+   * form then keeps its full bottom padding instead of ceding it to the
+   * inline advisory.
+   */
+  renderUsageAdvisory?: boolean;
 }
 
 interface DictationTarget {
@@ -381,6 +388,7 @@ export const ChatInput = ({
   controlledIsModelSelectionReady,
   controlledIsAudioMode,
   onControlledIsAudioModeChange,
+  renderUsageAdvisory = true,
   ref,
 }: ChatInputPropsWithRef) => {
   const {
@@ -490,14 +498,7 @@ export const ChatInput = ({
     enabled: audioConversationalEnabled,
     maxRecordingDurationSeconds: maxConversationalDurationSeconds,
   } = useAudioConversationalFeature();
-  const { autofocus: shouldAutofocus, showUsageAdvisory = true } =
-    useChatInputFeature();
-  // Dummy for i18n:extract
-  const _aiUsageAdvisoryDefault = t({
-    id: "chat.ai_usage_advisory",
-    message:
-      "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use.",
-  });
+  const { autofocus: shouldAutofocus } = useChatInputFeature();
   const aiUsageAdvisory = useOptionalTranslation("chat.ai_usage_advisory");
 
   // Use local model selection hook
@@ -2398,7 +2399,7 @@ export const ChatInput = ({
       <form
         ref={formRef}
         className={clsx("w-full ", className, {
-          "pb-0 sm:pb-0": aiUsageAdvisory,
+          "pb-0 sm:pb-0": renderUsageAdvisory && aiUsageAdvisory,
         })}
         onSubmit={handleComposerSubmit}
       >
@@ -3114,13 +3115,7 @@ export const ChatInput = ({
           )}
         </div>
       </form>
-      {showUsageAdvisory && aiUsageAdvisory && (
-        <div className="relative h-10">
-          <p className="absolute inset-0 flex items-center justify-center text-center text-xs text-theme-fg-muted">
-            {aiUsageAdvisory}
-          </p>
-        </div>
-      )}
+      {renderUsageAdvisory ? <ChatUsageAdvisory /> : null}
     </div>
   );
 };

--- a/frontend/src/components/ui/Chat/ChatUsageAdvisory.tsx
+++ b/frontend/src/components/ui/Chat/ChatUsageAdvisory.tsx
@@ -1,0 +1,40 @@
+import { t } from "@lingui/core/macro";
+
+import { useOptionalTranslation } from "@/hooks/i18n";
+import { useChatInputFeature } from "@/providers/FeatureConfigProvider";
+
+const advisoryStyle = {
+  maxWidth: "var(--theme-layout-chat-input-max-width)",
+} as const;
+
+/**
+ * The "you are talking to an AI" line that sits beneath the composer shell.
+ * Renders nothing when the feature is off or the deployment has no
+ * translation for it.
+ */
+export function ChatUsageAdvisory() {
+  const { showUsageAdvisory = true } = useChatInputFeature();
+  // Dummy for i18n:extract
+  void t({
+    id: "chat.ai_usage_advisory",
+    message:
+      "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use.",
+  });
+  const aiUsageAdvisory = useOptionalTranslation("chat.ai_usage_advisory");
+
+  if (!showUsageAdvisory || !aiUsageAdvisory) {
+    return null;
+  }
+
+  return (
+    <div
+      className="relative mx-auto h-10 w-full shrink-0"
+      style={advisoryStyle}
+      data-ui="chat-usage-advisory"
+    >
+      <p className="absolute inset-0 flex items-center justify-center text-center text-xs text-theme-fg-muted">
+        {aiUsageAdvisory}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -1415,7 +1415,7 @@ msgid "branding.welcomeScreen.title"
 msgstr "Willkommen beim KI-Assistenten"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Chat/ChatUsageAdvisory.tsx
 msgid "chat.ai_usage_advisory"
 msgstr "Sie interagieren mit einem KI-Chatbot. Generierte Antworten können sachliche Fehler enthalten und sollten vor der Verwendung überprüft werden."
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1415,7 +1415,7 @@ msgid "branding.welcomeScreen.title"
 msgstr "Welcome to AI Assistant"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Chat/ChatUsageAdvisory.tsx
 msgid "chat.ai_usage_advisory"
 msgstr "You are interacting with an AI chatbot. Generated answers may contain factual errors and should be verified before use."
 

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -1415,7 +1415,7 @@ msgid "branding.welcomeScreen.title"
 msgstr "Bienvenido al Asistente IA"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Chat/ChatUsageAdvisory.tsx
 msgid "chat.ai_usage_advisory"
 msgstr "Está interactuando con un chatbot de IA. Las respuestas generadas pueden contener errores fácticos y deben verificarse antes de usarse."
 

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -1415,7 +1415,7 @@ msgid "branding.welcomeScreen.title"
 msgstr "Bienvenue dans l'Assistant IA"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Chat/ChatUsageAdvisory.tsx
 msgid "chat.ai_usage_advisory"
 msgstr "Vous interagissez avec un chatbot IA. Les réponses générées peuvent contenir des erreurs factuelles et doivent être vérifiées avant utilisation."
 

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -1415,7 +1415,7 @@ msgid "branding.welcomeScreen.title"
 msgstr "Witamy w Asystencie AI"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatInput.tsx
+#: src/components/ui/Chat/ChatUsageAdvisory.tsx
 msgid "chat.ai_usage_advisory"
 msgstr "Wchodzisz w interakcję z chatbotem AI. Wygenerowane odpowiedzi mogą zawierać błędy merytoryczne i powinny zostać zweryfikowane przed użyciem."
 

--- a/frontend/src/providers/FeatureConfigProvider.tsx
+++ b/frontend/src/providers/FeatureConfigProvider.tsx
@@ -250,7 +250,7 @@ export const defaultStaticFeatureConfig: FeatureConfig = {
   },
   chatInput: {
     autofocus: true,
-    emptyStateLayout: "bottom",
+    emptyStateLayout: "centered",
     showUsageAdvisory: true,
     maxFiles: DEFAULT_MAX_FILES_PER_MESSAGE,
   },

--- a/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
+++ b/frontend/src/providers/__tests__/FeatureConfigProvider.test.tsx
@@ -58,7 +58,7 @@ describe("FeatureConfigProvider", () => {
       themeAssistantAvatarPath: null,
       disableUpload: false,
       disableChatInputAutofocus: false,
-      chatInputEmptyStateLayout: "bottom",
+      chatInputEmptyStateLayout: "centered",
       disableLogout: false,
       assistantsEnabled: false,
       assistantsShowRecentItems: false,
@@ -132,7 +132,7 @@ describe("FeatureConfigProvider", () => {
         },
         chatInput: {
           autofocus: true,
-          emptyStateLayout: "bottom",
+          emptyStateLayout: "centered",
           showUsageAdvisory: true,
           maxFiles: 10,
         },
@@ -295,7 +295,7 @@ describe("FeatureConfigProvider", () => {
 
       expect(result.current.chatInput).toEqual({
         autofocus: true,
-        emptyStateLayout: "bottom",
+        emptyStateLayout: "centered",
         showUsageAdvisory: false,
         maxFiles: 10,
       });
@@ -591,7 +591,7 @@ describe("FeatureConfigProvider", () => {
 
       expect(result.current).toEqual({
         autofocus: true,
-        emptyStateLayout: "bottom",
+        emptyStateLayout: "centered",
         showUsageAdvisory: true,
         maxFiles: 10,
       });
@@ -666,6 +666,42 @@ describe("FeatureConfigProvider", () => {
       });
 
       expect(result.current.emptyStateLayout).toBe("centered");
+    });
+
+    it("should return a bottom empty-state layout when configured", () => {
+      mockEnv.mockReturnValue({
+        apiRootUrl: "/api/",
+        themeCustomerName: null,
+        themePath: null,
+        themeConfigPath: null,
+        themeLogoPath: null,
+        themeLogoDarkPath: null,
+        themeAssistantAvatarPath: null,
+        disableUpload: false,
+        disableChatInputAutofocus: false,
+        chatInputEmptyStateLayout: "bottom",
+        disableLogout: false,
+        assistantsEnabled: false,
+        assistantsShowRecentItems: false,
+        assistantsShowRecentItemsCollapsible: false,
+        sharepointEnabled: false,
+        sharepointShowDisclaimer: false,
+        messageFeedbackEnabled: false,
+        messageFeedbackCommentsEnabled: false,
+        userPreferencesEnabled: true,
+        userPreferencesDataTabEnabled: true,
+        messageFeedbackEditTimeLimitSeconds: null,
+        maxUploadSizeBytes: 52428800,
+        sidebarCollapsedMode: "hidden",
+        sidebarLogoPath: null,
+        sidebarLogoDarkPath: null,
+      });
+
+      const { result } = renderHook(() => useChatInputFeature(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.emptyStateLayout).toBe("bottom");
     });
   });
 

--- a/frontend/src/stories/chat/ChatEmptyStateLayout.stories.tsx
+++ b/frontend/src/stories/chat/ChatEmptyStateLayout.stories.tsx
@@ -1,10 +1,12 @@
 import { action } from "@storybook/addon-actions";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ChatEmptyStateLayout } from "../../components/ui/Chat/ChatEmptyStateLayout";
 import { ChatInput } from "../../components/ui/Chat/ChatInput";
 import { ChatInputControlsProvider } from "../../components/ui/Chat/ChatInputControlsContext";
 import { ChatUsageAdvisory } from "../../components/ui/Chat/ChatUsageAdvisory";
 import { WelcomeScreen } from "../../components/ui/WelcomeScreen";
+import { facetsQuery } from "../../lib/generated/v1betaApi/v1betaApiComponents";
 import { StaticFeatureConfigProvider } from "../../providers/FeatureConfigProvider";
 
 import type { ChatInputControls } from "../../components/ui/Chat/ChatInputControlsContext";
@@ -18,6 +20,22 @@ const stubControls: ChatInputControls = {
   toggleFacetId: action("toggleFacetId"),
   addUploadedFiles: action("addUploadedFiles"),
   clearQueuedMessage: action("clearQueuedMessage"),
+};
+
+// Storybook has no backend; a seeded cache keeps the composer's tools menu
+// from showing its load-error banner.
+const makeQueryClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(facetsQuery({}).queryKey, {
+    facets: [],
+    global_facet_settings: {
+      only_single_facet: false,
+      show_facet_indicator_with_display_name: false,
+    },
+  });
+  return queryClient;
 };
 
 const meta: Meta<typeof ChatEmptyStateLayout> = {
@@ -34,21 +52,23 @@ const meta: Meta<typeof ChatEmptyStateLayout> = {
   },
   decorators: [
     (Story) => (
-      <StaticFeatureConfigProvider
-        config={{
-          chatInput: { autofocus: false },
-          starterPrompts: { enabled: false },
-        }}
-      >
-        <ChatInputControlsProvider value={stubControls}>
-          <div
-            className="flex h-screen w-full flex-col bg-theme-bg-primary"
-            data-ui="story-pane"
-          >
-            <Story />
-          </div>
-        </ChatInputControlsProvider>
-      </StaticFeatureConfigProvider>
+      <QueryClientProvider client={makeQueryClient()}>
+        <StaticFeatureConfigProvider
+          config={{
+            chatInput: { autofocus: false },
+            starterPrompts: { enabled: false },
+          }}
+        >
+          <ChatInputControlsProvider value={stubControls}>
+            <div
+              className="flex h-screen w-full flex-col bg-theme-bg-primary"
+              data-ui="story-pane"
+            >
+              <Story />
+            </div>
+          </ChatInputControlsProvider>
+        </StaticFeatureConfigProvider>
+      </QueryClientProvider>
     ),
   ],
 };

--- a/frontend/src/stories/chat/ChatEmptyStateLayout.stories.tsx
+++ b/frontend/src/stories/chat/ChatEmptyStateLayout.stories.tsx
@@ -1,0 +1,154 @@
+import { action } from "@storybook/addon-actions";
+
+import { ChatEmptyStateLayout } from "../../components/ui/Chat/ChatEmptyStateLayout";
+import { ChatInput } from "../../components/ui/Chat/ChatInput";
+import { ChatInputControlsProvider } from "../../components/ui/Chat/ChatInputControlsContext";
+import { ChatUsageAdvisory } from "../../components/ui/Chat/ChatUsageAdvisory";
+import { WelcomeScreen } from "../../components/ui/WelcomeScreen";
+import { StaticFeatureConfigProvider } from "../../providers/FeatureConfigProvider";
+
+import type { ChatInputControls } from "../../components/ui/Chat/ChatInputControlsContext";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const stubControls: ChatInputControls = {
+  setDraftMessage: action("setDraftMessage"),
+  focusInput: action("focusInput"),
+  setSelectedFacetIds: action("setSelectedFacetIds"),
+  setSelectedChatProviderId: action("setSelectedChatProviderId"),
+  toggleFacetId: action("toggleFacetId"),
+  addUploadedFiles: action("addUploadedFiles"),
+  clearQueuedMessage: action("clearQueuedMessage"),
+};
+
+const meta: Meta<typeof ChatEmptyStateLayout> = {
+  title: "Chat/EmptyStateLayout",
+  component: ChatEmptyStateLayout,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "The three-row frame Chat renders around the composer: welcome content above, the composer cluster, and the advisory plus supplementary content below. The story pane is a fixed-height stand-in for the chat pane.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <StaticFeatureConfigProvider
+        config={{
+          chatInput: { autofocus: false },
+          starterPrompts: { enabled: false },
+        }}
+      >
+        <ChatInputControlsProvider value={stubControls}>
+          <div
+            className="flex h-screen w-full flex-col bg-theme-bg-primary"
+            data-ui="story-pane"
+          >
+            <Story />
+          </div>
+        </ChatInputControlsProvider>
+      </StaticFeatureConfigProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const composer = (
+  <ChatInput
+    onSendMessage={action("onSendMessage")}
+    showControls
+    className="p-2 sm:p-4"
+    renderUsageAdvisory={false}
+  />
+);
+
+const extraParagraphs = (
+  <div className="w-full max-w-2xl px-6 text-theme-fg-secondary">
+    {Array.from({ length: 40 }, (_, index) => (
+      <p key={index} className="mb-3">
+        Paragraph {index + 1}: long welcome copy that keeps going so the upper
+        half has more content than it can show at once.
+      </p>
+    ))}
+  </div>
+);
+
+const tallBlock = (
+  <div className="w-full max-w-2xl px-6" data-ui="story-tall-block">
+    {Array.from({ length: 30 }, (_, index) => (
+      <div
+        key={index}
+        className="mb-2 rounded-[var(--theme-radius-control)] border border-theme-border p-4 text-theme-fg-secondary"
+      >
+        Supplementary row {index + 1}
+      </div>
+    ))}
+  </div>
+);
+
+export const CenteredDefault: Story = {
+  args: {
+    mode: "centered",
+    above: <WelcomeScreen />,
+    composer,
+    below: <ChatUsageAdvisory />,
+  },
+};
+
+export const CenteredLongContent: Story = {
+  args: {
+    mode: "centered",
+    above: (
+      <>
+        <WelcomeScreen />
+        {extraParagraphs}
+      </>
+    ),
+    composer,
+    below: (
+      <>
+        <ChatUsageAdvisory />
+        {tallBlock}
+      </>
+    ),
+  },
+};
+
+export const CenteredReadOnly: Story = {
+  args: {
+    mode: "centered",
+    above: (
+      <div className="mx-auto max-w-xl px-6 text-center text-theme-fg-secondary">
+        Loading shared chat...
+      </div>
+    ),
+    composer: null,
+    below: null,
+  },
+};
+
+export const BottomDefault: Story = {
+  args: {
+    mode: "bottom",
+    above: <WelcomeScreen />,
+    composer,
+    below: <ChatUsageAdvisory />,
+  },
+};
+
+export const BottomLongContent: Story = {
+  args: {
+    mode: "bottom",
+    above: (
+      <>
+        <WelcomeScreen />
+        {extraParagraphs}
+      </>
+    ),
+    composer,
+    below: <ChatUsageAdvisory />,
+  },
+};


### PR DESCRIPTION
Part 1 of the ERMAIN-731 stack (this PR → main; ERMAIN-737 stacks on top). Implements ERMAIN-736.

## What changes

- **Centered is the default** for the new-chat composer everywhere: backend `default_chat_input_empty_state_layout()`, the injected `CHAT_INPUT_EMPTY_STATE_LAYOUT`, `env.ts` (unknown values now fall back to `centered`), and `FeatureConfigProvider`. `chat_input_empty_state_layout = "bottom"` keeps the old layout; the template toml shows that override.
- **Three-row composition** (`ChatEmptyStateLayout`): `minmax(0,1fr) auto minmax(0,1fr)`. The composer cluster (DelegatedRunsSection + ChatInput) sits on the pane midline; the upper row bottom-aligns and scrolls on its own, the lower row holds the usage advisory first and scrolls on its own. Bottom mode is composed in `Chat.tsx` too (welcome above, composer pinned at the bottom, advisory beneath); the `MessageList` `emptyStateComponent` path and the `!translate-y-0` clone hack are gone from `Chat.tsx`. `MessageList` keeps its prop.
- **One mounted composer**: the three rows exist in every state (centered-empty, bottom-empty, conversation) so `ChatInput` keeps its DOM position through first send and message arrival. jsdom tests assert node identity and a surviving draft across those transitions in both modes.
- **Usage advisory** extracted into `ChatUsageAdvisory`; `ChatInput` gains `renderUsageAdvisory` (default `true`, so the add-in and direct `ChatInput` users are unchanged) and `Chat.tsx` renders the advisory in the lower row.
- **Additive lower slot** `Chat.emptyStateBelowComponent` (nothing passes it yet; ERMAIN-737 fills it). Shared-chat loading/error surfaces (`forceCenteredEmptyState` + `readOnly`) still render without a composer.
- Hooks kept: `chat-empty-state-centered-shell`, `welcome-screen-default`, `assistant-welcome-screen-default`, `starter-prompts-section`.

## Test setup for this stack level

Unit and backend gates:

```
cd frontend && pnpm lint:strict && pnpm typecheck && pnpm exec prettier . --check && ./scripts/check-i18n-extract.sh && pnpm exec vitest run
cd backend && cargo test -p erato_config && cargo test -p erato frontend_environment && cargo run --bin gen-config-reference -- --check
```

Browser geometry (Storybook story `Chat/EmptyStateLayout` + committed Playwright harness, see `e2e-tests/storybook-welcome-layout/README.md`):

```
cd frontend && VITE_API_ROOT_URL=http://localhost:4180/api/ pnpm exec storybook dev -p 6136 --no-open --ci
cd e2e-tests && pnpm exec playwright test -c storybook-welcome-layout/playwright.config.ts
```

Measured on this branch: shell center on the pane midline with 0.0 px delta at 1280×800, 1280×600, with long content in both halves, and after a 12-line draft grew the shell from 114 to 274 px; both halves scroll independently (scrollTop 0→200) without moving the shell; at 390×700 the shell stays fully inside the pane; bottom mode leaves a 56 px advisory gap under the shell. The harness is not picked up by the scenario projects.

## Deviations worth knowing

- Horizontal padding lives on the outer rows, not the grid, so the composer inset is identical in the empty and conversation states (no horizontal jump on first send).
- The upper row bottom-aligns through an inner `mt-auto` wrapper rather than `justify-end`, because `justify-end` makes overflowing content unscrollable from its top.
- No advisory in read-only mode (matches today, where it lived inside the un-rendered `ChatInput`).
- In bottom-empty mode a `topContent` strip would render inside the scrolling welcome row; that combination does not occur today (delegated-run headers and shared-chat titles come with messages).

## Follow-ups

- The Office add-in inherits the centered default through the shared env; confirm that is wanted for its narrow pane.
- Commits are unsigned (no pinentry in the build session); re-sign before merging: `git rebase --exec 'git commit --amend --no-edit -S' origin/main`.