### PR TITLE
Derive dropdown row radius from a panel radius token and four-sided inset

### DIFF
--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -291,13 +291,14 @@ describe("ThemeProvider", () => {
               },
               radius: {
                 shell: "1.25rem",
+                dropdown: "0.75rem",
               },
               elevation: {
                 dropdown: "0 16px 32px rgba(15, 23, 42, 0.18)",
               },
               spacing: {
                 dropdown: {
-                  chromePaddingY: "0.375rem",
+                  chromePadding: "0.375rem",
                 },
                 modal: {
                   closeButtonPadding: "0.375rem",
@@ -389,11 +390,12 @@ describe("ThemeProvider", () => {
       "--theme-overlay-modal: rgba(76, 29, 149, 0.32);",
     );
     expect(varsCss).toContain("--theme-radius-shell: 1.25rem;");
+    expect(varsCss).toContain("--theme-radius-dropdown: 0.75rem;");
     expect(varsCss).toContain(
       "--theme-elevation-dropdown: 0 16px 32px rgba(15, 23, 42, 0.18);",
     );
     expect(varsCss).toContain(
-      "--theme-spacing-dropdown-chrome-padding-y: 0.375rem;",
+      "--theme-spacing-dropdown-chrome-padding: 0.375rem;",
     );
     expect(varsCss).toContain(
       "--theme-spacing-modal-close-button-padding: 0.375rem;",

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -142,6 +142,7 @@ const getThemeVariableEntries = (theme: Theme): Array<[string, string]> => {
     ["--theme-radius-control", theme.radius.control],
     ["--theme-radius-message", theme.radius.message],
     ["--theme-radius-modal", theme.radius.modal],
+    ["--theme-radius-dropdown", theme.radius.dropdown],
     ["--theme-radius-pill", theme.radius.pill],
     ["--theme-spacing-shell-padding-x", theme.spacing.shell.paddingX],
     ["--theme-spacing-shell-padding-y", theme.spacing.shell.paddingY],
@@ -177,8 +178,8 @@ const getThemeVariableEntries = (theme: Theme): Array<[string, string]> => {
     ["--theme-spacing-dropdown-padding-x", theme.spacing.dropdown.paddingX],
     ["--theme-spacing-dropdown-padding-y", theme.spacing.dropdown.paddingY],
     [
-      "--theme-spacing-dropdown-chrome-padding-y",
-      theme.spacing.dropdown.chromePaddingY,
+      "--theme-spacing-dropdown-chrome-padding",
+      theme.spacing.dropdown.chromePadding,
     ],
     ["--theme-spacing-modal-padding", theme.spacing.modal.padding],
     [

--- a/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -83,7 +83,7 @@ const sectionDivider = "my-1 h-px bg-theme-border";
 // typography and hover/focus colors — so customer themes retune every menu
 // surface together.
 const rowClassName =
-  "dropdown-item-geometry theme-transition flex w-full items-center gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown";
+  "dropdown-item-geometry theme-transition flex w-full items-center gap-2 text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown";
 
 function buildRow<V extends string>(
   key: SubmenuKey,

--- a/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
+++ b/frontend/src/components/ui/Chat/ChatInputAddMenu.tsx
@@ -106,7 +106,7 @@ export const addMenuSectionDividerClassName = "my-1 h-px bg-theme-border";
 // Rows share DropdownMenu's item channel — geometry class, typography and
 // hover/focus colors — so customer themes retune every menu surface together.
 const rowClassName =
-  "dropdown-item-geometry theme-transition flex w-full items-center gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown";
+  "dropdown-item-geometry theme-transition flex w-full items-center gap-2 text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown";
 
 // CSS selector for the menu's navigable rows; natively-disabled rows are
 // excluded from roving focus (aria-disabled tool rows stay reachable).

--- a/frontend/src/components/ui/Controls/DropdownMenu.tsx
+++ b/frontend/src/components/ui/Controls/DropdownMenu.tsx
@@ -84,7 +84,7 @@ const MenuItem = memo(
     <button
       className={clsx(
         "dropdown-item-geometry",
-        "w-full rounded-[var(--theme-radius-control)] text-left text-sm",
+        "w-full text-left text-sm",
         "flex items-center gap-2",
         "theme-transition",
         "disabled:cursor-not-allowed disabled:opacity-50",

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -192,6 +192,7 @@ export type ThemeRadius = {
   control: string;
   message: string;
   modal: string;
+  dropdown: string;
   pill: string;
 };
 
@@ -228,7 +229,7 @@ export type ThemeSpacing = {
   dropdown: {
     paddingX: string;
     paddingY: string;
-    chromePaddingY: string;
+    chromePadding: string;
   };
   modal: {
     padding: string;
@@ -509,6 +510,7 @@ export const defaultTheme: Theme = {
     control: "0.5rem",
     message: "0.5rem",
     modal: "0.5rem",
+    dropdown: "0.5rem",
     pill: "9999px",
   },
   spacing: {
@@ -544,7 +546,7 @@ export const defaultTheme: Theme = {
     dropdown: {
       paddingX: "1rem",
       paddingY: "0.5rem",
-      chromePaddingY: "0.25rem",
+      chromePadding: "0.25rem",
     },
     modal: {
       padding: "1rem",

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -241,6 +241,7 @@
   --theme-radius-control: 0.5rem;
   --theme-radius-message: 0.5rem;
   --theme-radius-modal: 0.5rem;
+  --theme-radius-dropdown: 0.5rem;
   --theme-radius-pill: 9999px;
 
   /* Spacing */
@@ -265,7 +266,7 @@
   --theme-spacing-input-min-height: 2rem;
   --theme-spacing-dropdown-padding-x: 1rem;
   --theme-spacing-dropdown-padding-y: 0.5rem;
-  --theme-spacing-dropdown-chrome-padding-y: 0.25rem;
+  --theme-spacing-dropdown-chrome-padding: 0.25rem;
   --theme-spacing-modal-padding: 1rem;
   --theme-spacing-modal-close-button-padding: 0.25rem;
 
@@ -559,19 +560,22 @@ body {
     border-radius: var(--theme-radius-control);
   }
 
-  .btn-geometry-list-item {
-    padding-inline: var(--theme-spacing-dropdown-padding-x);
-    padding-block: var(--theme-spacing-dropdown-padding-y);
-    border-radius: var(--theme-radius-control);
-  }
-
+  /* Menu rows sit inside .dropdown-panel-chrome-geometry, so their radius is
+     derived, not tokenised: panel radius minus the panel inset keeps the row
+     highlight concentric with the panel corner for any theme values. */
+  .btn-geometry-list-item,
   .dropdown-item-geometry {
     padding-inline: var(--theme-spacing-dropdown-padding-x);
     padding-block: var(--theme-spacing-dropdown-padding-y);
+    border-radius: max(
+      0px,
+      var(--theme-radius-dropdown) -
+        var(--theme-spacing-dropdown-chrome-padding)
+    );
   }
 
   .dropdown-panel-chrome-geometry {
-    padding-block: var(--theme-spacing-dropdown-chrome-padding-y);
+    padding: var(--theme-spacing-dropdown-chrome-padding);
   }
 
   .modal-section-geometry {
@@ -873,7 +877,7 @@ body {
 .anchored-popover-skin {
   background-color: var(--theme-shell-dropdown);
   border-color: var(--theme-border-dropdown);
-  border-radius: var(--theme-radius-base);
+  border-radius: var(--theme-radius-dropdown);
   box-shadow: var(--theme-elevation-dropdown);
   max-width: calc(100vw - 16px);
 }

--- a/frontend/src/utils/themeUtils.test.ts
+++ b/frontend/src/utils/themeUtils.test.ts
@@ -18,6 +18,7 @@ describe("mergeThemeWithOverrides", () => {
       control: "1.25rem",
       message: "1.25rem",
       modal: "1.25rem",
+      dropdown: "1.25rem",
       pill: "1.25rem",
     });
   });

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -113,6 +113,7 @@ const withBorderRadiusCompatibility = (
       control: override.radius?.control ?? theme.borderRadius,
       message: override.radius?.message ?? theme.borderRadius,
       modal: override.radius?.modal ?? theme.borderRadius,
+      dropdown: override.radius?.dropdown ?? theme.borderRadius,
       pill: override.radius?.pill ?? theme.borderRadius,
     },
   };

--- a/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
+++ b/office-addin/src/outlook/components/AddinChatAddMenuExtraContent.tsx
@@ -13,7 +13,7 @@ const headerClassName =
 // Same row recipe as the shared "+" menu / DropdownMenu item channel, so
 // customer themes retune these injected rows together with every other menu.
 const rowClassName =
-  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
+  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
 const infoRowClassName = "dropdown-item-geometry text-xs";
 
 function formatFileSize(size: number): string {

--- a/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
+++ b/office-addin/src/teams/components/TeamsChatAddMenuExtraContent.tsx
@@ -14,7 +14,7 @@ const headerClassName =
 // Same row recipe as the shared "+" menu / DropdownMenu item channel, so
 // customer themes retune these injected rows together with every other menu.
 const rowClassName =
-  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 rounded-[var(--theme-radius-control)] text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
+  "dropdown-item-geometry theme-transition flex w-full items-start justify-between gap-2 text-left text-sm text-theme-fg-secondary hover:bg-theme-bg-hover hover:text-theme-fg-primary focus:bg-theme-bg-hover focus:text-theme-fg-primary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-theme-border-dropdown disabled:cursor-not-allowed disabled:opacity-50";
 
 /**
  * Teams contribution to the unified chat "+" menu: one row that opens the chat

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -131,10 +131,12 @@ The typed theme contract is grouped semantically so starter themes can express s
 - `colors.shell` covers app, page, sidebar, chat shell, modal, and dropdown surfaces
 - `colors.message` covers user and assistant message surfaces plus shared hover and controls surfaces
 - `colors.overlay` covers backdrops such as the modal overlay
-- `radius` covers base, shell, input, message, modal, and pill radii
-- `spacing` covers shell, message, controls, sidebar density, and chat input spacing
+- `radius` covers base, shell, input, control, message, modal, dropdown, and pill radii
+- `spacing` covers shell, message, controls, sidebar density, chat input, and dropdown spacing
 - `elevation` covers shell, input, modal, and dropdown shadows
 - `layout` covers chat content width, chat input width, and sidebar width
+
+Dropdown menus nest two shapes. The panel takes `radius.dropdown`, every row is inset by `spacing.dropdown.chromePadding` on all four sides, and the row highlight radius is derived as the panel radius minus that inset. Set those two tokens and the rows stay concentric with the panel; there is no separate row radius to keep in step.
 
 Existing theme JSON can omit these new groups. When a theme does not provide them yet, the corresponding CSS variables fall back to the built-in theme defaults until they are explicitly overridden.
 


### PR DESCRIPTION
## Problem

Every dropdown row highlight touched the panel's side borders while floating 4px off the top and bottom, and its corners were rounder than the panel's. The panel inset came from a vertical-only token (`chromePaddingY`), rows read `--theme-radius-control` (8px) inside a `--theme-radius-base` (6px) panel, and nothing tied the two radii together. Three independent commits produced it: the vertical-only inset (#545), the rounded row highlight (ERMAIN-467), and the row radius moving to the control token (#848). It affected every menu surface: `DropdownMenu`, `ChatInputAddMenu`, `ChatHistoryFilterMenu` (rows and flyout), and the two add-in row injectors.

## Change

The geometry is now a two-token contract with the row radius derived from it, so a theme cannot reintroduce the mismatch by moving one value.

- New `radius.dropdown` token (`--theme-radius-dropdown`, 0.5rem). `.anchored-popover-skin` reads it instead of the base radius, which is shared with attachment tiles and run rows. It is deliberately not the control token: customer themes scope that one to pill shapes for buttons.
- `spacing.dropdown.chromePaddingY` becomes `spacing.dropdown.chromePadding` and applies to all four sides (`--theme-spacing-dropdown-chrome-padding`, 0.25rem). Separate X and Y was the exact degree of freedom that caused the bug. The old key was undocumented and unset by every shipped theme.
- `.dropdown-item-geometry` and `.btn-geometry-list-item` set `border-radius: max(0px, panel radius − inset)` in `globals.css`. The `rounded-[var(--theme-radius-control)]` utility comes off all five copies of the row class string, because a utility outranks the layered rule and the derivation would otherwise never apply.
- The legacy `borderRadius` compatibility mapper fills the new key. `theming.mdx` lists both tokens and explains the derivation.

| | Panel radius | Row radius | Inset (incl. 1px border) |
|---|---|---|---|
| Before | 6px | 8px | top/bottom 5px, sides 1px |
| After | 8px | 4px | 5px on all sides |

## Verification

- `pnpm typecheck`, eslint on changed files, and `prettier . --check` are clean.
- Full frontend unit suite: 164 files, 1591 tests passed.
- Storybook pixel metrics on `DropdownMenu` (light and dark), `ChatInputAddMenu`, and `ChatHistoryFilterMenu` including its flyout: panel 8px, rows 4px, inset 5px on every side. A scoped `--theme-radius-dropdown: 1rem` on the panel yields 12px rows and the flyout inherits it, which is the customer-theme case below.

## Not covered

- `AssistantMentionPopover` and `DelegationRunModePopover` share the panel class and gain the side inset and 8px panel radius; they were not rendered. Their rows carry no themed rounding.
- The office add-in was not linted or typechecked; its two edits are string literals and pass prettier.
- If Chromatic runs, every menu and popover story will diff.

## Companion change (erato-subscription-content)

The open-webui-like theme patches this geometry by hand and must ship together with this change. Alone in either direction, its `padding-inline` patch double-insets the sides. Apply in `themes/open-webui-like/theme.css`:

```diff
 [data-ui="dropdown-panel"] {
-  --theme-radius-base: 1rem;
-}
-
-[data-ui="dropdown-panel"] > .dropdown-panel-chrome-geometry {
-  padding-inline: 0.25rem;
+  --theme-radius-dropdown: 1rem;
 }
```
