### PR TITLE
Align host i18n ids with the component kit

### DIFF
--- a/backend/erato/src/translation_po.rs
+++ b/backend/erato/src/translation_po.rs
@@ -554,9 +554,9 @@ msgstr ""
             json!(["Abtastrate: ", ["sampleRate"], " Hz"])
         );
         assert_eq!(
-            value["messages"]["rvEDpN"],
+            value["messages"]["chat.history.files.count"],
             json!([[
-                "0",
+                "count",
                 "plural",
                 {
                     "0": ["Keine Dateien"],

--- a/frontend/src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+++ b/frontend/src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -57,6 +57,15 @@ export interface AssistantWelcomeScreenProps {
 type AssistantChatSegment = "chats" | "delegated";
 
 const PAST_CHAT_PREVIEW_COUNT = 5;
+
+const getMoreConversationsLabel = (count: number) =>
+  t({
+    id: "assistant.welcome.more_conversations.count",
+    message: plural(count, {
+      one: "And # more conversation...",
+      other: "And # more conversations...",
+    }),
+  });
 
 /**
  * The screen unmounts as soon as a conversation is opened, so the selected
@@ -190,7 +199,10 @@ export function AssistantWelcomeUpper({
       <ModalBase
         isOpen={isConfigurationOpen}
         onClose={closeConfiguration}
-        title={t`Configuration`}
+        title={t({
+          id: "assistant.welcome.configuration.title",
+          message: "Configuration",
+        })}
         contentClassName="max-w-2xl"
       >
         <div className="space-y-5 text-left" data-ui="assistant-detail-card">
@@ -227,7 +239,10 @@ export function AssistantWelcomeUpper({
 
           <div>
             <h3 className="mb-2 text-sm font-medium text-theme-fg-secondary">
-              {t`System Prompt`}
+              {t({
+                id: "assistant.welcome.system_prompt",
+                message: "System Prompt",
+              })}
             </h3>
             <div className="max-h-48 overflow-y-auto rounded-[var(--theme-radius-message)] border border-theme-border bg-theme-bg-secondary p-3">
               <p className="whitespace-pre-wrap font-mono text-xs text-theme-fg-primary">
@@ -241,7 +256,11 @@ export function AssistantWelcomeUpper({
           {assistant.files.length > 0 && (
             <div>
               <h3 className="mb-2 text-sm font-medium text-theme-fg-secondary">
-                {t`Default Files`} ({assistant.files.length})
+                {t({
+                  id: "assistant.welcome.files.title",
+                  message: "Default Files",
+                })}{" "}
+                ({assistant.files.length})
               </h3>
               <div className="flex flex-wrap gap-2">
                 {assistant.files.map((file) => (
@@ -263,7 +282,10 @@ export function AssistantWelcomeUpper({
               icon={<EditIcon />}
               onClick={handleEditAssistant}
             >
-              {t`Edit Assistant Settings`}
+              {t({
+                id: "assistant.welcome.edit",
+                message: "Edit Assistant Settings",
+              })}
             </Button>
           )}
         </div>
@@ -359,7 +381,10 @@ export function AssistantWelcomeLower({
                   contentTextAlignment,
                 )}
               >
-                {t`Your conversations with this assistant`}
+                {t({
+                  id: "assistant.welcome.history",
+                  message: "Your conversations with this assistant",
+                })}
               </h2>
               {showSegments && (
                 <SegmentedControl
@@ -486,8 +511,9 @@ export function AssistantWelcomeLower({
                   contentTextAlignment,
                 )}
               >
-                {t`And`} {visibleChats.length - PAST_CHAT_PREVIEW_COUNT}{" "}
-                {t`more conversations...`}
+                {getMoreConversationsLabel(
+                  visibleChats.length - PAST_CHAT_PREVIEW_COUNT,
+                )}
               </p>
             )}
           </div>

--- a/frontend/src/components/ui/Chat/ChatHistoryList.tsx
+++ b/frontend/src/components/ui/Chat/ChatHistoryList.tsx
@@ -1,5 +1,4 @@
-import { t } from "@lingui/core/macro";
-import { Plural } from "@lingui/react/macro";
+import { plural, t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { memo, useEffect, useMemo, useRef } from "react";
 
@@ -150,6 +149,14 @@ export interface ChatHistoryListProps {
   disableRowLinks?: boolean;
 }
 
+// The placeholder must stay `count`: component-kit catalogs merge last and
+// format this id with {count, plural, …}.
+const getFileCountLabel = (count: number) =>
+  t({
+    id: "chat.history.files.count",
+    message: plural(count, { 0: "No files", one: "# file", other: "# files" }),
+  });
+
 const ChatHistoryListItem = memo<{
   session: ChatSession;
   isActive: boolean;
@@ -213,6 +220,7 @@ const ChatHistoryListItem = memo<{
             id: "chat.history.menu.pin",
             message: "Pin",
           });
+    const fileCountLabel = getFileCountLabel(session.metadata?.fileCount ?? 0);
     const rowBody = (
       // Row owns the row geometry, the selected fill and the hover tint; the
       // column flow stays here because the sidebar variant sets no axis.
@@ -297,13 +305,22 @@ const ChatHistoryListItem = memo<{
                   ? []
                   : [
                       {
-                        label: t`Remove`,
+                        label: t({
+                          id: "chat.history.menu.remove",
+                          message: "Remove",
+                        }),
                         icon: <Trash className="size-4" />,
                         variant: "danger" as const,
                         onClick: onArchive ?? (() => {}),
                         confirmAction: true,
-                        confirmTitle: t`Confirm Removal`,
-                        confirmMessage: t`Are you sure you want to remove this chat?`,
+                        confirmTitle: t({
+                          id: "chat.history.menu.confirm_remove.title",
+                          message: "Confirm Removal",
+                        }),
+                        confirmMessage: t({
+                          id: "chat.history.menu.confirm_remove.message",
+                          message: "Are you sure you want to remove this chat?",
+                        }),
                       },
                     ]),
               ]}
@@ -328,20 +345,9 @@ const ChatHistoryListItem = memo<{
                   ? "text-theme-fg-muted"
                   : "text-theme-fg-secondary",
               )}
-              title={
-                session.metadata?.fileCount === 0
-                  ? t`No files`
-                  : session.metadata?.fileCount === 1
-                    ? t`1 file`
-                    : `${session.metadata?.fileCount ?? 0} files`
-              }
+              title={fileCountLabel}
             >
-              <Plural
-                value={session.metadata?.fileCount ?? 0}
-                _0="No files"
-                one="# file"
-                other="# files"
-              />
+              {fileCountLabel}
             </p>
             {updatedAtDate && (
               <p className="text-xs text-theme-fg-secondary">
@@ -494,7 +500,10 @@ export const ChatHistoryList = memo<ChatHistoryListProps>(
             ref={loadMoreSentinelRef}
             className="flex justify-center py-2"
             data-ui="chat-history-load-more-sentinel"
-            aria-label={t`Loading...`}
+            aria-label={t({
+              id: "chat.history.loading_more",
+              message: "Loading...",
+            })}
           >
             {isLoadingMore && <SpinnerIcon size="md" aria-hidden />}
           </div>

--- a/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
+++ b/frontend/src/components/ui/FileUpload/AttachmentTile.tsx
@@ -85,7 +85,7 @@ const RemoveButton: React.FC<{
       onRemove();
     }}
     disabled={disabled}
-    aria-label={`${t`Remove`} ${filename}`}
+    aria-label={`${t({ id: "common.remove", message: "Remove" })} ${filename}`}
     className={clsx(
       // Overhangs just far enough to clear the tile's own content without
       // reaching into the neighbouring tile across the gap.
@@ -236,7 +236,7 @@ export const AttachmentTile: React.FC<AttachmentTileProps> = ({
           type="button"
           onClick={onActivate}
           title={filename}
-          aria-label={`${activateLabel ?? t`Preview attachment`} ${filename}, ${metaLabel}`}
+          aria-label={`${activateLabel ?? t({ id: "chat.file.preview_attachment", message: "Preview attachment" })} ${filename}, ${metaLabel}`}
           className={clsx(
             "block w-full cursor-pointer rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] text-left",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-theme-focus focus-visible:ring-offset-2",

--- a/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
+++ b/frontend/src/components/ui/FileUpload/FilePreviewBase.tsx
@@ -316,7 +316,7 @@ export const FilePreviewBase: React.FC<FilePreviewBaseProps> = ({
             onClick={(e) => handleRemove(e)}
             disabled={disabled}
             className={FILE_PREVIEW_STYLES.closeButton}
-            aria-label={`${t`Remove`} ${filename}`}
+            aria-label={`${t({ id: "common.remove", message: "Remove" })} ${filename}`}
           >
             <CloseIcon className="size-4" />
           </button>

--- a/frontend/src/components/ui/FileUpload/FilePreviewButton.tsx
+++ b/frontend/src/components/ui/FileUpload/FilePreviewButton.tsx
@@ -62,7 +62,7 @@ export const FilePreviewButton = memo<FilePreviewButtonProps>(
         variant="icon-only"
         size="sm"
         icon={<CloseIcon className="size-4" />}
-        aria-label={`${t`Remove`} ${(file as File).name || (file as FileUploadItem).filename}`}
+        aria-label={`${t({ id: "common.remove", message: "Remove" })} ${(file as File).name || (file as FileUploadItem).filename}`}
         onClick={(e) => {
           // Stop event propagation to prevent triggering parent container's click
           e.stopPropagation();

--- a/frontend/src/components/ui/FileUpload/FilePreviewLoading.tsx
+++ b/frontend/src/components/ui/FileUpload/FilePreviewLoading.tsx
@@ -15,7 +15,7 @@ interface FilePreviewLoadingProps {
 
 export const FilePreviewLoading = memo<FilePreviewLoadingProps>(
   ({
-    label = t`Loading file...`,
+    label = t({ id: "chat.file.loading", message: "Loading file..." }),
     description = t`Please wait`,
     className = "",
   }) => {

--- a/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+++ b/frontend/src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
@@ -1,4 +1,4 @@
-import { t } from "@lingui/core/macro";
+import { plural, t } from "@lingui/core/macro";
 import clsx from "clsx";
 import { useState } from "react";
 
@@ -172,6 +172,23 @@ type ItemWithFile = Extract<
   { kind: "attachment" | "selectableAttachment" | "context" }
 >;
 
+// The placeholder must stay `count`: component-kit catalogs merge last and
+// format these ids with {count, plural, …}.
+const getItemCountLabel = (count: number) =>
+  t({
+    id: "chat.attachments.items.count",
+    message: plural(count, { one: "# item", other: "# items" }),
+  });
+
+const getShowMoreItemsLabel = (count: number) =>
+  t({
+    id: "chat.attachments.show_more.count",
+    message: plural(count, {
+      one: "Show # more item",
+      other: "Show # more items",
+    }),
+  });
+
 function getFileKey(item: ItemWithFile): string {
   if ("id" in item.file) {
     return item.file.id;
@@ -265,7 +282,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
       onChange={onToggle}
       disabled={disabled}
       className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
-      aria-label={`${t`Include`} ${filename}`}
+      aria-label={`${t({ id: "chat.attachments.include", message: "Include" })} ${filename}`}
     />
   ) : null;
 
@@ -281,7 +298,7 @@ const SelectableAttachmentRow: React.FC<SelectableAttachmentRowProps> = ({
           onClick={onPreview}
           useDiv={true}
           className="min-w-0 flex-1 cursor-pointer rounded-[var(--attachment-tile-radius,var(--theme-radius-base))] hover:bg-theme-bg-accent"
-          aria-label={`${t`Preview attachment`} ${filename}`}
+          aria-label={`${t({ id: "chat.file.preview_attachment", message: "Preview attachment" })} ${filename}`}
         >
           {chip}
         </InteractiveContainer>
@@ -500,8 +517,7 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
               </h3>
               {group.metaLabel !== "" && (
                 <p className={FILE_PREVIEW_STYLES.group.meta}>
-                  {group.metaLabel ??
-                    (itemCount === 1 ? t`1 item` : t`${itemCount} items`)}
+                  {group.metaLabel ?? getItemCountLabel(itemCount)}
                 </p>
               )}
             </div>
@@ -543,7 +559,10 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                       onClick={() => setGroupExpanded(group.id, false)}
                       className={FILE_PREVIEW_STYLES.group.toggleButton}
                     >
-                      {t`Show less`}
+                      {t({
+                        id: "chat.attachments.show_less",
+                        message: "Show less",
+                      })}
                     </Button>
                   )}
                 </div>
@@ -563,7 +582,13 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                   >
                     <SpinnerIcon
                       size="md"
-                      srText={item.label ?? t`Loading attachment...`}
+                      srText={
+                        item.label ??
+                        t({
+                          id: "chat.attachments.loading",
+                          message: "Loading attachment...",
+                        })
+                      }
                     />
                     {item.description ? (
                       <span className="sr-only">{item.description}</span>
@@ -667,9 +692,7 @@ export const DefaultGroupedFileAttachmentsPreview: React.FC<
                 onClick={() => setGroupExpanded(group.id, true)}
                 className={FILE_PREVIEW_STYLES.group.moreButton}
               >
-                {hiddenCount === 1
-                  ? t`Show 1 more item`
-                  : t`Show ${hiddenCount} more items`}
+                {getShowMoreItemsLabel(hiddenCount)}
               </Button>
             )}
 

--- a/frontend/src/components/ui/FileUpload/ThreadMessageCard.tsx
+++ b/frontend/src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -102,7 +102,7 @@ export const ThreadMessageCard: React.FC<ThreadMessageCardProps> = ({
               className="inline-flex size-4 shrink-0 items-center justify-center text-theme-fg-muted"
               aria-expanded={!collapsed}
               aria-controls={panelId}
-              aria-label={`${t`Toggle attachments`} ${label}`}
+              aria-label={`${t({ id: "chat.attachments.toggle", message: "Toggle attachments" })} ${label}`}
             >
               {collapsed ? (
                 <ChevronRightIcon className="size-4" />
@@ -120,7 +120,7 @@ export const ThreadMessageCard: React.FC<ThreadMessageCardProps> = ({
               onChange={onToggle}
               disabled={disabled}
               className="size-4 shrink-0 rounded border-theme-border text-theme-fg-accent focus:ring-theme-focus disabled:cursor-not-allowed"
-              aria-label={`${t`Include message`} ${label}`}
+              aria-label={`${t({ id: "chat.attachments.include_message", message: "Include message" })} ${label}`}
               onClick={(event) => event.stopPropagation()}
             />
           )}

--- a/frontend/src/components/ui/Teams/TeamsConversationView.tsx
+++ b/frontend/src/components/ui/Teams/TeamsConversationView.tsx
@@ -365,7 +365,7 @@ const AssetRow: React.FC<
       onClick={preview}
       fullWidth={false}
       className="min-w-0 rounded-[var(--theme-radius-base)] text-left hover:bg-theme-bg-accent"
-      aria-label={`${t`Preview attachment`} ${label}`}
+      aria-label={`${t({ id: "chat.file.preview_attachment", message: "Preview attachment" })} ${label}`}
     >
       {chip}
     </InteractiveContainer>

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -339,6 +339,11 @@ msgstr "Assistentenkonfiguration anzeigen"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.configuration.title"
+msgstr "Konfiguration"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.delegated.empty"
 msgstr "Noch keine delegierten Läufe."
 
@@ -359,6 +364,11 @@ msgstr "Aus einer unbenannten Unterhaltung"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.edit"
+msgstr "Assistenten-Einstellungen bearbeiten"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible"
 msgstr "Einige Standarddateien sind wegen fehlender Berechtigungen nicht zugänglich."
 
@@ -366,6 +376,21 @@ msgstr "Einige Standarddateien sind wegen fehlender Berechtigungen nicht zugäng
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible.contact"
 msgstr "Kontaktieren Sie diesen Ersteller und bitten Sie ihn, die Dateien zu teilen:"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.files.title"
+msgstr "Standarddateien"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.history"
+msgstr "Deine Unterhaltungen mit diesem Assistenten"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.more_conversations.count"
+msgstr "{count, plural, one {Und # weitere Unterhaltung...} other {Und # weitere Unterhaltungen...}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -381,6 +406,11 @@ msgstr "Chats"
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.segment.delegated"
 msgstr "Delegierte Läufe"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.system_prompt"
+msgstr "System-Prompt"
 
 #. js-lingui-explicit-id
 #: src/pages/AssistantHubDetailPage.tsx
@@ -1425,6 +1455,41 @@ msgid "chat.attachment.teamsImage"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.include"
+msgstr "Einbeziehen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.include_message"
+msgstr "Nachricht einbeziehen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.items.count"
+msgstr "{count, plural, one {# Element} other {# Elemente}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.loading"
+msgstr "Anhang wird geladen..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_less"
+msgstr "Weniger anzeigen"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_more.count"
+msgstr "{count, plural, one {# weiteres Element anzeigen} other {# weitere Elemente anzeigen}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.toggle"
+msgstr "Anhänge umschalten"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
 msgid "chat.conversation.aria"
 msgstr "Chat-Unterhaltung"
@@ -1475,9 +1540,16 @@ msgstr "Tool {facetDisplayName} abwählen"
 #~ msgstr "Fehler beim Laden der Datei"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatMessage.tsx
-#~ msgid "chat.file.loading"
-#~ msgstr "Datei wird geladen..."
+#: src/components/ui/FileUpload/FilePreviewLoading.tsx
+msgid "chat.file.loading"
+msgstr "Datei wird geladen..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Teams/TeamsConversationView.tsx
+msgid "chat.file.preview_attachment"
+msgstr "Anhang anzeigen"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
@@ -1508,6 +1580,11 @@ msgstr "Delegierte Läufe ({runCount})"
 #: src/components/ui/Chat/DelegatedRunsSection.tsx
 msgid "chat.history.delegatedRuns.toggleStatus"
 msgstr "Delegierte Läufe ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "chat.history.files.count"
+msgstr "{count, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -1660,6 +1737,24 @@ msgid "chat.history.group.unread"
 msgstr "Ungelesen"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.loading_more"
+msgstr "Laden..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.message"
+msgstr "Möchten Sie diesen Chat wirklich entfernen?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.title"
+msgstr "Entfernung bestätigen"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
@@ -1672,6 +1767,12 @@ msgstr "Anheften"
 #: src/pages/SearchPage.tsx
 msgid "chat.history.menu.pinLimitReached"
 msgstr "Anheftlimit erreicht"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.remove"
+msgstr "Entfernen"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryList.tsx
@@ -2478,6 +2579,13 @@ msgstr "Nicht festgelegt"
 #: src/pages/AssistantHubSubmitPage.tsx
 msgid "common.preview"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/FilePreviewBase.tsx
+#: src/components/ui/FileUpload/FilePreviewButton.tsx
+msgid "common.remove"
+msgstr "Entfernen"
 
 #. js-lingui-explicit-id
 #: src/pages/assistantHubUtils.tsx
@@ -4205,10 +4313,9 @@ msgstr " Dateianhänge beanspruchen {fileTokensFormatted} Token."
 msgid "(no body)"
 msgstr ""
 
-#. placeholder {0}: session.metadata?.fileCount ?? 0
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
-msgstr "{0, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
+#~ msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgstr "{0, plural, =0 {Keine Dateien} one {# Datei} other {# Dateien}}"
 
 #. placeholder {0}: queuedMessage.attachedFiles.length
 #: src/components/ui/Chat/ChatInput.tsx
@@ -4237,8 +4344,8 @@ msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "{itemCount} items"
-msgstr "{itemCount} Elemente"
+#~ msgid "{itemCount} items"
+#~ msgstr "{itemCount} Elemente"
 
 #: src/utils/teams/teamsSentAttachmentGroups.ts
 msgid "{sharedCount} shared files"
@@ -4296,7 +4403,6 @@ msgstr "• Hinweis: Sprachänderungen werden beim Neuladen der Seite nicht gesp
 msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• \"Auf Browsererkennung zurücksetzen\" verwenden, um die Erkennung neu zu testen"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -4304,8 +4410,8 @@ msgid "1 file"
 msgstr "1 Datei"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "1 item"
-msgstr "1 Element"
+#~ msgid "1 item"
+#~ msgstr "1 Element"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "1 message could not be loaded."
@@ -4332,8 +4438,8 @@ msgid "All file types accepted"
 msgstr "Alle Dateitypen akzeptiert"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "And"
-msgstr "Und"
+#~ msgid "And"
+#~ msgstr "Und"
 
 #: src/components/ui/DesktopSidecar/SidecarLocalAnswerPanel.tsx
 msgid "Answer from this device"
@@ -4362,8 +4468,8 @@ msgstr "Möchten Sie wirklich fortfahren?"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Are you sure you want to remove this chat?"
-msgstr "Möchten Sie diesen Chat wirklich entfernen?"
+#~ msgid "Are you sure you want to remove this chat?"
+#~ msgstr "Möchten Sie diesen Chat wirklich entfernen?"
 
 #: src/components/ui/Feedback/Avatar.tsx
 msgid "Assistant avatar"
@@ -4651,8 +4757,8 @@ msgid "Completed"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Configuration"
-msgstr "Konfiguration"
+#~ msgid "Configuration"
+#~ msgstr "Konfiguration"
 
 #: src/pages/AssistantCreatePage.tsx
 #~ msgid "Configure a custom assistant with specific instructions and capabilities"
@@ -4677,8 +4783,8 @@ msgstr "Aktion bestätigen"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Confirm Removal"
-msgstr "Entfernung bestätigen"
+#~ msgid "Confirm Removal"
+#~ msgstr "Entfernung bestätigen"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"
@@ -4786,7 +4892,6 @@ msgid "Date"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Default Files"
 msgstr "Standarddateien"
 
@@ -4876,8 +4981,8 @@ msgstr "Bearbeiten"
 #~ msgstr "Assistent bearbeiten"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Edit Assistant Settings"
-msgstr "Assistenten-Einstellungen bearbeiten"
+#~ msgid "Edit Assistant Settings"
+#~ msgstr "Assistenten-Einstellungen bearbeiten"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit queued message"
@@ -5046,12 +5151,12 @@ msgid "In Progress"
 msgstr "In Bearbeitung"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Include"
-msgstr "Einbeziehen"
+#~ msgid "Include"
+#~ msgstr "Einbeziehen"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Include message"
-msgstr "Nachricht einbeziehen"
+#~ msgid "Include message"
+#~ msgstr "Nachricht einbeziehen"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 #~ msgid "Input Parameters"
@@ -5107,21 +5212,19 @@ msgstr "Laden"
 #~ msgstr ""
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Loading attachment..."
-msgstr ""
+#~ msgid "Loading attachment..."
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
 msgid "Loading conversation…"
 msgstr "Unterhaltung wird geladen …"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
-msgid "Loading file..."
-msgstr ""
+#~ msgid "Loading file..."
+#~ msgstr ""
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/Chat/ModelSelector.tsx
 #: src/components/ui/Message/LoadMoreButton.tsx
-#: src/pages/SearchPage.tsx
 msgid "Loading..."
 msgstr "Laden..."
 
@@ -5175,8 +5278,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "more conversations..."
-msgstr ""
+#~ msgid "more conversations..."
+#~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "My Assistant"
@@ -5209,8 +5312,8 @@ msgid "No chats found"
 msgstr "Keine Chats gefunden"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "No files"
-msgstr ""
+#~ msgid "No files"
+#~ msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "No messages yet"
@@ -5292,8 +5395,8 @@ msgstr ""
 #: src/components/ui/FileUpload/AttachmentTile.tsx
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Teams/TeamsConversationView.tsx
-msgid "Preview attachment"
-msgstr "Anhang anzeigen"
+#~ msgid "Preview attachment"
+#~ msgstr "Anhang anzeigen"
 
 #: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/Modal/FilePreviewModal.tsx
@@ -5389,8 +5492,8 @@ msgstr "Verbleibender Kontext: {remainingContextPercentage}%"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 #: src/components/ui/FileUpload/FilePreviewButton.tsx
 #: src/pages/SearchPage.tsx
-msgid "Remove"
-msgstr "Entfernen"
+#~ msgid "Remove"
+#~ msgstr "Entfernen"
 
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 msgid "Remove all"
@@ -5493,12 +5596,12 @@ msgid "Show"
 msgstr "Anzeigen"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show {hiddenCount} more items"
-msgstr "{hiddenCount} weitere Elemente anzeigen"
+#~ msgid "Show {hiddenCount} more items"
+#~ msgstr "{hiddenCount} weitere Elemente anzeigen"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show 1 more item"
-msgstr "1 weiteres Element anzeigen"
+#~ msgid "Show 1 more item"
+#~ msgstr "1 weiteres Element anzeigen"
 
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show all {lineCount} lines"
@@ -5508,7 +5611,6 @@ msgstr ""
 msgid "Show details"
 msgstr "Details anzeigen"
 
-#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Weniger anzeigen"
@@ -5633,7 +5735,6 @@ msgid "Supported Locales:"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "System Prompt"
 msgstr ""
 
@@ -5728,8 +5829,8 @@ msgid "To"
 msgstr ""
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Toggle attachments"
-msgstr "Anhänge umschalten"
+#~ msgid "Toggle attachments"
+#~ msgstr "Anhänge umschalten"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
@@ -5884,5 +5985,5 @@ msgstr "Ihre Frage: {query}"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Your conversations with this assistant"
-msgstr "Deine Unterhaltungen mit diesem Assistenten"
+#~ msgid "Your conversations with this assistant"
+#~ msgstr "Deine Unterhaltungen mit diesem Assistenten"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -339,6 +339,11 @@ msgstr "View assistant configuration"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.configuration.title"
+msgstr "Configuration"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.delegated.empty"
 msgstr "No delegated runs yet."
 
@@ -359,6 +364,11 @@ msgstr "From an untitled conversation"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.edit"
+msgstr "Edit Assistant Settings"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible"
 msgstr "Some default files are inaccessible due to missing permissions."
 
@@ -366,6 +376,21 @@ msgstr "Some default files are inaccessible due to missing permissions."
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible.contact"
 msgstr "Contact this creator and ask them to share the files:"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.files.title"
+msgstr "Default Files"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.history"
+msgstr "Your conversations with this assistant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.more_conversations.count"
+msgstr "{count, plural, one {And # more conversation...} other {And # more conversations...}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -381,6 +406,11 @@ msgstr "Chats"
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.segment.delegated"
 msgstr "Delegated runs"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.system_prompt"
+msgstr "System Prompt"
 
 #. js-lingui-explicit-id
 #: src/pages/AssistantHubDetailPage.tsx
@@ -1425,6 +1455,41 @@ msgid "chat.attachment.teamsImage"
 msgstr "Image"
 
 #. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.include"
+msgstr "Include"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.include_message"
+msgstr "Include message"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.items.count"
+msgstr "{count, plural, one {# item} other {# items}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.loading"
+msgstr "Loading attachment..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_less"
+msgstr "Show less"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_more.count"
+msgstr "{count, plural, one {Show # more item} other {Show # more items}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.toggle"
+msgstr "Toggle attachments"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
 msgid "chat.conversation.aria"
 msgstr "Chat conversation"
@@ -1475,9 +1540,16 @@ msgstr "Deselect {facetDisplayName}"
 #~ msgstr "Error loading file"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatMessage.tsx
-#~ msgid "chat.file.loading"
-#~ msgstr "Loading file..."
+#: src/components/ui/FileUpload/FilePreviewLoading.tsx
+msgid "chat.file.loading"
+msgstr "Loading file..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Teams/TeamsConversationView.tsx
+msgid "chat.file.preview_attachment"
+msgstr "Preview attachment"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
@@ -1508,6 +1580,11 @@ msgstr "Delegated runs ({runCount})"
 #: src/components/ui/Chat/DelegatedRunsSection.tsx
 msgid "chat.history.delegatedRuns.toggleStatus"
 msgstr "Delegated runs ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "chat.history.files.count"
+msgstr "{count, plural, =0 {No files} one {# file} other {# files}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -1660,6 +1737,24 @@ msgid "chat.history.group.unread"
 msgstr "Unread"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.loading_more"
+msgstr "Loading..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.message"
+msgstr "Are you sure you want to remove this chat?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.title"
+msgstr "Confirm Removal"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
@@ -1672,6 +1767,12 @@ msgstr "Pin"
 #: src/pages/SearchPage.tsx
 msgid "chat.history.menu.pinLimitReached"
 msgstr "Pin limit reached"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.remove"
+msgstr "Remove"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryList.tsx
@@ -2478,6 +2579,13 @@ msgstr "Not set"
 #: src/pages/AssistantHubSubmitPage.tsx
 msgid "common.preview"
 msgstr "Preview"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/FilePreviewBase.tsx
+#: src/components/ui/FileUpload/FilePreviewButton.tsx
+msgid "common.remove"
+msgstr "Remove"
 
 #. js-lingui-explicit-id
 #: src/pages/assistantHubUtils.tsx
@@ -4205,10 +4313,9 @@ msgstr " File attachments account for {fileTokensFormatted} tokens."
 msgid "(no body)"
 msgstr "(no body)"
 
-#. placeholder {0}: session.metadata?.fileCount ?? 0
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
-msgstr "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgstr "{0, plural, =0 {No files} one {# file} other {# files}}"
 
 #. placeholder {0}: queuedMessage.attachedFiles.length
 #: src/components/ui/Chat/ChatInput.tsx
@@ -4237,8 +4344,8 @@ msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "{itemCount} items"
-msgstr "{itemCount} items"
+#~ msgid "{itemCount} items"
+#~ msgstr "{itemCount} items"
 
 #: src/utils/teams/teamsSentAttachmentGroups.ts
 msgid "{sharedCount} shared files"
@@ -4296,7 +4403,6 @@ msgstr "• Note: Locale changes are not persisted across page refreshes"
 msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Use \"Reset to Browser Detection\" to test fresh detection"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -4304,8 +4410,8 @@ msgid "1 file"
 msgstr "1 file"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "1 item"
-msgstr "1 item"
+#~ msgid "1 item"
+#~ msgstr "1 item"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "1 message could not be loaded."
@@ -4332,8 +4438,8 @@ msgid "All file types accepted"
 msgstr "All file types accepted"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "And"
-msgstr "And"
+#~ msgid "And"
+#~ msgstr "And"
 
 #: src/components/ui/DesktopSidecar/SidecarLocalAnswerPanel.tsx
 msgid "Answer from this device"
@@ -4362,8 +4468,8 @@ msgstr "Are you sure you want to proceed?"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Are you sure you want to remove this chat?"
-msgstr "Are you sure you want to remove this chat?"
+#~ msgid "Are you sure you want to remove this chat?"
+#~ msgstr "Are you sure you want to remove this chat?"
 
 #: src/components/ui/Feedback/Avatar.tsx
 msgid "Assistant avatar"
@@ -4651,8 +4757,8 @@ msgid "Completed"
 msgstr "Completed"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Configuration"
-msgstr "Configuration"
+#~ msgid "Configuration"
+#~ msgstr "Configuration"
 
 #: src/pages/AssistantCreatePage.tsx
 #~ msgid "Configure a custom assistant with specific instructions and capabilities"
@@ -4677,8 +4783,8 @@ msgstr "Confirm Action"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Confirm Removal"
-msgstr "Confirm Removal"
+#~ msgid "Confirm Removal"
+#~ msgstr "Confirm Removal"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"
@@ -4786,7 +4892,6 @@ msgid "Date"
 msgstr "Date"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Default Files"
 msgstr "Default Files"
 
@@ -4876,8 +4981,8 @@ msgstr "Edit"
 #~ msgstr "Edit Assistant"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Edit Assistant Settings"
-msgstr "Edit Assistant Settings"
+#~ msgid "Edit Assistant Settings"
+#~ msgstr "Edit Assistant Settings"
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit queued message"
@@ -5046,12 +5151,12 @@ msgid "In Progress"
 msgstr "In Progress"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Include"
-msgstr "Include"
+#~ msgid "Include"
+#~ msgstr "Include"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Include message"
-msgstr "Include message"
+#~ msgid "Include message"
+#~ msgstr "Include message"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 #~ msgid "Input Parameters"
@@ -5107,21 +5212,19 @@ msgstr "Loading"
 #~ msgstr "Loading assistants..."
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Loading attachment..."
-msgstr "Loading attachment..."
+#~ msgid "Loading attachment..."
+#~ msgstr "Loading attachment..."
 
 #: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
 msgid "Loading conversation…"
 msgstr "Loading conversation…"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
-msgid "Loading file..."
-msgstr "Loading file..."
+#~ msgid "Loading file..."
+#~ msgstr "Loading file..."
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/Chat/ModelSelector.tsx
 #: src/components/ui/Message/LoadMoreButton.tsx
-#: src/pages/SearchPage.tsx
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -5175,8 +5278,8 @@ msgstr "Microphone permission denied. Allow microphone access and try again."
 #~ msgstr "Microphone settings:"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "more conversations..."
-msgstr "more conversations..."
+#~ msgid "more conversations..."
+#~ msgstr "more conversations..."
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "My Assistant"
@@ -5209,8 +5312,8 @@ msgid "No chats found"
 msgstr "No chats found"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "No files"
-msgstr "No files"
+#~ msgid "No files"
+#~ msgstr "No files"
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "No messages yet"
@@ -5292,8 +5395,8 @@ msgstr "Please wait"
 #: src/components/ui/FileUpload/AttachmentTile.tsx
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Teams/TeamsConversationView.tsx
-msgid "Preview attachment"
-msgstr "Preview attachment"
+#~ msgid "Preview attachment"
+#~ msgstr "Preview attachment"
 
 #: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/Modal/FilePreviewModal.tsx
@@ -5389,8 +5492,8 @@ msgstr "Remaining context: {remainingContextPercentage}%"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 #: src/components/ui/FileUpload/FilePreviewButton.tsx
 #: src/pages/SearchPage.tsx
-msgid "Remove"
-msgstr "Remove"
+#~ msgid "Remove"
+#~ msgstr "Remove"
 
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 msgid "Remove all"
@@ -5493,12 +5596,12 @@ msgid "Show"
 msgstr "Show"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show {hiddenCount} more items"
-msgstr "Show {hiddenCount} more items"
+#~ msgid "Show {hiddenCount} more items"
+#~ msgstr "Show {hiddenCount} more items"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show 1 more item"
-msgstr "Show 1 more item"
+#~ msgid "Show 1 more item"
+#~ msgstr "Show 1 more item"
 
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show all {lineCount} lines"
@@ -5508,7 +5611,6 @@ msgstr "Show all {lineCount} lines"
 msgid "Show details"
 msgstr "Show details"
 
-#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Show less"
@@ -5633,7 +5735,6 @@ msgid "Supported Locales:"
 msgstr "Supported Locales:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "System Prompt"
 msgstr "System Prompt"
 
@@ -5728,8 +5829,8 @@ msgid "To"
 msgstr "To"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Toggle attachments"
-msgstr "Toggle attachments"
+#~ msgid "Toggle attachments"
+#~ msgstr "Toggle attachments"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
@@ -5884,5 +5985,5 @@ msgstr "You asked: {query}"
 #~ msgstr "You don't have permission to edit this assistant. Only the owner can modify assistant settings."
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Your conversations with this assistant"
-msgstr "Your conversations with this assistant"
+#~ msgid "Your conversations with this assistant"
+#~ msgstr "Your conversations with this assistant"

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -339,6 +339,11 @@ msgstr "Ver configuración del asistente"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.configuration.title"
+msgstr "Configuración"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.delegated.empty"
 msgstr "Todavía no hay ejecuciones delegadas."
 
@@ -359,6 +364,11 @@ msgstr "Desde una conversación sin título"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.edit"
+msgstr "Editar la configuración del asistente"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible"
 msgstr "Algunos archivos predeterminados son inaccesibles debido a permisos faltantes."
 
@@ -366,6 +376,21 @@ msgstr "Algunos archivos predeterminados son inaccesibles debido a permisos falt
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible.contact"
 msgstr "Contacta con este creador y pídele que comparta los archivos:"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.files.title"
+msgstr "Archivos predeterminados"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.history"
+msgstr "Tus conversaciones con este asistente"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.more_conversations.count"
+msgstr "{count, plural, one {Y # conversación más...} other {Y # conversaciones más...}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -381,6 +406,11 @@ msgstr "Chats"
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.segment.delegated"
 msgstr "Ejecuciones delegadas"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.system_prompt"
+msgstr "Prompt del sistema"
 
 #. js-lingui-explicit-id
 #: src/pages/AssistantHubDetailPage.tsx
@@ -1425,6 +1455,41 @@ msgid "chat.attachment.teamsImage"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.include"
+msgstr "Incluir"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.include_message"
+msgstr "Incluir mensaje"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.items.count"
+msgstr "{count, plural, one {# elemento} other {# elementos}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.loading"
+msgstr "Cargando archivo adjunto..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_less"
+msgstr "Mostrar menos"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_more.count"
+msgstr "{count, plural, one {Mostrar # elemento más} other {Mostrar # elementos más}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.toggle"
+msgstr "Alternar adjuntos"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
 msgid "chat.conversation.aria"
 msgstr "Conversación de chat"
@@ -1475,9 +1540,16 @@ msgstr "Deseleccionar {facetDisplayName}"
 #~ msgstr "Error al cargar el archivo"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatMessage.tsx
-#~ msgid "chat.file.loading"
-#~ msgstr "Cargando archivo..."
+#: src/components/ui/FileUpload/FilePreviewLoading.tsx
+msgid "chat.file.loading"
+msgstr "Cargando archivo..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Teams/TeamsConversationView.tsx
+msgid "chat.file.preview_attachment"
+msgstr "Vista previa del archivo adjunto"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
@@ -1508,6 +1580,11 @@ msgstr "Ejecuciones delegadas ({runCount})"
 #: src/components/ui/Chat/DelegatedRunsSection.tsx
 msgid "chat.history.delegatedRuns.toggleStatus"
 msgstr "Ejecuciones delegadas ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "chat.history.files.count"
+msgstr "{count, plural, =0 {Sin archivos} one {# archivo} other {# archivos}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -1660,6 +1737,24 @@ msgid "chat.history.group.unread"
 msgstr "No leídos"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.loading_more"
+msgstr "Cargando..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.message"
+msgstr "¿Está seguro de que desea eliminar este chat?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.title"
+msgstr "Confirmar eliminación"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
@@ -1672,6 +1767,12 @@ msgstr "Fijar"
 #: src/pages/SearchPage.tsx
 msgid "chat.history.menu.pinLimitReached"
 msgstr "Límite de fijados alcanzado"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.remove"
+msgstr "Eliminar"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryList.tsx
@@ -2478,6 +2579,13 @@ msgstr "No establecido"
 #: src/pages/AssistantHubSubmitPage.tsx
 msgid "common.preview"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/FilePreviewBase.tsx
+#: src/components/ui/FileUpload/FilePreviewButton.tsx
+msgid "common.remove"
+msgstr "Eliminar"
 
 #. js-lingui-explicit-id
 #: src/pages/assistantHubUtils.tsx
@@ -4205,10 +4313,9 @@ msgstr " Los archivos adjuntos ocupan {fileTokensFormatted} tokens."
 msgid "(no body)"
 msgstr ""
 
-#. placeholder {0}: session.metadata?.fileCount ?? 0
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
-msgstr "{0, plural, =0 {Sin archivos} one {# archivo} other {# archivos}}"
+#~ msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgstr "{0, plural, =0 {Sin archivos} one {# archivo} other {# archivos}}"
 
 #. placeholder {0}: queuedMessage.attachedFiles.length
 #: src/components/ui/Chat/ChatInput.tsx
@@ -4237,8 +4344,8 @@ msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "{itemCount} items"
-msgstr "{itemCount} elementos"
+#~ msgid "{itemCount} items"
+#~ msgstr "{itemCount} elementos"
 
 #: src/utils/teams/teamsSentAttachmentGroups.ts
 msgid "{sharedCount} shared files"
@@ -4296,7 +4403,6 @@ msgstr "• Nota: Los cambios de idioma no se guardan al actualizar la página"
 msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Use \"Restablecer a detección del navegador\" para probar detección nueva"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -4304,8 +4410,8 @@ msgid "1 file"
 msgstr "1 archivo"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "1 item"
-msgstr "1 elemento"
+#~ msgid "1 item"
+#~ msgstr "1 elemento"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "1 message could not be loaded."
@@ -4332,8 +4438,8 @@ msgid "All file types accepted"
 msgstr "Todos los tipos de archivo aceptados"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "And"
-msgstr ""
+#~ msgid "And"
+#~ msgstr ""
 
 #: src/components/ui/DesktopSidecar/SidecarLocalAnswerPanel.tsx
 msgid "Answer from this device"
@@ -4362,8 +4468,8 @@ msgstr "¿Está seguro de que desea continuar?"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Are you sure you want to remove this chat?"
-msgstr "¿Está seguro de que desea eliminar este chat?"
+#~ msgid "Are you sure you want to remove this chat?"
+#~ msgstr "¿Está seguro de que desea eliminar este chat?"
 
 #: src/components/ui/Feedback/Avatar.tsx
 msgid "Assistant avatar"
@@ -4651,8 +4757,8 @@ msgid "Completed"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Configuration"
-msgstr ""
+#~ msgid "Configuration"
+#~ msgstr ""
 
 #: src/pages/AssistantCreatePage.tsx
 #~ msgid "Configure a custom assistant with specific instructions and capabilities"
@@ -4677,8 +4783,8 @@ msgstr "Confirmar acción"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Confirm Removal"
-msgstr "Confirmar eliminación"
+#~ msgid "Confirm Removal"
+#~ msgstr "Confirmar eliminación"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"
@@ -4786,7 +4892,6 @@ msgid "Date"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Default Files"
 msgstr ""
 
@@ -4876,8 +4981,8 @@ msgstr "Editar"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Edit Assistant Settings"
-msgstr ""
+#~ msgid "Edit Assistant Settings"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit queued message"
@@ -5046,12 +5151,12 @@ msgid "In Progress"
 msgstr "En progreso"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Include"
-msgstr "Incluir"
+#~ msgid "Include"
+#~ msgstr "Incluir"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Include message"
-msgstr "Incluir mensaje"
+#~ msgid "Include message"
+#~ msgstr "Incluir mensaje"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 #~ msgid "Input Parameters"
@@ -5107,21 +5212,19 @@ msgstr "Cargando"
 #~ msgstr ""
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Loading attachment..."
-msgstr ""
+#~ msgid "Loading attachment..."
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
 msgid "Loading conversation…"
 msgstr "Cargando la conversación…"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
-msgid "Loading file..."
-msgstr ""
+#~ msgid "Loading file..."
+#~ msgstr ""
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/Chat/ModelSelector.tsx
 #: src/components/ui/Message/LoadMoreButton.tsx
-#: src/pages/SearchPage.tsx
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -5175,8 +5278,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "more conversations..."
-msgstr ""
+#~ msgid "more conversations..."
+#~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "My Assistant"
@@ -5209,8 +5312,8 @@ msgid "No chats found"
 msgstr "No se encontraron chats"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "No files"
-msgstr ""
+#~ msgid "No files"
+#~ msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "No messages yet"
@@ -5292,8 +5395,8 @@ msgstr ""
 #: src/components/ui/FileUpload/AttachmentTile.tsx
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Teams/TeamsConversationView.tsx
-msgid "Preview attachment"
-msgstr "Vista previa del archivo adjunto"
+#~ msgid "Preview attachment"
+#~ msgstr "Vista previa del archivo adjunto"
 
 #: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/Modal/FilePreviewModal.tsx
@@ -5389,8 +5492,8 @@ msgstr "Contexto restante: {remainingContextPercentage}%"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 #: src/components/ui/FileUpload/FilePreviewButton.tsx
 #: src/pages/SearchPage.tsx
-msgid "Remove"
-msgstr "Eliminar"
+#~ msgid "Remove"
+#~ msgstr "Eliminar"
 
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 msgid "Remove all"
@@ -5493,12 +5596,12 @@ msgid "Show"
 msgstr "Mostrar"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show {hiddenCount} more items"
-msgstr "Mostrar {hiddenCount} elementos más"
+#~ msgid "Show {hiddenCount} more items"
+#~ msgstr "Mostrar {hiddenCount} elementos más"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show 1 more item"
-msgstr "Mostrar 1 elemento más"
+#~ msgid "Show 1 more item"
+#~ msgstr "Mostrar 1 elemento más"
 
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show all {lineCount} lines"
@@ -5508,7 +5611,6 @@ msgstr ""
 msgid "Show details"
 msgstr "Mostrar detalles"
 
-#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Mostrar menos"
@@ -5633,7 +5735,6 @@ msgid "Supported Locales:"
 msgstr "Idiomas compatibles:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "System Prompt"
 msgstr ""
 
@@ -5728,8 +5829,8 @@ msgid "To"
 msgstr ""
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Toggle attachments"
-msgstr "Alternar adjuntos"
+#~ msgid "Toggle attachments"
+#~ msgstr "Alternar adjuntos"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
@@ -5884,5 +5985,5 @@ msgstr "Tu pregunta: {query}"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Your conversations with this assistant"
-msgstr "Tus conversaciones con este asistente"
+#~ msgid "Your conversations with this assistant"
+#~ msgstr "Tus conversaciones con este asistente"

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -339,6 +339,11 @@ msgstr "Afficher la configuration de l'assistant"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.configuration.title"
+msgstr "Configuration"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.delegated.empty"
 msgstr "Aucune exécution déléguée pour le moment."
 
@@ -359,6 +364,11 @@ msgstr "Depuis une conversation sans titre"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.edit"
+msgstr "Modifier les paramètres de l'assistant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible"
 msgstr "Certains fichiers par défaut sont inaccessibles en raison de permissions insuffisantes."
 
@@ -366,6 +376,21 @@ msgstr "Certains fichiers par défaut sont inaccessibles en raison de permission
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible.contact"
 msgstr "Contactez ce créateur et demandez-lui de partager les fichiers :"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.files.title"
+msgstr "Fichiers par défaut"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.history"
+msgstr "Vos conversations avec cet assistant"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.more_conversations.count"
+msgstr "{count, plural, one {Et # autre conversation...} other {Et # autres conversations...}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -381,6 +406,11 @@ msgstr "Chats"
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.segment.delegated"
 msgstr "Exécutions déléguées"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.system_prompt"
+msgstr "Prompt système"
 
 #. js-lingui-explicit-id
 #: src/pages/AssistantHubDetailPage.tsx
@@ -1425,6 +1455,41 @@ msgid "chat.attachment.teamsImage"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.include"
+msgstr "Inclure"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.include_message"
+msgstr "Inclure le message"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.items.count"
+msgstr "{count, plural, one {# élément} other {# éléments}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.loading"
+msgstr "Chargement de la pièce jointe..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_less"
+msgstr "Afficher moins"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_more.count"
+msgstr "{count, plural, one {Afficher # élément de plus} other {Afficher # éléments de plus}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.toggle"
+msgstr "Afficher ou masquer les pièces jointes"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
 msgid "chat.conversation.aria"
 msgstr "Conversation de chat"
@@ -1475,9 +1540,16 @@ msgstr "Désélectionner {facetDisplayName}"
 #~ msgstr "Erreur lors du chargement du fichier"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatMessage.tsx
-#~ msgid "chat.file.loading"
-#~ msgstr "Chargement du fichier..."
+#: src/components/ui/FileUpload/FilePreviewLoading.tsx
+msgid "chat.file.loading"
+msgstr "Chargement du fichier..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Teams/TeamsConversationView.tsx
+msgid "chat.file.preview_attachment"
+msgstr "Aperçu de la pièce jointe"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
@@ -1508,6 +1580,11 @@ msgstr "Exécutions déléguées ({runCount})"
 #: src/components/ui/Chat/DelegatedRunsSection.tsx
 msgid "chat.history.delegatedRuns.toggleStatus"
 msgstr "Exécutions déléguées ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "chat.history.files.count"
+msgstr "{count, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -1660,6 +1737,24 @@ msgid "chat.history.group.unread"
 msgstr "Non lus"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.loading_more"
+msgstr "Chargement..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.message"
+msgstr "Êtes-vous sûr de vouloir supprimer ce chat ?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.title"
+msgstr "Confirmer la suppression"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
@@ -1672,6 +1767,12 @@ msgstr "Épingler"
 #: src/pages/SearchPage.tsx
 msgid "chat.history.menu.pinLimitReached"
 msgstr "Limite d’épingles atteinte"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.remove"
+msgstr "Supprimer"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryList.tsx
@@ -2478,6 +2579,13 @@ msgstr "Non défini"
 #: src/pages/AssistantHubSubmitPage.tsx
 msgid "common.preview"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/FilePreviewBase.tsx
+#: src/components/ui/FileUpload/FilePreviewButton.tsx
+msgid "common.remove"
+msgstr "Supprimer"
 
 #. js-lingui-explicit-id
 #: src/pages/assistantHubUtils.tsx
@@ -4205,10 +4313,9 @@ msgstr " Les pièces jointes représentent {fileTokensFormatted} tokens."
 msgid "(no body)"
 msgstr ""
 
-#. placeholder {0}: session.metadata?.fileCount ?? 0
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
-msgstr "{0, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
+#~ msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgstr "{0, plural, =0 {Aucun fichier} one {# fichier} other {# fichiers}}"
 
 #. placeholder {0}: queuedMessage.attachedFiles.length
 #: src/components/ui/Chat/ChatInput.tsx
@@ -4237,8 +4344,8 @@ msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName} : {filePercentage}%"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "{itemCount} items"
-msgstr "{itemCount} éléments"
+#~ msgid "{itemCount} items"
+#~ msgstr "{itemCount} éléments"
 
 #: src/utils/teams/teamsSentAttachmentGroups.ts
 msgid "{sharedCount} shared files"
@@ -4296,7 +4403,6 @@ msgstr ""
 msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr ""
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -4304,8 +4410,8 @@ msgid "1 file"
 msgstr "1 fichier"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "1 item"
-msgstr "1 élément"
+#~ msgid "1 item"
+#~ msgstr "1 élément"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "1 message could not be loaded."
@@ -4332,8 +4438,8 @@ msgid "All file types accepted"
 msgstr "Tous les types de fichiers acceptés"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "And"
-msgstr ""
+#~ msgid "And"
+#~ msgstr ""
 
 #: src/components/ui/DesktopSidecar/SidecarLocalAnswerPanel.tsx
 msgid "Answer from this device"
@@ -4362,8 +4468,8 @@ msgstr "Êtes-vous sûr de vouloir continuer ?"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Are you sure you want to remove this chat?"
-msgstr "Êtes-vous sûr de vouloir supprimer ce chat ?"
+#~ msgid "Are you sure you want to remove this chat?"
+#~ msgstr "Êtes-vous sûr de vouloir supprimer ce chat ?"
 
 #: src/components/ui/Feedback/Avatar.tsx
 msgid "Assistant avatar"
@@ -4651,8 +4757,8 @@ msgid "Completed"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Configuration"
-msgstr ""
+#~ msgid "Configuration"
+#~ msgstr ""
 
 #: src/pages/AssistantCreatePage.tsx
 #~ msgid "Configure a custom assistant with specific instructions and capabilities"
@@ -4677,8 +4783,8 @@ msgstr "Confirmer l'action"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Confirm Removal"
-msgstr "Confirmer la suppression"
+#~ msgid "Confirm Removal"
+#~ msgstr "Confirmer la suppression"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"
@@ -4786,7 +4892,6 @@ msgid "Date"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Default Files"
 msgstr ""
 
@@ -4876,8 +4981,8 @@ msgstr "Modifier"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Edit Assistant Settings"
-msgstr ""
+#~ msgid "Edit Assistant Settings"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit queued message"
@@ -5046,12 +5151,12 @@ msgid "In Progress"
 msgstr "En cours"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Include"
-msgstr "Inclure"
+#~ msgid "Include"
+#~ msgstr "Inclure"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Include message"
-msgstr "Inclure le message"
+#~ msgid "Include message"
+#~ msgstr "Inclure le message"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 #~ msgid "Input Parameters"
@@ -5107,21 +5212,19 @@ msgstr "Chargement"
 #~ msgstr ""
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Loading attachment..."
-msgstr ""
+#~ msgid "Loading attachment..."
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
 msgid "Loading conversation…"
 msgstr "Chargement de la conversation…"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
-msgid "Loading file..."
-msgstr ""
+#~ msgid "Loading file..."
+#~ msgstr ""
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/Chat/ModelSelector.tsx
 #: src/components/ui/Message/LoadMoreButton.tsx
-#: src/pages/SearchPage.tsx
 msgid "Loading..."
 msgstr "Chargement..."
 
@@ -5175,8 +5278,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "more conversations..."
-msgstr ""
+#~ msgid "more conversations..."
+#~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "My Assistant"
@@ -5209,8 +5312,8 @@ msgid "No chats found"
 msgstr "Aucun chat trouvé"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "No files"
-msgstr ""
+#~ msgid "No files"
+#~ msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "No messages yet"
@@ -5292,8 +5395,8 @@ msgstr ""
 #: src/components/ui/FileUpload/AttachmentTile.tsx
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Teams/TeamsConversationView.tsx
-msgid "Preview attachment"
-msgstr "Aperçu de la pièce jointe"
+#~ msgid "Preview attachment"
+#~ msgstr "Aperçu de la pièce jointe"
 
 #: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/Modal/FilePreviewModal.tsx
@@ -5389,8 +5492,8 @@ msgstr "Contexte restant : {remainingContextPercentage}%"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 #: src/components/ui/FileUpload/FilePreviewButton.tsx
 #: src/pages/SearchPage.tsx
-msgid "Remove"
-msgstr "Supprimer"
+#~ msgid "Remove"
+#~ msgstr "Supprimer"
 
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 msgid "Remove all"
@@ -5493,12 +5596,12 @@ msgid "Show"
 msgstr "Afficher"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show {hiddenCount} more items"
-msgstr "Afficher {hiddenCount} éléments de plus"
+#~ msgid "Show {hiddenCount} more items"
+#~ msgstr "Afficher {hiddenCount} éléments de plus"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show 1 more item"
-msgstr "Afficher 1 élément de plus"
+#~ msgid "Show 1 more item"
+#~ msgstr "Afficher 1 élément de plus"
 
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show all {lineCount} lines"
@@ -5508,7 +5611,6 @@ msgstr ""
 msgid "Show details"
 msgstr "Afficher les détails"
 
-#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Afficher moins"
@@ -5633,7 +5735,6 @@ msgid "Supported Locales:"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "System Prompt"
 msgstr ""
 
@@ -5728,8 +5829,8 @@ msgid "To"
 msgstr ""
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Toggle attachments"
-msgstr "Afficher ou masquer les pièces jointes"
+#~ msgid "Toggle attachments"
+#~ msgstr "Afficher ou masquer les pièces jointes"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
@@ -5884,5 +5985,5 @@ msgstr "Votre question : {query}"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Your conversations with this assistant"
-msgstr "Vos conversations avec cet assistant"
+#~ msgid "Your conversations with this assistant"
+#~ msgstr "Vos conversations avec cet assistant"

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -339,6 +339,11 @@ msgstr "Wyświetl konfigurację asystenta"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.configuration.title"
+msgstr "Konfiguracja"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.delegated.empty"
 msgstr "Brak delegowanych uruchomień."
 
@@ -359,6 +364,11 @@ msgstr "Z rozmowy bez tytułu"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.edit"
+msgstr "Edytuj ustawienia asystenta"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible"
 msgstr "Niektóre pliki domyślne są niedostępne z powodu braku uprawnień."
 
@@ -366,6 +376,21 @@ msgstr "Niektóre pliki domyślne są niedostępne z powodu braku uprawnień."
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.files.inaccessible.contact"
 msgstr "Skontaktuj się z tym twórcą i poproś go o udostępnienie plików:"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.files.title"
+msgstr "Pliki domyślne"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.history"
+msgstr "Twoje rozmowy z tym asystentem"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.more_conversations.count"
+msgstr "{count, plural, one {I jeszcze # rozmowa...} few {I jeszcze # rozmowy...} other {I jeszcze # rozmów...}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
@@ -381,6 +406,11 @@ msgstr "Czaty"
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "assistant.welcome.segment.delegated"
 msgstr "Delegowane uruchomienia"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
+msgid "assistant.welcome.system_prompt"
+msgstr "Prompt systemowy"
 
 #. js-lingui-explicit-id
 #: src/pages/AssistantHubDetailPage.tsx
@@ -1425,6 +1455,41 @@ msgid "chat.attachment.teamsImage"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.include"
+msgstr "Dołącz"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.include_message"
+msgstr "Uwzględnij wiadomość"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.items.count"
+msgstr "{count, plural, one {# element} few {# elementy} other {# elementów}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.loading"
+msgstr "Wczytywanie załącznika..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_less"
+msgstr "Pokaż mniej"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+msgid "chat.attachments.show_more.count"
+msgstr "{count, plural, one {Pokaż jeszcze # element} few {Pokaż jeszcze # elementy} other {Pokaż jeszcze # elementów}}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/ThreadMessageCard.tsx
+msgid "chat.attachments.toggle"
+msgstr "Przełącz załączniki"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Chat/Chat.tsx
 msgid "chat.conversation.aria"
 msgstr "Rozmowa czatu"
@@ -1475,9 +1540,16 @@ msgstr "Odznacz {facetDisplayName}"
 #~ msgstr "Błąd wczytywania pliku"
 
 #. js-lingui-explicit-id
-#: src/components/ui/Chat/ChatMessage.tsx
-#~ msgid "chat.file.loading"
-#~ msgstr "Ładowanie pliku..."
+#: src/components/ui/FileUpload/FilePreviewLoading.tsx
+msgid "chat.file.loading"
+msgstr "Ładowanie pliku..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
+#: src/components/ui/Teams/TeamsConversationView.tsx
+msgid "chat.file.preview_attachment"
+msgstr "Podgląd załącznika"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatMessage.tsx
@@ -1508,6 +1580,11 @@ msgstr "Delegowane uruchomienia ({runCount})"
 #: src/components/ui/Chat/DelegatedRunsSection.tsx
 msgid "chat.history.delegatedRuns.toggleStatus"
 msgstr "Delegowane uruchomienia ({runCount}), {attentionLabel}"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+msgid "chat.history.files.count"
+msgstr "{count, plural, =0 {Brak plików} one {# plik} few {# pliki} other {# plików}}"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryFilterMenu.tsx
@@ -1660,6 +1737,24 @@ msgid "chat.history.group.unread"
 msgstr "Nieprzeczytane"
 
 #. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.loading_more"
+msgstr "Ładowanie..."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.message"
+msgstr "Czy na pewno chcesz usunąć ten czat?"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.confirm_remove.title"
+msgstr "Potwierdź usunięcie"
+
+#. js-lingui-explicit-id
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
@@ -1672,6 +1767,12 @@ msgstr "Przypnij"
 #: src/pages/SearchPage.tsx
 msgid "chat.history.menu.pinLimitReached"
 msgstr "Osiągnięto limit przypięć"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Chat/ChatHistoryList.tsx
+#: src/pages/SearchPage.tsx
+msgid "chat.history.menu.remove"
+msgstr "Usuń"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Chat/ChatHistoryList.tsx
@@ -2478,6 +2579,13 @@ msgstr "Nie ustawiono"
 #: src/pages/AssistantHubSubmitPage.tsx
 msgid "common.preview"
 msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/FileUpload/AttachmentTile.tsx
+#: src/components/ui/FileUpload/FilePreviewBase.tsx
+#: src/components/ui/FileUpload/FilePreviewButton.tsx
+msgid "common.remove"
+msgstr "Usuń"
 
 #. js-lingui-explicit-id
 #: src/pages/assistantHubUtils.tsx
@@ -4205,10 +4313,9 @@ msgstr " Załączniki plików zajmują {fileTokensFormatted} tokenów."
 msgid "(no body)"
 msgstr ""
 
-#. placeholder {0}: session.metadata?.fileCount ?? 0
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
-msgstr "{0, plural, =0 {Brak plików} one {# plik} few {# pliki} other {# plików}}"
+#~ msgid "{0, plural, =0 {No files} one {# file} other {# files}}"
+#~ msgstr "{0, plural, =0 {Brak plików} one {# plik} few {# pliki} other {# plików}}"
 
 #. placeholder {0}: queuedMessage.attachedFiles.length
 #: src/components/ui/Chat/ChatInput.tsx
@@ -4237,8 +4344,8 @@ msgid "{fileName}: {filePercentage}%"
 msgstr "{fileName}: {filePercentage}%"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "{itemCount} items"
-msgstr "{itemCount} elementów"
+#~ msgid "{itemCount} items"
+#~ msgstr "{itemCount} elementów"
 
 #: src/utils/teams/teamsSentAttachmentGroups.ts
 msgid "{sharedCount} shared files"
@@ -4296,7 +4403,6 @@ msgstr "• Uwaga: Zmiany języka nie są zachowywane po odświeżeniu strony"
 msgid "• Use \"Reset to Browser Detection\" to test fresh detection"
 msgstr "• Użyj \"Resetuj do wykrywania przeglądarki\" aby przetestować świeże wykrywanie"
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/FilePreview/EmlPreview.tsx
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
@@ -4304,8 +4410,8 @@ msgid "1 file"
 msgstr "1 plik"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "1 item"
-msgstr "1 element"
+#~ msgid "1 item"
+#~ msgstr "1 element"
 
 #: src/components/ui/Teams/TeamsConversationView.tsx
 msgid "1 message could not be loaded."
@@ -4332,8 +4438,8 @@ msgid "All file types accepted"
 msgstr "Wszystkie typy plików akceptowane"
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "And"
-msgstr ""
+#~ msgid "And"
+#~ msgstr ""
 
 #: src/components/ui/DesktopSidecar/SidecarLocalAnswerPanel.tsx
 msgid "Answer from this device"
@@ -4362,8 +4468,8 @@ msgstr "Czy na pewno chcesz kontynuować?"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Are you sure you want to remove this chat?"
-msgstr "Czy na pewno chcesz usunąć ten czat?"
+#~ msgid "Are you sure you want to remove this chat?"
+#~ msgstr "Czy na pewno chcesz usunąć ten czat?"
 
 #: src/components/ui/Feedback/Avatar.tsx
 msgid "Assistant avatar"
@@ -4651,8 +4757,8 @@ msgid "Completed"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Configuration"
-msgstr ""
+#~ msgid "Configuration"
+#~ msgstr ""
 
 #: src/pages/AssistantCreatePage.tsx
 #~ msgid "Configure a custom assistant with specific instructions and capabilities"
@@ -4677,8 +4783,8 @@ msgstr "Potwierdź akcję"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/pages/SearchPage.tsx
-msgid "Confirm Removal"
-msgstr "Potwierdź usunięcie"
+#~ msgid "Confirm Removal"
+#~ msgstr "Potwierdź usunięcie"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "Context usage"
@@ -4786,7 +4892,6 @@ msgid "Date"
 msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "Default Files"
 msgstr ""
 
@@ -4876,8 +4981,8 @@ msgstr "Edytuj"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Edit Assistant Settings"
-msgstr ""
+#~ msgid "Edit Assistant Settings"
+#~ msgstr ""
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "Edit queued message"
@@ -5046,12 +5151,12 @@ msgid "In Progress"
 msgstr "W trakcie"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Include"
-msgstr "Dołącz"
+#~ msgid "Include"
+#~ msgstr "Dołącz"
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Include message"
-msgstr "Uwzględnij wiadomość"
+#~ msgid "Include message"
+#~ msgstr "Uwzględnij wiadomość"
 
 #: src/components/ui/ToolCall/ToolCallInput.tsx
 #~ msgid "Input Parameters"
@@ -5107,21 +5212,19 @@ msgstr "Ładowanie"
 #~ msgstr ""
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Loading attachment..."
-msgstr ""
+#~ msgid "Loading attachment..."
+#~ msgstr ""
 
 #: src/components/ui/FilePreview/TeamsTranscriptPreview.tsx
 msgid "Loading conversation…"
 msgstr "Wczytywanie konwersacji…"
 
 #: src/components/ui/FileUpload/FilePreviewLoading.tsx
-msgid "Loading file..."
-msgstr ""
+#~ msgid "Loading file..."
+#~ msgstr ""
 
-#: src/components/ui/Chat/ChatHistoryList.tsx
 #: src/components/ui/Chat/ModelSelector.tsx
 #: src/components/ui/Message/LoadMoreButton.tsx
-#: src/pages/SearchPage.tsx
 msgid "Loading..."
 msgstr "Ładowanie..."
 
@@ -5175,8 +5278,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "more conversations..."
-msgstr ""
+#~ msgid "more conversations..."
+#~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantForm.tsx
 msgid "My Assistant"
@@ -5209,8 +5312,8 @@ msgid "No chats found"
 msgstr "Nie znaleziono czatów"
 
 #: src/components/ui/Chat/ChatHistoryList.tsx
-msgid "No files"
-msgstr ""
+#~ msgid "No files"
+#~ msgstr ""
 
 #: src/components/ui/Message/ConversationIndicator.tsx
 msgid "No messages yet"
@@ -5292,8 +5395,8 @@ msgstr ""
 #: src/components/ui/FileUpload/AttachmentTile.tsx
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Teams/TeamsConversationView.tsx
-msgid "Preview attachment"
-msgstr "Podgląd załącznika"
+#~ msgid "Preview attachment"
+#~ msgstr "Podgląd załącznika"
 
 #: src/components/ui/FilePreview/FilePreviewContent.tsx
 #: src/components/ui/Modal/FilePreviewModal.tsx
@@ -5389,8 +5492,8 @@ msgstr "Pozostały kontekst: {remainingContextPercentage}%"
 #: src/components/ui/FileUpload/FilePreviewBase.tsx
 #: src/components/ui/FileUpload/FilePreviewButton.tsx
 #: src/pages/SearchPage.tsx
-msgid "Remove"
-msgstr "Usuń"
+#~ msgid "Remove"
+#~ msgstr "Usuń"
 
 #: src/components/ui/FileUpload/AttachmentTileList.tsx
 msgid "Remove all"
@@ -5493,12 +5596,12 @@ msgid "Show"
 msgstr "Pokaż"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show {hiddenCount} more items"
-msgstr "Pokaż jeszcze {hiddenCount} elementów"
+#~ msgid "Show {hiddenCount} more items"
+#~ msgstr "Pokaż jeszcze {hiddenCount} elementów"
 
 #: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
-msgid "Show 1 more item"
-msgstr "Pokaż jeszcze 1 element"
+#~ msgid "Show 1 more item"
+#~ msgstr "Pokaż jeszcze 1 element"
 
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show all {lineCount} lines"
@@ -5508,7 +5611,6 @@ msgstr ""
 msgid "Show details"
 msgstr "Pokaż szczegóły"
 
-#: src/components/ui/FileUpload/GroupedFileAttachmentsPreview.tsx
 #: src/components/ui/Message/CollapsibleCodeBlock.tsx
 msgid "Show less"
 msgstr "Pokaż mniej"
@@ -5633,7 +5735,6 @@ msgid "Supported Locales:"
 msgstr "Obsługiwane języki:"
 
 #: src/components/ui/Assistant/AssistantForm.tsx
-#: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
 msgid "System Prompt"
 msgstr ""
 
@@ -5728,8 +5829,8 @@ msgid "To"
 msgstr ""
 
 #: src/components/ui/FileUpload/ThreadMessageCard.tsx
-msgid "Toggle attachments"
-msgstr "Przełącz załączniki"
+#~ msgid "Toggle attachments"
+#~ msgstr "Przełącz załączniki"
 
 #: src/components/ui/Feedback/ChatWarnings/TokenUsageWarning.tsx
 msgid "Token Limit Exceeded"
@@ -5884,5 +5985,5 @@ msgstr "Twoje pytanie: {query}"
 #~ msgstr ""
 
 #: src/components/ui/Assistant/AssistantWelcomeScreen.tsx
-msgid "Your conversations with this assistant"
-msgstr "Twoje rozmowy z tym asystentem"
+#~ msgid "Your conversations with this assistant"
+#~ msgstr "Twoje rozmowy z tym asystentem"

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -425,15 +425,25 @@ export default function SearchPage() {
                             disabled: !result.canEdit,
                           },
                           {
-                            label: t`Remove`,
+                            label: t({
+                              id: "chat.history.menu.remove",
+                              message: "Remove",
+                            }),
                             icon: <Trash className="size-4" />,
                             variant: "danger",
                             onClick: () => {
                               void handleArchiveResult(result.chatId);
                             },
                             confirmAction: true,
-                            confirmTitle: t`Confirm Removal`,
-                            confirmMessage: t`Are you sure you want to remove this chat?`,
+                            confirmTitle: t({
+                              id: "chat.history.menu.confirm_remove.title",
+                              message: "Confirm Removal",
+                            }),
+                            confirmMessage: t({
+                              id: "chat.history.menu.confirm_remove.message",
+                              message:
+                                "Are you sure you want to remove this chat?",
+                            }),
                           },
                         ]}
                       />
@@ -447,7 +457,10 @@ export default function SearchPage() {
                   ref={loadMoreSentinelRef}
                   className="flex justify-center py-6"
                   data-ui="search-load-more-sentinel"
-                  aria-label={t`Loading...`}
+                  aria-label={t({
+                    id: "chat.history.loading_more",
+                    message: "Loading...",
+                  })}
                 >
                   {(isFetchingNextPage || isSearching) && (
                     <SpinnerIcon size="md" aria-hidden />


### PR DESCRIPTION
## Summary

The openwebui component kit addresses its strings by explicit Lingui ids, while 20 host strings with the same wording were still auto-hash `t\`…\`` calls from the original i18n rollout. A hash-keyed string cannot be overridden by a theme or kit catalog without matching the hash, so customer renames keyed on the kit ids never reached the host surfaces.

This moves those 20 strings onto the kit's ids:

- **Chat history menu** (`ChatHistoryList`, `SearchPage`): `chat.history.menu.remove`, `…confirm_remove.title`, `…confirm_remove.message`, `chat.history.loading_more`, `chat.history.files.count`
- **Attachment controls** (`AttachmentTile`, `FilePreviewBase`, `FilePreviewButton`, `FilePreviewLoading`, `GroupedFileAttachmentsPreview`, `ThreadMessageCard`, `TeamsConversationView`): `common.remove`, `chat.file.preview_attachment`, `chat.file.loading`, `chat.attachments.include`, `…include_message`, `…toggle`, `…loading`, `…show_less`, `…show_more.count`, `…items.count`
- **Assistant welcome screen**: `assistant.welcome.configuration.title`, `…system_prompt`, `…files.title`, `…edit`, `…history`

Plural ids shared with the kit pass their value under the placeholder name `count`, because the kit catalogs merge last and format these ids with `{count, plural, …}`.

### Fixed in passing

- The history-row file-count tooltip built `N files` as a raw template string and was never translated.
- The welcome screen assembled "And" / number / "more conversations..." as three fragments no translation could reorder. It is now one plural under a host-owned id (`assistant.welcome.more_conversations.count`), deliberately not shared with the kit's placeholder-less `assistant.welcome.more_conversations`.

### Catalogs

`de`/`fr`/`pl`/`es` are filled from the host's existing translations where they existed and from the kit's where they did not (80 entries). System Prompt, Loading attachment…, Loading file… and No files had no translation in any locale before; Configuration, Default Files and Edit Assistant Settings had only German. The four composed `assistant.welcome.more_conversations.count` plurals are new wording and would benefit from a native read.

Two ids share the kit key but keep the host English (`assistant.welcome.edit`, `assistant.welcome.history`); tests assert that text.

### Customer effect

Related to CBCKHOF-42. Beckhoff's fork renames `chat.history.menu.remove` and the two confirm strings to "Archivieren" in its theme catalog. Upstream, the host-owned surfaces could not pick that up because they were hash-keyed; after this change they share the id. Note the fork's baseline (3b36af2a) predates kit catalog loading (91fa0847), and the kit catalog merges *after* the theme layer, so once the fork syncs past that commit the kit's own "Entfernen" will override the theme rename everywhere. The rename should then live in the kit catalog or the runtime overrides layer, which is outside this PR.

### Left out on purpose

- Kit `chat.untitled` vs host `chat.history.rename.generated.fallback`: both explicit, canonical id undecided.
- Hand-rolled `1 file / N files` plurals in `ThreadMessageCard`, `AttachmentTileList`, `EmlPreview`, `teamsSentAttachmentGroups`.
- `AssistantForm`'s own System Prompt / Default Files labels.
- Kit ids with no host counterpart: `chat.file.error`, `chat.file.preview.aria`.

## Test plan

- [x] `pnpm typecheck`, `eslint --max-warnings=0` and `prettier --check` on changed files
- [x] `./scripts/check-i18n-extract.sh` (the CI catalog gate) passes on the commit
- [x] `lingui compile` accepts all ICU plurals; compiled `de`/`pl` show the `count` placeholder
- [x] vitest: 41 files / 472 tests across `Assistant`, `Chat`, `FileUpload`, `FilePreview`, `Teams`, `pages`
- [ ] Beckhoff overlay smoke check: `just use beckhoff ours`, confirm the chat-history Remove entry reads "Archivieren" on the search page too