### PR TITLE
Add a user text-size setting to the Appearance tab (ERMAIN-739)

### DIFF
--- a/e2e-tests/tests/presentation.basic.spec.ts
+++ b/e2e-tests/tests/presentation.basic.spec.ts
@@ -156,6 +156,31 @@ test(
 );
 
 test(
+  "Can pick a larger text size and keep it after reload",
+  { tag: TAG_CI },
+  async ({ page }) => {
+    const html = page.locator("html");
+    const rootFontSize = () =>
+      page.evaluate(() => getComputedStyle(document.documentElement).fontSize);
+
+    await page.goto("/");
+    await chatIsReadyToChat(page);
+    expect(await html.getAttribute("data-text-size")).toBeNull();
+    expect(await rootFontSize()).toBe("16px");
+
+    await openAppearanceSettings(page);
+    await page.getByRole("tab", { name: "Large", exact: true }).click();
+    await expect(html).toHaveAttribute("data-text-size", "large");
+    expect(await rootFontSize()).toBe("18px");
+
+    await page.reload();
+    await chatIsReadyToChat(page);
+    await expect(html).toHaveAttribute("data-text-size", "large");
+    expect(await rootFontSize()).toBe("18px");
+  },
+);
+
+test(
   "Can login and see german language by default",
   { tag: TAG_CI },
   async ({ browser }) => {

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -11,7 +11,10 @@ import {
   ThemeProvider,
   useTheme,
 } from "../src/components/providers/ThemeProvider";
-import type { ThemeMode } from "../src/components/providers/ThemeProvider";
+import type {
+  TextSize,
+  ThemeMode,
+} from "../src/components/providers/ThemeProvider";
 import { FeatureConfigProvider } from "../src/providers/FeatureConfigProvider";
 import { RootProvider } from "../src/providers/RootProvider";
 import { defaultTheme, darkTheme } from "../src/config/theme";
@@ -161,14 +164,19 @@ const withI18n: Decorator = (Story, context) => {
 const ThemeSynchronizer: React.FC<{
   children: React.ReactNode;
   storybookTheme: ThemeMode;
-}> = ({ children, storybookTheme }) => {
-  const { setThemeMode } = useTheme();
+  storybookTextSize: TextSize;
+}> = ({ children, storybookTheme, storybookTextSize }) => {
+  const { setThemeMode, setTextSize } = useTheme();
 
   // Sync Storybook theme with ThemeProvider
   useEffect(() => {
     // Set the theme mode
     setThemeMode(storybookTheme);
   }, [storybookTheme, setThemeMode]);
+
+  useEffect(() => {
+    setTextSize(storybookTextSize);
+  }, [storybookTextSize, setTextSize]);
 
   return <>{children}</>;
 };
@@ -271,10 +279,14 @@ const withAppProviders: Decorator = (Story) => {
 const withThemeDecorator: Decorator = (Story, context) => {
   const { globals } = context;
   const selectedTheme = (globals.theme || "light") as ThemeMode;
+  const selectedTextSize = (globals.textSize || "default") as TextSize;
 
   return (
     <ThemeProvider>
-      <ThemeSynchronizer storybookTheme={selectedTheme}>
+      <ThemeSynchronizer
+        storybookTheme={selectedTheme}
+        storybookTextSize={selectedTextSize}
+      >
         <Story />
       </ThemeSynchronizer>
     </ThemeProvider>
@@ -320,6 +332,21 @@ const preview: Preview = {
           { value: "dark", icon: "circle", title: "Dark Theme" },
         ],
         // Property that specifies if the name of the item will be displayed
+        showName: true,
+      },
+    },
+    textSize: {
+      name: "Text size",
+      description: "User text-size preference (root font-size scale)",
+      defaultValue: "default",
+      toolbar: {
+        icon: "zoom",
+        items: [
+          { value: "small", title: "Small" },
+          { value: "default", title: "Default" },
+          { value: "large", title: "Large" },
+          { value: "x-large", title: "Extra large" },
+        ],
         showName: true,
       },
     },

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/env", () => ({
@@ -7,7 +13,12 @@ vi.mock("@/app/env", () => ({
 
 import { env } from "@/app/env";
 
-import { THEME_MODE_LOCAL_STORAGE_KEY, ThemeProvider } from "./ThemeProvider";
+import {
+  TEXT_SIZE_LOCAL_STORAGE_KEY,
+  THEME_MODE_LOCAL_STORAGE_KEY,
+  ThemeProvider,
+  useTheme,
+} from "./ThemeProvider";
 
 import type { Env } from "@/app/env";
 import type { CustomThemeConfig } from "@/utils/themeUtils";
@@ -105,6 +116,7 @@ describe("ThemeProvider", () => {
       .forEach((node) => node.remove());
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-name");
+    document.documentElement.removeAttribute("data-text-size");
     document.documentElement.removeAttribute("style");
   });
 
@@ -484,5 +496,72 @@ describe("ThemeProvider", () => {
     expect(varsCss).toContain("--theme-border-field-focus: #6b7280;");
     expect(varsCss).toContain("--theme-border-chat-input-focus: #6b7280;");
     expect(varsCss).toContain("--theme-radius-shell: 1rem;");
+  });
+  it("applies a persisted text size to documentElement", () => {
+    localStorage.setItem(TEXT_SIZE_LOCAL_STORAGE_KEY, "large");
+
+    render(
+      <ThemeProvider>
+        <div>content</div>
+      </ThemeProvider>,
+    );
+
+    expect(document.documentElement).toHaveAttribute("data-text-size", "large");
+  });
+
+  it("sets no text-size attribute for the default or an unknown stored size", () => {
+    const { unmount } = render(
+      <ThemeProvider>
+        <div>content</div>
+      </ThemeProvider>,
+    );
+    expect(document.documentElement).not.toHaveAttribute("data-text-size");
+    unmount();
+
+    localStorage.setItem(TEXT_SIZE_LOCAL_STORAGE_KEY, "huge");
+    render(
+      <ThemeProvider>
+        <div>content</div>
+      </ThemeProvider>,
+    );
+    expect(document.documentElement).not.toHaveAttribute("data-text-size");
+  });
+
+  it("persists a chosen text size unless persistence is disabled", () => {
+    const Chooser = () => {
+      const { setTextSize } = useTheme();
+      return (
+        <button type="button" onClick={() => setTextSize("x-large")}>
+          choose
+        </button>
+      );
+    };
+
+    const { unmount } = render(
+      <ThemeProvider>
+        <Chooser />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "choose" }));
+    expect(document.documentElement).toHaveAttribute(
+      "data-text-size",
+      "x-large",
+    );
+    expect(localStorage.getItem(TEXT_SIZE_LOCAL_STORAGE_KEY)).toBe("x-large");
+    unmount();
+    expect(document.documentElement).not.toHaveAttribute("data-text-size");
+
+    localStorage.clear();
+    render(
+      <ThemeProvider persistTextSize={false}>
+        <Chooser />
+      </ThemeProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "choose" }));
+    expect(document.documentElement).toHaveAttribute(
+      "data-text-size",
+      "x-large",
+    );
+    expect(localStorage.getItem(TEXT_SIZE_LOCAL_STORAGE_KEY)).toBeNull();
   });
 });

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable lingui/no-unlocalized-strings */
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
 
 import { defaultTheme, darkTheme } from "@/config/theme";
 import {
@@ -21,16 +27,31 @@ export type ThemeMode = "light" | "dark" | "system";
 
 export const THEME_MODE_LOCAL_STORAGE_KEY = "theme-mode";
 
+export type TextSize = "small" | "default" | "large" | "x-large";
+
+export const TEXT_SIZE_OPTIONS: readonly TextSize[] = [
+  "small",
+  "default",
+  "large",
+  "x-large",
+];
+
+export const TEXT_SIZE_LOCAL_STORAGE_KEY = "text-size";
+
 export interface ThemeProviderProps extends PropsWithChildren {
   enableCustomTheme?: boolean;
   initialThemeMode?: ThemeMode;
   persistThemeMode?: boolean;
+  initialTextSize?: TextSize;
+  persistTextSize?: boolean;
 }
 
 type ThemeContextType = {
   theme: Theme;
   themeMode: ThemeMode;
   setThemeMode: (mode: ThemeMode) => void;
+  textSize: TextSize;
+  setTextSize: (size: TextSize) => void;
   isCustomTheme: boolean;
   customThemeName?: string;
   customThemeConfig?: CustomThemeConfig | null;
@@ -335,6 +356,16 @@ const getSavedTheme = (): ThemeMode => {
   return "system"; // Default to system if nothing saved
 };
 
+const isTextSize = (value: unknown): value is TextSize =>
+  TEXT_SIZE_OPTIONS.includes(value as TextSize);
+
+const getSavedTextSize = (): TextSize => {
+  if (typeof window === "undefined") return "default";
+
+  const saved = localStorage.getItem(TEXT_SIZE_LOCAL_STORAGE_KEY);
+  return isTextSize(saved) ? saved : "default";
+};
+
 // Get the effective theme based on the selected mode and system preference
 const getEffectiveTheme = (mode: ThemeMode): "light" | "dark" => {
   if (mode === "light") return "light";
@@ -355,6 +386,8 @@ export function ThemeProvider({
   enableCustomTheme = true,
   initialThemeMode,
   persistThemeMode = true,
+  initialTextSize,
+  persistTextSize = true,
 }: ThemeProviderProps) {
   const savedOrDefaultThemeMode = initialThemeMode ?? getSavedTheme();
   const [themeMode, setThemeMode] = useState<ThemeMode>(
@@ -362,6 +395,9 @@ export function ThemeProvider({
   );
   const [effectiveTheme, setEffectiveTheme] = useState<"light" | "dark">(
     getEffectiveTheme(savedOrDefaultThemeMode),
+  );
+  const [textSize, setTextSizeState] = useState<TextSize>(
+    () => initialTextSize ?? getSavedTextSize(),
   );
   const [theme, setTheme] = useState<Theme>(defaultTheme);
   const [customThemeConfig, setCustomThemeConfig] =
@@ -534,6 +570,20 @@ export function ThemeProvider({
     };
   }, [theme]);
 
+  // Layout effect: the attribute changes the root font-size, and a passive
+  // effect would paint one frame at the old scale first.
+  useLayoutEffect(() => {
+    if (textSize === "default") {
+      document.documentElement.removeAttribute("data-text-size");
+    } else {
+      document.documentElement.setAttribute("data-text-size", textSize);
+    }
+
+    return () => {
+      document.documentElement.removeAttribute("data-text-size");
+    };
+  }, [textSize]);
+
   const toggleTheme = (mode: ThemeMode) => {
     if (persistThemeMode) {
       localStorage.setItem(THEME_MODE_LOCAL_STORAGE_KEY, mode);
@@ -541,10 +591,19 @@ export function ThemeProvider({
     setThemeMode(mode);
   };
 
+  const setTextSize = (size: TextSize) => {
+    if (persistTextSize) {
+      localStorage.setItem(TEXT_SIZE_LOCAL_STORAGE_KEY, size);
+    }
+    setTextSizeState(size);
+  };
+
   const contextValue: ThemeContextType = {
     theme,
     themeMode,
     setThemeMode: toggleTheme,
+    textSize,
+    setTextSize,
     isCustomTheme,
     customThemeName: customThemeConfig?.name,
     customThemeConfig,

--- a/frontend/src/components/ui/Chat/SidebarResizeHandle.tsx
+++ b/frontend/src/components/ui/Chat/SidebarResizeHandle.tsx
@@ -74,14 +74,15 @@ export const useApplySidebarWidth = () => {
   // The customer theme (and its sidebar width) lands asynchronously after
   // mount; re-clamping on theme identity keeps the override from staying
   // pinned to the built-in width's bounds.
-  const { effectiveTheme, customThemeName } = useTheme();
+  // textSize: the min width is measured in px from a rem token.
+  const { effectiveTheme, customThemeName, textSize } = useTheme();
 
   // No unmount cleanup: the override is app-global state, and sidebar
   // instances can overlap during route transitions — a departing instance's
   // cleanup would wipe the value the arriving instance just applied.
   useEffect(() => {
     syncOverrideFromStore(sidebarWidth);
-  }, [sidebarWidth, effectiveTheme, customThemeName]);
+  }, [sidebarWidth, effectiveTheme, customThemeName, textSize]);
 };
 
 interface DragState {

--- a/frontend/src/components/ui/Controls/CountBadge.tsx
+++ b/frontend/src/components/ui/Controls/CountBadge.tsx
@@ -33,7 +33,7 @@ export const CountBadge = ({
     aria-hidden="true"
     {...props}
     className={clsx(
-      "flex min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-semibold leading-4",
+      "flex min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] font-semibold leading-4",
       VARIANT_STYLES[variant],
       className,
     )}

--- a/frontend/src/components/ui/Settings/TextSizeSetting.test.tsx
+++ b/frontend/src/components/ui/Settings/TextSizeSetting.test.tsx
@@ -1,0 +1,50 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThemeProvider } from "@/components/providers/ThemeProvider";
+
+import { TextSizeSetting } from "./TextSizeSetting";
+
+describe("TextSizeSetting", () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-text-size");
+  });
+
+  it("offers the four sizes and applies the chosen one", () => {
+    render(
+      <ThemeProvider
+        enableCustomTheme={false}
+        persistThemeMode={false}
+        persistTextSize={false}
+      >
+        <TextSizeSetting />
+      </ThemeProvider>,
+    );
+
+    const control = screen.getByRole("tablist", { name: "Text size" });
+    expect(
+      within(control)
+        .getAllByRole("tab")
+        .map((tab) => tab.textContent),
+    ).toEqual(["Small", "Default", "Large", "Extra large"]);
+    expect(
+      within(control).getByRole("tab", { name: "Default" }),
+    ).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(within(control).getByRole("tab", { name: "Large" }));
+
+    expect(within(control).getByRole("tab", { name: "Large" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(document.documentElement).toHaveAttribute("data-text-size", "large");
+  });
+});

--- a/frontend/src/components/ui/Settings/TextSizeSetting.tsx
+++ b/frontend/src/components/ui/Settings/TextSizeSetting.tsx
@@ -1,0 +1,61 @@
+import { t } from "@lingui/core/macro";
+
+import {
+  TEXT_SIZE_OPTIONS,
+  useTheme,
+  type TextSize,
+} from "@/components/providers/ThemeProvider";
+
+import { SegmentedControl } from "../Controls/SegmentedControl";
+
+export function TextSizeSetting() {
+  const { textSize, setTextSize } = useTheme();
+
+  const labels: Record<TextSize, string> = {
+    small: t({
+      id: "preferences.dialog.appearance.textSize.option.small",
+      message: "Small",
+    }),
+    default: t({
+      id: "preferences.dialog.appearance.textSize.option.default",
+      message: "Default",
+    }),
+    large: t({
+      id: "preferences.dialog.appearance.textSize.option.large",
+      message: "Large",
+    }),
+    "x-large": t({
+      id: "preferences.dialog.appearance.textSize.option.xLarge",
+      message: "Extra large",
+    }),
+  };
+  const heading = t({
+    id: "preferences.dialog.appearance.textSize.heading",
+    message: "Text size",
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-medium text-theme-fg-primary">{heading}</h2>
+        <p className="text-sm text-theme-fg-secondary">
+          {t({
+            id: "preferences.dialog.appearance.textSize.description",
+            message: "Scales the whole interface on this device.",
+          })}
+        </p>
+      </div>
+      <SegmentedControl
+        aria-label={heading}
+        size="md"
+        className="flex-wrap"
+        options={TEXT_SIZE_OPTIONS.map((value) => ({
+          value,
+          label: labels[value],
+        }))}
+        value={textSize}
+        onChange={setTextSize}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
@@ -223,6 +223,22 @@ describe("UserPreferencesDialog", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the text size control on the appearance tab", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Appearance" }));
+
+    const control = screen.getByRole("tablist", { name: "Text size" });
+    expect(
+      within(control)
+        .getAllByRole("tab")
+        .map((tab) => tab.textContent),
+    ).toEqual(["Small", "Default", "Large", "Extra large"]);
+    expect(
+      within(control).getByRole("tab", { name: "Default" }),
+    ).toHaveAttribute("aria-selected", "true");
+  });
+
   it("renders accessible vertical tabs and linked tabpanels", () => {
     renderDialog();
 

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
@@ -47,6 +47,7 @@ import {
   type StartingAssistantPick,
   type StartScreenChoice,
 } from "./StartingAssistantSetting";
+import { TextSizeSetting } from "./TextSizeSetting";
 
 import type {
   ChatModel,
@@ -834,6 +835,8 @@ export function UserPreferencesDialog({
               </div>
 
               <AppearanceTabContent />
+
+              <TextSizeSetting />
             </section>
 
             {audioInputSettingsEnabled ? (

--- a/frontend/src/library/EratoUiProvider.tsx
+++ b/frontend/src/library/EratoUiProvider.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 import {
   ThemeProvider,
+  type TextSize,
   type ThemeMode,
 } from "@/components/providers/ThemeProvider";
 import {
@@ -34,6 +35,7 @@ if (!i18n.locale) {
 export interface EratoUiProviderProps extends PropsWithChildren {
   locale?: string;
   themeMode?: ThemeMode;
+  textSize?: TextSize;
   featureConfig?: Partial<FeatureConfig>;
   voiceRuntimeAssets?: VoiceRuntimeAssetOverrides | string;
 }
@@ -42,6 +44,7 @@ export function EratoUiProvider({
   children,
   locale = defaultLocale,
   themeMode = "light",
+  textSize = "default",
   featureConfig,
   voiceRuntimeAssets,
 }: EratoUiProviderProps) {
@@ -57,6 +60,8 @@ export function EratoUiProvider({
             enableCustomTheme={false}
             initialThemeMode={themeMode}
             persistThemeMode={false}
+            initialTextSize={textSize}
+            persistTextSize={false}
           >
             {children}
           </ThemeProvider>

--- a/frontend/src/library/index.ts
+++ b/frontend/src/library/index.ts
@@ -6,8 +6,10 @@ export * from "@/shared";
 
 export { Trans, useLingui } from "@lingui/react";
 export {
+  TEXT_SIZE_OPTIONS,
   ThemeProvider,
   useTheme,
+  type TextSize,
   type ThemeMode,
   type ThemeProviderProps,
 } from "@/components/providers/ThemeProvider";
@@ -80,6 +82,7 @@ export {
 export { AppearanceTabContent } from "@/components/ui/Settings/AppearanceTabContent";
 export { AudioInputTabContent } from "@/components/ui/Settings/AudioInputTabContent";
 export { DesktopSidecarTabContent } from "@/components/ui/Settings/DesktopSidecarTabContent";
+export { TextSizeSetting } from "@/components/ui/Settings/TextSizeSetting";
 export {
   EntityRow,
   type EntityRowStatus,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -2895,6 +2895,36 @@ msgid "preferences.dialog.actions.saving"
 msgstr "Speichere..."
 
 #. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.description"
+msgstr "Skaliert die gesamte Oberfläche auf diesem Gerät."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.heading"
+msgstr "Textgröße"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.default"
+msgstr "Standard"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.large"
+msgstr "Groß"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.small"
+msgstr "Klein"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.xLarge"
+msgstr "Sehr groß"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Settings/AppearanceTabContent.tsx
 msgid "preferences.dialog.appearance.theme.current.dark"
 msgstr "Derzeit dunkel"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -2895,6 +2895,36 @@ msgid "preferences.dialog.actions.saving"
 msgstr "Saving..."
 
 #. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.description"
+msgstr "Scales the whole interface on this device."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.heading"
+msgstr "Text size"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.default"
+msgstr "Default"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.large"
+msgstr "Large"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.small"
+msgstr "Small"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.xLarge"
+msgstr "Extra large"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Settings/AppearanceTabContent.tsx
 msgid "preferences.dialog.appearance.theme.current.dark"
 msgstr "Currently dark"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -2895,6 +2895,36 @@ msgid "preferences.dialog.actions.saving"
 msgstr "Guardando..."
 
 #. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.description"
+msgstr "Ajusta el tamaño de toda la interfaz en este dispositivo."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.heading"
+msgstr "Tamaño del texto"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.default"
+msgstr "Predeterminado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.large"
+msgstr "Grande"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.small"
+msgstr "Pequeño"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.xLarge"
+msgstr "Muy grande"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Settings/AppearanceTabContent.tsx
 msgid "preferences.dialog.appearance.theme.current.dark"
 msgstr "Actualmente oscuro"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -2895,6 +2895,36 @@ msgid "preferences.dialog.actions.saving"
 msgstr "Enregistrement..."
 
 #. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.description"
+msgstr "Met à l’échelle toute l’interface sur cet appareil."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.heading"
+msgstr "Taille du texte"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.default"
+msgstr "Par défaut"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.large"
+msgstr "Grande"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.small"
+msgstr "Petite"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.xLarge"
+msgstr "Très grande"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Settings/AppearanceTabContent.tsx
 msgid "preferences.dialog.appearance.theme.current.dark"
 msgstr "Actuellement sombre"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -2895,6 +2895,36 @@ msgid "preferences.dialog.actions.saving"
 msgstr "Zapisywanie..."
 
 #. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.description"
+msgstr "Skaluje cały interfejs na tym urządzeniu."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.heading"
+msgstr "Rozmiar tekstu"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.default"
+msgstr "Domyślny"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.large"
+msgstr "Duży"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.small"
+msgstr "Mały"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/TextSizeSetting.tsx
+msgid "preferences.dialog.appearance.textSize.option.xLarge"
+msgstr "Bardzo duży"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Settings/AppearanceTabContent.tsx
 msgid "preferences.dialog.appearance.theme.current.dark"
 msgstr "Obecnie ciemny"

--- a/frontend/src/shared/component-registry.generated.ts
+++ b/frontend/src/shared/component-registry.generated.ts
@@ -2,9 +2,12 @@
 // It exposes registry component roots and their transitive component dependencies.
 // Do not edit it by hand.
 
+export { TEXT_SIZE_LOCAL_STORAGE_KEY } from "@/components/providers/ThemeProvider";
+export { TEXT_SIZE_OPTIONS } from "@/components/providers/ThemeProvider";
 export { THEME_MODE_LOCAL_STORAGE_KEY } from "@/components/providers/ThemeProvider";
 export { ThemeProvider } from "@/components/providers/ThemeProvider";
 export { useTheme } from "@/components/providers/ThemeProvider";
+export type { TextSize } from "@/components/providers/ThemeProvider";
 export type { ThemeMode } from "@/components/providers/ThemeProvider";
 export type { ThemeProviderProps } from "@/components/providers/ThemeProvider";
 export { AssistantWelcomeScreen } from "@/components/ui/Assistant/AssistantWelcomeScreen";

--- a/frontend/src/stories/Theme/Theme.mdx
+++ b/frontend/src/stories/Theme/Theme.mdx
@@ -49,6 +49,8 @@ Typography tokens let themes change body, heading, emphasis, and mono/code prese
 
 Supported scale keys are `xs`, `sm`, `base`, `lg`, `xl`, and `2xl`.
 
+A person's **Text size** preference (Preferences → Appearance) scales the root font-size through `data-text-size` on `<html>`. The typography tokens stay theme-owned and are multiplied, not replaced.
+
 ```json
 {
   "theme": {

--- a/frontend/src/stories/ui/TextSizeSetting.stories.tsx
+++ b/frontend/src/stories/ui/TextSizeSetting.stories.tsx
@@ -1,0 +1,28 @@
+import { TextSizeSetting } from "@/components/ui/Settings/TextSizeSetting";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta = {
+  title: "UI/Settings/TextSizeSetting",
+  component: TextSizeSetting,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TextSizeSetting>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="max-w-xl p-6">
+      <TextSizeSetting />
+    </div>
+  ),
+};
+
+export const NarrowPane: Story = {
+  render: () => (
+    <div className="w-72 p-4">
+      <TextSizeSetting />
+    </div>
+  ),
+};

--- a/frontend/src/stories/ui/UserPreferencesDialog.stories.tsx
+++ b/frontend/src/stories/ui/UserPreferencesDialog.stories.tsx
@@ -1,7 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import {
+  ThemeProvider,
+  type TextSize,
+} from "@/components/providers/ThemeProvider";
 import { Button } from "@/components/ui/Controls/Button";
 import { UserPreferencesDialog } from "@/components/ui/Settings/UserPreferencesDialog";
 import { StaticFeatureConfigProvider } from "@/providers/FeatureConfigProvider";
@@ -11,8 +14,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 const UserPreferencesDialogStory = ({
   userProfile,
+  textSize,
 }: {
   userProfile?: UserProfile;
+  textSize?: TextSize;
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const [queryClient] = useState(
@@ -30,7 +35,12 @@ const UserPreferencesDialogStory = ({
         userPreferences: { enabled: true, mcpServersTabEnabled: true },
       }}
     >
-      <ThemeProvider persistThemeMode={false} enableCustomTheme={false}>
+      <ThemeProvider
+        persistThemeMode={false}
+        enableCustomTheme={false}
+        initialTextSize={textSize}
+        persistTextSize={false}
+      >
         <QueryClientProvider client={queryClient}>
           <div className="min-h-screen bg-theme-bg-secondary p-6">
             <Button variant="secondary" onClick={() => setIsOpen(true)}>
@@ -85,4 +95,13 @@ export const Empty: Story = {
 
 export const WithExistingPreferences: Story = {
   render: () => <UserPreferencesDialogStory userProfile={mockUserProfile} />,
+};
+
+export const LargeTextSize: Story = {
+  render: () => (
+    <UserPreferencesDialogStory
+      userProfile={mockUserProfile}
+      textSize="large"
+    />
+  ),
 };

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -931,6 +931,20 @@ body {
   border-radius: var(--thread-message-card-radius);
 }
 
+/* Preferences → Appearance → Text size. Percent, not px, so the browser's own
+   default-font-size preference still applies underneath. */
+:root[data-text-size="small"] {
+  font-size: 87.5%;
+}
+
+:root[data-text-size="large"] {
+  font-size: 112.5%;
+}
+
+:root[data-text-size="x-large"] {
+  font-size: 125%;
+}
+
 /* Surface for AnchoredPopover panels (dropdown menus, the chat "+" menu).
    Deliberately declared here, after @tailwind utilities and outside
    @layer components: it must still outrank a utility a caller passes through

--- a/office-addin/src/core/AddinSettingsDialogCore.tsx
+++ b/office-addin/src/core/AddinSettingsDialogCore.tsx
@@ -3,6 +3,7 @@ import {
   AudioInputTabContent,
   ModalBase,
   ServersToolsPane,
+  TextSizeSetting,
   useFeatureConfig,
 } from "@erato/frontend/library";
 import { t } from "@lingui/core/macro";
@@ -218,6 +219,7 @@ export function AddinSettingsDialogCore({
               }
             />
             {hostContribution?.appearanceNotice}
+            <TextSizeSetting />
           </section>
 
           <section

--- a/office-addin/src/core/__tests__/AddinSettingsDialogCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinSettingsDialogCore.test.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from "react";
 
 vi.mock("@erato/frontend/library", () => ({
   AppearanceTabContent: () => <div data-testid="appearance-settings" />,
+  TextSizeSetting: () => <div data-testid="text-size-settings" />,
   AudioInputTabContent: () => null,
   ServersToolsPane: () => null,
   ModalBase: ({
@@ -38,6 +39,8 @@ describe("AddinSettingsDialogCore", () => {
     render(<AddinSettingsDialogCore isOpen={true} onClose={() => {}} />);
 
     expect(screen.getByRole("tab", { name: "Appearance" })).toBeInTheDocument();
+    expect(screen.getByTestId("appearance-settings")).toBeInTheDocument();
+    expect(screen.getByTestId("text-size-settings")).toBeInTheDocument();
     expect(
       screen.getByRole("tab", { name: "User settings" }),
     ).toBeInTheDocument();


### PR DESCRIPTION
Adds a "Text size" option to Preferences → Appearance that scales the whole interface in the web app, the Outlook add-in and Teams. Linear: ERMAIN-739 (the default-token baseline reduction is tracked separately).

## What
- `ThemeProvider` owns `textSize` (`small | default | large | x-large`), persisted per device under the `text-size` localStorage key like `theme-mode`, and writes `data-text-size` on `<html>` in a layout effect. The default state sets no attribute, so existing baselines are untouched.
- `globals.css` maps the attribute to root font-size percentages (87.5 / 112.5 / 125). Everything sized in rem follows, including customer themes and the add-in's own stylesheet; px chrome (borders, scrollbars, modal caps) does not.
- New `TextSizeSetting` (SegmentedControl) after the color-mode cards in `UserPreferencesDialog` and `AddinSettingsDialogCore`; exported from the library barrel and the generated shared surface (additive, no version bump).
- `EratoUiProvider` gets a `textSize` prop; `useApplySidebarWidth` re-clamps the persisted sidebar width on a size change; `CountBadge` drops its last px font size; Storybook gets a text-size toolbar global and stories; catalogs extracted with de/fr/pl/es translations