### PR TITLE
Let theme packs declare optional assets instead of 404ing on them

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -324,7 +324,9 @@ public/custom-theme/my-company/
 ├── theme.css              # Optional, loaded after fonts.css
 ├── logo.svg
 ├── logo-dark.svg
-└── assistant-avatar.svg
+├── assistant-avatar.svg    # Optional, see "Optional Assets"
+├── sidebar-logo.svg        # Optional, see "Optional Assets"
+└── sidebar-logo-dark.svg   # Optional, see "Optional Assets"
 ```
 
 When `VITE_THEME_CONFIG_PATH` points at a specific `theme.json`, `fonts.css` and `theme.css` are resolved relative to that resolved file path. Otherwise they follow the active theme pack directory from `VITE_THEME_PATH`, `VITE_CUSTOMER_NAME`, or the default `/custom-theme/` location.
@@ -339,6 +341,46 @@ You can also provide custom logos for your theme:
    - `/custom-theme/{customer-name}/logo.svg` - Main logo
    - `/custom-theme/{customer-name}/logo-dark.svg` - Dark mode logo (optional)
 
+### Optional Assets
+
+The assistant avatar and the sidebar logo are optional: a theme pack may ship
+them or not. Declare them in `theme.json` so the app knows which case applies
+without having to go looking:
+
+```json
+{
+  "assets": {
+    "assistantAvatar": { "path": "./assistant-avatar.svg" },
+    "sidebarLogo": {
+      "path": "./sidebar-logo.svg",
+      "darkPath": "./sidebar-logo-dark.svg"
+    }
+  }
+}
+```
+
+Each key accepts three states:
+
+| Value                | Meaning                                                                     |
+| -------------------- | --------------------------------------------------------------------------- |
+| `{ "path": "..." }`  | The pack ships this asset. Used as-is, with no existence check.              |
+| `null`               | The pack deliberately does not ship it. Never requested.                     |
+| key omitted          | Fall back to the filename convention below, checked once per page load.      |
+
+Set a key to `null` when your pack does not include that asset — that is what
+stops the browser from requesting a file that was never there:
+
+```json
+{
+  "assets": { "assistantAvatar": null, "sidebarLogo": null }
+}
+```
+
+`darkPath` is optional and falls back to `path`. Declared paths follow the same
+rules as `icons`: `./file.svg` (or a bare `file.svg`) resolves against the theme
+pack directory, `/file.svg` is treated as deployment-absolute, and absolute URLs
+are used verbatim.
+
 ### Custom Assistant Avatar
 
 You can customize the assistant's avatar image to match your branding:
@@ -349,7 +391,8 @@ You can customize the assistant's avatar image to match your branding:
 
    - `/custom-theme/{customer-name}/assistant-avatar.svg` - Assistant avatar image
 
-   The avatar will be automatically detected and loaded when available.
+   When the file is not declared under `assets`, it is checked for once per page
+   load and used when present.
 
 2. **Using Environment Variables**:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -361,11 +361,11 @@ without having to go looking:
 
 Each key accepts three states:
 
-| Value                | Meaning                                                                     |
-| -------------------- | --------------------------------------------------------------------------- |
-| `{ "path": "..." }`  | The pack ships this asset. Used as-is, with no existence check.              |
-| `null`               | The pack deliberately does not ship it. Never requested.                     |
-| key omitted          | Fall back to the filename convention below, checked once per page load.      |
+| Value               | Meaning                                                                 |
+| ------------------- | ----------------------------------------------------------------------- |
+| `{ "path": "..." }` | The pack ships this asset. Used as-is, with no existence check.         |
+| `null`              | The pack deliberately does not ship it. Never requested.                |
+| key omitted         | Fall back to the filename convention below, checked once per page load. |
 
 Set a key to `null` when your pack does not include that asset — that is what
 stops the browser from requesting a file that was never there:

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -598,7 +598,9 @@ describe("ThemeProvider", () => {
     const AssetProbe = () => {
       const { assetPaths } = useTheme();
       return (
-        <div data-testid="avatar-path">{assetPaths.assistantAvatar ?? "none"}</div>
+        <div data-testid="avatar-path">
+          {assetPaths.assistantAvatar ?? "none"}
+        </div>
       );
     };
 
@@ -703,15 +705,16 @@ describe("ThemeProvider", () => {
         expect(screen.getByTestId("avatar-path")).toHaveTextContent("none");
       });
 
-      expect(
-        requestedUrls().filter((url) => url === AVATAR_URL),
-      ).toHaveLength(1);
+      expect(requestedUrls().filter((url) => url === AVATAR_URL)).toHaveLength(
+        1,
+      );
     });
 
     it("does not let a light sidebar logo override stand in for the dark one", async () => {
       // A deployment may set only the light variable while shipping the dark
       // file beside theme.json; dark mode must still find that file.
-      const DARK_LOGO_URL = "/public/common/custom-theme/acme/sidebar-logo-dark.svg";
+      const DARK_LOGO_URL =
+        "/public/common/custom-theme/acme/sidebar-logo-dark.svg";
       localStorage.setItem(THEME_MODE_LOCAL_STORAGE_KEY, "dark");
       mockEnv.mockReturnValue(
         createMockEnv({

--- a/frontend/src/components/providers/ThemeProvider.test.tsx
+++ b/frontend/src/components/providers/ThemeProvider.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/app/env", () => ({
 import { env } from "@/app/env";
 
 import {
+  __resetThemeAssetProbeCache,
   TEXT_SIZE_LOCAL_STORAGE_KEY,
   THEME_MODE_LOCAL_STORAGE_KEY,
   ThemeProvider,
@@ -104,6 +105,7 @@ describe("ThemeProvider", () => {
     global.fetch = vi.fn();
     window.matchMedia = createMatchMedia(false);
     localStorage.clear();
+    __resetThemeAssetProbeCache();
   });
 
   afterEach(() => {
@@ -565,5 +567,203 @@ describe("ThemeProvider", () => {
       "x-large",
     );
     expect(localStorage.getItem(TEXT_SIZE_LOCAL_STORAGE_KEY)).toBeNull();
+  });
+  describe("optional theme assets", () => {
+    const THEME_URL = "/public/common/custom-theme/acme/theme.json";
+    const AVATAR_URL = "/public/common/custom-theme/acme/assistant-avatar.svg";
+
+    /**
+     * Routes by URL rather than call order, so an added or removed request
+     * cannot silently shift which response a call receives.
+     */
+    const mockFetchRoutes = (options: {
+      theme: CustomThemeConfig;
+      existingFiles?: string[];
+    }) => {
+      const existing = new Set(options.existingFiles ?? []);
+      global.fetch = vi.fn((url: string, init?: { method?: string }) => {
+        if (init?.method === "HEAD") {
+          return Promise.resolve({
+            ok: existing.has(url),
+            headers: new Headers({ "content-type": "image/svg+xml" }),
+          });
+        }
+        if (url === THEME_URL) {
+          return Promise.resolve({ ok: true, json: () => options.theme });
+        }
+        return Promise.resolve({ ok: false });
+      }) as unknown as typeof fetch;
+    };
+
+    const AssetProbe = () => {
+      const { assetPaths } = useTheme();
+      return (
+        <div data-testid="avatar-path">{assetPaths.assistantAvatar ?? "none"}</div>
+      );
+    };
+
+    const renderWithTheme = () =>
+      render(
+        <ThemeProvider>
+          <AssetProbe />
+        </ThemeProvider>,
+      );
+
+    const requestedUrls = () =>
+      (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map(([url]) =>
+        String(url),
+      );
+
+    beforeEach(() => {
+      mockEnv.mockReturnValue(createMockEnv({ themeCustomerName: "acme" }));
+    });
+
+    it("never requests an asset the theme declares as absent", async () => {
+      mockFetchRoutes({
+        theme: { ...mockTheme, assets: { assistantAvatar: null } },
+      });
+
+      renderWithTheme();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent("none");
+      });
+
+      // The whole point of the declaration: no probe, no <img>, no 404.
+      expect(
+        requestedUrls().some((url) => url.includes("assistant-avatar")),
+      ).toBe(false);
+    });
+
+    it("trusts a declared path without probing for it", async () => {
+      mockFetchRoutes({
+        theme: {
+          ...mockTheme,
+          assets: { assistantAvatar: { path: "./brand/avatar.svg" } },
+        },
+      });
+
+      renderWithTheme();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent(
+          "/public/common/custom-theme/acme/brand/avatar.svg",
+        );
+      });
+
+      expect(requestedUrls().some((url) => url.includes("avatar.svg"))).toBe(
+        false,
+      );
+    });
+
+    it("uses the dark variant of a declared asset in dark mode", async () => {
+      localStorage.setItem(THEME_MODE_LOCAL_STORAGE_KEY, "dark");
+      mockFetchRoutes({
+        theme: {
+          ...mockTheme,
+          assets: {
+            assistantAvatar: {
+              path: "./avatar.svg",
+              darkPath: "./avatar-dark.svg",
+            },
+          },
+        },
+      });
+
+      renderWithTheme();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent(
+          "/public/common/custom-theme/acme/avatar-dark.svg",
+        );
+      });
+    });
+
+    it("falls back to the filename convention when nothing is declared", async () => {
+      mockFetchRoutes({ theme: mockTheme, existingFiles: [AVATAR_URL] });
+
+      renderWithTheme();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent(AVATAR_URL);
+      });
+    });
+
+    it("probes a convention asset once per page, not once per mount", async () => {
+      mockFetchRoutes({ theme: mockTheme });
+
+      const first = renderWithTheme();
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent("none");
+      });
+      first.unmount();
+
+      renderWithTheme();
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent("none");
+      });
+
+      expect(
+        requestedUrls().filter((url) => url === AVATAR_URL),
+      ).toHaveLength(1);
+    });
+
+    it("does not let a light sidebar logo override stand in for the dark one", async () => {
+      // A deployment may set only the light variable while shipping the dark
+      // file beside theme.json; dark mode must still find that file.
+      const DARK_LOGO_URL = "/public/common/custom-theme/acme/sidebar-logo-dark.svg";
+      localStorage.setItem(THEME_MODE_LOCAL_STORAGE_KEY, "dark");
+      mockEnv.mockReturnValue(
+        createMockEnv({
+          themeCustomerName: "acme",
+          sidebarLogoPath: "/branding/sidebar-light.svg",
+        }),
+      );
+
+      const SidebarLogoProbe = () => {
+        const { assetPaths } = useTheme();
+        return (
+          <div data-testid="sidebar-logo-path">
+            {assetPaths.sidebarLogo ?? "none"}
+          </div>
+        );
+      };
+
+      mockFetchRoutes({ theme: mockTheme, existingFiles: [DARK_LOGO_URL] });
+
+      render(
+        <ThemeProvider>
+          <SidebarLogoProbe />
+        </ThemeProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("sidebar-logo-path")).toHaveTextContent(
+          DARK_LOGO_URL,
+        );
+      });
+    });
+
+    it("trusts an environment override without probing", async () => {
+      mockEnv.mockReturnValue(
+        createMockEnv({
+          themeCustomerName: "acme",
+          themeAssistantAvatarPath: "/branding/avatar.svg",
+        }),
+      );
+      mockFetchRoutes({ theme: mockTheme });
+
+      renderWithTheme();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("avatar-path")).toHaveTextContent(
+          "/branding/avatar.svg",
+        );
+      });
+
+      expect(requestedUrls().some((url) => url.includes("avatar.svg"))).toBe(
+        false,
+      );
+    });
   });
 });

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -9,15 +9,21 @@ import {
   useState,
 } from "react";
 
+import { env } from "@/app/env";
 import { defaultTheme, darkTheme } from "@/config/theme";
 import {
   defaultThemeConfig,
   loadResolvedThemeConfig,
+  resolveDeclaredAssetPath,
   resolveIconPaths,
 } from "@/config/themeConfig";
+import { debugLog } from "@/utils/debugLogger";
 import {
+  checkFileExists,
   mergeThemeWithOverrides,
+  THEME_ASSET_KEYS,
   type CustomThemeConfig,
+  type ThemeAssetKey,
 } from "@/utils/themeUtils";
 
 import type { Theme } from "@/config/theme";
@@ -66,6 +72,127 @@ type ThemeContextType = {
     actions?: Record<string, string>;
     navigation?: Record<string, string>;
   };
+  /**
+   * Resolved locations of the optional theme assets, or null when the active
+   * theme does not provide one. Already accounts for the current light/dark
+   * mode, so consumers can render the value directly.
+   */
+  assetPaths: ThemeAssetPaths;
+};
+
+/** Resolved location of each optional theme asset, or null when unavailable. */
+export type ThemeAssetPaths = Record<ThemeAssetKey, string | null>;
+
+const EMPTY_ASSET_PATHS: ThemeAssetPaths = {
+  assistantAvatar: null,
+  sidebarLogo: null,
+};
+
+/**
+ * Existence probes for convention-located assets, keyed by URL.
+ *
+ * Module-level so a missing asset costs one request per page load rather than
+ * one per component mount. Promises (not booleans) are cached so concurrent
+ * callers share a single in-flight request.
+ */
+const assetProbeCache = new Map<string, Promise<boolean>>();
+
+const probeAssetOnce = (url: string): Promise<boolean> => {
+  const cached = assetProbeCache.get(url);
+  if (cached) return cached;
+
+  const probe = checkFileExists(url);
+  assetProbeCache.set(url, probe);
+  return probe;
+};
+
+/** Exported for tests; resets the per-page probe memoisation. */
+export const __resetThemeAssetProbeCache = () => {
+  assetProbeCache.clear();
+};
+
+/**
+ * Environment overrides win over everything: an operator setting these is
+ * asserting the file is there, so no existence check is performed.
+ *
+ * Each mode reads only its own variable. A light-mode override deliberately
+ * does not stand in for a missing dark one, so a deployment that sets
+ * `VITE_SIDEBAR_LOGO_PATH` while shipping `sidebar-logo-dark.svg` beside
+ * `theme.json` keeps getting the dark file in dark mode.
+ */
+const getAssetEnvOverride = (
+  key: ThemeAssetKey,
+  isDark: boolean,
+): string | null => {
+  const { themeAssistantAvatarPath, sidebarLogoPath, sidebarLogoDarkPath } =
+    env();
+
+  // The assistant avatar has a single variable covering both modes.
+  if (key === "assistantAvatar") return themeAssistantAvatarPath;
+  return isDark ? sidebarLogoDarkPath : sidebarLogoPath;
+};
+
+const getConventionAssetPath = (
+  key: ThemeAssetKey,
+  themeName: string | undefined,
+  isDark: boolean,
+): string | null =>
+  key === "assistantAvatar"
+    ? defaultThemeConfig.getAssistantAvatarPath(themeName)
+    : defaultThemeConfig.getSidebarLogoPath(themeName, isDark);
+
+/**
+ * Works out where an optional asset lives, in precedence order:
+ *
+ * 1. environment override -- trusted, never probed
+ * 2. `theme.json` declares it -- trusted, never probed
+ * 3. `theme.json` declares it as `null` -- deliberately absent, never requested
+ * 4. neither -- fall back to the filename convention, probed once
+ *
+ * The gap between (3) and (4) is why this reads `key in assets` rather than
+ * testing the value for truthiness: collapsing `null` into "undeclared" would
+ * reintroduce the very request the declaration exists to prevent.
+ */
+const resolveThemeAssetPath = async (
+  key: ThemeAssetKey,
+  options: {
+    themeConfig: CustomThemeConfig | null;
+    resolvedThemeConfigPath: string | null;
+    isDark: boolean;
+  },
+): Promise<string | null> => {
+  const { themeConfig, resolvedThemeConfigPath, isDark } = options;
+
+  const envOverride = getAssetEnvOverride(key, isDark);
+  if (envOverride) return envOverride;
+
+  const assets = themeConfig?.assets;
+  if (assets && key in assets) {
+    const declaration = assets[key];
+    // Explicit `null` means "this pack does not ship it" -- stop here.
+    if (!declaration) return null;
+
+    const declaredPath =
+      isDark && declaration.darkPath ? declaration.darkPath : declaration.path;
+    return resolveDeclaredAssetPath(declaredPath, resolvedThemeConfigPath);
+  }
+
+  const conventionPath = getConventionAssetPath(
+    key,
+    themeConfig?.name,
+    isDark,
+  );
+  if (!conventionPath) return null;
+
+  if (await probeAssetOnce(conventionPath)) return conventionPath;
+
+  debugLog(
+    "UI",
+    `Optional theme asset "${key}" was not found at ${conventionPath}. ` +
+      `Add "assets": { "${key}": { "path": "./..." } } to theme.json to point at it, ` +
+      `or "assets": { "${key}": null } to stop looking for it.`,
+  );
+  return null;
 };
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -413,6 +540,13 @@ export function ThemeProvider({
     actions?: Record<string, string>;
     navigation?: Record<string, string>;
   }>();
+  const [assetPaths, setAssetPaths] =
+    useState<ThemeAssetPaths>(EMPTY_ASSET_PATHS);
+  // Optional assets must not be resolved until the theme load has settled:
+  // before then `customThemeConfig` is still null, so a pack that declares an
+  // asset as absent would be indistinguishable from one that declares nothing
+  // and we would fire the very request the declaration exists to prevent.
+  const [isThemeLoadSettled, setIsThemeLoadSettled] = useState(false);
   const [systemThemeOverride, setSystemThemeOverride] = useState<
     "light" | "dark" | null
   >(null);
@@ -427,8 +561,11 @@ export function ThemeProvider({
       setResolvedThemeConfigPath(null);
       setIsCustomTheme(false);
       setIconMappings(undefined);
+      setIsThemeLoadSettled(true);
       return;
     }
+
+    setIsThemeLoadSettled(false);
 
     const loadTheme = async () => {
       const loadedTheme = await loadResolvedThemeConfig(defaultThemeConfig);
@@ -446,6 +583,7 @@ export function ThemeProvider({
         // instead of themeConfig.name (e.g., "ACME Theme") which is the display name
         const resolvedIcons = resolveIconPaths(themeConfig.icons, undefined);
         setIconMappings(resolvedIcons);
+        setIsThemeLoadSettled(true);
         return;
       }
 
@@ -453,6 +591,7 @@ export function ThemeProvider({
       setResolvedThemeConfigPath(null);
       setIsCustomTheme(false);
       setIconMappings(undefined);
+      setIsThemeLoadSettled(true);
     };
 
     void loadTheme();
@@ -491,6 +630,48 @@ export function ThemeProvider({
       removeThemeStylesheets();
     };
   }, [customThemeConfig, enableCustomTheme, resolvedThemeConfigPath]);
+
+  // Resolve the optional theme assets once per theme/mode, so consumers can
+  // render a path without each one probing for the file itself.
+  useEffect(() => {
+    if (!isThemeLoadSettled) return;
+
+    let isMounted = true;
+    const isDark = effectiveTheme === "dark";
+
+    const resolveAll = async () => {
+      const entries = await Promise.all(
+        THEME_ASSET_KEYS.map(
+          async (key) =>
+            [
+              key,
+              await resolveThemeAssetPath(key, {
+                themeConfig: enableCustomTheme ? customThemeConfig : null,
+                resolvedThemeConfigPath,
+                isDark,
+              }),
+            ] as const,
+        ),
+      );
+
+      if (!isMounted) return;
+      setAssetPaths(
+        Object.fromEntries(entries) as unknown as ThemeAssetPaths,
+      );
+    };
+
+    void resolveAll();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    customThemeConfig,
+    effectiveTheme,
+    enableCustomTheme,
+    isThemeLoadSettled,
+    resolvedThemeConfigPath,
+  ]);
 
   // Listen for system preference changes when in system mode
   useEffect(() => {
@@ -611,6 +792,7 @@ export function ThemeProvider({
     effectiveTheme,
     setSystemThemeOverride,
     iconMappings,
+    assetPaths,
   };
 
   return (
@@ -626,4 +808,16 @@ export function useTheme() {
     throw new Error("useTheme must be used within a ThemeProvider");
   }
   return context;
+}
+
+/**
+ * Theme context when a provider is present, `undefined` otherwise.
+ *
+ * Ubiquitous leaf components (avatars, for instance) get rendered in tests and
+ * stories without a provider, and throwing there would be the wrong trade: a
+ * component that merely wants to *style* itself should not hard-require the
+ * provider.
+ */
+export function useOptionalTheme() {
+  return useContext(ThemeContext);
 }

--- a/frontend/src/components/providers/ThemeProvider.tsx
+++ b/frontend/src/components/providers/ThemeProvider.tsx
@@ -177,11 +177,7 @@ const resolveThemeAssetPath = async (
     return resolveDeclaredAssetPath(declaredPath, resolvedThemeConfigPath);
   }
 
-  const conventionPath = getConventionAssetPath(
-    key,
-    themeConfig?.name,
-    isDark,
-  );
+  const conventionPath = getConventionAssetPath(key, themeConfig?.name, isDark);
   if (!conventionPath) return null;
 
   if (await probeAssetOnce(conventionPath)) return conventionPath;
@@ -655,9 +651,7 @@ export function ThemeProvider({
       );
 
       if (!isMounted) return;
-      setAssetPaths(
-        Object.fromEntries(entries) as unknown as ThemeAssetPaths,
-      );
+      setAssetPaths(Object.fromEntries(entries) as unknown as ThemeAssetPaths);
     };
 
     void resolveAll();

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/components/providers/ThemeProvider", () => ({
   useTheme: () => ({
     effectiveTheme: "light",
     customThemeName: null,
+    assetPaths: { assistantAvatar: null, sidebarLogo: null },
   }),
 }));
 

--- a/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistorySidebar.tsx
@@ -12,7 +12,6 @@ import {
   componentRegistry,
   resolveComponentOverride,
 } from "@/config/componentRegistry";
-import { defaultThemeConfig } from "@/config/themeConfig";
 import {
   hasActiveFilters,
   useChatHistoryFilterFoldback,
@@ -31,7 +30,6 @@ import {
 } from "@/providers/FeatureConfigProvider";
 import { UNTITLED_BACKEND_SENTINEL } from "@/utils/chat/recentChatSession";
 import { createLogger } from "@/utils/debugLogger";
-import { checkFileExists } from "@/utils/themeUtils";
 
 import { ChatHistoryFilterMenu } from "./ChatHistoryFilterMenu";
 import { ChatHistoryList, ChatHistoryListSkeleton } from "./ChatHistoryList";
@@ -418,7 +416,6 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
     onLoadMoreSessions,
   }) => {
     const ref = useRef<HTMLElement>(null);
-    const [sidebarLogoPath, setSidebarLogoPath] = useState<string | null>(null);
     const navigate = useNavigate();
     const location = useLocation();
     const isOnSearchPage = location.pathname === "/search";
@@ -431,11 +428,9 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
       location.pathname.startsWith(assistantHubRoute);
 
     // Get sidebar configuration
-    const {
-      collapsedMode,
-      logoPath: envLogoPath,
-      logoDarkPath: envLogoDarkPath,
-    } = useSidebarFeature();
+    // Logo env overrides are resolved by ThemeProvider, which also decides
+    // whether the file exists; only the collapse mode is read here.
+    const { collapsedMode } = useSidebarFeature();
 
     // Get responsive collapsed mode (forces hidden on mobile even if config is slim)
     const effectiveCollapsedMode = useResponsiveCollapsedMode(collapsedMode);
@@ -451,7 +446,8 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
     );
 
     // Get theme information
-    const { effectiveTheme, customThemeName } = useTheme();
+    const { assetPaths } = useTheme();
+    const sidebarLogoPath = assetPaths.sidebarLogo;
 
     // Apply any user-dragged sidebar width as the width-token override.
     useApplySidebarWidth();
@@ -631,32 +627,6 @@ export const ChatHistorySidebar = memo<ChatHistorySidebarProps>(
 
     // Only use ResizeObserver in the browser
     const isBrowser = typeof window !== "undefined";
-
-    // Memoize logo path resolution to avoid recalculating on every render
-    const resolvedLogoPath = useMemo(() => {
-      const isDark = effectiveTheme === "dark";
-      // Check env vars first (from FeatureConfigProvider)
-      if (isDark && envLogoDarkPath) return envLogoDarkPath;
-      if (!isDark && envLogoPath) return envLogoPath;
-      // Fall back to theme-based paths
-      return defaultThemeConfig.getSidebarLogoPath(customThemeName, isDark);
-    }, [effectiveTheme, customThemeName, envLogoPath, envLogoDarkPath]);
-
-    // Load sidebar logo if configured
-    useEffect(() => {
-      if (!resolvedLogoPath) {
-        setSidebarLogoPath(null);
-        return;
-      }
-
-      const loadSidebarLogo = async () => {
-        // Check if the logo file exists
-        const exists = await checkFileExists(resolvedLogoPath);
-        setSidebarLogoPath(exists ? resolvedLogoPath : null);
-      };
-
-      void loadSidebarLogo();
-    }, [resolvedLogoPath]);
 
     // Memoize event handlers to prevent unnecessary re-renders of child components
     const handleSignOut = useCallback(() => {

--- a/frontend/src/components/ui/Feedback/Avatar.tsx
+++ b/frontend/src/components/ui/Feedback/Avatar.tsx
@@ -30,7 +30,8 @@ export const Avatar = React.memo<AvatarProps>(
 
     // Compute assistant avatar path once
     const assistantAvatarPath = useMemo(() => {
-      if (typeof userOrAssistant === "undefined" || userOrAssistant) return null;
+      if (typeof userOrAssistant === "undefined" || userOrAssistant)
+        return null;
 
       // The provider is the only place that knows whether the asset actually
       // exists, so trust its answer -- including a deliberate null. Falling

--- a/frontend/src/components/ui/Feedback/Avatar.tsx
+++ b/frontend/src/components/ui/Feedback/Avatar.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/core/macro";
 import clsx from "clsx";
 import React, { useEffect, useMemo, useState } from "react";
 
+import { useOptionalTheme } from "@/components/providers/ThemeProvider";
 import { defaultThemeConfig } from "@/config/themeConfig";
 import { mapApiUserProfileToUiProfile } from "@/utils/adapters/userProfileAdapter";
 
@@ -25,14 +26,20 @@ export const Avatar = React.memo<AvatarProps>(
 
     const [imageLoadFailed, setImageLoadFailed] = useState(false);
     const avatarUrl = uiProfile?.avatarUrl ?? null;
+    const themeContext = useOptionalTheme();
 
     // Compute assistant avatar path once
     const assistantAvatarPath = useMemo(() => {
-      if (typeof userOrAssistant !== "undefined" && !userOrAssistant) {
-        return defaultThemeConfig.getAssistantAvatarPath(undefined);
-      }
-      return null;
-    }, [userOrAssistant]);
+      if (typeof userOrAssistant === "undefined" || userOrAssistant) return null;
+
+      // The provider is the only place that knows whether the asset actually
+      // exists, so trust its answer -- including a deliberate null. Falling
+      // back to the convention path here would re-request the missing file.
+      if (themeContext) return themeContext.assetPaths.assistantAvatar;
+
+      // Rendered outside a ThemeProvider (tests, stories): best effort only.
+      return defaultThemeConfig.getAssistantAvatarPath(undefined);
+    }, [themeContext, userOrAssistant]);
 
     useEffect(() => {
       setImageLoadFailed(false);

--- a/frontend/src/config/themeConfig.ts
+++ b/frontend/src/config/themeConfig.ts
@@ -26,17 +26,27 @@ export interface ThemeLocationConfig {
   getLogoPath: (themeName: string | undefined, isDark: boolean) => string;
 
   /**
-   * Function to determine assistant avatar path
+   * Function to determine the by-convention assistant avatar path.
+   *
+   * This only builds a path; it cannot know whether the file exists. Deciding
+   * availability is `ThemeProvider`'s job -- read `assetPaths` from
+   * `useTheme()` instead of calling this directly in UI code.
+   *
    * @param themeName The name of the loaded theme
-   * @returns Path to the assistant avatar file, or null if not available
+   * @returns Convention path, or null when no theme location is configured
    */
   getAssistantAvatarPath: (themeName: string | undefined) => string | null;
 
   /**
-   * Function to determine sidebar logo paths based on theme name and mode
+   * Function to determine the by-convention sidebar logo path.
+   *
+   * As with the assistant avatar, this only builds a path. `ThemeProvider`
+   * resolves declarations and existence; UI code should read `assetPaths`
+   * from `useTheme()`.
+   *
    * @param themeName The name of the loaded theme
    * @param isDark Whether dark mode is active
-   * @returns Path to the sidebar logo file, or null if not available (falls back to regular logo)
+   * @returns Convention path, or null when no theme location is configured
    */
   getSidebarLogoPath: (
     themeName: string | undefined,
@@ -367,6 +377,46 @@ export const defaultThemeConfig: ThemeLocationConfig = {
       }) ?? `${commonPublicBasePath}/custom-theme/theme.css`
     );
   },
+};
+
+/**
+ * Resolves a path declared in `theme.json`'s `assets` block.
+ *
+ * Mirrors the `icons` resolution rules, minus the "bare string is an iconoir
+ * name" branch -- every value here is a file, so `avatar.svg` and
+ * `./avatar.svg` both resolve against the theme pack directory.
+ */
+export const resolveDeclaredAssetPath = (
+  declaredPath: string,
+  resolvedThemeConfigPath?: string | null,
+): string => {
+  // Absolute URLs are used verbatim.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(declaredPath)) return declaredPath;
+  // Root-relative paths already address the deployment root.
+  if (declaredPath.startsWith("/")) return declaredPath;
+
+  const filename = declaredPath.startsWith("./")
+    ? declaredPath.slice(2)
+    : declaredPath;
+  const {
+    commonPublicBasePath,
+    frontendPublicBasePath,
+    themeConfigPath,
+    themePath,
+    themeCustomerName,
+  } = env();
+
+  return (
+    resolveThemePackAssetPath({
+      commonPublicBasePath,
+      filename,
+      platformPublicBasePath: frontendPublicBasePath,
+      resolvedThemeConfigPath,
+      themeConfigPath,
+      themePath,
+      themeCustomerName,
+    }) ?? `${commonPublicBasePath}/custom-theme/${filename}`
+  );
 };
 
 export interface LoadedThemeConfig {

--- a/frontend/src/utils/themeUtils.ts
+++ b/frontend/src/utils/themeUtils.ts
@@ -32,6 +32,43 @@ export interface LayoutConfig {
 }
 
 /**
+ * Declaration for an optional theme asset that a theme pack may ship.
+ *
+ * Paths follow the same resolution rules as `icons`: `./file.svg` (or a bare
+ * `file.svg`) resolves against the theme pack directory, `/file.svg` is used
+ * as-is, and absolute URLs are passed through untouched.
+ */
+export interface ThemeAssetDeclaration {
+  path: string;
+  /** Variant used in dark mode. Falls back to `path` when omitted. */
+  darkPath?: string;
+}
+
+/**
+ * Optional assets a theme pack may declare.
+ *
+ * Each key is tri-state, and the distinction between `null` and *absent*
+ * matters:
+ * - a declaration object: use those paths, no existence check is performed
+ * - `null`: the pack deliberately does not ship this asset, so it is never
+ *   requested
+ * - key absent: fall back to the historical filename convention beside
+ *   `theme.json`, probed once
+ */
+export interface ThemeAssets {
+  assistantAvatar?: ThemeAssetDeclaration | null;
+  sidebarLogo?: ThemeAssetDeclaration | null;
+}
+
+/** Keys of {@link ThemeAssets}, for iterating without losing type safety. */
+export const THEME_ASSET_KEYS = [
+  "assistantAvatar",
+  "sidebarLogo",
+] as const satisfies readonly (keyof ThemeAssets)[];
+
+export type ThemeAssetKey = (typeof THEME_ASSET_KEYS)[number];
+
+/**
  * Custom theme configuration interface
  */
 export interface CustomThemeConfig {
@@ -56,6 +93,7 @@ export interface CustomThemeConfig {
     actions?: Record<string, string>;
     navigation?: Record<string, string>;
   };
+  assets?: ThemeAssets;
   layout?: LayoutConfig;
 }
 


### PR DESCRIPTION
## Problem

The assistant avatar and sidebar logo are optional theme assets, but nothing could say so, and a theme pack that ships neither had no way to stop the browser requesting them.

`resolveAssetPath`'s `hasDefault: false` was meant to express "not available". It never gets the chance: `resolveThemeFilePath` returns a by-convention path as soon as a customer name or theme path is configured, before `defaultPath` is consulted. So every branded deployment received a path whether or not the file existed, and the `ThemeLocationConfig` contract promising "null if not available" was unsatisfiable — the resolver has no way to know availability.

`Avatar` then rendered that path unconditionally with an `onError` fallback. Since `imageLoadFailed` is per-instance state and browsers do not cache 404s, a deployment without the file got one failed GET **per avatar mount** — one per assistant message. The sidebar logo did probe first, but the probe re-ran per mount too.

Observed on a deployment whose theme pack ships neither file:

```
GET /public/common/custom-theme/<theme>/assistant-avatar.svg 404 (Not Found)   ← repeatedly
GET /public/common/custom-theme/<theme>/sidebar-logo.svg     404 (Not Found)
```

No configuration could suppress this: `CustomThemeConfig` had no field for these assets, and `VITE_ASSISTANT_AVATAR_PATH` / `VITE_SIDEBAR_LOGO_PATH` can only *point at* a path (an empty value normalises to `null`, re-enabling the convention). The only workaround was committing placeholder files.

## Change

`theme.json` gains an `assets` block. Each key is tri-state:

```jsonc
{
  "assets": {
    "assistantAvatar": { "path": "./assistant-avatar.svg" },  // trusted, never probed
    "sidebarLogo": null                                        // not shipped, never requested
    // key omitted                                             → filename convention, probed once
  }
}
```

`darkPath` is optional and falls back to `path`. Declared paths follow the existing `icons` rules (`./x.svg` and bare `x.svg` resolve against the theme pack directory, `/x.svg` is deployment-absolute, absolute URLs pass through).

The distinction between `null` and *absent* is load-bearing, so the resolver tests `key in assets` rather than truthiness — one `??` or truthiness check there would collapse `null` into "undeclared" and reintroduce the exact request the declaration exists to prevent. There's a test pinning that.

`ThemeProvider` owns resolution, since it is the only place that knows both the loaded config and whether a file resolved. Consumers read `assetPaths` from `useTheme()` and render a string; the duplicate `checkFileExists` call in `ChatHistorySidebar` is deleted rather than duplicated into `Avatar`. Probes are memoised at module level, so a missing convention asset costs one HEAD per page load instead of one per mount.

Resolution waits for the theme load to settle. Without that gate it runs while `customThemeConfig` is still `null`, so a pack declaring an asset absent would be indistinguishable from one declaring nothing — and would fire the request anyway.

`Avatar` reaches the context via a new non-throwing `useOptionalTheme`, so rendering it without a provider (tests, stories) stays valid