### PR TITLE
Give customer themes hooks and tokens for cards, tab rails, attachments, and the add-in header

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -256,6 +256,24 @@ const eslintConfig = [
       lingui: linguiPlugin,
     },
     rules: {
+      // A data-ui hook promises a theme it can retune the surface. A Tailwind
+      // rounding utility on the same element would sit outside every token
+      // and geometry class, so the corner has to come from one of those.
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'JSXOpeningElement:has(JSXAttribute[name.name="data-ui"]) JSXAttribute[name.name="className"] Literal[value=/(^|\\s)rounded(?!-\\[)(-(t|b|l|r|tl|tr|bl|br|s|e|ss|se|es|ee))?(-(none|sm|md|lg|xl|2xl|3xl|full))?(\\s|$)/]',
+          message:
+            "Elements carrying a data-ui hook take their corner radius from a token-reading class or a rounded-[var(--theme-radius-…)] value, never a Tailwind rounded-* utility, so customer themes can retune them.",
+        },
+        {
+          selector:
+            'JSXOpeningElement:has(JSXAttribute[name.name="data-ui"]) JSXAttribute[name.name="className"] TemplateElement[value.raw=/(^|\\s)rounded(?!-\\[)(-(t|b|l|r|tl|tr|bl|br|s|e|ss|se|es|ee))?(-(none|sm|md|lg|xl|2xl|3xl|full))?(\\s|$)/]',
+          message:
+            "Elements carrying a data-ui hook take their corner radius from a token-reading class or a rounded-[var(--theme-radius-…)] value, never a Tailwind rounded-* utility, so customer themes can retune them.",
+        },
+      ],
       // Lingui i18n rules - detect hardcoded strings in user-facing code only
       "lingui/no-unlocalized-strings": [
         "warn",

--- a/frontend/scripts/generate-component-registry-shared-exports.mjs
+++ b/frontend/scripts/generate-component-registry-shared-exports.mjs
@@ -262,6 +262,14 @@ const ownExports = (filePath) => {
   return exports;
 };
 
+// Kit-facing modules that stay on the surface even when no registry component
+// imports them any more. A deployed kit links against the surface by name, so
+// a module leaving it is a load-time failure for that kit; pinning it here
+// beats keeping a dead import alive in a host component.
+const pinnedComponentModules = [
+  path.join(componentsDir, "ui", "FileUpload", "FilePreviewLoading.tsx"),
+];
+
 const collectRegistryComponentModules = () => {
   const configPath = path.join(rootDir, "tsconfig.json");
   const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
@@ -286,7 +294,7 @@ const collectRegistryComponentModules = () => {
     registryPath,
   );
   const componentModules = new Set();
-  const pendingModules = [...registryRoots];
+  const pendingModules = [...registryRoots, ...pinnedComponentModules];
 
   while (pendingModules.length > 0) {
     const modulePath = pendingModules.pop();

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -292,6 +292,7 @@ describe("ThemeProvider", () => {
               radius: {
                 shell: "1.25rem",
                 dropdown: "0.75rem",
+                card: "1.5rem",
               },
               elevation: {
                 dropdown: "0 16px 32px rgba(15, 23, 42, 0.18)",
@@ -391,6 +392,7 @@ describe("ThemeProvider", () => {
     );
     expect(varsCss).toContain("--theme-radius-shell: 1.25rem;");
     expect(varsCss).toContain("--theme-radius-dropdown: 0.75rem;");
+    expect(varsCss).toContain("--theme-radius-card: 1.5rem;");
     expect(varsCss).toContain(
       "--theme-elevation-dropdown: 0 16px 32px rgba(15, 23, 42, 0.18);",
     );

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -143,6 +143,7 @@ const getThemeVariableEntries = (theme: Theme): Array<[string, string]> => {
     ["--theme-radius-message", theme.radius.message],
     ["--theme-radius-modal", theme.radius.modal],
     ["--theme-radius-dropdown", theme.radius.dropdown],
+    ["--theme-radius-card", theme.radius.card],
     ["--theme-radius-pill", theme.radius.pill],
     ["--theme-spacing-shell-padding-x", theme.spacing.shell.paddingX],
     ["--theme-spacing-shell-padding-y", theme.spacing.shell.paddingY],

--- a/frontend/src/components/ui/Chat/Chat.tsx
+++ b/frontend/src/components/ui/Chat/Chat.tsx
@@ -806,12 +806,21 @@ export const Chat = ({
               </div>
             )}
             {TopLeftAccessory ? (
-              <TopLeftAccessory
-                availableModels={availableModels}
-                selectedModel={selectedModel}
-                onModelChange={setSelectedModel}
-                isModelSelectionReady={isSelectionReady}
-              />
+              // In hidden mode the sidebar's floating toggle sits at the
+              // page's top-left; reserve its column so an in-flow accessory
+              // does not slide under it.
+              <div
+                className={clsx(
+                  sidebarCollapsed && collapsedMode === "hidden" && "pl-12",
+                )}
+              >
+                <TopLeftAccessory
+                  availableModels={availableModels}
+                  selectedModel={selectedModel}
+                  onModelChange={setSelectedModel}
+                  isModelSelectionReady={isSelectionReady}
+                />
+              </div>
             ) : null}
             {shouldRenderCenteredEmptyState ? (
               <div

--- a/frontend/src/components/ui/Controls/RadioCard.tsx
+++ b/frontend/src/components/ui/Controls/RadioCard.tsx
@@ -59,19 +59,22 @@ export function RadioCard({
   const hideRadio = Boolean(icon);
 
   const cardClasses = clsx(
-    "theme-transition border",
+    // The hover fill sits on the inner label, so the card clips it to its
+    // rounded border.
+    "option-card-geometry theme-transition overflow-hidden border",
     // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind has-selector for keyboard focus
     "[&:has(input:focus-visible)]:ring-2 [&:has(input:focus-visible)]:ring-theme-focus",
-    size === "md" ? "rounded-lg" : "rounded-md",
     checked
-      ? "border-theme-border-focus bg-theme-bg-hover"
+      ? "border-theme-border-focus bg-theme-bg-selected"
       : "border-theme-border bg-theme-bg-primary",
     disabled && "opacity-60",
   );
 
   const rowClasses = clsx(
     "relative flex items-start gap-3",
-    disabled ? "cursor-not-allowed" : "cursor-pointer hover:bg-theme-bg-hover",
+    disabled ? "cursor-not-allowed" : "cursor-pointer",
+    // Hover is lighter than the selected tint, so a checked card keeps its fill.
+    !disabled && !checked && "hover:bg-theme-bg-hover",
     size === "md" ? "p-4" : "p-3",
   );
 
@@ -86,7 +89,11 @@ export function RadioCard({
   );
 
   return (
-    <div className={cardClasses}>
+    <div
+      className={cardClasses}
+      data-ui="option-card"
+      data-selected={checked || undefined}
+    >
       <label htmlFor={inputId} className={rowClasses}>
         <input
           id={inputId}
@@ -109,8 +116,9 @@ export function RadioCard({
         {icon ? (
           <span
             aria-hidden="true"
+            data-ui="option-card-icon"
             className={clsx(
-              "mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border bg-theme-bg-secondary",
+              "option-card-geometry mt-0.5 flex size-9 shrink-0 items-center justify-center border bg-theme-bg-secondary",
               checked
                 ? "border-theme-border-focus text-theme-fg-primary"
                 : "border-theme-border text-theme-fg-secondary",
@@ -128,7 +136,12 @@ export function RadioCard({
         </div>
       </label>
       {checked && children ? (
-        <div className="border-t border-theme-border">{children}</div>
+        <div
+          className="border-t border-theme-border"
+          data-ui="option-card-details"
+        >
+          {children}
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -174,7 +174,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           : { width: geometry.mediaSize, height: geometry.mediaSize }
       }
       className={clsx(
-        "rounded-[var(--theme-radius-base)] border [border-color:var(--theme-border-media)]",
+        "rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] border [border-color:var(--theme-border-media)]",
         // Cropping is right for a thumbnail standing in for the file, wrong
         // once the point is seeing what the image actually contains.
         expanded ? "w-full object-contain" : "object-cover",
@@ -183,7 +183,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
   ) : (
     <div
       className={clsx(
-        "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border p-2 text-left",
+        "flex w-full items-center gap-2 rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] border p-2 text-left",
         "border-[var(--theme-border)] bg-[var(--theme-bg-secondary)]",
         onActivate &&
           "transition-colors group-hover:border-[var(--theme-border-focus)] group-hover:bg-[var(--theme-bg-accent)]",
@@ -192,7 +192,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       <span
         className={clsx(
           geometry.iconBox,
-          "flex shrink-0 items-center justify-center rounded-[var(--theme-radius-base)]",
+          "flex shrink-0 items-center justify-center rounded-[var(--attachment-tile-icon-radius,var(--theme-radius-base))]",
         )}
         // The per-type colour already lives in FILE_TYPES; a tinted plate is
         // what makes it readable at tile size without shouting.
@@ -236,7 +236,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           title={filename}
           aria-label={`${activateLabel ?? t`Preview attachment`} ${filename}, ${metaLabel}`}
           className={clsx(
-            "block w-full cursor-pointer rounded-[var(--theme-radius-base)] text-left",
+            "block w-full cursor-pointer rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] text-left",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2",
             isMedia && "hover:opacity-90",
           )}

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -165,6 +165,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
       src={previewUrl ?? undefined}
       alt={onActivate ? "" : filename}
       onError={() => setImageFailed(true)}
+      data-ui="attachment-tile"
       style={
         expanded
           ? {
@@ -182,6 +183,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
     />
   ) : (
     <div
+      data-ui="attachment-tile"
       className={clsx(
         "flex w-full items-center gap-2 rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] border p-2 text-left",
         "border-[var(--theme-border)] bg-[var(--theme-bg-secondary)]",

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -85,7 +85,7 @@ describe("GroupedFileAttachmentsPreview", () => {
     expect(screen.getByText("notes.docx")).toBeVisible();
   });
 
-  it("renders loading items inline with the standardized loading row", async () => {
+  it("renders loading items as a bare spinner with an accessible label", async () => {
     await renderWithI18n(
       <GroupedFileAttachmentsPreview
         groups={[
@@ -104,8 +104,10 @@ describe("GroupedFileAttachmentsPreview", () => {
       />,
     );
 
-    expect(screen.getByText(/loading attachment/i)).toBeVisible();
-    expect(screen.getByText(/please wait/i)).toBeVisible();
+    // A status region takes its name from an author label, not its content,
+    // so the spinner's screen-reader text is asserted as text.
+    expect(screen.getByText(/loading attachment/i)).toBeInTheDocument();
+    expect(screen.queryByText(/please wait/i)).not.toBeInTheDocument();
   });
 
   it("supports custom loading labels for grouped async sources", async () => {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -304,7 +304,7 @@ describe("GroupedFileAttachmentsPreview", () => {
     expect(screen.getByRole("button", { name: /current email/i })).toHaveClass(
       "sticky",
       "top-0",
-      "border",
+      "border-b",
     );
   });
 

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -578,14 +578,14 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
             : baseItems;
         const hiddenCount = isCollapsed ? 0 : itemCount - visibleItems.length;
         const sectionClassName = stickyGroupHeaders
-          ? "attachment-group-geometry bg-[var(--theme-bg-primary)]"
+          ? "attachment-group-geometry overflow-clip border border-[var(--theme-border)] bg-[var(--theme-bg-primary)]"
           : FILE_PREVIEW_STYLES.group.container;
         const headerClassName = clsx(
           stickyGroupHeaders
             ? "flex min-w-0 items-start gap-2"
             : FILE_PREVIEW_STYLES.group.header,
           stickyGroupHeaders &&
-            "attachment-group-header-geometry sticky top-0 z-10 border border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
+            "attachment-group-header-geometry sticky top-0 z-10 border-b border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
         );
         // Tiles wrap into rows; checkbox rows and notices stay a column. In
         // practice a group is homogeneous — staged emails are all selectable,
@@ -600,7 +600,7 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
             ? "flex flex-wrap items-start gap-2"
             : "flex flex-col gap-2",
           stickyGroupHeaders &&
-            "attachment-group-items-geometry border-x border-b border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
+            "attachment-group-items-geometry bg-[var(--theme-bg-primary)]",
         );
 
         const headerInner = (

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -353,9 +353,10 @@ const ThreadMessageGroupSection: React.FC<ThreadMessageGroupSectionProps> = ({
   return (
     <div
       className={clsx(
-        "rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary p-2",
+        "thread-message-card-geometry border border-theme-border bg-theme-bg-secondary p-2",
         !selected && "opacity-60",
       )}
+      data-ui="thread-message-card"
     >
       <div className="flex items-center gap-2">
         {/* Fixed columns across tree levels: disclosure, selection, text. */}
@@ -577,19 +578,14 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
             : baseItems;
         const hiddenCount = isCollapsed ? 0 : itemCount - visibleItems.length;
         const sectionClassName = stickyGroupHeaders
-          ? "rounded-[var(--theme-radius-input)] bg-[var(--theme-bg-primary)]"
+          ? "attachment-group-geometry bg-[var(--theme-bg-primary)]"
           : FILE_PREVIEW_STYLES.group.container;
         const headerClassName = clsx(
           stickyGroupHeaders
             ? "flex min-w-0 items-start gap-2"
             : FILE_PREVIEW_STYLES.group.header,
           stickyGroupHeaders &&
-            clsx(
-              "sticky top-0 z-10 border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] px-3 pb-2 pt-3",
-              isCollapsed
-                ? "rounded-[var(--theme-radius-input)]"
-                : "rounded-t-[var(--theme-radius-input)]",
-            ),
+            "attachment-group-header-geometry sticky top-0 z-10 border border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
         );
         // Tiles wrap into rows; checkbox rows and notices stay a column. In
         // practice a group is homogeneous — staged emails are all selectable,
@@ -604,7 +600,7 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
             ? "flex flex-wrap items-start gap-2"
             : "flex flex-col gap-2",
           stickyGroupHeaders &&
-            "rounded-b-md border-x border-b border-[var(--theme-border)] bg-[var(--theme-bg-primary)] px-3 pb-3 pt-2",
+            "attachment-group-items-geometry border-x border-b border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
         );
 
         const headerInner = (
@@ -639,7 +635,11 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
         );
 
         return (
-          <section key={group.id} className={sectionClassName}>
+          <section
+            key={group.id}
+            className={sectionClassName}
+            data-ui="attachment-group"
+          >
             {group.collapsible ? (
               <button
                 type="button"

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -10,10 +10,10 @@ import {
   getFileName,
   type FileResource,
 } from "./FilePreviewBase";
-import { FilePreviewLoading } from "./FilePreviewLoading";
 import { FILE_PREVIEW_STYLES } from "./fileUploadStyles";
 import { InteractiveContainer } from "../Container/InteractiveContainer";
 import { Button } from "../Controls/Button";
+import { SpinnerIcon } from "../Feedback/SpinnerIcon";
 import {
   ChevronDownIcon,
   ChevronRightIcon,
@@ -217,7 +217,7 @@ interface SelectableAttachmentRowProps {
 }
 
 const SELECTABLE_ROW_CLASS =
-  "flex w-full items-center gap-2 rounded-[var(--theme-radius-base)] border border-[var(--theme-border)] bg-[var(--theme-bg-secondary)] p-2";
+  "flex w-full items-center gap-2 rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] border border-[var(--theme-border)] bg-[var(--theme-bg-secondary)] p-2";
 
 const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   file,
@@ -266,12 +266,12 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
 
   if (onPreview) {
     return (
-      <div className={rowClassName}>
+      <div className={rowClassName} data-ui="attachment-tile">
         {checkbox}
         <InteractiveContainer
           onClick={onPreview}
           useDiv={true}
-          className="min-w-0 flex-1 cursor-pointer rounded-[var(--theme-radius-base)] hover:bg-theme-bg-accent"
+          className="min-w-0 flex-1 cursor-pointer rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] hover:bg-theme-bg-accent"
           aria-label={`${t`Preview attachment`} ${filename}`}
         >
           {chip}
@@ -283,11 +283,15 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   // Without a toggle there is nothing to label, so the row is a plain
   // container rather than a `label` pointing at a control that isn't there.
   if (!onToggle) {
-    return <div className={rowClassName}>{chip}</div>;
+    return (
+      <div className={rowClassName} data-ui="attachment-tile">
+        {chip}
+      </div>
+    );
   }
 
   return (
-    <label className={rowClassName}>
+    <label className={rowClassName} data-ui="attachment-tile">
       {checkbox}
       {chip}
     </label>
@@ -670,13 +674,23 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
               <div className={itemsClassName}>
                 {visibleItems.map((item) => {
                   if (item.kind === "loading") {
+                    // Inside a group the placeholder is a bare centred
+                    // spinner; the framed loading chip belongs to the
+                    // composer, where a loading file stands in a row of files.
                     return (
-                      <FilePreviewLoading
+                      <div
                         key={item.id}
-                        className="w-full"
-                        label={item.label ?? t`Loading attachment...`}
-                        description={item.description}
-                      />
+                        className="flex w-full justify-center py-2"
+                        data-ui="attachment-loading"
+                      >
+                        <SpinnerIcon
+                          size="md"
+                          srText={item.label ?? t`Loading attachment...`}
+                        />
+                        {item.description ? (
+                          <span className="sr-only">{item.description}</span>
+                        ) : null}
+                      </div>
                     );
                   }
 

--- a/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
+++ b/frontend/src/components/ui/FileUpload/fileUploadStyles.ts
@@ -18,7 +18,7 @@ export const FILE_PREVIEW_STYLES = {
   },
   group: {
     container:
-      "rounded-[var(--theme-radius-input)] border border-[var(--theme-border)] bg-[var(--theme-bg-primary)] p-3",
+      "attachment-group-geometry attachment-group-frame-geometry border border-[var(--theme-border)] bg-[var(--theme-bg-primary)]",
     header: "mb-2 flex min-w-0 items-start gap-2",
     title: "truncate text-sm font-medium text-[var(--theme-fg-secondary)]",
     meta: "text-xs text-[var(--theme-fg-muted)]",

--- a/frontend/src/components/ui/Settings/EntityRow.tsx
+++ b/frontend/src/components/ui/Settings/EntityRow.tsx
@@ -73,7 +73,8 @@ export function EntityRow({
 
   return (
     <article
-      className="rounded-[var(--theme-radius-control)] border border-theme-border bg-theme-bg-secondary"
+      className="rounded-[var(--theme-radius-card)] border border-theme-border bg-theme-bg-secondary"
+      data-ui="entity-row"
       data-testid={dataTestId}
     >
       <div className="flex items-center gap-2 p-3">

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.tsx
@@ -638,6 +638,7 @@ export function UserPreferencesDialog({
         <aside className="shrink-0 border-b border-theme-border pb-3 md:w-48 md:border-b-0 md:border-r md:pb-0 md:pr-4">
           <div
             role="tablist"
+            data-ui="tab-rail"
             aria-label={t({
               id: "preferences.dialog.title",
               message: "Preferences",

--- a/frontend/src/config/theme.ts
+++ b/frontend/src/config/theme.ts
@@ -193,6 +193,7 @@ export type ThemeRadius = {
   message: string;
   modal: string;
   dropdown: string;
+  card: string;
   pill: string;
 };
 
@@ -511,6 +512,7 @@ export const defaultTheme: Theme = {
     message: "0.5rem",
     modal: "0.5rem",
     dropdown: "0.5rem",
+    card: "0.5rem",
     pill: "9999px",
   },
   spacing: {

--- a/frontend/src/pages/AssistantsPage.tsx
+++ b/frontend/src/pages/AssistantsPage.tsx
@@ -670,7 +670,7 @@ function AssistantListCard({
     <div
       data-ui="assistant-list-card"
       data-testid="assistant-list-item"
-      className="rounded-lg border border-theme-border bg-theme-bg-primary p-4"
+      className="rounded-[var(--theme-radius-card)] border border-theme-border bg-theme-bg-primary p-4"
     >
       <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
         <button

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -341,7 +341,7 @@ export default function SearchPage() {
                       e.preventDefault();
                       handleResultClick(result);
                     }}
-                    className="block cursor-pointer rounded-lg border border-theme-border bg-theme-bg-primary p-4 transition-all hover:border-theme-border-focus hover:bg-theme-bg-hover focus:bg-theme-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus"
+                    className="block cursor-pointer rounded-[var(--theme-radius-card)] border border-theme-border bg-theme-bg-primary p-4 transition-all hover:border-theme-border-focus hover:bg-theme-bg-hover focus:bg-theme-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus"
                     aria-label={result.chatTitle}
                   >
                     <div className="flex items-center gap-4">

--- a/frontend/src/pages/__tests__/assistantHubUtils.test.tsx
+++ b/frontend/src/pages/__tests__/assistantHubUtils.test.tsx
@@ -165,7 +165,10 @@ describe("AssistantHubVersionCard", () => {
       document.querySelector(
         '[data-ui="assistant-hub-management-card-category"]',
       ),
-    ).toHaveClass("rounded-full", "bg-theme-bg-secondary");
+    ).toHaveClass(
+      "rounded-[var(--theme-radius-pill)]",
+      "bg-theme-bg-secondary",
+    );
 
     const rating = document.querySelector<HTMLElement>(
       '[data-ui="assistant-hub-management-card-rating"]',
@@ -220,7 +223,10 @@ describe("AssistantHubVersionOverviewSection", () => {
     expect(header).toContainElement(screen.getByText("by Assistant creator"));
     expect(
       document.querySelector('[data-ui="assistant-hub-overview-category"]'),
-    ).toHaveClass("rounded-full", "bg-theme-bg-secondary");
+    ).toHaveClass(
+      "rounded-[var(--theme-radius-pill)]",
+      "bg-theme-bg-secondary",
+    );
 
     const rating = document.querySelector<HTMLElement>(
       '[data-ui="assistant-hub-overview-rating"]',

--- a/frontend/src/pages/assistantHubUtils.tsx
+++ b/frontend/src/pages/assistantHubUtils.tsx
@@ -386,7 +386,7 @@ export function AssistantHubVersionCard({
       >
         <span
           aria-hidden="true"
-          className="flex size-10 shrink-0 items-center justify-center rounded-full bg-theme-bg-secondary text-sm font-semibold text-theme-fg-primary"
+          className="flex size-10 shrink-0 items-center justify-center rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary text-sm font-semibold text-theme-fg-primary"
           data-ui="assistant-hub-card-avatar"
         >
           {avatarLetter}
@@ -436,7 +436,7 @@ export function AssistantHubVersionCard({
         )}
         {categoryNames.length > 0 && (
           <span
-            className="ml-auto truncate rounded-full bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
+            className="ml-auto truncate rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
             data-ui="assistant-hub-card-category"
           >
             {categoryNames.join(", ")}
@@ -491,7 +491,7 @@ export function AssistantHubVersionCard({
         {categoryNames.map((categoryName) => (
           <span
             key={categoryName}
-            className="inline-flex min-h-6 items-center rounded-full bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
+            className="inline-flex min-h-6 items-center rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
             data-ui="assistant-hub-management-card-category"
           >
             {categoryName}
@@ -593,7 +593,7 @@ export function AssistantHubVersionOverviewSection({
         >
           <span
             aria-hidden="true"
-            className="flex size-14 shrink-0 items-center justify-center rounded-full bg-theme-bg-secondary text-xl font-semibold text-theme-fg-primary"
+            className="flex size-14 shrink-0 items-center justify-center rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary text-xl font-semibold text-theme-fg-primary"
             data-ui="assistant-hub-overview-avatar"
           >
             {avatarLetter}
@@ -614,7 +614,7 @@ export function AssistantHubVersionOverviewSection({
               {categoryNames.map((categoryName) => (
                 <span
                   key={categoryName}
-                  className="rounded-full bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
+                  className="rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary px-2 py-1 text-xs font-medium text-theme-fg-secondary"
                   data-ui="assistant-hub-overview-category"
                 >
                   {categoryName}

--- a/frontend/src/stories/ui/GroupedFileAttachmentsPreview.stories.tsx
+++ b/frontend/src/stories/ui/GroupedFileAttachmentsPreview.stories.tsx
@@ -1,6 +1,7 @@
 import { GroupedFileAttachmentsPreview } from "../../components/ui/FileUpload/GroupedFileAttachmentsPreview";
 
 import type { Meta, StoryObj } from "@storybook/react";
+import type React from "react";
 
 const meta = {
   title: "UI/GroupedFileAttachmentsPreview",
@@ -72,6 +73,114 @@ export const Collapsed: Story = {
     onRemoveFile: () => {},
     defaultVisibleItems: 2,
     showFileTypes: true,
+  },
+};
+
+const threadMessage = (
+  id: string,
+  label: string,
+  sublabel: string,
+  attachments: { id: string; filename: string; size: number }[],
+) => ({
+  kind: "threadMessageGroup" as const,
+  id,
+  label,
+  sublabel,
+  selected: true,
+  onToggle: () => {},
+  defaultCollapsed: attachments.length === 0,
+  attachments: attachments.map((file) => ({
+    id: file.id,
+    file,
+    selected: true,
+    onToggle: () => {},
+  })),
+});
+
+/* Sticky headers only make sense inside a bounded scroll region, which is
+   how the Office add-in shows a staged email thread. */
+const boundedScroll = (Story: () => React.JSX.Element) => (
+  <div className="max-h-[260px] overflow-y-auto pr-1">
+    <Story />
+  </div>
+);
+
+export const StickyThread: Story = {
+  decorators: [boundedScroll],
+  args: {
+    groups: [
+      {
+        id: "thread",
+        label: "Re: Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+        metaLabel: "13 messages",
+        collapsible: true,
+        defaultCollapsed: false,
+        items: [
+          threadMessage(
+            "m1",
+            "Daniel Person",
+            "19/05/2026, 18:58:51 · Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+            [
+              {
+                id: "a1",
+                filename: "Lastenheft_Kundenportal_v1.pdf",
+                size: 240000,
+              },
+            ],
+          ),
+          threadMessage(
+            "m2",
+            "Max Token",
+            "19/05/2026, 19:00:16 · AW: Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+            [],
+          ),
+          threadMessage(
+            "m3",
+            "Daniel Person",
+            "19/05/2026, 19:00:49 · Re: Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+            [],
+          ),
+          threadMessage(
+            "m4",
+            "Max Token",
+            "19/05/2026, 19:02:28 · AW: Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+            [
+              { id: "a2", filename: "Angebot_v2.xlsx", size: 18000 },
+              { id: "a3", filename: "Zeitplan.png", size: 52000 },
+            ],
+          ),
+        ],
+      },
+    ],
+    onRemoveFile: () => {},
+    stickyGroupHeaders: true,
+    showFileTypes: true,
+    defaultVisibleItems: 10,
+  },
+};
+
+export const StickyThreadLoading: Story = {
+  decorators: [boundedScroll],
+  args: {
+    groups: [
+      {
+        id: "thread",
+        label: "Re: Kickoff Kundenportal 2.0 – Lastenheft im Anhang",
+        metaLabel: "",
+        collapsible: true,
+        defaultCollapsed: false,
+        items: [
+          {
+            kind: "loading",
+            id: "thread-loading",
+            label: "Loading email thread...",
+            description: "Preparing the email context",
+          },
+        ],
+      },
+    ],
+    onRemoveFile: () => {},
+    stickyGroupHeaders: true,
   },
 };
 

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -242,6 +242,7 @@
   --theme-radius-message: 0.5rem;
   --theme-radius-modal: 0.5rem;
   --theme-radius-dropdown: 0.5rem;
+  --theme-radius-card: 0.5rem;
   --theme-radius-pill: 9999px;
 
   /* Spacing */
@@ -578,6 +579,15 @@ body {
     padding: var(--theme-spacing-dropdown-chrome-padding);
   }
 
+  /* Selectable option cards and their icon tiles read one token. The tile is
+     not derived from the card corner: card padding exceeds the card radius
+     for every shipped theme, so radius-minus-padding would square it. A theme
+     re-declares --theme-radius-control on [data-ui="option-card"] to move
+     card and tile together. */
+  .option-card-geometry {
+    border-radius: var(--theme-radius-control);
+  }
+
   .modal-section-geometry {
     padding: var(--theme-spacing-modal-padding);
   }
@@ -867,6 +877,41 @@ body {
 
 :root[data-sidebar-resizing] .sidebar-resize-handle {
   background-color: var(--theme-border-divider);
+}
+
+/* Attachment group frames and the thread cards inside them. The frame reads
+   the input radius like the app's other framed cards; a card inside derives
+   its corner from the frame radius minus the frame inset, so the two stay
+   concentric for any theme value. Unlayered so a theme.css rule can retune
+   any of it through the data-ui hooks. */
+.attachment-group-geometry {
+  --attachment-group-inset: 0.75rem;
+  border-radius: var(--theme-radius-input);
+}
+
+.attachment-group-frame-geometry {
+  padding: var(--attachment-group-inset);
+}
+
+.attachment-group-header-geometry {
+  padding: var(--attachment-group-inset) var(--attachment-group-inset) 0.5rem;
+  border-radius: var(--theme-radius-input) var(--theme-radius-input) 0 0;
+}
+
+.attachment-group-header-geometry[aria-expanded="false"] {
+  border-radius: var(--theme-radius-input);
+}
+
+.attachment-group-items-geometry {
+  padding: 0.5rem var(--attachment-group-inset) var(--attachment-group-inset);
+  border-radius: 0 0 var(--theme-radius-input) var(--theme-radius-input);
+}
+
+.thread-message-card-geometry {
+  border-radius: max(
+    0px,
+    var(--theme-radius-input) - var(--attachment-group-inset, 0.75rem)
+  );
 }
 
 /* Surface for AnchoredPopover panels (dropdown menus, the chat "+" menu).

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -907,11 +907,25 @@ body {
   border-radius: 0 0 var(--theme-radius-input) var(--theme-radius-input);
 }
 
+/* The thread card derives from the group frame, and the attachment tiles
+   inside it derive from the card in turn (the tile reads
+   --attachment-tile-radius with the base radius as its fallback elsewhere).
+   The floors keep a deep nest from squaring off entirely. */
 .thread-message-card-geometry {
-  border-radius: max(
+  --thread-message-card-radius: max(
     0px,
     var(--theme-radius-input) - var(--attachment-group-inset, 0.75rem)
   );
+  --thread-message-card-inset: 0.5rem;
+  --attachment-tile-radius: max(
+    0.25rem,
+    var(--thread-message-card-radius) - var(--thread-message-card-inset)
+  );
+  --attachment-tile-icon-radius: max(
+    0.125rem,
+    var(--attachment-tile-radius) - 0.5rem
+  );
+  border-radius: var(--thread-message-card-radius);
 }
 
 /* Surface for AnchoredPopover panels (dropdown menus, the chat "+" menu).

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -883,7 +883,11 @@ body {
    the input radius like the app's other framed cards; a card inside derives
    its corner from the frame radius minus the frame inset, so the two stay
    concentric for any theme value. Unlayered so a theme.css rule can retune
-   any of it through the data-ui hooks. */
+   any of it through the data-ui hooks. A sticky-header group clips to the
+   frame (overflow: clip creates no scroll container, so the header still
+   sticks to the outer scroll region) while header and items stay square
+   inside it, so nothing shows through a corner once the frame's top has
+   scrolled away. */
 .attachment-group-geometry {
   --attachment-group-inset: 0.75rem;
   border-radius: var(--theme-radius-input);
@@ -895,16 +899,15 @@ body {
 
 .attachment-group-header-geometry {
   padding: var(--attachment-group-inset) var(--attachment-group-inset) 0.5rem;
-  border-radius: var(--theme-radius-input) var(--theme-radius-input) 0 0;
 }
 
+/* Collapsed, the frame's own bottom border closes the card. */
 .attachment-group-header-geometry[aria-expanded="false"] {
-  border-radius: var(--theme-radius-input);
+  border-bottom-width: 0;
 }
 
 .attachment-group-items-geometry {
   padding: 0.5rem var(--attachment-group-inset) var(--attachment-group-inset);
-  border-radius: 0 0 var(--theme-radius-input) var(--theme-radius-input);
 }
 
 /* The thread card derives from the group frame, and the attachment tiles

--- a/frontend/src/utils/themeUtils.test.ts
+++ b/frontend/src/utils/themeUtils.test.ts
@@ -19,6 +19,7 @@ describe("mergeThemeWithOverrides", () => {
       message: "1.25rem",
       modal: "1.25rem",
       dropdown: "1.25rem",
+      card: "1.25rem",
       pill: "1.25rem",
     });
   });

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -114,6 +114,7 @@ const withBorderRadiusCompatibility = (
       message: override.radius?.message ?? theme.borderRadius,
       modal: override.radius?.modal ?? theme.borderRadius,
       dropdown: override.radius?.dropdown ?? theme.borderRadius,
+      card: override.radius?.card ?? theme.borderRadius,
       pill: override.radius?.pill ?? theme.borderRadius,
     },
   };

--- a/office-addin/eslint.config.mjs
+++ b/office-addin/eslint.config.mjs
@@ -83,6 +83,24 @@ const eslintConfig = [
       lingui: linguiPlugin,
     },
     rules: {
+      // A data-ui hook promises a theme it can retune the surface. A Tailwind
+      // rounding utility on the same element would sit outside every token
+      // and geometry class, so the corner has to come from one of those.
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'JSXOpeningElement:has(JSXAttribute[name.name="data-ui"]) JSXAttribute[name.name="className"] Literal[value=/(^|\\s)rounded(?!-\\[)(-(t|b|l|r|tl|tr|bl|br|s|e|ss|se|es|ee))?(-(none|sm|md|lg|xl|2xl|3xl|full))?(\\s|$)/]',
+          message:
+            "Elements carrying a data-ui hook take their corner radius from a token-reading class or a rounded-[var(--theme-radius-…)] value, never a Tailwind rounded-* utility, so customer themes can retune them.",
+        },
+        {
+          selector:
+            'JSXOpeningElement:has(JSXAttribute[name.name="data-ui"]) JSXAttribute[name.name="className"] TemplateElement[value.raw=/(^|\\s)rounded(?!-\\[)(-(t|b|l|r|tl|tr|bl|br|s|e|ss|se|es|ee))?(-(none|sm|md|lg|xl|2xl|3xl|full))?(\\s|$)/]',
+          message:
+            "Elements carrying a data-ui hook take their corner radius from a token-reading class or a rounded-[var(--theme-radius-…)] value, never a Tailwind rounded-* utility, so customer themes can retune them.",
+        },
+      ],
       "@typescript-eslint/consistent-type-imports": [
         "warn",
         { prefer: "type-imports" },

--- a/office-addin/src/core/AddinChatCore.tsx
+++ b/office-addin/src/core/AddinChatCore.tsx
@@ -89,9 +89,12 @@ const floatingTriggerStyle: CSSProperties = {
 function HistoryDrawerTrigger({
   isOpen,
   onOpen,
+  floating = true,
 }: {
   isOpen: boolean;
   onOpen: () => void;
+  /** In a header row the trigger sits in flow; `relative` keeps its badge anchored. */
+  floating?: boolean;
 }) {
   const attentionCount = useGenerationIndicatorCount();
 
@@ -121,7 +124,11 @@ function HistoryDrawerTrigger({
               message: "Open menu",
             })
       }
-      className="absolute left-2 top-2 z-20 border"
+      className={
+        floating
+          ? "absolute left-2 top-2 z-20 border"
+          : "relative my-2 ml-2 shrink-0 border"
+      }
       style={floatingTriggerStyle}
       data-testid="addin-history-drawer-trigger"
     >
@@ -671,10 +678,34 @@ export function AddinChatCoreView({
           through the session controller instead of routes the pane lacks. */}
       <DelegatedRunOpenProvider onOpen={controller.openChatById}>
         <div className="app-shell-skin relative flex size-full min-w-0 flex-col">
-          <HistoryDrawerTrigger
-            isOpen={controller.isHistoryMenuOpen}
-            onOpen={() => controller.setIsHistoryMenuOpen(true)}
-          />
+          {TopLeftAccessory ? (
+            // A kit accessory earns a header row and the trigger joins it in
+            // flow, so neither can land on the other at any pane width.
+            // pr-12, not pr-10: the start-view toggle is 8px plus up to 36px.
+            <div
+              className={`flex min-w-0 items-center${hasStartViewToggle ? " pr-12" : ""}`}
+              data-ui="addin-chat-header"
+            >
+              <HistoryDrawerTrigger
+                floating={false}
+                isOpen={controller.isHistoryMenuOpen}
+                onOpen={() => controller.setIsHistoryMenuOpen(true)}
+              />
+              <div className="min-w-0 flex-1">
+                <TopLeftAccessory
+                  availableModels={controller.availableModels}
+                  selectedModel={controller.selectedModel}
+                  onModelChange={controller.setSelectedModel}
+                  isModelSelectionReady={controller.isSelectionReady}
+                />
+              </div>
+            </div>
+          ) : (
+            <HistoryDrawerTrigger
+              isOpen={controller.isHistoryMenuOpen}
+              onOpen={() => controller.setIsHistoryMenuOpen(true)}
+            />
+          )}
 
           <ChatErrorBoundary onReset={() => void controller.refetchHistory()}>
             <div
@@ -713,23 +744,12 @@ export function AddinChatCoreView({
               {beforeMessages}
               {controller.delegatedRunHeader ? (
                 // pl-10 clears the floating drawer trigger, which otherwise
-                // sits on the header's title.
+                // sits on the header's title; with a header row the trigger
+                // is in flow and needs no clearance.
                 <div
-                  className={`relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3 pl-10${hasStartViewToggle ? " pr-10" : ""}`}
+                  className={`relative z-10 shrink-0 border-b border-theme-border bg-[var(--theme-shell-page)] p-3${TopLeftAccessory ? "" : " pl-10"}${hasStartViewToggle ? " pr-10" : ""}`}
                 >
                   {controller.delegatedRunHeader}
-                </div>
-              ) : null}
-              {TopLeftAccessory ? (
-                // Cleared past the floating drawer trigger, which otherwise
-                // sits exactly on a top-left accessory.
-                <div className={`pl-10${hasStartViewToggle ? " pr-10" : ""}`}>
-                  <TopLeftAccessory
-                    availableModels={controller.availableModels}
-                    selectedModel={controller.selectedModel}
-                    onModelChange={controller.setSelectedModel}
-                    isModelSelectionReady={controller.isSelectionReady}
-                  />
                 </div>
               ) : null}
               <MessageEditProvider value={controller.messageEditValue}>

--- a/office-addin/src/core/AddinHistoryDrawerCore.tsx
+++ b/office-addin/src/core/AddinHistoryDrawerCore.tsx
@@ -19,6 +19,7 @@ import {
   useAssistantsFeature,
   useChatContext,
   useChatSharingFeature,
+  useFeatureConfig,
   useGroupedChatSessions,
   useSanitizedChatHistoryFilters,
 } from "@erato/frontend/library";
@@ -85,6 +86,8 @@ export function AddinHistoryDrawerCore({
     filterStore,
   );
   const { enabled: sharingEnabled } = useChatSharingFeature();
+  // Same source as the web sidebar: the backend's sidebar metadata switch.
+  const { chatHistoryShowMetadata } = useFeatureConfig().sidebar;
 
   const panelRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
@@ -341,6 +344,7 @@ export function AddinHistoryDrawerCore({
       // The pane serves no chat routes and has no tabs; every activation,
       // modified clicks included, selects in place.
       disableRowLinks={true}
+      showTimestamps={chatHistoryShowMetadata}
       onSessionSelect={handleSelect}
       onSessionArchive={handleArchive}
       onSessionEditTitle={setTitleDialogSessionId}

--- a/office-addin/src/core/AddinSettingsDialogCore.tsx
+++ b/office-addin/src/core/AddinSettingsDialogCore.tsx
@@ -154,6 +154,7 @@ export function AddinSettingsDialogCore({
         <div className="shrink-0 border-b border-theme-border pb-2">
           <div
             role="tablist"
+            data-ui="tab-rail"
             aria-label={dialogTitle}
             aria-orientation="horizontal"
             className="flex gap-1 overflow-x-auto"

--- a/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
+++ b/office-addin/src/core/__tests__/AddinHistoryDrawerCore.test.tsx
@@ -46,6 +46,7 @@ const spies = vi.hoisted(() => {
       onSessionEditTitle?: (id: string) => void;
       onSessionShare?: (id: string) => void;
       disableRowLinks?: boolean;
+      showTimestamps?: boolean;
     }>,
     renameDialogProps: {
       current: null as {
@@ -56,6 +57,7 @@ const spies = vi.hoisted(() => {
     },
     filterMenuStore,
     sharingEnabled: { current: true },
+    showMetadata: { current: true },
   };
 });
 
@@ -160,6 +162,9 @@ vi.mock("@erato/frontend/library", () => ({
     fetchNextHistoryPage: spies.fetchNextHistoryPage,
   }),
   useChatSharingFeature: () => ({ enabled: spies.sharingEnabled.current }),
+  useFeatureConfig: () => ({
+    sidebar: { chatHistoryShowMetadata: spies.showMetadata.current },
+  }),
   useGroupedChatSessions: (sessions: { id: string }[]) =>
     sessions.length === 0
       ? []
@@ -209,6 +214,7 @@ describe("AddinHistoryDrawerCore", () => {
     spies.renameDialogProps.current = null;
     spies.filterMenuStore.current = null;
     spies.sharingEnabled.current = true;
+    spies.showMetadata.current = true;
     spies.chatContext.chats = [{ id: "c1" }, { id: "c2" }];
     spies.chatContext.isLoading = false;
     spies.chatContext.isHistoryLoading = false;
@@ -234,6 +240,20 @@ describe("AddinHistoryDrawerCore", () => {
     expect(onClose).toHaveBeenCalled();
     // The pane has no tabs: rows must render without link escape hatches.
     expect(spies.historyListProps[0]?.disableRowLinks).toBe(true);
+  });
+
+  it("passes the sidebar metadata switch through as showTimestamps", () => {
+    spies.showMetadata.current = false;
+
+    renderDrawer();
+
+    expect(spies.historyListProps[0]?.showTimestamps).toBe(false);
+  });
+
+  it("keeps row metadata when the sidebar switch is on", () => {
+    renderDrawer();
+
+    expect(spies.historyListProps[0]?.showTimestamps).toBe(true);
   });
 
   it("puts the pagination sentinel on the last group only", () => {

--- a/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
+++ b/office-addin/src/core/__tests__/NeutralAddinChatPage.test.tsx
@@ -23,6 +23,9 @@ const spies = vi.hoisted(() => ({
   },
   clearNewlyCreatedChatId: vi.fn(),
   generationIndicatorCount: { current: 0 },
+  componentRegistry: {
+    ChatTopLeftAccessory: undefined as (() => ReactNode) | undefined,
+  },
   setGenerationCurrentChatId: vi.fn(),
   updateChatTitle: vi.fn(async () => undefined),
   runOpenHandler: { current: null as ((chatId: string) => void) | null },
@@ -226,7 +229,7 @@ vi.mock("@erato/frontend/library", async () => {
     ),
     MessageEditProvider: ({ children }: { children?: ReactNode }) => children,
     chatMessagesQuery: () => ({ queryKey: ["chat-messages"] }),
-    componentRegistry: {},
+    componentRegistry: spies.componentRegistry,
     extractTextFromContent: () => "",
     resolveComponentOverride: (override: unknown, fallback: unknown) =>
       override ?? fallback,
@@ -305,6 +308,7 @@ describe("NeutralAddinChatPage host boundary", () => {
   const originalOffice = Object.getOwnPropertyDescriptor(globalThis, "Office");
 
   beforeEach(() => {
+    spies.componentRegistry.ChatTopLeftAccessory = undefined;
     i18n.activate("en");
     Reflect.deleteProperty(globalThis, "Office");
     spies.drawerProps.length = 0;
@@ -621,6 +625,32 @@ describe("NeutralAddinChatPage host boundary", () => {
     expect(screen.getByTestId("neutral-run-banner").parentElement).toHaveClass(
       "pl-10",
     );
+  });
+
+  it("puts a kit accessory and the drawer trigger in one header row", () => {
+    function KitAccessory() {
+      return <div data-testid="kit-accessory" />;
+    }
+    spies.componentRegistry.ChatTopLeftAccessory = KitAccessory;
+
+    renderPage();
+
+    const header = screen
+      .getByTestId("kit-accessory")
+      .closest('[data-ui="addin-chat-header"]');
+    const trigger = screen.getByTestId("addin-history-drawer-trigger");
+    expect(header).not.toBeNull();
+    expect(header).toContainElement(trigger);
+    expect(trigger).not.toHaveClass("absolute");
+  });
+
+  it("keeps the trigger floating without a kit accessory", () => {
+    renderPage();
+
+    expect(screen.getByTestId("addin-history-drawer-trigger")).toHaveClass(
+      "absolute",
+    );
+    expect(document.querySelector('[data-ui="addin-chat-header"]')).toBeNull();
   });
 
   // The pane's only aggregate signal: with the drawer shut there is no row to

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -180,7 +180,7 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="search-result-card"`
 - `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and `data-ui="option-card-details"` the section shown under a checked card)
 - `data-ui="tab-rail"` (the hand-rolled settings tab rails; their tabs read `--theme-radius-control`)
-- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread)
+- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow)
 - `data-ui="addin-chat-header"` (the Office add-in's header row when a component kit supplies a top-left accessory)
 
 Every popover panel (dropdown menus, the chat "+" menu, the history filter menu and its flyout, the mention and run-mode menus) also carries the class `anchored-popover-skin`, and every menu row the class `dropdown-item-geometry`. Both are stable hooks: one rule on the skin restyles the whole popover family, and one rule on the row class reshapes every menu row.

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -131,12 +131,14 @@ The typed theme contract is grouped semantically so starter themes can express s
 - `colors.shell` covers app, page, sidebar, chat shell, modal, and dropdown surfaces
 - `colors.message` covers user and assistant message surfaces plus shared hover and controls surfaces
 - `colors.overlay` covers backdrops such as the modal overlay
-- `radius` covers base, shell, input, control, message, modal, dropdown, and pill radii
+- `radius` covers base, shell, input, control, message, modal, dropdown, card, and pill radii
 - `spacing` covers shell, message, controls, sidebar density, chat input, and dropdown spacing
 - `elevation` covers shell, input, modal, and dropdown shadows
 - `layout` covers chat content width, chat input width, and sidebar width
 
 Dropdown menus nest two shapes. The panel takes `radius.dropdown`, every row is inset by `spacing.dropdown.chromePadding` on all four sides, and the row highlight radius is derived as the panel radius minus that inset. Set those two tokens and the rows stay concentric with the panel; there is no separate row radius to keep in step.
+
+Framed cards read `radius.card`: entity rows in settings, assistant cards, and search result cards. Selectable option cards and their icon tiles read `radius.control` instead, because they are choices with a selected state rather than containers.
 
 Existing theme JSON can omit these new groups. When a theme does not provide them yet, the corresponding CSS variables fall back to the built-in theme defaults until they are explicitly overridden.
 
@@ -173,6 +175,15 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="modal-overlay"`
 - `data-ui="modal-shell"`
 - `data-ui="dropdown-panel"`
+- `data-ui="entity-row"`
+- `data-ui="assistant-list-card"`
+- `data-ui="search-result-card"`
+- `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and `data-ui="option-card-details"` the section shown under a checked card)
+- `data-ui="tab-rail"` (the hand-rolled settings tab rails; their tabs read `--theme-radius-control`)
+- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread)
+- `data-ui="addin-chat-header"` (the Office add-in's header row when a component kit supplies a top-left accessory)
+
+Every popover panel (dropdown menus, the chat "+" menu, the history filter menu and its flyout, the mention and run-mode menus) also carries the class `anchored-popover-skin`, and every menu row the class `dropdown-item-geometry`. Both are stable hooks: one rule on the skin restyles the whole popover family, and one rule on the row class reshapes every menu row.
 
 Messages also expose `data-role="user"` and `data-role="assistant"` on the message shell.
 

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -180,7 +180,8 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="search-result-card"`
 - `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and `data-ui="option-card-details"` the section shown under a checked card)
 - `data-ui="tab-rail"` (the hand-rolled settings tab rails; their tabs read `--theme-radius-control`)
-- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow; each chip carries `data-ui="attachment-tile"`)
+- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow)
+- `data-ui="attachment-tile"` (each attachment chip), `data-ui="attachment-row"` (a selectable attachment row with its checkbox, in kits that offer per-attachment selection), `data-ui="attachment-loading"` (the placeholder while a group's contents load)
 - `data-ui="addin-chat-header"` (the Office add-in's header row when a component kit supplies a top-left accessory)
 
 Every popover panel (dropdown menus, the chat "+" menu, the history filter menu and its flyout, the mention and run-mode menus) also carries the class `anchored-popover-skin`, and every menu row the class `dropdown-item-geometry`. Both are stable hooks: one rule on the skin restyles the whole popover family, and one rule on the row class reshapes every menu row.
@@ -188,6 +189,37 @@ Every popover panel (dropdown menus, the chat "+" menu, the history filter menu 
 Messages also expose `data-role="user"` and `data-role="assistant"` on the message shell.
 
 `message-body` wraps the avatar and the message content. On a user message carrying files, `message-attachments` is a sibling rendered above it, so a fill applied to `message-body` covers the text without covering the attachments; on an assistant message the attachments stay inside `message-body` and the hook is absent. Themes that need to work against both shapes can branch on `:has([data-ui="message-body"])`.
+
+## Surface Glossary
+
+The names people use for these surfaces rarely match the component names, and the same surface can be drawn by the host or by a component kit. This table maps the everyday name to the hook a theme keys on and to where its corner radius comes from, so a theme can give any of them a different shape without touching per-component rules. Elements that carry a `data-ui` hook never use Tailwind rounding utilities; a lint rule enforces that, so every such corner is reachable from a theme.
+
+| What people call it                                        | Hook                                         | Corner comes from                                                                   | Retune                                                               |
+| ---------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Attachment frame, email preview frame                      | `attachment-group`                           | `radius.input`                                                                      | set `radius.input`, or re-declare `--theme-radius-input` on the hook |
+| Email thread card, the collapsible message row             | `thread-message-card`                        | frame radius minus the frame inset                                                  | set `border-radius` on the hook                                      |
+| Attachment chip, file chip inside a thread card            | `attachment-tile`                            | `--attachment-tile-radius`, derived from the card by default; its icon tile follows | declare `--attachment-tile-radius` on `thread-message-card`          |
+| Loading placeholder inside a group                         | `attachment-loading`                         | none, a bare spinner                                                                | style the hook                                                       |
+| Entity card in settings (MCP, apps)                        | `entity-row`                                 | `radius.card`                                                                       | set `radius.card`                                                    |
+| Assistant card, search result card                         | `assistant-list-card`, `search-result-card`  | `radius.card`                                                                       | set `radius.card`                                                    |
+| Option card (appearance, Outlook behaviour), its icon tile | `option-card`, `option-card-icon`            | `radius.control`                                                                    | re-declare `--theme-radius-control` on `option-card`                 |
+| Settings tabs                                              | `tab-rail`                                   | `radius.control`                                                                    | re-declare `--theme-radius-control` on the hook                      |
+| Menu panel, "+" menu, filter menu and flyout               | class `anchored-popover-skin`                | `radius.dropdown`                                                                   | set `radius.dropdown`; rows via class `dropdown-item-geometry`       |
+| Sidebar rows and nav rows                                  | `chat-history-item`, `.sidebar-row-geometry` | `radius.shell`                                                                      | set `radius.shell`                                                   |
+
+Two examples, both from the Open WebUI-like theme:
+
+```css
+/* Pills for the chips inside an email thread card; the icon tiles become circles. */
+[data-ui="thread-message-card"] {
+  --attachment-tile-radius: var(--theme-radius-pill);
+}
+
+/* The same chips as tight rectangles for a denser theme. */
+[data-ui="thread-message-card"] {
+  --attachment-tile-radius: 0.25rem;
+}
+```
 
 ## Custom Logos
 

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -180,7 +180,7 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="search-result-card"`
 - `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and `data-ui="option-card-details"` the section shown under a checked card)
 - `data-ui="tab-rail"` (the hand-rolled settings tab rails; their tabs read `--theme-radius-control`)
-- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow)
+- `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow; each chip carries `data-ui="attachment-tile"`)
 - `data-ui="addin-chat-header"` (the Office add-in's header row when a component kit supplies a top-left accessory)
 
 Every popover panel (dropdown menus, the chat "+" menu, the history filter menu and its flyout, the mention and run-mode menus) also carries the class `anchored-popover-skin`, and every menu row the class `dropdown-item-geometry`. Both are stable hooks: one rule on the skin restyles the whole popover family, and one rule on the row class reshapes every menu row.


### PR DESCRIPTION
Host and add-in half of the Outlook add-in parity work under customer themes. Every change here either gives a theme a stable hook or token where it previously had to key on DOM shape, or fixes a layout that only broke once a theme resized the controls. Nothing here changes the stock look except where noted.

## Theme contract

- New `radius.card` token (`--theme-radius-card`, default 0.5rem), plumbed like `radius.dropdown`: framed cards read it, selectable option cards keep reading `radius.control`. Entity rows (`data-ui="entity-row"`), assistant cards and search result cards move to the card token. Stock delta: entity rows go from 0.75rem to 0.5rem; the two page cards were already 0.5rem.
- `RadioCard` reads the control token through a new `.option-card-geometry` class on the card and its icon tile, clips its hover fill to the rounded border, uses `background.selected` for the checked tint, suppresses hover on a checked card (hover is lighter than selected in every shipped theme), and carries `data-ui="option-card"` with `data-selected`, `option-card-icon`, and `option-card-details`. Stock delta: the small size and the icon tile go from 0.375rem to 0.5rem; the checked tint moves from neutral-200 to neutral-300.
- Hand-rolled settings tab rails (web preferences, add-in settings) carry `data-ui="tab-rail"`, so a theme can pill them with one token rule instead of orientation or portal-scope selectors.
- Attachment group frames and the per-message cards of an email thread read unlayered geometry classes: the frame takes the input radius, the header and item well follow it, and a thread card derives its corner from the frame radius minus the inset, so nested cards stay concentric for any theme value. This also fixes the expanded sticky frame, whose item well hardcoded `rounded-b-md`. Hooks: `data-ui="attachment-group"`, `data-ui="thread-message-card"`.
- Docs list every new hook, the card token, and name `anchored-popover-skin` and `dropdown-item-geometry` as the stable class hooks for the popover family.

## Add-in

- The history drawer now passes the backend's `sidebar_chat_history_show_metadata` switch through as `showTimestamps`, the same source the web sidebar uses. Previously the drawer rendered the host list with its default and showed file counts and ages regardless of configuration.
- When a component kit supplies a top-left accessory, the shell renders one header row (`data-ui="addin-chat-header"`) with the drawer trigger in flow beside the accessory, instead of a floating trigger over a zero-height padded wrapper that could not move an absolutely positioned accessory. Without a kit accessory the trigger keeps floating as before. The delegated-run header only reserves the trigger column when the trigger floats.
- Web counterpart: with the sidebar collapsed in hidden mode, the chat surface reserves the floating toggle's column for an in-flow kit accessory.

## Verification

- Frontend: typecheck, eslint, prettier, full unit suite (164 files, 1591 tests).
- Add-in: typecheck, eslint, prettier, full unit suite (100 files, 1095 tests), including new tests for the metadata switch pass-through and for the header row with and without a kit accessory.

## Not in this PR

The theme-side changes for the Open WebUI-like theme (popover family rules keyed on `anchored-popover-skin`, the card token value, deleting the sidebar-header centring rule) and the openwebui kit changes (accessory rendered in flow, tokenised email preview frame) live in erato-subscription-content.
