### PR TITLE
Move the capsule dialect, the alert frame and selected state onto themable channels

### DIFF
--- a/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.test.tsx
@@ -290,6 +290,7 @@ describe("ChatHistoryList", () => {
 
     expect(historyItem).toHaveClass("sidebar-row-geometry");
     expect(historyItem).toHaveClass("sidebar-row-selected");
+    expect(historyItem).toHaveAttribute("data-selected");
     expect(historyItem?.getAttribute("style") ?? "").toBe("");
     expect(historyItem).not.toHaveClass(
       "hover:bg-[var(--theme-shell-sidebar-hover)]",
@@ -301,6 +302,7 @@ describe("ChatHistoryList", () => {
         "calc(var(--theme-spacing-shell-padding-y) / 2) calc(var(--theme-spacing-shell-padding-x) / 2)",
     });
     expect(historyItems[1]).not.toHaveClass("sidebar-row-selected");
+    expect(historyItems[1]).not.toHaveAttribute("data-selected");
   });
 
   it("uses the same sidebar tokens in the loading skeleton", () => {

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -224,6 +224,7 @@ const ChatHistoryListItem = memo<{
           layout === "compact" ? "gap-0.5" : "gap-1",
         )}
         data-chat-id={session.id}
+        data-selected={isActive || undefined}
         data-ui="chat-history-item"
       >
         <div className="flex items-center justify-between gap-2">

--- a/frontend/src/components/ui/Chat/ChatInput.tsx
+++ b/frontend/src/components/ui/Chat/ChatInput.tsx
@@ -2429,12 +2429,7 @@ export const ChatInput = ({
                 return (
                   <div
                     key={attachment.fileId}
-                    className="mb-0 border bg-theme-bg-primary text-theme-fg-primary [border-color:var(--theme-border-attachment)]"
-                    style={{
-                      borderRadius: "var(--theme-radius-message)",
-                      padding:
-                        "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-                    }}
+                    className="message-frame-geometry mb-0 border bg-theme-bg-primary text-theme-fg-primary [border-color:var(--theme-border-attachment)]"
                     role="status"
                     data-testid={`chat-audio-transcription-${attachment.fileId}`}
                   >
@@ -2542,15 +2537,12 @@ export const ChatInput = ({
 
         {/* Queued next message: auto-sends when the current turn finishes.
             Geometry and surface tokens match the sibling attachment preview;
-            `data-ui` lets kits restyle it. */}
+            `data-ui` lets kits restyle it. `gap-2` deliberately outranks the
+            gap `.message-frame-geometry` carries, keeping the row on the
+            attachment preview's gap rather than the framed-message one. */}
         {queuedMessage && (
           <div
-            className="theme-transition mb-2 flex items-center gap-2 border bg-theme-bg-primary text-sm [border-color:var(--theme-border-attachment)]"
-            style={{
-              borderRadius: "var(--theme-radius-message)",
-              padding:
-                "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-            }}
+            className="message-frame-geometry theme-transition mb-2 flex items-center gap-2 border bg-theme-bg-primary text-sm [border-color:var(--theme-border-attachment)]"
             data-ui="chat-input-queued-message"
             data-testid="chat-input-queued-message"
             role="status"

--- a/frontend/src/components/ui/Chat/SidebarNavigationItem.tsx
+++ b/frontend/src/components/ui/Chat/SidebarNavigationItem.tsx
@@ -73,6 +73,10 @@ export const SidebarNavigationItem = ({
           )}
           aria-label={label}
           title={isSlimMode ? label : undefined}
+          // This branch renders no link, so the row itself has to announce
+          // that it is the current page.
+          aria-current="page"
+          data-selected={true}
           data-ui={dataUi}
         >
           {icon}

--- a/frontend/src/components/ui/Chat/__tests__/SidebarNavigationItem.test.tsx
+++ b/frontend/src/components/ui/Chat/__tests__/SidebarNavigationItem.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SidebarNavigationItem } from "../SidebarNavigationItem";
+
+const renderItem = (
+  props: Partial<Parameters<typeof SidebarNavigationItem>[0]> = {},
+) => {
+  const { container } = render(
+    <SidebarNavigationItem
+      label="Search"
+      icon={<span />}
+      data-ui="sidebar-nav-item"
+      {...props}
+    />,
+  );
+  const row = container.querySelector('[data-ui="sidebar-nav-item"]');
+  expect(row).not.toBeNull();
+  return row as HTMLElement;
+};
+
+describe("SidebarNavigationItem", () => {
+  // The active row renders no link, so the row element is the only thing that
+  // can carry the current-page semantics.
+  it("announces the active row as the current page", () => {
+    const row = renderItem({ active: true, href: "/search" });
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(row).toHaveAttribute("aria-current", "page");
+    expect(row).toHaveAttribute("data-selected");
+  });
+
+  it("leaves the state channels off an inactive link row", () => {
+    const row = renderItem({ href: "/search", onClick: vi.fn() });
+
+    expect(screen.getByRole("link")).not.toHaveAttribute("aria-current");
+    expect(row).not.toHaveAttribute("aria-current");
+    expect(row).not.toHaveAttribute("data-selected");
+  });
+
+  it("leaves the state channels off an inactive button row", () => {
+    const row = renderItem({ onClick: vi.fn() });
+
+    expect(row).not.toHaveAttribute("aria-current");
+    expect(row).not.toHaveAttribute("data-selected");
+  });
+});

--- a/frontend/src/components/ui/CloudFilePicker/CloudDriveList.tsx
+++ b/frontend/src/components/ui/CloudFilePicker/CloudDriveList.tsx
@@ -208,7 +208,7 @@ export const CloudDriveList = memo<CloudDriveListProps>(
                       {drive.name}
                     </h3>
                     <span
-                      className={`rounded-full px-2 py-0.5 text-xs ${getDriveBadgeColor(drive.kind)}`}
+                      className={`pill-geometry px-2 py-0.5 text-xs ${getDriveBadgeColor(drive.kind)}`}
                     >
                       {getDriveKindLabel(drive.kind)}
                     </span>

--- a/frontend/src/components/ui/Controls/CountBadge.tsx
+++ b/frontend/src/components/ui/Controls/CountBadge.tsx
@@ -33,7 +33,7 @@ export const CountBadge = ({
     aria-hidden="true"
     {...props}
     className={clsx(
-      "flex min-w-4 items-center justify-center rounded-full px-1 text-[0.625rem] font-semibold leading-4",
+      "pill-geometry flex min-w-4 items-center justify-center px-1 text-[0.625rem] font-semibold leading-4",
       VARIANT_STYLES[variant],
       className,
     )}

--- a/frontend/src/components/ui/Controls/RadioCard.tsx
+++ b/frontend/src/components/ui/Controls/RadioCard.tsx
@@ -117,6 +117,7 @@ export function RadioCard({
           <span
             aria-hidden="true"
             data-ui="option-card-icon"
+            data-selected={checked || undefined}
             className={clsx(
               "option-card-geometry mt-0.5 flex size-9 shrink-0 items-center justify-center border bg-theme-bg-secondary",
               checked

--- a/frontend/src/components/ui/Controls/__tests__/CountBadge.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/CountBadge.test.tsx
@@ -53,7 +53,7 @@ describe("CountBadge", () => {
     );
 
     const badge = screen.getByTestId("badge");
-    expect(badge).toHaveClass("rounded-full");
+    expect(badge).toHaveClass("pill-geometry");
     expect(badge).toHaveClass("shrink-0");
   });
 });

--- a/frontend/src/components/ui/Controls/__tests__/RadioCard.test.tsx
+++ b/frontend/src/components/ui/Controls/__tests__/RadioCard.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RadioCard } from "../RadioCard";
+
+const renderCard = (checked: boolean) => {
+  const { container } = render(
+    <RadioCard
+      name="mode"
+      value="fast"
+      checked={checked}
+      onChange={vi.fn()}
+      label="Fast"
+      icon={<span />}
+    />,
+  );
+  return {
+    card: container.querySelector('[data-ui="option-card"]'),
+    iconTile: container.querySelector('[data-ui="option-card-icon"]'),
+  };
+};
+
+describe("RadioCard", () => {
+  it("reports the selection on the card and its icon tile", () => {
+    const { card, iconTile } = renderCard(true);
+
+    expect(card).toHaveAttribute("data-selected", "true");
+    expect(iconTile).toHaveAttribute("data-selected", "true");
+  });
+
+  it("drops the attribute entirely while unselected", () => {
+    const { card, iconTile } = renderCard(false);
+
+    expect(card).not.toHaveAttribute("data-selected");
+    expect(iconTile).not.toHaveAttribute("data-selected");
+  });
+});

--- a/frontend/src/components/ui/Feedback/Alert.test.tsx
+++ b/frontend/src/components/ui/Feedback/Alert.test.tsx
@@ -34,26 +34,29 @@ describe("Alert", () => {
 
     const alert = screen.getByRole("alert");
 
-    expect(alert.className).toContain("gap-3");
-    expect(alert.className).toContain("rounded-md");
-    expect(alert.className).toContain("p-3");
+    expect(alert).toHaveAttribute("data-ui", "alert");
+    expect(alert).toHaveAttribute("data-tone", "info");
+    expect(alert).toHaveClass("alert-geometry", "gap-3", "p-3");
+    expect(alert.className).not.toContain("rounded-md");
+    expect(alert.className).not.toContain("message-frame-geometry");
     expect(alert.getAttribute("style")).toBeNull();
   });
 
   it("supports opt-in message geometry for chat surfaces", () => {
     render(
-      <Alert type="info" geometryVariant="message">
+      <Alert type="error" geometryVariant="message">
         Alert content
       </Alert>,
     );
 
     const alert = screen.getByRole("alert");
 
-    expect(alert).toHaveStyle({
-      borderRadius: "var(--theme-radius-message)",
-      gap: "var(--theme-spacing-control-gap)",
-      padding:
-        "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-    });
+    expect(alert).toHaveAttribute("data-ui", "alert");
+    expect(alert).toHaveAttribute("data-tone", "error");
+    expect(alert).toHaveClass("message-frame-geometry");
+    expect(alert.className).not.toContain("alert-geometry");
+    expect(alert).not.toHaveClass("gap-3");
+    expect(alert).not.toHaveClass("p-3");
+    expect(alert.getAttribute("style")).toBeNull();
   });
 });

--- a/frontend/src/components/ui/Feedback/Alert.tsx
+++ b/frontend/src/components/ui/Feedback/Alert.tsx
@@ -46,16 +46,6 @@ export const Alert: React.FC<AlertProps> = ({
   geometryVariant = "default",
   "data-testid": dataTestId,
 }) => {
-  const alertFrameStyle =
-    geometryVariant === "message"
-      ? ({
-          borderRadius: "var(--theme-radius-message)",
-          gap: "var(--theme-spacing-control-gap)",
-          padding:
-            "var(--theme-spacing-message-padding-y) var(--theme-spacing-message-padding-x)",
-        } as const)
-      : undefined;
-
   // Get themed icon IDs for each alert type
   const errorIconId = useThemedIcon("status", "error");
   const warningIconId = useThemedIcon("status", "warning");
@@ -94,12 +84,15 @@ export const Alert: React.FC<AlertProps> = ({
     <div
       className={clsx(
         "flex items-start border",
-        geometryVariant === "message" ? "" : "gap-3 rounded-md p-3",
+        geometryVariant === "message"
+          ? "message-frame-geometry"
+          : "alert-geometry gap-3 p-3",
         styles[type].container,
         className,
       )}
-      style={alertFrameStyle}
       role="alert"
+      data-ui="alert"
+      data-tone={type}
       data-testid={dataTestId}
     >
       <div className="mt-0.5 shrink-0">{alertIcon}</div>

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.test.tsx
@@ -339,7 +339,7 @@ describe("GroupedFileAttachmentsPreview", () => {
   });
 
   it("renders a thread message without checkboxes when it cannot be toggled", async () => {
-    await renderWithI18n(
+    const { container } = await renderWithI18n(
       <GroupedFileAttachmentsPreview
         groups={[
           {
@@ -369,6 +369,85 @@ describe("GroupedFileAttachmentsPreview", () => {
     expect(screen.getByText("Anna Schmidt")).toBeVisible();
     expect(screen.getByText("invoice")).toBeVisible();
     expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(
+      container.querySelector('[data-ui="attachment-tile"]'),
+    ).not.toHaveAttribute("data-selected");
+  });
+
+  it("reports the selection on toggleable attachment rows", async () => {
+    const { container } = await renderWithI18n(
+      <GroupedFileAttachmentsPreview
+        groups={[
+          {
+            id: "group-email",
+            label: "Current email",
+            items: [
+              {
+                kind: "selectableAttachment",
+                id: "file-1",
+                file: { id: "file-1", filename: "invoice.pdf", size: 2048 },
+                selected: true,
+                onToggle: () => {},
+              },
+              {
+                kind: "selectableAttachment",
+                id: "file-2",
+                file: { id: "file-2", filename: "notes.docx", size: 4096 },
+                selected: false,
+                onToggle: () => {},
+              },
+            ],
+          },
+        ]}
+        onRemoveFile={() => {}}
+      />,
+    );
+
+    const tiles = container.querySelectorAll('[data-ui="attachment-tile"]');
+    expect(tiles[0]).toHaveAttribute("data-selected", "true");
+    expect(tiles[1]).not.toHaveAttribute("data-selected");
+  });
+
+  it("keeps the selection off a preview row that owns no toggle", async () => {
+    const { container } = await renderWithI18n(
+      <GroupedFileAttachmentsPreview
+        groups={[
+          {
+            id: "group-conversation",
+            label: "Project Alpha",
+            items: [
+              {
+                kind: "threadMessageGroup",
+                id: "message-1",
+                label: "Anna Schmidt",
+                defaultCollapsed: false,
+                attachments: [
+                  {
+                    id: "file-1",
+                    file: { id: "file-1", filename: "invoice.pdf", size: 2048 },
+                    selected: true,
+                    onToggle: () => {},
+                  },
+                  {
+                    id: "file-2",
+                    file: { id: "file-2", filename: "notes.docx", size: 4096 },
+                    selected: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        onRemoveFile={() => {}}
+        onFilePreview={() => {}}
+      />,
+    );
+
+    const tiles = container.querySelectorAll('[data-ui="attachment-tile"]');
+    expect(tiles[0]).toHaveAttribute("data-selected", "true");
+    // A read-only row still defaults to `selected`; without a toggle it has
+    // nothing to report.
+    expect(tiles[1]).not.toHaveAttribute("data-selected");
   });
 
   it("forwards file removal through item ids", async () => {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -233,6 +233,9 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   const filename = getFileName(file);
   const invalid = validation?.ok === false;
   const rowClassName = clsx(SELECTABLE_ROW_CLASS, !selected && "opacity-50");
+  // A row without a toggle is read-only, so it has no selection to report and
+  // must not look selected to a theme rule.
+  const rowSelected = onToggle ? selected || undefined : undefined;
   const chip = (
     <div className="min-w-0 flex-1">
       <FilePreviewBase
@@ -266,7 +269,11 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
 
   if (onPreview) {
     return (
-      <div className={rowClassName} data-ui="attachment-tile">
+      <div
+        className={rowClassName}
+        data-selected={rowSelected}
+        data-ui="attachment-tile"
+      >
         {checkbox}
         <InteractiveContainer
           onClick={onPreview}
@@ -291,7 +298,11 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
   }
 
   return (
-    <label className={rowClassName} data-ui="attachment-tile">
+    <label
+      className={rowClassName}
+      data-selected={rowSelected}
+      data-ui="attachment-tile"
+    >
       {checkbox}
       {chip}
     </label>

--- a/frontend/src/components/ui/Modal/ModalBase.tsx
+++ b/frontend/src/components/ui/Modal/ModalBase.tsx
@@ -106,12 +106,13 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
             {/* Simple Close Button — positioned using the same modal padding token */}
             <button
               onClick={onClose}
-              className="focus-ring-tight absolute rounded-full text-theme-fg-muted hover:bg-theme-bg-secondary"
+              className="modal-close-geometry focus-ring-tight absolute text-theme-fg-muted hover:bg-theme-bg-secondary"
               style={{
                 padding: "var(--theme-spacing-modal-close-button-padding)",
                 right: "var(--theme-spacing-modal-padding)",
                 top: "var(--theme-spacing-modal-padding)",
               }}
+              data-geometry="icon-sm"
               aria-label={t`Close modal`}
             >
               <CloseIcon className="size-6" />

--- a/frontend/src/components/ui/Modal/ModalBase.tsx
+++ b/frontend/src/components/ui/Modal/ModalBase.tsx
@@ -112,7 +112,6 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
                 right: "var(--theme-spacing-modal-padding)",
                 top: "var(--theme-spacing-modal-padding)",
               }}
-              data-geometry="icon-sm"
               aria-label={t`Close modal`}
             >
               <CloseIcon className="size-6" />

--- a/frontend/src/components/ui/Sharing/ShareGrantsList.tsx
+++ b/frontend/src/components/ui/Sharing/ShareGrantsList.tsx
@@ -120,7 +120,7 @@ const GrantRow = memo<GrantRowProps>(
             <span className="truncate font-medium text-theme-fg-primary">
               {displayName}
             </span>
-            <span className="shrink-0 rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+            <span className="pill-geometry shrink-0 bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
               {isGroup
                 ? t({ id: "sharing.type.group", message: "Group" })
                 : isOrganization
@@ -130,7 +130,7 @@ const GrantRow = memo<GrantRowProps>(
                     })
                   : t({ id: "sharing.type.user", message: "User" })}
             </span>
-            <span className="shrink-0 rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+            <span className="pill-geometry shrink-0 bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
               {grant.role === "editor"
                 ? t({ id: "sharing.role.editor", message: "Editor" })
                 : t({ id: "sharing.role.viewer", message: "Viewer" })}

--- a/frontend/src/components/ui/Sharing/SubjectSelector.tsx
+++ b/frontend/src/components/ui/Sharing/SubjectSelector.tsx
@@ -334,7 +334,7 @@ const SubjectRow = memo<SubjectRowProps>(
             <span className="truncate font-medium text-theme-fg-primary">
               {subject.display_name}
             </span>
-            <span className="shrink-0 rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+            <span className="pill-geometry shrink-0 bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
               {subject.type === "user"
                 ? t({ id: "sharing.type.user", message: "User" })
                 : subject.type === "organization"

--- a/frontend/src/components/ui/ToolCall/ToolCallItem.tsx
+++ b/frontend/src/components/ui/ToolCall/ToolCallItem.tsx
@@ -68,7 +68,7 @@ export const ToolCallItem: React.FC<ToolCallItemProps> = ({
         <div className="flex items-center gap-2">
           <div
             className={clsx(
-              "flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium",
+              "pill-geometry flex items-center gap-1 px-2 py-1 text-xs font-medium",
               config.bgColor,
               config.color,
             )}

--- a/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
+++ b/frontend/src/components/ui/Trace/TraceClusterHeader.tsx
@@ -56,7 +56,7 @@ export const TraceClusterHeader = ({
       aria-expanded={isOpen}
       onClick={onToggle}
       className={clsx(
-        "flex items-center gap-2 rounded-full px-3 py-1 text-sm",
+        "pill-geometry flex items-center gap-2 px-3 py-1 text-sm",
         "text-theme-fg-secondary transition-colors hover:text-theme-fg-primary",
         "cursor-pointer",
       )}

--- a/frontend/src/components/ui/Trace/steps/ToolStatusPill.tsx
+++ b/frontend/src/components/ui/Trace/steps/ToolStatusPill.tsx
@@ -41,7 +41,7 @@ interface ToolStatusPillProps {
 }
 
 // eslint-disable-next-line lingui/no-unlocalized-strings -- utility classes
-const PILL_CLASS = "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium";
+const PILL_CLASS = "pill-geometry shrink-0 px-2 py-0.5 text-xs font-medium";
 
 /**
  * Informational pill for a settled step whose state deserves naming.

--- a/frontend/src/pages/AssistantsPage.tsx
+++ b/frontend/src/pages/AssistantsPage.tsx
@@ -209,7 +209,7 @@ const getOwnedAssistantStatusLabel = (status: OwnedAssistantStatusFilter) => {
 
 const getOwnedAssistantStatusClassName = (status: OwnedAssistantStatus) =>
   clsx(
-    "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+    "pill-geometry inline-flex items-center border px-2 py-0.5 text-xs font-medium",
     status === "in_review" &&
       "border-theme-info-border bg-theme-info-bg text-theme-info-fg",
     status === "published" &&

--- a/frontend/src/pages/DesktopSidecarSetupPage.tsx
+++ b/frontend/src/pages/DesktopSidecarSetupPage.tsx
@@ -367,7 +367,7 @@ function ArtifactCard({
           </div>
         </div>
         {isDefault ? (
-          <span className="shrink-0 rounded-full bg-theme-bg-selected px-2.5 py-1 text-xs font-semibold text-theme-fg-accent">
+          <span className="pill-geometry shrink-0 bg-theme-bg-selected px-2.5 py-1 text-xs font-semibold text-theme-fg-accent">
             <Trans id="desktopSidecar.setup.artifact.recommended">
               Recommended
             </Trans>

--- a/frontend/src/pages/assistantHubUtils.tsx
+++ b/frontend/src/pages/assistantHubUtils.tsx
@@ -66,7 +66,7 @@ export const getAssistantHubStatusLabel = (status: string) => {
 export const getAssistantHubStatusClassName = (status: string) =>
   clsx(
     // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind class list
-    "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+    "pill-geometry inline-flex items-center px-2 py-0.5 text-xs font-medium",
     isAssistantHubReviewAcceptedStatus(status) &&
       "border border-theme-success-border bg-theme-success-bg text-theme-success-fg",
     isAssistantHubReviewDeclinedStatus(status) &&
@@ -122,7 +122,7 @@ export const getAssistantHubRatingLabel = (
 
 export function AssistantHubCurrentPublishedIndicator() {
   return (
-    <span className="inline-flex min-h-6 items-center rounded-full border border-theme-info-border bg-theme-info-bg px-2 py-0.5 text-xs font-medium text-theme-info-fg">
+    <span className="pill-geometry inline-flex min-h-6 items-center border border-theme-info-border bg-theme-info-bg px-2 py-0.5 text-xs font-medium text-theme-info-fg">
       {t({
         id: "assistantHub.my.currentPublished",
         message: "Current published version",
@@ -386,7 +386,7 @@ export function AssistantHubVersionCard({
       >
         <span
           aria-hidden="true"
-          className="flex size-10 shrink-0 items-center justify-center rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary text-sm font-semibold text-theme-fg-primary"
+          className="avatar-geometry flex size-10 shrink-0 items-center justify-center bg-theme-bg-secondary text-sm font-semibold text-theme-fg-primary"
           data-ui="assistant-hub-card-avatar"
         >
           {avatarLetter}
@@ -593,7 +593,7 @@ export function AssistantHubVersionOverviewSection({
         >
           <span
             aria-hidden="true"
-            className="flex size-14 shrink-0 items-center justify-center rounded-[var(--theme-radius-pill)] bg-theme-bg-secondary text-xl font-semibold text-theme-fg-primary"
+            className="avatar-geometry flex size-14 shrink-0 items-center justify-center bg-theme-bg-secondary text-xl font-semibold text-theme-fg-primary"
             data-ui="assistant-hub-overview-avatar"
           >
             {avatarLetter}

--- a/frontend/src/stories/ui/Alert.stories.tsx
+++ b/frontend/src/stories/ui/Alert.stories.tsx
@@ -46,6 +46,15 @@ const meta = {
       control: "text",
       description: "Additional CSS classes",
     },
+    geometryVariant: {
+      control: "inline-radio",
+      options: ["default", "message"],
+      description:
+        "Frame geometry: `default` reads radius.base, `message` reads radius.message plus the message padding and control gap",
+      table: {
+        defaultValue: { summary: "default" },
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -243,6 +252,41 @@ export const AllTypes: Story = {
       <Alert type="success" title="Success">
         Success message with green styling
       </Alert>
+    </div>
+  ),
+  args: {
+    type: "info",
+    children: "",
+  },
+};
+
+/**
+ * Every tone in both frame geometries. The default frame reads `radius.base`;
+ * the message frame reads `radius.message` with the message padding and the
+ * control gap, and is what the chat surfaces opt into. Each alert also carries
+ * `data-ui="alert"` and a `data-tone`, the hooks a theme keys on.
+ */
+export const ToneAndGeometryMatrix: Story = {
+  render: () => (
+    <div className="space-y-8">
+      {(["default", "message"] as const).map((geometryVariant) => (
+        <div key={geometryVariant} className="space-y-4">
+          <h3 className="text-sm font-medium text-theme-fg-secondary">
+            geometryVariant=&quot;{geometryVariant}&quot;
+          </h3>
+
+          {(["info", "warning", "error", "success"] as const).map((type) => (
+            <Alert
+              key={type}
+              type={type}
+              geometryVariant={geometryVariant}
+              title={type}
+            >
+              data-tone=&quot;{type}&quot;
+            </Alert>
+          ))}
+        </div>
+      ))}
     </div>
   ),
   args: {

--- a/frontend/src/stories/ui/PillGeometry.stories.tsx
+++ b/frontend/src/stories/ui/PillGeometry.stories.tsx
@@ -1,0 +1,175 @@
+import { CountBadge } from "@/components/ui/Controls/CountBadge";
+import { SpinnerIcon } from "@/components/ui/Feedback/SpinnerIcon";
+import {
+  SettledInfoPill,
+  ToolStatusPill,
+} from "@/components/ui/Trace/steps/ToolStatusPill";
+import {
+  AssistantHubCurrentPublishedIndicator,
+  getAssistantHubStatusClassName,
+} from "@/pages/assistantHubUtils";
+
+import type { Meta, StoryObj } from "@storybook/react";
+import type { CSSProperties, ReactNode } from "react";
+
+const meta = {
+  title: "UI/Pill Geometry",
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Two shapes look alike at the shipped radius values and are not the same thing.
+
+A **capsule** is a text label plus inline padding — a badge, a status chip, a filter pill. Its
+corner is a design choice, so it reads the pill radius token through one class:
+
+\`\`\`css
+.pill-geometry {
+  border-radius: var(--theme-radius-pill);
+}
+\`\`\`
+
+A **circle** is an intrinsic square with no label — an avatar, a status dot, a spinner ring. Its
+corner is not a choice: it is what makes the shape a circle at all, so it declares \`50%\`
+(\`.avatar-geometry\`, \`.spinner-geometry\`) and never reads the pill token.
+
+At stock \`radius.pill\` is \`9999px\` and the distinction is invisible. It becomes visible the moment
+a theme sets \`radius.pill\` — or the legacy top-level \`borderRadius\`, which back-fills every radius
+key — to something smaller: the capsules soften to that value while the circles stay round.
+        `,
+      },
+    },
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Every specimen is a real migrated surface, named by where it ships. */
+const CAPSULES: { source: string; node: ReactNode }[] = [
+  { source: "CountBadge", node: <CountBadge variant="count">12</CountBadge> },
+  {
+    source: "CountBadge (attention)",
+    node: <CountBadge variant="attention">3</CountBadge>,
+  },
+  { source: "ToolStatusPill", node: <ToolStatusPill status="running" /> },
+  { source: "ToolStatusPill (error)", node: <ToolStatusPill status="error" /> },
+  { source: "SettledInfoPill", node: <SettledInfoPill label="Completed" /> },
+  {
+    source: "AssistantHubCurrentPublishedIndicator",
+    node: <AssistantHubCurrentPublishedIndicator />,
+  },
+  {
+    source: "getAssistantHubStatusClassName",
+    node: (
+      <span className={getAssistantHubStatusClassName("submitted")}>
+        Submitted
+      </span>
+    ),
+  },
+  {
+    source: "ShareGrantsList / SubjectSelector scope badge",
+    node: (
+      <span className="pill-geometry shrink-0 bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+        Group
+      </span>
+    ),
+  },
+];
+
+const CIRCLES: { source: string; node: ReactNode }[] = [
+  {
+    source: "assistantHubUtils avatar (.avatar-geometry)",
+    node: (
+      <span className="avatar-geometry flex size-10 shrink-0 items-center justify-center bg-theme-bg-secondary text-sm font-semibold text-theme-fg-primary">
+        AB
+      </span>
+    ),
+  },
+  {
+    source: "SpinnerIcon (.spinner-geometry)",
+    node: <SpinnerIcon size="lg" />,
+  },
+  {
+    source: "status dot (rounded-full)",
+    node: (
+      <span className="block size-3 rounded-full bg-theme-action-primary-bg" />
+    ),
+  },
+];
+
+const Specimens = () => (
+  <div className="flex flex-col gap-5">
+    <div className="flex flex-wrap items-center gap-2">
+      {CAPSULES.map(({ source, node }) => (
+        <div key={source}>{node}</div>
+      ))}
+    </div>
+    <div className="flex flex-wrap items-center gap-4">
+      {CIRCLES.map(({ source, node }) => (
+        <div key={source}>{node}</div>
+      ))}
+    </div>
+  </div>
+);
+
+const Column = ({
+  heading,
+  caption,
+  style,
+}: {
+  heading: string;
+  caption: string;
+  style?: CSSProperties;
+}) => (
+  <section
+    className="flex min-w-72 flex-1 flex-col gap-4 border border-theme-border p-4"
+    style={style}
+  >
+    <header className="flex flex-col gap-1">
+      <h3 className="text-sm font-semibold text-theme-fg-primary">{heading}</h3>
+      <p className="text-xs text-theme-fg-muted">{caption}</p>
+    </header>
+    <Specimens />
+  </section>
+);
+
+/**
+ * The same specimens twice. The right column overrides `--theme-radius-pill`
+ * on its own wrapper, which is what a theme setting `radius.pill` does to the
+ * whole page.
+ */
+export const Dialect: Story = {
+  name: "Capsules soften, circles stay round",
+  render: () => (
+    <div className="flex flex-wrap items-start gap-6 bg-theme-bg-primary text-theme-fg-primary">
+      <Column
+        heading="Stock — radius.pill: 9999px"
+        caption="Capsules and circles are indistinguishable here."
+      />
+      <Column
+        heading="Retuned — radius.pill: 0.5rem"
+        caption="Capsules take the theme's corner; the circles are untouched."
+        style={{ "--theme-radius-pill": "0.5rem" } as CSSProperties}
+      />
+    </div>
+  ),
+};
+
+/** The capsule inventory on `.pill-geometry`, labelled by shipping surface. */
+export const Capsules: Story = {
+  render: () => (
+    <ul className="flex flex-col gap-3 bg-theme-bg-primary text-theme-fg-primary">
+      {CAPSULES.map(({ source, node }) => (
+        <li key={source} className="flex items-center gap-3">
+          <span className="w-80 shrink-0 font-mono text-xs text-theme-fg-muted">
+            {source}
+          </span>
+          {node}
+        </li>
+      ))}
+    </ul>
+  ),
+};

--- a/frontend/src/stories/ui/SharingDialog.stories.tsx
+++ b/frontend/src/stories/ui/SharingDialog.stories.tsx
@@ -117,7 +117,7 @@ const MockSubjectSelector = memo<MockSubjectSelectorProps>(
                       <span className="font-medium text-theme-fg-primary">
                         {user.display_name}
                       </span>
-                      <span className="rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+                      <span className="pill-geometry bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
                         User
                       </span>
                     </div>
@@ -147,7 +147,7 @@ const MockSubjectSelector = memo<MockSubjectSelectorProps>(
                       <span className="font-medium text-theme-fg-primary">
                         {group.display_name}
                       </span>
-                      <span className="rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+                      <span className="pill-geometry bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
                         Group
                       </span>
                     </div>

--- a/frontend/src/stories/ui/SubjectSelector.stories.tsx
+++ b/frontend/src/stories/ui/SubjectSelector.stories.tsx
@@ -207,7 +207,7 @@ const SubjectRow = memo<SubjectRowProps>(
             <span className="truncate font-medium text-theme-fg-primary">
               {subject.display_name}
             </span>
-            <span className="shrink-0 rounded-full bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
+            <span className="pill-geometry shrink-0 bg-theme-bg-secondary px-2 py-0.5 text-xs text-theme-fg-secondary">
               {subject.type === "user" ? "User" : "Group"}
             </span>
           </div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -561,6 +561,22 @@ body {
     border-radius: var(--theme-radius-control);
   }
 
+  /* The capsule/circle dialect. A capsule is a text label plus inline padding
+     and reads the pill token; a circle is an intrinsic square with no label
+     and declares 50%, so a theme softening the pill radius — which is what
+     makes every capsule retunable — cannot square a circle along with it. */
+  .pill-geometry {
+    border-radius: var(--theme-radius-pill);
+  }
+
+  .avatar-geometry {
+    border-radius: 50%;
+  }
+
+  .modal-close-geometry {
+    border-radius: 50%;
+  }
+
   /* Menu rows sit inside .dropdown-panel-chrome-geometry, so their radius is
      derived, not tokenised: panel radius minus the panel inset keeps the row
      highlight concentric with the panel corner for any theme values. */
@@ -668,6 +684,20 @@ body {
   pre.message-content-code-block > div,
   pre.message-content-raw-block > code {
     min-width: max-content;
+  }
+
+  .alert-geometry {
+    border-radius: var(--theme-radius-base);
+  }
+
+  /* The framed variant of an alert, worn by the chat input's non-alert notices
+     as well, so the name stays neutral: an alert- name on a plain notice would
+     invite a theme rule that paints it as one. */
+  .message-frame-geometry {
+    border-radius: var(--theme-radius-message);
+    padding: var(--theme-spacing-message-padding-y)
+      var(--theme-spacing-message-padding-x);
+    gap: var(--theme-spacing-control-gap);
   }
 
   /* The spinner ring. --spinner-* are private to this family rather than

--- a/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
+++ b/office-addin/src/teams/components/TeamsChatPickerDialog.tsx
@@ -1162,7 +1162,7 @@ function SharedFileChips({
               id: "officeAddin.teams.picker.openSharedFile",
               message: `Open ${file.name}`,
             })}
-            className="theme-transition flex max-w-44 items-center gap-1 rounded-full border border-theme-border bg-theme-bg-accent px-2 py-0.5 text-[11px] text-theme-fg-muted hover:bg-theme-bg-hover hover:text-theme-fg-primary"
+            className="pill-geometry theme-transition flex max-w-44 items-center gap-1 border border-theme-border bg-theme-bg-accent px-2 py-0.5 text-[11px] text-theme-fg-muted hover:bg-theme-bg-hover hover:text-theme-fg-primary"
           >
             {isLoading ? (
               <SpinnerIcon size="sm" className="shrink-0" aria-hidden />

--- a/site/content/docs/features/theming.mdx
+++ b/site/content/docs/features/theming.mdx
@@ -142,6 +142,8 @@ Framed cards read `radius.card`: entity rows in settings, assistant cards, and s
 
 Existing theme JSON can omit these new groups. When a theme does not provide them yet, the corresponding CSS variables fall back to the built-in theme defaults until they are explicitly overridden.
 
+One older field is not a fallback case. A theme that still sets a single top-level `borderRadius` inside `theme.light` or `theme.dark` has that one value copied onto every radius key it leaves unset under `radius`: `base`, `shell`, `input`, `control`, `message`, `modal`, `dropdown`, `card` and `pill` alike, resolved separately per mode. Any per-key value under `radius` still wins over it. The consequence worth knowing is `pill`: under such a theme every badge, chip and status pill takes that radius instead of staying a full capsule. Set `radius.pill` explicitly to keep them round while the rest of the theme softens.
+
 ## Optional Stylesheets
 
 Theme packs can include these optional sibling stylesheets beside `theme.json`:
@@ -178,11 +180,12 @@ For shell-level overrides in `theme.css`, prefer the app-owned `data-ui` and `da
 - `data-ui="entity-row"`
 - `data-ui="assistant-list-card"`
 - `data-ui="search-result-card"`
-- `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and `data-ui="option-card-details"` the section shown under a checked card)
+- `data-ui="option-card"` (carries `data-selected="true"` when checked; `data-ui="option-card-icon"` marks its icon tile and carries it too, and `data-ui="option-card-details"` the section shown under a checked card)
 - `data-ui="tab-rail"` (the hand-rolled settings tab rails; their tabs read `--theme-radius-control`)
 - `data-ui="attachment-group"` and `data-ui="thread-message-card"` (attachment group frames and the per-message cards of an email thread; declare `--attachment-tile-radius` on the card to reshape the attachment chips inside it, their icon tiles follow)
 - `data-ui="attachment-tile"` (each attachment chip), `data-ui="attachment-row"` (a selectable attachment row with its checkbox, in kits that offer per-attachment selection), `data-ui="attachment-loading"` (the placeholder while a group's contents load)
 - `data-ui="addin-chat-header"` (the Office add-in's header row when a component kit supplies a top-left accessory)
+- `data-ui="alert"` (the shared inline error, warning, info and success banners; `data-tone` on the same element says which one, taking `error`, `warning`, `info` or `success`, so a theme can restyle a single tone or the whole family. A few hand-rolled banners still sit outside this hook and carry only their tone colours)
 - `data-ui="spinner"` (every loading ring the app and the Office add-in draw, and those of a component kit that adopts the host spinner; declare `--spinner-track`, `--spinner-head`, `--spinner-thickness` and `--spinner-duration` on it to restyle all of them at once; the head defaults to `--theme-fg-secondary` and the track to a 25% dilution of it, which keeps the ink a full circle so the ring stays centred as it turns and cannot wash out to a lone arc on a faded control). A ring that carries a visible caption wraps two sub-parts, `data-ui="spinner-ring"` and `data-ui="spinner-label"`.
 
 Every popover panel (dropdown menus, the chat "+" menu, the history filter menu and its flyout, the mention and run-mode menus) also carries the class `anchored-popover-skin`, and every menu row the class `dropdown-item-geometry`. Both are stable hooks: one rule on the skin restyles the whole popover family, and one rule on the row class reshapes every menu row.
@@ -208,6 +211,13 @@ The names people use for these surfaces rarely match the component names, and th
 | Settings tabs                                              | `tab-rail`                                   | `radius.control`                                                                    | re-declare `--theme-radius-control` on the hook                                                      |
 | Menu panel, "+" menu, filter menu and flyout               | class `anchored-popover-skin`                | `radius.dropdown`                                                                   | set `radius.dropdown`; rows via class `dropdown-item-geometry`                                       |
 | Sidebar rows and nav rows                                  | `chat-history-item`, `.sidebar-row-geometry` | `radius.shell`                                                                      | set `radius.shell`                                                                                   |
+| Badge, chip, status pill                                   | class `pill-geometry`                        | `radius.pill`                                                                       | set `radius.pill`                                                                                    |
+| Avatar circle                                              | class `avatar-geometry`                      | `50%`, a circle reads no radius token                                               | none, a circle stays a circle                                                                        |
+| Alert, inline error or warning banner                      | `alert`                                      | `radius.base`; the framed alerts inside a chat take `radius.message`                | set `radius.base`, or `radius.message` for the framed form                                           |
+
+Capsules and circles are deliberately kept apart. A badge, chip or status pill is a text label with side padding, so it follows `radius.pill` and softens along with the theme. An avatar, status dot, spinner or round close button is a fixed-size square rather than a padded label, so it declares `50%` and reads no radius token at all, even when it holds an initial. That separation is what lets a theme set `radius.pill`, or the legacy `borderRadius` above, to a small value and get square-ish chips without turning every avatar and dot into a rounded square.
+
+`radius.base` deserves a second look, because the plain alert is its most visible reader: every inline error, warning, info and success banner that does not take the framed form reads it. A theme that raises `base` rounds all of them along with the rest of the app — under the Open WebUI-like theme's `0.75rem` they are twice as round as the app's own `0.375rem`, and a theme setting only the legacy `borderRadius` moves them too. Give the banners a corner of their own with a `[data-ui="alert"]` rule in `theme.css` if that is not what you want.
 
 Two examples, both from the Open WebUI-like theme:
 
@@ -222,6 +232,34 @@ Two examples, both from the Open WebUI-like theme:
   --attachment-tile-radius: 0.25rem;
 }
 ```
+
+## State
+
+Selected, pressed, expanded, current and disabled are announced on the element itself, so a theme can paint them without knowing how the app tracks them.
+
+The ARIA attribute comes first. Where an element already is the widget the state belongs to, that widget's own ARIA attribute is the channel to key on, and no parallel `data-` attribute is emitted beside it:
+
+- `aria-selected` on the segments of a segmented control and on settings tabs
+- `aria-checked` on menu rows that toggle something
+- `aria-pressed` on toggle buttons; the shared button also derives its selected tint from it
+- `aria-current="page"` on the link of the open conversation in the history list
+- `aria-expanded` on the row of an open submenu, which the app itself styles through the `aria-expanded:` variant
+- `aria-disabled` on a control that is inert but must stay reachable
+
+A `data-` attribute is minted only where the element carrying the hook is not that widget (a wrapper row, an icon tile, a decorative box), and then only as a presence boolean: it is there with the value `true` while the state holds and absent otherwise, never written as `"false"`, so `[data-selected]` on its own is a sufficient selector. The surfaces that carry one:
+
+- `data-ui="chat-history-item"` takes `data-selected` on the open conversation's row, beside the `aria-current` on its link
+- the sidebar navigation row takes both `aria-current="page"` and `data-selected`, because the active row is drawn without a link and would otherwise announce nothing
+- `data-ui="option-card"` and `data-ui="option-card-icon"` take `data-selected` while the card is checked; the radio input underneath keeps the ARIA
+- `data-ui="attachment-tile"` takes `data-selected` only when the row owns a checkbox and is selected. A read-only attachment row never carries it, whether or not it can be previewed
+
+`data-state` and `data-active` are not part of this contract and are emitted nowhere. Rules written against them match nothing.
+
+Three details are easy to read the wrong way:
+
+- `data-pressed` on a button is an animation, not a state. It sits on the shared button at all times, reading `false` at rest and flipping to `true` for 200 milliseconds after a click, on the same element as `aria-pressed`, which is the real toggle state. A rule keyed on `[data-pressed="true"]` paints a flicker on every click and never the sustained state it looks like it should. Key on `aria-pressed` instead.
+- A control that is unavailable but must stay reachable by keyboard uses `aria-disabled` together with the `aria-disabled:` variant for its dimmed look, rather than the native `disabled` attribute, so the control keeps its place in the tab order and can still explain why it is unavailable. No `data-disabled` is minted for that case; key on `aria-disabled`.
+- The highlight a newly arrived message wears is an exception to all of this: it is a lasting state painted with the hover surface, so a theme that retints hover retints that highlight with it. Giving it a surface of its own would change how it looks, and that is held for a later pass.
 
 ## Custom Logos
 


### PR DESCRIPTION
Second of nine topics in the styling-primitives work; the first was #1092 (the spinner). Where that
one collapsed 35 hand-rolled rings into a primitive, this one is almost entirely a **channel
consolidation**: it takes geometry and state that today live in hardcoded Tailwind utilities and
inline `style` objects, and moves them onto classes and attributes a theme can actually reach. Nearly
every row is pixel-identical at stock — the deliberate deltas are listed below.

## What moves

**The capsule/circle dialect.** A capsule is a text label with side padding; a circle is a fixed-size
square with no label. They looked the same in the source — both `rounded-full` — so a theme could not
soften one without squaring the other. Capsules now wear `.pill-geometry` and read `radius.pill`;
circles declare `50%` and read no radius token at all. Twelve capsules moved, across badges, status
pills, trace and tool-call chips, the cloud-drive and sharing badges, and the Teams picker chip in the
add-in.

That split also fixes a live defect: the two assistant-hub avatars were reading
`--theme-radius-pill` on `size-10`/`size-14` boxes. Under the Trilux themes that token already
resolves to `0.5rem`, so those avatars ship today as rounded squares. They now use `.avatar-geometry`
and are circles under every theme.

**The alert frame.** `Alert` built its geometry from an inline `style` object, which no theme rule can
outrank. That object is gone: the default variant wears `.alert-geometry`, the framed variant
`.message-frame-geometry`, and the element now emits `data-ui="alert"` and `data-tone={type}` — the
family's first theme hook. The chat input's queued-message notice and audio-transcription card carried
a byte-identical inline recipe and now share `.message-frame-geometry`; they are deliberately *not*
given an `alert-` name, since they are not alerts.

The modal close button keeps its raw `<button>` and gains `.modal-close-geometry`. It was considered
for conversion to `<Button variant="icon-only">`, which does not work: `Button` emits `focus-ring`
unconditionally and can never emit the `focus-ring-tight` this button relies on, and `.focus-ring`'s
`ring-offset-2` would draw an outside ring on an absolutely positioned element. Keeping the raw button
also keeps `--theme-spacing-modal-close-button-padding`'s only consumer alive.

It briefly also carried `data-geometry="icon-sm"`, to put it on the channel both customer themes'
dialog-button rules key on. That was removed: it would have made this the first raw `<button>` ever to
carry the attribute, and both themes key rules on it under an explicit comment that it "reaches only
real Button components". The attribute could not have done anything for this element anyway — those
rules only re-point `--theme-radius-control`, which `.modal-close-geometry` never reads, since it
declares `50%` outright. So it bought nothing and falsified a documented contract in two themes.

**Selected state.** The contract is ARIA-first: where an element already *is* the widget, its ARIA
attribute is the channel and no parallel `data-` attribute is minted. A `data-` attribute appears only
on wrappers, icon tiles and decorative boxes that are not the widget, and only as a presence boolean.
Four surfaces gain one. The sidebar navigation row also gains `aria-current="page"`: its active branch
renders no link, so until now the current page was announced by nothing at all.

Explicitly *not* given the attribute: the chat-history loading skeleton, which borrows the selected
surface class as a placeholder fill. Marking it selected would make future `[data-selected]` theme
rules paint five phantom selected rows during load.

## One deliberate visible delta

`.alert-geometry` reads `radius.base`. The `rounded-md` it replaces is a hardcoded `0.375rem`, and
`open-webui-like` sets `radius.base: 0.75rem` — so **every plain Alert doubles its corner radius under
that theme** (6px → 12px), and moves 6px → 8px under Trilux via the legacy `borderRadius` back-fill.
That is the majority of the ~77 `<Alert>` sites, the component kits included.

This is the intended consequence of putting the frame on a token, and it is what those themes' own
JSON asks for, so it is being taken deliberately rather than reverted — but it is a visible change on
live customer themes, so it is called out here rather than buried. The same applies to the Beckhoff
fork theme, which also sets `radius.base: 0.75rem` and renders a default-variant alert from its kit.
If a customer should keep today's corner, the fix is one rule in their `theme.css` — no code change
here:

```css
[data-ui="alert"] { border-radius: 0.375rem; }
```

That works because Tailwind v3 compiles its own `@layer` away, so an unlayered rule in a customer
stylesheet wins on source order. The docs now say so.