### PR TITLE
Resolve dropped .msg emails that ANSI-encode the Message-ID, and attach ones the mailbox cannot find

### DIFF
--- a/office-addin/src/outlook/utils/__tests__/extractMsgInternetMessageId.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/extractMsgInternetMessageId.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCfbWith, utf16le } from "../../../test/fixtures/msg";
+import { buildCfbWith, latin1, utf16le } from "../../../test/fixtures/msg";
 import {
   extractMsgInternetMessageId,
   extractMsgInternetMessageIdFromBytes,
@@ -47,6 +47,74 @@ describe("extractMsgInternetMessageIdFromBytes", () => {
       },
     ]);
     expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBeNull();
+  });
+
+  it("reads the ANSI (PT_STRING8) stream when only that variant is present", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001E",
+        content: latin1("<ansi-only@example.com>"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe(
+      "<ansi-only@example.com>",
+    );
+  });
+
+  it("prefers the Unicode stream when both variants are present", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001E",
+        content: latin1("<ansi@example.com>"),
+      },
+      {
+        name: "__substg1.0_1035001F",
+        content: utf16le("<unicode@example.com>"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe(
+      "<unicode@example.com>",
+    );
+  });
+
+  it("strips trailing null padding from the ANSI stream", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "__substg1.0_1035001E",
+        content: latin1("<padded@host>  \u0000\u0000"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe(
+      "<padded@host>",
+    );
+  });
+
+  it("ignores an embedded attachment's Message-ID when the top level has none", () => {
+    // A bare stream name resolves against every leaf in the tree, so an
+    // embedded forwarded message can shadow the carrier's own id.
+    const cfbBytes = buildCfbWith([
+      {
+        name: "/__attach_version1.0_#00000000/__substg1.0_3701000D/__substg1.0_1035001F",
+        content: utf16le("<embedded@example.com>"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBeNull();
+  });
+
+  it("returns the top-level Message-ID even when an embedded one exists", () => {
+    const cfbBytes = buildCfbWith([
+      {
+        name: "/__attach_version1.0_#00000000/__substg1.0_3701000D/__substg1.0_1035001F",
+        content: utf16le("<embedded@example.com>"),
+      },
+      {
+        name: "/__substg1.0_1035001F",
+        content: utf16le("<carrier@example.com>"),
+      },
+    ]);
+    expect(extractMsgInternetMessageIdFromBytes(cfbBytes)).toBe(
+      "<carrier@example.com>",
+    );
   });
 
   it("returns null for non-CFB input", () => {

--- a/office-addin/src/outlook/utils/__tests__/parseDroppedFiles.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/parseDroppedFiles.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  buildAnsiMsgWithInternetMessageId,
+  buildMsgWithInternetMessageId,
+} from "../../../test/fixtures/msg";
 import { parseDroppedFiles } from "../parseDroppedFiles";
+
+import type { OutlookMessageFetcher } from "../fetchOutlookMessage";
 
 const CRLF = "\r\n";
 
@@ -17,6 +23,33 @@ function buildEml(messageId: string | null, subject = "Hi"): string {
     `MIME-Version: 1.0${CRLF}` +
     `Content-Type: text/plain${CRLF}${CRLF}body`
   );
+}
+
+/**
+ * Dropped `.msg` files arrive with an EMPTY `type`, so fixtures must not lean
+ * on the `application/vnd.ms-outlook` type a file picker would supply.
+ */
+function makeDroppedMsgFile(bytes: Uint8Array, name = "dropped.msg"): File {
+  const buffer = new ArrayBuffer(bytes.length);
+  new Uint8Array(buffer).set(bytes);
+  return new File([buffer], name, { type: "" });
+}
+
+function makeFetcherStub(): {
+  fetcher: OutlookMessageFetcher;
+  byteLookups: string[];
+} {
+  const byteLookups: string[] = [];
+  const fetcher = {
+    fetchMessageBytesByInternetMessageId: async (internetMessageId: string) => {
+      byteLookups.push(internetMessageId);
+      return {
+        bytes: new TextEncoder().encode(buildEml(internetMessageId, "Fetched")),
+        internetMessageId,
+      };
+    },
+  } as unknown as OutlookMessageFetcher;
+  return { fetcher, byteLookups };
 }
 
 describe("parseDroppedFiles", () => {
@@ -66,6 +99,45 @@ describe("parseDroppedFiles", () => {
 
     expect(result.emails).toHaveLength(1);
     expect(tryAttachEmail).not.toHaveBeenCalled();
+  });
+
+  it("resolves a dropped .msg that stores its Message-ID as ANSI", async () => {
+    const { fetcher, byteLookups } = makeFetcherStub();
+    const msg = makeDroppedMsgFile(
+      buildAnsiMsgWithInternetMessageId("<ansi-drop@example.com>"),
+    );
+
+    const result = await parseDroppedFiles([msg], { fetcher });
+
+    expect(byteLookups).toEqual(["<ansi-drop@example.com>"]);
+    expect(result.emails).toHaveLength(1);
+    expect(result.nonEmail).toEqual([]);
+  });
+
+  it("resolves a dropped .msg with a Unicode Message-ID and no MIME type", async () => {
+    const { fetcher, byteLookups } = makeFetcherStub();
+    const msg = makeDroppedMsgFile(
+      buildMsgWithInternetMessageId("<unicode-drop@example.com>"),
+    );
+
+    const result = await parseDroppedFiles([msg], { fetcher });
+
+    expect(byteLookups).toEqual(["<unicode-drop@example.com>"]);
+    expect(result.emails).toHaveLength(1);
+  });
+
+  it("warns instead of silently dropping a .msg with no Message-ID", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { fetcher, byteLookups } = makeFetcherStub();
+    const msg = makeDroppedMsgFile(new Uint8Array([1, 2, 3, 4]), "broken.msg");
+
+    const result = await parseDroppedFiles([msg], { fetcher });
+
+    expect(byteLookups).toEqual([]);
+    expect(result.emails).toEqual([]);
+    expect(result.nonEmail).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it("skips .msg drops without a message fetcher", async () => {

--- a/office-addin/src/outlook/utils/__tests__/parseMsgFile.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/parseMsgFile.test.ts
@@ -232,7 +232,7 @@ describe("parseMsgFileToParsedEmail", () => {
     expect(result.messageId).toBe("<abc@host>");
   });
 
-  it("returns null parsed + null id when the CFB has no Message-ID", async () => {
+  it("reads the file itself when the CFB has no Message-ID", async () => {
     const file = msgFileFromBytes(
       buildCfbWith([
         { name: "__substg1.0_0037001F", content: utf16le("Some subject") },
@@ -247,7 +247,10 @@ describe("parseMsgFileToParsedEmail", () => {
       createGraphOutlookMessageFetcher(acquireToken),
     );
 
-    expect(result).toEqual({ parsed: null, messageId: null });
+    expect(result.parsed).not.toBeNull();
+    expect(result.parsed?.subject).toBe("Some subject");
+    expect(result.messageId).toBeNull();
+    // Without an id there is nothing to look up, so the network stays untouched.
     expect(fetchMock).not.toHaveBeenCalled();
     expect(acquireToken).not.toHaveBeenCalled();
   });
@@ -269,7 +272,7 @@ describe("parseMsgFileToParsedEmail", () => {
       }),
     },
   ])(
-    "preserves the CFB Message-ID with null parsed when $label",
+    "falls back to the file itself, preserving the Message-ID, when $label",
     async ({ responder }) => {
       const file = msgFileFromBytes(
         buildMsgWithInternetMessageId("<abc@host>"),
@@ -282,7 +285,11 @@ describe("parseMsgFileToParsedEmail", () => {
         createGraphOutlookMessageFetcher(acquireToken),
       );
 
-      expect(result).toEqual({ parsed: null, messageId: "<abc@host>" });
+      // The id must survive a failed lookup either way: the dedup path claims
+      // against it, so losing it would let a duplicate through.
+      expect(result.messageId).toBe("<abc@host>");
+      expect(result.parsed).not.toBeNull();
+      expect(result.parsed?.messageId).toBe("<abc@host>");
     },
   );
 });

--- a/office-addin/src/outlook/utils/__tests__/parseMsgLocally.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/parseMsgLocally.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRichMsg,
+  cp1251,
+  utf8,
+  type RichMsgOptions,
+} from "../../../test/fixtures/msg";
+import { parseMsgLocallyToEml, readMsgMessage } from "../parseMsgLocally";
+import { parseEmlBytes } from "../parsedEmail";
+
+const SAMPLE: Omit<RichMsgOptions, "encoding"> = {
+  messageId: "<local@example.com>",
+  subject: "Angebot für Straßenbeleuchtung",
+  body: "Guten Tag,\n\nanbei das Angebot.\n\nGrüße",
+  senderName: "Jörg Müller",
+  senderAddress: "joerg@example.com",
+  to: [{ name: "Anna Schmidt", address: "anna@example.com" }],
+  cc: [{ name: "Team", address: "team@example.com" }],
+  sentAt: new Date("2026-03-04T09:15:00.000Z"),
+  attachments: [
+    {
+      filename: "Angebot.pdf",
+      mimeType: "application/pdf",
+      content: new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31]),
+    },
+  ],
+};
+
+async function parseThroughEml(bytes: Uint8Array) {
+  const eml = parseMsgLocallyToEml(bytes, { filename: "sample.eml" });
+  expect(eml).not.toBeNull();
+  return parseEmlBytes(await eml!.arrayBuffer(), { filename: "sample.eml" });
+}
+
+describe.each(["unicode", "ansi"] as const)(
+  "readMsgMessage (%s encoding)",
+  (encoding) => {
+    const bytes = () => buildRichMsg({ ...SAMPLE, encoding });
+
+    it("reads every field the synthesizer needs", () => {
+      const message = readMsgMessage(bytes());
+
+      expect(message).not.toBeNull();
+      expect(message?.internetMessageId).toBe("<local@example.com>");
+      expect(message?.subject).toBe("Angebot für Straßenbeleuchtung");
+      expect(message?.from).toEqual({
+        name: "Jörg Müller",
+        address: "joerg@example.com",
+      });
+      expect(message?.to).toEqual([
+        { name: "Anna Schmidt", address: "anna@example.com" },
+      ]);
+      expect(message?.cc).toEqual([
+        { name: "Team", address: "team@example.com" },
+      ]);
+      expect(message?.date).toBe("2026-03-04T09:15:00.000Z");
+      expect(message?.bodyText).toContain("anbei das Angebot");
+      expect(message?.attachments).toHaveLength(1);
+      expect(message?.attachments[0]).toMatchObject({
+        filename: "Angebot.pdf",
+        mimeType: "application/pdf",
+      });
+    });
+
+    it("round-trips through the synthesized .eml", async () => {
+      const parsed = await parseThroughEml(bytes());
+
+      expect(parsed?.subject).toBe("Angebot für Straßenbeleuchtung");
+      expect(parsed?.messageId).toBe("<local@example.com>");
+      expect(parsed?.from?.address).toBe("joerg@example.com");
+      expect(parsed?.to.map((entry) => entry.address)).toEqual([
+        "anna@example.com",
+      ]);
+      expect(parsed?.cc.map((entry) => entry.address)).toEqual([
+        "team@example.com",
+      ]);
+      expect(parsed?.text).toContain("anbei das Angebot");
+      expect(parsed?.attachments).toHaveLength(1);
+      expect(parsed?.attachments[0].filename).toBe("Angebot.pdf");
+      expect(parsed?.attachments[0].size).toBe(6);
+    });
+  },
+);
+
+describe("PT_STRING8 code pages", () => {
+  // These are the cases the windows-1252 default gets WRONG, so they fail if
+  // PidTagMessageCodepage is ignored: utf-8 bytes read as 1252 mojibake, and
+  // Cyrillic 1251 bytes land on Western glyphs.
+  it("decodes a utf-8 (65001) message", () => {
+    const message = readMsgMessage(
+      buildRichMsg({
+        encoding: "ansi",
+        codepage: 65001,
+        encodeAnsi: utf8,
+        subject: "Jörg Müller grüßt",
+        senderName: "Jörg Müller",
+      }),
+    );
+
+    expect(message?.subject).toBe("Jörg Müller grüßt");
+    expect(message?.from?.name).toBe("Jörg Müller");
+  });
+
+  it("decodes a windows-1251 Cyrillic message", () => {
+    const message = readMsgMessage(
+      buildRichMsg({
+        encoding: "ansi",
+        codepage: 1251,
+        encodeAnsi: cp1251,
+        subject: "Привет",
+      }),
+    );
+
+    expect(message?.subject).toBe("Привет");
+  });
+
+  it("falls back to windows-1252 when the code page is absent", () => {
+    const message = readMsgMessage(
+      buildRichMsg({ encoding: "ansi", subject: "Grüße" }),
+    );
+
+    expect(message?.subject).toBe("Grüße");
+  });
+
+  it("falls back to windows-1252 for a code page it cannot decode", () => {
+    const message = readMsgMessage(
+      buildRichMsg({ encoding: "ansi", codepage: 99999, subject: "Grüße" }),
+    );
+
+    expect(message?.subject).toBe("Grüße");
+  });
+});
+
+describe("readMsgMessage edge cases", () => {
+  it("returns null for bytes that are not a compound file", () => {
+    expect(readMsgMessage(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+    expect(parseMsgLocallyToEml(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+  });
+
+  it("omits bcc recipients from the synthesized message", async () => {
+    const parsed = await parseThroughEml(
+      buildRichMsg({
+        ...SAMPLE,
+        encoding: "unicode",
+        bcc: [{ name: "Hidden", address: "hidden@example.com" }],
+      }),
+    );
+
+    const everyAddress = [...parsed!.to, ...parsed!.cc, ...parsed!.bcc].map(
+      (entry) => entry.address,
+    );
+    expect(everyAddress).not.toContain("hidden@example.com");
+  });
+
+  it("still describes a message with no recipients or attachments", async () => {
+    const parsed = await parseThroughEml(
+      buildRichMsg({
+        encoding: "unicode",
+        subject: "Nur Betreff",
+        body: "kurz",
+      }),
+    );
+
+    expect(parsed?.subject).toBe("Nur Betreff");
+    expect(parsed?.to).toEqual([]);
+    expect(parsed?.attachments).toEqual([]);
+  });
+
+  it.each([
+    ["text/html\r\nX-Injected: yes", "a CRLF header injection"],
+    ["text/html; boundary=--nope", "a smuggled parameter"],
+    ["not-a-mime-type", "a malformed value"],
+  ])("discards %j as an attachment MIME type (%s)", (mimeTag) => {
+    const message = readMsgMessage(
+      buildRichMsg({
+        encoding: "unicode",
+        subject: "s",
+        attachments: [
+          {
+            filename: "a.bin",
+            mimeType: mimeTag,
+            content: new Uint8Array([1, 2, 3]),
+          },
+        ],
+      }),
+    );
+
+    expect(message?.attachments[0].mimeType).toBe("application/octet-stream");
+  });
+
+  it("keeps a well-formed attachment MIME type", () => {
+    const message = readMsgMessage(
+      buildRichMsg({
+        encoding: "unicode",
+        subject: "s",
+        attachments: [
+          {
+            filename: "a.pdf",
+            mimeType: "application/pdf",
+            content: new Uint8Array([1]),
+          },
+        ],
+      }),
+    );
+
+    expect(message?.attachments[0].mimeType).toBe("application/pdf");
+  });
+
+  it("drops an X.500 sender address rather than forging a From", () => {
+    const message = readMsgMessage(
+      buildRichMsg({
+        encoding: "unicode",
+        subject: "s",
+        senderName: "Jörg Müller",
+        senderAddress: undefined,
+      }),
+    );
+
+    expect(message?.from).toEqual({ name: "Jörg Müller", address: "" });
+  });
+});

--- a/office-addin/src/outlook/utils/__tests__/synthesizeThreadEml.test.ts
+++ b/office-addin/src/outlook/utils/__tests__/synthesizeThreadEml.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseEmlBytes } from "../parsedEmail";
 import {
+  synthesizeMessageEml,
   synthesizeThreadEml,
   type ThreadMessageInput,
 } from "../synthesizeThreadEml";
@@ -273,5 +274,93 @@ describe("synthesizeThreadEml", () => {
     // Round-trip filename via postal-mime.
     const nestedParsed = await parseEmlBytes(await nestedFile.arrayBuffer());
     expect(nestedParsed?.attachments[0].filename).toBe(filename);
+  });
+});
+
+describe("synthesizeMessageEml display names", () => {
+  const base: ThreadMessageInput = {
+    internetMessageId: "<solo@example.com>",
+    subject: "Betreff",
+    from: null,
+    to: [],
+    cc: [],
+    date: "2026-03-01T09:00:00Z",
+    bodyText: "hallo",
+    bodyHtml: null,
+    attachments: [],
+  };
+
+  async function parseFrom(from: ThreadMessageInput["from"]) {
+    const eml = synthesizeMessageEml({ ...base, from });
+    return parseEmlBytes(await eml.arrayBuffer());
+  }
+
+  it("keeps a comma-bearing display name as one address", async () => {
+    const parsed = await parseFrom({
+      name: "Jensch, Esther",
+      address: "esther@example.com",
+    });
+
+    expect(parsed?.from).toEqual({
+      name: "Jensch, Esther",
+      address: "esther@example.com",
+    });
+  });
+
+  it("keeps a comma-bearing recipient list from splitting", async () => {
+    const eml = synthesizeMessageEml({
+      ...base,
+      to: [
+        { name: "Jensch, Esther", address: "esther@example.com" },
+        { name: "Heinze, Sascha", address: "sascha@example.com" },
+      ],
+    });
+    const parsed = await parseEmlBytes(await eml.arrayBuffer());
+
+    expect(parsed?.to).toEqual([
+      { name: "Jensch, Esther", address: "esther@example.com" },
+      { name: "Heinze, Sascha", address: "sascha@example.com" },
+    ]);
+  });
+
+  it("round-trips a non-ASCII display name", async () => {
+    const parsed = await parseFrom({
+      name: "Jörg Müller",
+      address: "joerg@example.com",
+    });
+
+    expect(parsed?.from).toEqual({
+      name: "Jörg Müller",
+      address: "joerg@example.com",
+    });
+  });
+
+  it("keeps an ASCII name with no routable address, without inventing one", async () => {
+    for (const name of ["Jensch, Esther", "Plain Name"]) {
+      const parsed = await parseFrom({ name, address: "" });
+      expect(parsed?.from?.name).toBe(name);
+      expect(parsed?.from?.address).toBe("");
+    }
+  });
+
+  it("omits the sender entirely when a non-ASCII name has no address", async () => {
+    // An encoded-word before an empty angle-addr is read back as the address,
+    // and header bytes are ASCII, so there is no faithful form here.
+    const parsed = await parseFrom({ name: "Jörg Müller", address: "" });
+
+    expect(parsed?.from).toBeNull();
+  });
+
+  it("emits a standalone message rather than a one-member thread envelope", async () => {
+    const eml = synthesizeMessageEml({
+      ...base,
+      from: { name: "A", address: "a@example.com" },
+    });
+    const parsed = await parseEmlBytes(await eml.arrayBuffer());
+
+    expect(parsed?.subject).toBe("Betreff");
+    expect(parsed?.text?.trim()).toBe("hallo");
+    // A thread envelope would surface the message itself as a nested .eml.
+    expect(parsed?.attachments).toEqual([]);
   });
 });

--- a/office-addin/src/outlook/utils/extractMsgInternetMessageId.ts
+++ b/office-addin/src/outlook/utils/extractMsgInternetMessageId.ts
@@ -1,17 +1,26 @@
 import * as CFB from "cfb";
 
 /**
- * Reads ONLY the PR_INTERNET_MESSAGE_ID stream (MAPI tag 0x1035, type PT_UNICODE)
- * from a `.msg` Compound File Binary Format blob. Deliberately avoids full
- * MSG semantics — all we need is the RFC 5322 `Message-ID` so we can look
- * the message up via Microsoft Graph.
+ * Reads ONLY the PR_INTERNET_MESSAGE_ID stream (MAPI tag 0x1035) from a
+ * `.msg` Compound File Binary Format blob. Deliberately avoids full MSG
+ * semantics — all we need is the RFC 5322 `Message-ID` so we can look the
+ * message up via the environment's mail backend.
  *
  * MAPI stream naming convention: each string property is stored in a stream
  * named `__substg1.0_<TAG>`, where `<TAG>` is the 4-byte property tag in
- * uppercase hex. PR_INTERNET_MESSAGE_ID_W = 0x1035001F.
+ * uppercase hex. The low two bytes are the property TYPE, so the same
+ * property appears under two different names depending on how the writer
+ * encoded it: `001F` = PT_UNICODE (UTF-16LE), `001E` = PT_STRING8. Outlook
+ * writes one or the other, never both, so reading only the Unicode name
+ * silently yields nothing for a PT_STRING8 file.
+ *
+ * PT_STRING8 is nominally in the code page named by PR_INTERNET_CPID; we
+ * decode windows-1252 unconditionally because RFC 5322 restricts msg-id to
+ * printable US-ASCII, which every candidate code page agrees on.
  */
 
-const INTERNET_MESSAGE_ID_STREAM_NAME = "__substg1.0_1035001F";
+const UNICODE_STREAM_PATH = "/__substg1.0_1035001F";
+const ANSI_STREAM_PATH = "/__substg1.0_1035001E";
 
 export async function extractMsgInternetMessageId(
   file: File,
@@ -30,7 +39,23 @@ export function extractMsgInternetMessageIdFromBytes(
     return null;
   }
 
-  const entry = CFB.find(container, INTERNET_MESSAGE_ID_STREAM_NAME);
+  return (
+    readStream(container, UNICODE_STREAM_PATH, "utf-16le") ??
+    readStream(container, ANSI_STREAM_PATH, "windows-1252")
+  );
+}
+
+/**
+ * `path` must stay root-anchored: `CFB.find` resolves a bare name against
+ * every leaf in the tree, so an embedded forwarded message's copy of the
+ * property would otherwise shadow the carrier's own.
+ */
+function readStream(
+  container: CFB.CFB$Container,
+  path: string,
+  encoding: string,
+): string | null {
+  const entry = CFB.find(container, path);
   if (!entry) {
     return null;
   }
@@ -42,7 +67,7 @@ export function extractMsgInternetMessageIdFromBytes(
     return null;
   }
 
-  const decoded = new TextDecoder("utf-16le").decode(streamBytes);
+  const decoded = new TextDecoder(encoding).decode(streamBytes);
   const trimmed = decoded.replace(/\0+$/u, "").trim();
   return trimmed.length > 0 ? trimmed : null;
 }

--- a/office-addin/src/outlook/utils/msgProperties.ts
+++ b/office-addin/src/outlook/utils/msgProperties.ts
@@ -1,0 +1,223 @@
+import * as CFB from "cfb";
+
+/**
+ * Minimal MAPI property reads over a `.msg` Compound File. Enough to describe
+ * an email locally — subject, addresses, body, attachments — without taking on
+ * full MSG semantics (no RTF decompression, no named-property resolution).
+ *
+ * Two format rules drive everything here, both from MS-OXMSG:
+ *
+ *  - A string property lives in a stream named `__substg1.0_<TAG><TYPE>`, where
+ *    TYPE is `001F` for PtypString (UTF-16LE) or `001E` for PtypString8. A file
+ *    is entirely one or the other and may never mix them, so trying both names
+ *    and taking whichever exists is exhaustive.
+ *  - Fixed-width properties are inlined in a `__properties_version1.0` stream as
+ *    16-byte entries (tag, flags, 8-byte value) after a header whose size
+ *    depends on what owns the stream.
+ */
+
+/** Header preceding the 16-byte entries of a `__properties_version1.0` stream. */
+export const PROPERTIES_HEADER_SIZE = {
+  /** Top-level message. */
+  message: 32,
+  /** Attachment or recipient storage. */
+  substorage: 8,
+} as const;
+
+/**
+ * Every path is root-anchored. `CFB.find` resolves a bare name against every
+ * leaf in the tree, so an embedded message's copy of a property would otherwise
+ * shadow the carrier's own.
+ */
+export type StoragePath = string;
+
+export const ROOT: StoragePath = "";
+
+export function readStringProperty(
+  container: CFB.CFB$Container,
+  storage: StoragePath,
+  tag: string,
+  ansiDecoder: TextDecoder,
+): string | null {
+  return (
+    decodeStream(container, `${storage}/__substg1.0_${tag}001F`, UTF16LE) ??
+    decodeStream(container, `${storage}/__substg1.0_${tag}001E`, ansiDecoder)
+  );
+}
+
+export function readBinaryProperty(
+  container: CFB.CFB$Container,
+  storage: StoragePath,
+  tag: string,
+): Uint8Array | null {
+  const bytes = readStream(container, `${storage}/__substg1.0_${tag}0102`);
+  return bytes && bytes.length > 0 ? bytes : null;
+}
+
+export function readInt32Property(
+  container: CFB.CFB$Container,
+  storage: StoragePath,
+  tag: string,
+  headerSize: number,
+): number | null {
+  const entry = findPropertyEntry(container, storage, tag, "0003", headerSize);
+  if (!entry) return null;
+  let value = 0;
+  for (let i = 3; i >= 0; i -= 1) value = value * 256 + entry[8 + i];
+  return value;
+}
+
+/**
+ * PtypTime is a FILETIME: 100-nanosecond ticks since 1601-01-01 UTC. Read as
+ * two 32-bit halves and recombined in floating point, which stays exact for
+ * any date this will ever see.
+ */
+export function readTimeProperty(
+  container: CFB.CFB$Container,
+  storage: StoragePath,
+  tag: string,
+  headerSize: number,
+): Date | null {
+  const entry = findPropertyEntry(container, storage, tag, "0040", headerSize);
+  if (!entry) return null;
+  let low = 0;
+  let high = 0;
+  for (let i = 3; i >= 0; i -= 1) low = low * 256 + entry[8 + i];
+  for (let i = 3; i >= 0; i -= 1) high = high * 256 + entry[12 + i];
+  const ticks = high * 4294967296 + low;
+  if (ticks === 0) return null;
+  const FILETIME_EPOCH_OFFSET_MS = 11644473600000;
+  const millis = ticks / 10000 - FILETIME_EPOCH_OFFSET_MS;
+  const date = new Date(millis);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+/** Child storages of `storage` whose names start with `prefix`, in tree order. */
+export function listStorages(
+  container: CFB.CFB$Container,
+  prefix: string,
+): StoragePath[] {
+  const rootPrefix = container.FullPaths[0];
+  const seen = new Set<string>();
+  const found: StoragePath[] = [];
+  for (const fullPath of container.FullPaths) {
+    if (!fullPath.startsWith(rootPrefix)) continue;
+    const relative = fullPath.slice(rootPrefix.length);
+    const [head] = relative.split("/");
+    if (!head.startsWith(prefix) || seen.has(head)) continue;
+    seen.add(head);
+    found.push("/" + head);
+  }
+  return found;
+}
+
+/**
+ * Decoder for this file's PtypString8 properties. PidTagMessageCodepage
+ * describes the message's own 8-bit strings; PidTagInternetCodepage is about
+ * its internet representation, so it is only a fallback. Unknown or
+ * unsupported code pages fall back to windows-1252 rather than throwing —
+ * a wrong accent beats losing the whole email.
+ */
+export function resolveAnsiDecoder(container: CFB.CFB$Container): TextDecoder {
+  const codepage =
+    readInt32Property(
+      container,
+      ROOT,
+      "3FFD",
+      PROPERTIES_HEADER_SIZE.message,
+    ) ??
+    readInt32Property(container, ROOT, "3FDE", PROPERTIES_HEADER_SIZE.message);
+  return decoderForCodepage(codepage);
+}
+
+function decoderForCodepage(codepage: number | null): TextDecoder {
+  const label = codepage === null ? null : CODEPAGE_LABELS[codepage];
+  if (label) {
+    try {
+      return new TextDecoder(label);
+    } catch {
+      // Fall through to the default below.
+    }
+  }
+  return new TextDecoder("windows-1252");
+}
+
+/**
+ * Code pages seen on real Outlook output, plus the Western/Central European
+ * neighbours a German or Eastern European mailbox is most likely to produce.
+ * Anything absent decodes as windows-1252.
+ */
+const CODEPAGE_LABELS: Record<number, string> = {
+  874: "windows-874",
+  932: "shift_jis",
+  936: "gbk",
+  949: "euc-kr",
+  950: "big5",
+  1250: "windows-1250",
+  1251: "windows-1251",
+  1252: "windows-1252",
+  1253: "windows-1253",
+  1254: "windows-1254",
+  1255: "windows-1255",
+  1256: "windows-1256",
+  1257: "windows-1257",
+  1258: "windows-1258",
+  10000: "macintosh",
+  20866: "koi8-r",
+  21866: "koi8-u",
+  28591: "iso-8859-1",
+  28592: "iso-8859-2",
+  28595: "iso-8859-5",
+  28597: "iso-8859-7",
+  28599: "iso-8859-9",
+  28605: "iso-8859-15",
+  65001: "utf-8",
+};
+
+const UTF16LE = new TextDecoder("utf-16le");
+
+function findPropertyEntry(
+  container: CFB.CFB$Container,
+  storage: StoragePath,
+  tag: string,
+  type: string,
+  headerSize: number,
+): Uint8Array | null {
+  const bytes = readStream(container, `${storage}/__properties_version1.0`);
+  if (!bytes) return null;
+  const tagValue = Number.parseInt(tag + type, 16);
+  if (!Number.isFinite(tagValue)) return null;
+  const expected = [
+    tagValue & 0xff,
+    (tagValue >>> 8) & 0xff,
+    (tagValue >>> 16) & 0xff,
+    (tagValue >>> 24) & 0xff,
+  ];
+  for (let i = headerSize; i + 16 <= bytes.length; i += 16) {
+    if (expected.every((byte, k) => bytes[i + k] === byte)) {
+      return bytes.subarray(i, i + 16);
+    }
+  }
+  return null;
+}
+
+function readStream(
+  container: CFB.CFB$Container,
+  path: string,
+): Uint8Array | null {
+  const entry = CFB.find(container, path);
+  if (!entry || !entry.content) return null;
+  const content = entry.content;
+  return content instanceof Uint8Array ? content : new Uint8Array(content);
+}
+
+function decodeStream(
+  container: CFB.CFB$Container,
+  path: string,
+  decoder: TextDecoder,
+): string | null {
+  const bytes = readStream(container, path);
+  if (!bytes || bytes.length === 0) return null;
+  const trimmed = decoder.decode(bytes).replace(/\0+$/u, "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/office-addin/src/outlook/utils/parseMsgFile.ts
+++ b/office-addin/src/outlook/utils/parseMsgFile.ts
@@ -1,8 +1,9 @@
-import { extractMsgInternetMessageId } from "./extractMsgInternetMessageId";
+import { extractMsgInternetMessageIdFromBytes } from "./extractMsgInternetMessageId";
 import {
   OUTLOOK_GRAPH_MESSAGE_TIMEOUT_MS,
   runWithGraphTimeout,
 } from "./graphRequestTimeout";
+import { parseMsgLocallyToEml } from "./parseMsgLocally";
 import { parseEmlBytes } from "./parsedEmail";
 
 import type { OutlookMessageFetcher } from "./fetchOutlookMessage";
@@ -31,9 +32,11 @@ export async function parseMsgFileToFiles(
   file: File,
   fetcher: OutlookMessageFetcher,
 ): Promise<MsgParseResult> {
-  const internetMessageId = await extractMessageIdSafely(file);
+  const bytes = await readBytesSafely(file);
+  const internetMessageId = bytes
+    ? extractMessageIdSafely(bytes, file.name)
+    : null;
   if (!internetMessageId) {
-    warnMissingMessageId(file);
     return { files: [], messageId: null };
   }
 
@@ -74,12 +77,44 @@ export async function parseMsgFileToParsedEmail(
   file: File,
   fetcher: OutlookMessageFetcher,
 ): Promise<MsgParsedResult> {
-  const internetMessageId = await extractMessageIdSafely(file);
-  if (!internetMessageId) {
-    warnMissingMessageId(file);
+  const bytes = await readBytesSafely(file);
+  if (!bytes) {
     return { parsed: null, messageId: null };
   }
 
+  const internetMessageId = extractMessageIdSafely(bytes, file.name);
+
+  // The backend copy is preferred whenever it can be had: it owns the
+  // fidelity-sensitive work (RTF-encapsulated HTML, embedded content types)
+  // that the local reader deliberately skips.
+  if (internetMessageId) {
+    const fetched = await fetchParsedEmail(file, fetcher, internetMessageId);
+    if (fetched) {
+      return {
+        parsed: fetched,
+        messageId: fetched.messageId ?? internetMessageId,
+      };
+    }
+  }
+
+  // Every remaining path — no Message-ID, no match, network or auth failure —
+  // used to drop the email with nothing to show for it. The file itself still
+  // describes the message well enough to attach.
+  const parsed = await parseMsgBytesLocally(bytes, file.name);
+  if (!parsed) {
+    console.warn(
+      "[parseMsgFile] could not resolve or read dropped .msg:",
+      file.name,
+    );
+  }
+  return { parsed, messageId: parsed?.messageId ?? internetMessageId };
+}
+
+async function fetchParsedEmail(
+  file: File,
+  fetcher: OutlookMessageFetcher,
+  internetMessageId: string,
+): Promise<ParsedEmail | null> {
   let bytesResult;
   try {
     bytesResult = await runWithGraphTimeout(
@@ -91,49 +126,48 @@ export async function parseMsgFileToParsedEmail(
           signal,
         }),
     );
+  } catch {
+    return null;
+  }
+  if (!bytesResult) {
+    return null;
+  }
+  return parseEmlBytes(bytesResult.bytes);
+}
+
+async function parseMsgBytesLocally(
+  bytes: Uint8Array,
+  sourceName: string,
+): Promise<ParsedEmail | null> {
+  const filename = sourceName.replace(/\.msg$/i, "") + ".eml";
+  const eml = parseMsgLocallyToEml(bytes, { filename });
+  if (!eml) return null;
+  return parseEmlBytes(await eml.arrayBuffer(), { filename });
+}
+
+async function readBytesSafely(file: File): Promise<Uint8Array | null> {
+  try {
+    return new Uint8Array(await file.arrayBuffer());
   } catch (error) {
     console.warn(
-      "[parseMsgFile] message fetch failed for dropped .msg:",
+      "[parseMsgFile] could not read dropped .msg:",
       file.name,
       error,
     );
-    return { parsed: null, messageId: internetMessageId };
+    return null;
   }
-
-  if (!bytesResult) {
-    console.warn(
-      "[parseMsgFile] lookup returned no match for Message-ID:",
-      internetMessageId,
-    );
-    return { parsed: null, messageId: internetMessageId };
-  }
-
-  const parsed = await parseEmlBytes(bytesResult.bytes);
-  return {
-    parsed,
-    messageId: parsed?.messageId ?? internetMessageId,
-  };
 }
 
-/**
- * The no-Message-ID exit drops the file with no other trace: callers treat an
- * empty result as "nothing to attach", so without this the drop is a no-op the
- * user cannot distinguish from a dead dropzone.
- */
-function warnMissingMessageId(file: File): void {
-  console.warn(
-    "[parseMsgFile] no PR_INTERNET_MESSAGE_ID in dropped .msg — cannot resolve it:",
-    file.name,
-  );
-}
-
-async function extractMessageIdSafely(file: File): Promise<string | null> {
+function extractMessageIdSafely(
+  bytes: Uint8Array,
+  sourceName: string,
+): string | null {
   try {
-    return await extractMsgInternetMessageId(file);
+    return extractMsgInternetMessageIdFromBytes(bytes);
   } catch (error) {
     console.warn(
       "[parseMsgFile] Failed to read CFB from dropped .msg:",
-      file.name,
+      sourceName,
       error,
     );
     return null;

--- a/office-addin/src/outlook/utils/parseMsgFile.ts
+++ b/office-addin/src/outlook/utils/parseMsgFile.ts
@@ -33,6 +33,7 @@ export async function parseMsgFileToFiles(
 ): Promise<MsgParseResult> {
   const internetMessageId = await extractMessageIdSafely(file);
   if (!internetMessageId) {
+    warnMissingMessageId(file);
     return { files: [], messageId: null };
   }
 
@@ -75,6 +76,7 @@ export async function parseMsgFileToParsedEmail(
 ): Promise<MsgParsedResult> {
   const internetMessageId = await extractMessageIdSafely(file);
   if (!internetMessageId) {
+    warnMissingMessageId(file);
     return { parsed: null, messageId: null };
   }
 
@@ -111,6 +113,18 @@ export async function parseMsgFileToParsedEmail(
     parsed,
     messageId: parsed?.messageId ?? internetMessageId,
   };
+}
+
+/**
+ * The no-Message-ID exit drops the file with no other trace: callers treat an
+ * empty result as "nothing to attach", so without this the drop is a no-op the
+ * user cannot distinguish from a dead dropzone.
+ */
+function warnMissingMessageId(file: File): void {
+  console.warn(
+    "[parseMsgFile] no PR_INTERNET_MESSAGE_ID in dropped .msg — cannot resolve it:",
+    file.name,
+  );
 }
 
 async function extractMessageIdSafely(file: File): Promise<string | null> {

--- a/office-addin/src/outlook/utils/parseMsgLocally.ts
+++ b/office-addin/src/outlook/utils/parseMsgLocally.ts
@@ -1,0 +1,225 @@
+import * as CFB from "cfb";
+
+import {
+  PROPERTIES_HEADER_SIZE,
+  ROOT,
+  listStorages,
+  readBinaryProperty,
+  readInt32Property,
+  readStringProperty,
+  readTimeProperty,
+  resolveAnsiDecoder,
+  type StoragePath,
+} from "./msgProperties";
+import { synthesizeMessageEml } from "./synthesizeThreadEml";
+
+import type {
+  ThreadAttachmentInput,
+  ThreadMessageInput,
+} from "./synthesizeThreadEml";
+
+/**
+ * Describes a dropped `.msg` from its own bytes, for the case where the mail
+ * backend cannot resolve it (archive, PST, shared mailbox, deleted item).
+ * The backend stays the preferred source — it owns the fidelity-sensitive
+ * work — so this runs only after a lookup comes back empty.
+ *
+ * Deliberately does NOT read the RTF-compressed body (PidTagRtfCompressed).
+ * Decompression is the one genuinely heavy part of the format, and the plain
+ * text body is present far more reliably than the HTML one, so an email
+ * rendered from here is plain text with its attachments intact.
+ */
+
+const MAPI = {
+  internetMessageId: "1035",
+  subject: "0037",
+  bodyText: "1000",
+  bodyHtml: "1013",
+  senderName: "0C1A",
+  senderSmtpAddress: "5D01",
+  senderEmailAddress: "0C1F",
+  clientSubmitTime: "0039",
+  messageDeliveryTime: "0E06",
+  displayName: "3001",
+  smtpAddress: "39FE",
+  emailAddress: "3003",
+  recipientType: "0C15",
+  attachLongFilename: "3707",
+  attachFilename: "3704",
+  attachMimeTag: "370E",
+  attachData: "3701",
+} as const;
+
+const RECIPIENT_TYPE = { to: 1, cc: 2, bcc: 3 } as const;
+
+export interface LocalMsgParseOptions {
+  /** Overrides the synthesized `.eml` filename. Defaults to a subject slug. */
+  filename?: string;
+}
+
+/**
+ * Renders the `.msg` as an `.eml` File so the rest of the pipeline — preview,
+ * per-attachment selection, upload — treats it exactly like every other email.
+ * Returns null when the bytes are not a readable compound file.
+ */
+export function parseMsgLocallyToEml(
+  bytes: Uint8Array,
+  options: LocalMsgParseOptions = {},
+): File | null {
+  const message = readMsgMessage(bytes);
+  if (!message) return null;
+  return synthesizeMessageEml(message, { filename: options.filename });
+}
+
+export function readMsgMessage(bytes: Uint8Array): ThreadMessageInput | null {
+  let container: CFB.CFB$Container;
+  try {
+    container = CFB.read(bytes, { type: "array" });
+  } catch {
+    return null;
+  }
+
+  const ansi = resolveAnsiDecoder(container);
+  const str = (storage: StoragePath, tag: string) =>
+    readStringProperty(container, storage, tag, ansi);
+
+  const recipients = readRecipients(container, ansi);
+  const date =
+    readTimeProperty(
+      container,
+      ROOT,
+      MAPI.clientSubmitTime,
+      PROPERTIES_HEADER_SIZE.message,
+    ) ??
+    readTimeProperty(
+      container,
+      ROOT,
+      MAPI.messageDeliveryTime,
+      PROPERTIES_HEADER_SIZE.message,
+    );
+
+  return {
+    internetMessageId: str(ROOT, MAPI.internetMessageId),
+    subject: str(ROOT, MAPI.subject) ?? "",
+    from: readSender(container, ansi),
+    to: recipients.to,
+    cc: recipients.cc,
+    date: date ? date.toISOString() : null,
+    bodyText: str(ROOT, MAPI.bodyText),
+    bodyHtml: readHtmlBody(container, ansi),
+    attachments: readAttachments(container, ansi),
+  };
+}
+
+function readSender(
+  container: CFB.CFB$Container,
+  ansi: TextDecoder,
+): ThreadMessageInput["from"] {
+  const name = readStringProperty(container, ROOT, MAPI.senderName, ansi);
+  const address =
+    readStringProperty(container, ROOT, MAPI.senderSmtpAddress, ansi) ??
+    smtpOnly(
+      readStringProperty(container, ROOT, MAPI.senderEmailAddress, ansi),
+    );
+  if (!name && !address) return null;
+  return { name: name ?? "", address: address ?? "" };
+}
+
+function readRecipients(
+  container: CFB.CFB$Container,
+  ansi: TextDecoder,
+): { to: ThreadMessageInput["to"]; cc: ThreadMessageInput["cc"] } {
+  const to: ThreadMessageInput["to"] = [];
+  const cc: ThreadMessageInput["cc"] = [];
+
+  for (const storage of listStorages(container, "__recip_version1.0_#")) {
+    const name = readStringProperty(container, storage, MAPI.displayName, ansi);
+    const address =
+      readStringProperty(container, storage, MAPI.smtpAddress, ansi) ??
+      smtpOnly(readStringProperty(container, storage, MAPI.emailAddress, ansi));
+    if (!name && !address) continue;
+
+    const entry = { name: name ?? "", address: address ?? "" };
+    const type = readInt32Property(
+      container,
+      storage,
+      MAPI.recipientType,
+      PROPERTIES_HEADER_SIZE.substorage,
+    );
+    // Bcc is omitted so a synthesized header can never disclose more than the
+    // sender chose to reveal. A Sent Items copy does carry its Bcc list, so
+    // this loses those recipients — the safe direction to be wrong in.
+    if (type === RECIPIENT_TYPE.bcc) continue;
+    if (type === RECIPIENT_TYPE.cc) cc.push(entry);
+    else to.push(entry);
+  }
+
+  return { to, cc };
+}
+
+function readAttachments(
+  container: CFB.CFB$Container,
+  ansi: TextDecoder,
+): ThreadAttachmentInput[] {
+  const attachments: ThreadAttachmentInput[] = [];
+
+  for (const storage of listStorages(container, "__attach_version1.0_#")) {
+    const contentBytes = readBinaryProperty(
+      container,
+      storage,
+      MAPI.attachData,
+    );
+    // An attachment with no binary stream is an embedded message or an OLE
+    // object; both need MSG recursion this reader deliberately does not do.
+    if (!contentBytes) continue;
+
+    const filename =
+      readStringProperty(container, storage, MAPI.attachLongFilename, ansi) ??
+      readStringProperty(container, storage, MAPI.attachFilename, ansi) ??
+      "attachment";
+    const mimeType = safeMimeType(
+      readStringProperty(container, storage, MAPI.attachMimeTag, ansi),
+    );
+
+    attachments.push({ filename, mimeType, contentBytes });
+  }
+
+  return attachments;
+}
+
+/**
+ * PidTagAttachMimeTag is written by whoever produced the `.msg`, and on this
+ * path that file came from outside the mailbox. The value lands in a
+ * `Content-Type:` header, so anything but a bare `type/subtype` of RFC 2045
+ * token characters — a stray parameter, a CRLF — is discarded rather than
+ * given the chance to reshape the part.
+ */
+function safeMimeType(value: string | null): string {
+  const fallback = "application/octet-stream";
+  if (!value) return fallback;
+  return /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+$/.test(value)
+    ? value
+    : fallback;
+}
+
+/**
+ * PidTagSenderEmailAddress holds an X.500 DN for Exchange senders, which is
+ * not routable and must not become a From address.
+ */
+function smtpOnly(address: string | null): string | null {
+  if (!address) return null;
+  return address.includes("@") ? address : null;
+}
+
+function readHtmlBody(
+  container: CFB.CFB$Container,
+  ansi: TextDecoder,
+): string | null {
+  const asString = readStringProperty(container, ROOT, MAPI.bodyHtml, ansi);
+  if (asString) return asString;
+  // PidTagBodyHtml is often stored as PtypBinary rather than a string.
+  const binary = readBinaryProperty(container, ROOT, MAPI.bodyHtml);
+  if (!binary) return null;
+  const decoded = ansi.decode(binary).replace(/\0+$/u, "").trim();
+  return decoded.length > 0 ? decoded : null;
+}

--- a/office-addin/src/outlook/utils/synthesizeThreadEml.ts
+++ b/office-addin/src/outlook/utils/synthesizeThreadEml.ts
@@ -101,16 +101,37 @@ export function synthesizeThreadEml(options: SynthesizeThreadOptions): File {
   });
 }
 
+/**
+ * One message as a standalone `.eml` File. Same RFC 822 rendering the thread
+ * envelope uses for its nested parts, minus the multipart/mixed wrapper — a
+ * single message must not arrive looking like a one-member thread, or its own
+ * attachments would surface as the envelope's.
+ */
+export function synthesizeMessageEml(
+  message: ThreadMessageInput,
+  options: { filename?: string } = {},
+): File {
+  const bytes = buildNestedMessage(message);
+  return new File(
+    [bytes as BlobPart],
+    options.filename ?? slugFilename(message.subject),
+    { type: "message/rfc822" },
+  );
+}
+
 function buildNestedMessage(message: ThreadMessageInput): Uint8Array {
   const headerLines: [string, string][] = [];
-  if (message.from) {
-    headerLines.push(["From", formatAddress(message.from)]);
+  const from = message.from ? formatAddress(message.from) : null;
+  if (from) {
+    headerLines.push(["From", from]);
   }
-  if (message.to.length > 0) {
-    headerLines.push(["To", formatAddressList(message.to)]);
+  const to = formatAddressList(message.to);
+  if (to) {
+    headerLines.push(["To", to]);
   }
-  if (message.cc.length > 0) {
-    headerLines.push(["Cc", formatAddressList(message.cc)]);
+  const cc = formatAddressList(message.cc);
+  if (cc) {
+    headerLines.push(["Cc", cc]);
   }
   headerLines.push(["Subject", encodeHeader(message.subject)]);
   headerLines.push(["Date", formatRfcDate(message.date)]);
@@ -192,16 +213,59 @@ function encodeBodyBase64(body: string): string {
   return `${wrapBase64(base64Encode(utf8Bytes(body)))}${CRLF}`;
 }
 
-function formatAddress(addr: { name: string; address: string }): string {
+/**
+ * Null when the address cannot be written without inventing one, so the caller
+ * omits the header entirely.
+ *
+ * Exchange senders whose only address is an X.500 DN reach us with a display
+ * name and nothing routable. A quoted ASCII name ahead of an empty angle-addr
+ * reads back cleanly as a name with no address — but an RFC 2047 encoded-word
+ * there is read back AS the address, and header bytes are ASCII, so a non-ASCII
+ * name cannot be carried literally either. That last combination has no
+ * faithful representation, and a fabricated sender is worse than none.
+ */
+function formatAddress(addr: { name: string; address: string }): string | null {
   const trimmedName = addr.name.trim();
+  if (addr.address.length === 0) {
+    if (trimmedName.length === 0 || !isPrintableAscii(trimmedName)) {
+      return null;
+    }
+    return `${quoteDisplayName(trimmedName)} <>`;
+  }
   if (trimmedName.length === 0) {
     return addr.address;
   }
-  return `${encodeHeader(trimmedName)} <${addr.address}>`;
+  return `${formatDisplayName(trimmedName)} <${addr.address}>`;
+}
+
+/**
+ * RFC 5322 `display-name` is an atom sequence, so a name carrying any special —
+ * above all the comma in Outlook's default "Lastname, Firstname" — has to be a
+ * quoted-string or the comma reads as the address-list separator and splits one
+ * sender into two bogus addresses.
+ *
+ * A non-ASCII name needs no quoting: its encoded-word hides every special, and
+ * RFC 2047 §5 forbids encoded-words inside a quoted-string anyway.
+ */
+function formatDisplayName(name: string): string {
+  if (!isPrintableAscii(name)) {
+    return encodeHeader(name);
+  }
+  if (!/[()<>[\]:;@\\,."]/.test(name)) {
+    return name;
+  }
+  return quoteDisplayName(name);
+}
+
+function quoteDisplayName(name: string): string {
+  return `"${name.replace(/(["\\])/g, "\\$1")}"`;
 }
 
 function formatAddressList(addrs: { name: string; address: string }[]): string {
-  return addrs.map(formatAddress).join(", ");
+  return addrs
+    .map(formatAddress)
+    .filter((entry): entry is string => entry !== null)
+    .join(", ");
 }
 
 /**

--- a/office-addin/src/test/fixtures/msg.ts
+++ b/office-addin/src/test/fixtures/msg.ts
@@ -50,3 +50,28 @@ export function msgFileFromBytes(bytes: Uint8Array, name = "item.msg"): File {
   new Uint8Array(buffer).set(bytes);
   return new File([buffer], name, { type: "application/vnd.ms-outlook" });
 }
+
+/** windows-1252 encoding for MAPI PT_STRING8 string properties. */
+export function latin1(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index += 1) {
+    bytes[index] = value.charCodeAt(index) & 0xff;
+  }
+  return bytes;
+}
+
+/** Stream name for PR_INTERNET_MESSAGE_ID_A (MAPI tag 0x1035, PT_STRING8). */
+export const INTERNET_MESSAGE_ID_ANSI_STREAM_NAME = "__substg1.0_1035001E";
+
+/**
+ * Builds a `.msg` CFB blob that stores its Message-ID in the ANSI
+ * (PT_STRING8) property stream instead of the Unicode one. A writer picks one
+ * encoding for all string properties, so both variants must resolve.
+ */
+export function buildAnsiMsgWithInternetMessageId(
+  messageId: string,
+): Uint8Array {
+  return buildCfbWith([
+    { name: INTERNET_MESSAGE_ID_ANSI_STREAM_NAME, content: latin1(messageId) },
+  ]);
+}

--- a/office-addin/src/test/fixtures/msg.ts
+++ b/office-addin/src/test/fixtures/msg.ts
@@ -75,3 +75,165 @@ export function buildAnsiMsgWithInternetMessageId(
     { name: INTERNET_MESSAGE_ID_ANSI_STREAM_NAME, content: latin1(messageId) },
   ]);
 }
+
+/** One 16-byte `__properties_version1.0` entry: tag, flags, then an 8-byte value. */
+function propertyEntry(tagHex: string, value: Uint8Array): Uint8Array {
+  const entry = new Uint8Array(16);
+  const tag = Number.parseInt(tagHex, 16);
+  for (let i = 0; i < 4; i += 1) entry[i] = (tag >>> (i * 8)) & 0xff;
+  entry.set(value.subarray(0, 8), 8);
+  return entry;
+}
+
+function int32Value(value: number): Uint8Array {
+  const out = new Uint8Array(8);
+  for (let i = 0; i < 4; i += 1) out[i] = (value >>> (i * 8)) & 0xff;
+  return out;
+}
+
+/** FILETIME: 100ns ticks since 1601-01-01 UTC. */
+function fileTimeValue(date: Date): Uint8Array {
+  const ticks = (date.getTime() + 11644473600000) * 10000;
+  const out = new Uint8Array(8);
+  let high = Math.floor(ticks / 4294967296);
+  let low = ticks - high * 4294967296;
+  for (let i = 0; i < 4; i += 1) {
+    out[i] = low & 0xff;
+    low = Math.floor(low / 256);
+  }
+  for (let i = 4; i < 8; i += 1) {
+    out[i] = high & 0xff;
+    high = Math.floor(high / 256);
+  }
+  return out;
+}
+
+function propertiesStream(
+  headerSize: number,
+  entries: Uint8Array[],
+): Uint8Array {
+  const out = new Uint8Array(headerSize + entries.length * 16);
+  entries.forEach((entry, index) => out.set(entry, headerSize + index * 16));
+  return out;
+}
+
+export interface RichMsgOptions {
+  /** `unicode` writes PT_UNICODE (001F) streams, `ansi` writes PT_STRING8 (001E). */
+  encoding: "unicode" | "ansi";
+  /**
+   * PidTagMessageCodepage. Real files always carry one; set it together with a
+   * matching `encodeAnsi` to exercise decoding of a specific code page.
+   */
+  codepage?: number;
+  /** Byte encoder for PT_STRING8 streams. Defaults to latin1. */
+  encodeAnsi?: (value: string) => Uint8Array;
+  messageId?: string;
+  subject?: string;
+  body?: string;
+  senderName?: string;
+  senderAddress?: string;
+  to?: { name: string; address: string }[];
+  cc?: { name: string; address: string }[];
+  bcc?: { name: string; address: string }[];
+  sentAt?: Date;
+  attachments?: { filename: string; mimeType: string; content: Uint8Array }[];
+}
+
+/**
+ * A `.msg` carrying the properties the local reader consumes, in either
+ * encoding. Mirrors the layout real Outlook output uses: string properties as
+ * `__substg1.0_<TAG><TYPE>` streams, fixed-width ones inline in
+ * `__properties_version1.0`, recipients and attachments as numbered storages.
+ */
+export function buildRichMsg(options: RichMsgOptions): Uint8Array {
+  const unicode = options.encoding === "unicode";
+  const suffix = unicode ? "001F" : "001E";
+  const encode = unicode ? utf16le : (options.encodeAnsi ?? latin1);
+  const entries: { name: string; content: Uint8Array }[] = [];
+
+  const addString = (storage: string, tag: string, value?: string) => {
+    if (value === undefined) return;
+    entries.push({
+      name: `${storage}__substg1.0_${tag}${suffix}`,
+      content: encode(value),
+    });
+  };
+
+  addString("/", "1035", options.messageId);
+  addString("/", "0037", options.subject);
+  addString("/", "1000", options.body);
+  addString("/", "0C1A", options.senderName);
+  addString("/", "5D01", options.senderAddress);
+
+  const rootProperties: Uint8Array[] = [];
+  if (options.sentAt) {
+    rootProperties.push(
+      propertyEntry("00390040", fileTimeValue(options.sentAt)),
+    );
+  }
+  if (options.codepage !== undefined) {
+    rootProperties.push(
+      propertyEntry("3FFD0003", int32Value(options.codepage)),
+    );
+  }
+  // PidTagStoreSupportMask with STORE_UNICODE_OK, as real writers emit it. The
+  // parser deliberately dispatches on the stream-name suffix instead, so this
+  // is present for fidelity, not because anything reads it.
+  rootProperties.push(
+    propertyEntry("340D0003", int32Value(unicode ? 0x00040000 : 0)),
+  );
+  entries.push({
+    name: "/__properties_version1.0",
+    content: propertiesStream(32, rootProperties),
+  });
+
+  const recipients: {
+    entry: { name: string; address: string };
+    type: number;
+  }[] = [
+    ...(options.to ?? []).map((entry) => ({ entry, type: 1 })),
+    ...(options.cc ?? []).map((entry) => ({ entry, type: 2 })),
+    ...(options.bcc ?? []).map((entry) => ({ entry, type: 3 })),
+  ];
+  recipients.forEach(({ entry, type }, index) => {
+    const storage = `/__recip_version1.0_#${index.toString(16).padStart(8, "0").toUpperCase()}/`;
+    addString(storage, "3001", entry.name);
+    addString(storage, "39FE", entry.address);
+    entries.push({
+      name: `${storage}__properties_version1.0`,
+      content: propertiesStream(8, [
+        propertyEntry("0C150003", int32Value(type)),
+      ]),
+    });
+  });
+
+  (options.attachments ?? []).forEach((attachment, index) => {
+    const storage = `/__attach_version1.0_#${index.toString(16).padStart(8, "0").toUpperCase()}/`;
+    addString(storage, "3707", attachment.filename);
+    addString(storage, "370E", attachment.mimeType);
+    entries.push({
+      name: `${storage}__substg1.0_37010102`,
+      content: attachment.content,
+    });
+  });
+
+  return buildCfbWith(entries);
+}
+
+/** windows-1251 bytes for the Cyrillic range, enough for test strings. */
+export function cp1251(value: string): Uint8Array {
+  const out = new Uint8Array(value.length);
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0x0410 && code <= 0x044f) out[index] = code - 0x0410 + 0xc0;
+    else if (code === 0x0401) out[index] = 0xa8;
+    else if (code === 0x0451) out[index] = 0xb8;
+    else out[index] = code & 0xff;
+  }
+  return out;
+}
+
+/** UTF-8 bytes, for a `.msg` whose PT_STRING8 code page is 65001. */
+export function utf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}


### PR DESCRIPTION
Dropped `.msg` emails silently vanished for a customer: no chip, no error, nothing in the console. Diagnosed from a console probe on their machine.

## Root cause

`extractMsgInternetMessageId` read only `__substg1.0_1035001F` (`PT_UNICODE`). Their files store `PR_INTERNET_MESSAGE_ID` as `__substg1.0_1035001E` (`PT_STRING8`), so extraction returned null, the chain returned nothing, and `nonEmail.length === 0` short-circuited the upload. **Every exit on that path was silent**, which is why a probe was needed to find it at all.

Per [MS-OXMSG], a `.msg` is entirely Unicode or entirely non-Unicode and may never mix the two, so trying both stream names is exhaustive rather than a guess.

## Changes

**1. Resolve `.msg` files that store the Message-ID as ANSI**

- Try `001F` (UTF-16LE), fall back to `001E` (windows-1252 — `msg-id` is ASCII per RFC 5322).
- Root-anchor both lookups. `CFB.find` matches a bare name against *every* leaf in the tree, so an embedded forwarded message could shadow the carrier's own ID — a latent wrong-ID bug independent of the encoding issue, with its own test.

**2. Attach dropped `.msg` emails the mailbox cannot resolve**

Previously a `.msg` whose lookup returned no match (archive, PST, shared mailbox, deleted item) was dropped silently. It's now read locally and attached.

`msgProperties.ts` (root-anchored MAPI reads, codepage-aware) → `parseMsgLocally.ts` → new `synthesizeMessageEml()` → the existing `parseEmlBytes`, so the fallback rejoins the normal pipeline and preview, per-attachment selection and upload all work unchanged. The backend copy stays preferred; this runs only after a lookup comes back empty.

No new dependencies. RTF body decompression is deliberately skipped — it's the genuinely heavy part of the format, and the plain-text body is far more reliably present than the HTML one.

## Also fixed: a pre-existing display-name bug

`formatAddress` emitted display names unquoted, so Outlook's default **"Lastname, Firstname"** made the comma read as the RFC 5322 address-list separator and one sender parsed as two bogus addresses. **This affects the existing thread-synthesis feature too, not just the new path.**

Relatedly, an RFC 2047 encoded-word before an empty `<>` is read back *as* the address, fabricating a sender; that case now omits the header instead.

## Validation

Unit tests aside, the parser was run against a corpus of 25 real Outlook-written `.msg` files (local, not committed):

| | before | after |
|---|---|---|
| files rendered | — | 25/25 |
| sender addresses surviving | 6/25 | 20/20 |
| recipients | — | 55/55 |
| attachments | — | 47 |
| fabricated addresses | — | 0 |

Each fix was verified load-bearing by reverting it in isolation and confirming the matching test fails. 1126 tests pass; format, strict lint and typecheck clean.