### PR TITLE
Surface provider content blocks in audio transcription as a user-facing error

### DIFF
--- a/backend/erato/src/server/api/v1beta/audio_transcription.rs
+++ b/backend/erato/src/server/api/v1beta/audio_transcription.rs
@@ -133,6 +133,7 @@ enum ServerControlFrame {
         file_upload_id: String,
         chunk_index: usize,
         error: String,
+        error_code: AudioTranscriptionErrorCode,
         audio_transcription: AudioTranscriptionMetadata,
     },
     Completed {
@@ -176,10 +177,88 @@ enum DictationServerControlFrame {
         chunk_index: usize,
         transcript: String,
     },
+    ChunkFailed {
+        chunk_index: usize,
+        error: String,
+        error_code: AudioTranscriptionErrorCode,
+    },
     Completed,
     Error {
         error: String,
     },
+}
+
+/// Why a chunk could not be transcribed, in a form the client can translate and the
+/// user can quote. The snake_case literals are part of the socket protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AudioTranscriptionErrorCode {
+    ProviderContentBlocked,
+    ProviderError,
+    TranscriptionFailed,
+}
+
+impl AudioTranscriptionErrorCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ProviderContentBlocked => "provider_content_blocked",
+            Self::ProviderError => "provider_error",
+            Self::TranscriptionFailed => "transcription_failed",
+        }
+    }
+}
+
+/// Provider-side transcription failure. The raw response is logged where it is
+/// classified; the Display text is the short, user-safe message sent to the client.
+#[derive(Debug)]
+struct AudioTranscriptionProviderError {
+    code: AudioTranscriptionErrorCode,
+    block_reason: Option<String>,
+}
+
+impl AudioTranscriptionProviderError {
+    fn from_response_body(response_body: &serde_json::Value) -> Self {
+        let block_reason = response_body
+            .pointer("/promptFeedback/blockReason")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        Self {
+            code: if block_reason.is_some() {
+                AudioTranscriptionErrorCode::ProviderContentBlocked
+            } else {
+                AudioTranscriptionErrorCode::ProviderError
+            },
+            block_reason,
+        }
+    }
+}
+
+impl std::fmt::Display for AudioTranscriptionProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.code, self.block_reason.as_deref()) {
+            (AudioTranscriptionErrorCode::ProviderContentBlocked, Some(reason)) => write!(
+                f,
+                "The AI provider's content filter blocked this passage (reason: {reason})"
+            ),
+            (AudioTranscriptionErrorCode::ProviderContentBlocked, None) => {
+                write!(f, "The AI provider's content filter blocked this passage")
+            }
+            _ => write!(f, "The AI provider could not transcribe this passage"),
+        }
+    }
+}
+
+impl std::error::Error for AudioTranscriptionProviderError {}
+
+/// Maps any transcription failure to a protocol code and a short message.
+fn classify_transcription_failure(error: &Report) -> (AudioTranscriptionErrorCode, String) {
+    match error.downcast_ref::<AudioTranscriptionProviderError>() {
+        Some(provider_error) => (provider_error.code, provider_error.to_string()),
+        None => (
+            AudioTranscriptionErrorCode::TranscriptionFailed,
+            "This passage could not be transcribed".to_string(),
+        ),
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -485,14 +564,37 @@ async fn handle_dictation_audio_bytes(
     let ack = DictationServerControlFrame::ChunkAck {
         chunk_index: pending.chunk_index,
     };
-    let transcribed_chunk = transcribe_audio_chunk_with_retry(
+    let transcribed_chunk = match transcribe_audio_chunk_with_retry(
         app_state,
         audio_feature,
         Some(chat_provider_headers_context),
         &pending,
         validated_chunk.provider_audio_bytes,
     )
-    .await?;
+    .await
+    {
+        Ok(transcribed_chunk) => transcribed_chunk,
+        Err(error) => {
+            let (error_code, error_message) = classify_transcription_failure(&error);
+            warn!(
+                chunk_index = pending.chunk_index,
+                error_code = error_code.as_str(),
+                error = %error,
+                "Audio dictation chunk failed; continuing with the next chunk"
+            );
+            // The passage is lost either way; stay in step with the client so the
+            // chunks after it are still transcribed instead of failing on their index.
+            *next_chunk_index += 1;
+            return Ok(vec![
+                ack,
+                DictationServerControlFrame::ChunkFailed {
+                    chunk_index: pending.chunk_index,
+                    error: error_message,
+                    error_code,
+                },
+            ]);
+        }
+    };
     *next_chunk_index += 1;
 
     Ok(vec![
@@ -826,11 +928,13 @@ async fn handle_audio_bytes(
     {
         Ok(transcribed_chunk) => transcribed_chunk,
         Err(error) => {
+            let (error_code, error_message) = classify_transcription_failure(&error);
             warn!(
                 file_upload_id = %session.file_upload.id,
                 chunk_index = pending.chunk_index,
                 byte_start,
                 byte_end,
+                error_code = error_code.as_str(),
                 error = %error,
                 "Audio transcription chunk failed"
             );
@@ -842,12 +946,12 @@ async fn handle_audio_bytes(
                     byte_start: Some(byte_start),
                     byte_end: Some(byte_end),
                     transcript: None,
-                    error: Some(error.to_string()),
+                    error: Some(error_message.clone()),
                     attempts: app_state.config.audio_transcription.max_attempts,
                 },
             );
             session.metadata.status = "failed".to_string();
-            session.metadata.error = Some(error.to_string());
+            session.metadata.error = Some(error_message.clone());
             session.metadata.progress = Some(progress_for_metadata(&session.metadata));
             persist_session_metadata(app_state, session).await?;
             return Ok(vec![
@@ -855,7 +959,8 @@ async fn handle_audio_bytes(
                 ServerControlFrame::ChunkFailed {
                     file_upload_id: session.file_upload.id.to_string(),
                     chunk_index: pending.chunk_index,
-                    error: error.to_string(),
+                    error: error_message,
+                    error_code,
                     audio_transcription: session.metadata.clone(),
                 },
             ]);
@@ -1559,12 +1664,48 @@ async fn transcribe_audio_chunk_genai(
     );
     let chat_options = ChatOptions::default()
         .with_capture_content(true)
+        .with_capture_raw_body(true)
         .with_temperature(0.0)
         .with_reasoning_effort(reasoning_effort)
         .with_max_tokens(max_output_tokens);
-    let response = client
+    let response = match client
         .exec_chat("PLACEHOLDER_MODEL", chat_request, Some(&chat_options))
-        .await?;
+        .await
+    {
+        Ok(response) => response,
+        Err(genai::Error::ChatResponseGeneration {
+            model_iden,
+            response_body,
+            cause,
+            ..
+        }) => {
+            // The default rendering of this error embeds the whole request payload,
+            // including the base64 audio. Log the provider's raw response and the cause
+            // on their own; only the classification travels to the client.
+            let provider_error =
+                AudioTranscriptionProviderError::from_response_body(&response_body);
+            warn!(
+                chunk_index = pending.chunk_index,
+                model = %model_iden,
+                error_code = provider_error.code.as_str(),
+                cause = %cause,
+                response_body = %response_body,
+                "Audio transcription provider returned an unusable response"
+            );
+            return Err(Report::new(provider_error));
+        }
+        Err(error) => {
+            warn!(
+                chunk_index = pending.chunk_index,
+                error = %error,
+                "Audio transcription provider call failed"
+            );
+            return Err(Report::new(AudioTranscriptionProviderError {
+                code: AudioTranscriptionErrorCode::ProviderError,
+                block_reason: None,
+            }));
+        }
+    };
     let transcript = response.first_text().unwrap_or_default().trim().to_string();
     let transcript = if is_punctuation_only_transcript(&transcript) {
         if !transcript.is_empty() {
@@ -1735,6 +1876,14 @@ async fn retry_failed_chunks(
                 );
             }
             Err(error) => {
+                let (error_code, error_message) = classify_transcription_failure(&error);
+                warn!(
+                    file_upload_id = %session.file_upload.id,
+                    chunk_index = chunk.index,
+                    error_code = error_code.as_str(),
+                    error = %error,
+                    "Audio transcription chunk retry failed"
+                );
                 update_chunk_status(
                     &mut session.metadata,
                     ChunkStatusUpdate {
@@ -1743,19 +1892,20 @@ async fn retry_failed_chunks(
                         byte_start: Some(byte_start),
                         byte_end: Some(byte_end),
                         transcript: None,
-                        error: Some(error.to_string()),
+                        error: Some(error_message.clone()),
                         attempts: chunk.attempts
                             + app_state.config.audio_transcription.max_attempts,
                     },
                 );
                 session.metadata.status = "failed".to_string();
-                session.metadata.error = Some(error.to_string());
+                session.metadata.error = Some(error_message.clone());
                 session.metadata.progress = Some(progress_for_metadata(&session.metadata));
                 persist_session_metadata(app_state, session).await?;
                 return Ok(ServerControlFrame::ChunkFailed {
                     file_upload_id: session.file_upload.id.to_string(),
                     chunk_index: chunk.index,
-                    error: error.to_string(),
+                    error: error_message,
+                    error_code,
                     audio_transcription: session.metadata.clone(),
                 });
             }
@@ -1803,6 +1953,86 @@ fn audio_transcription_reasoning_effort(provider_kind: &str, model_name: &str) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn audio_transcription_error_codes_use_protocol_literals() {
+        for (code, literal) in [
+            (
+                AudioTranscriptionErrorCode::ProviderContentBlocked,
+                "provider_content_blocked",
+            ),
+            (AudioTranscriptionErrorCode::ProviderError, "provider_error"),
+            (
+                AudioTranscriptionErrorCode::TranscriptionFailed,
+                "transcription_failed",
+            ),
+        ] {
+            assert_eq!(serde_json::to_value(code).unwrap(), literal);
+            assert_eq!(code.as_str(), literal);
+        }
+    }
+
+    #[test]
+    fn classifies_prompt_blocks_from_the_provider_response_body() {
+        let blocked = AudioTranscriptionProviderError::from_response_body(&serde_json::json!({
+            "promptFeedback": {
+                "blockReason": "SAFETY",
+                "blockReasonMessage": "The prompt is blocked due to safety"
+            },
+            "usageMetadata": {"promptTokenCount": 451}
+        }));
+        assert_eq!(
+            blocked.code,
+            AudioTranscriptionErrorCode::ProviderContentBlocked
+        );
+        assert_eq!(blocked.block_reason.as_deref(), Some("SAFETY"));
+        let (code, message) = classify_transcription_failure(&Report::new(blocked));
+        assert_eq!(code, AudioTranscriptionErrorCode::ProviderContentBlocked);
+        assert!(message.contains("SAFETY"));
+
+        let other = AudioTranscriptionProviderError::from_response_body(
+            &serde_json::json!({"candidates": []}),
+        );
+        assert_eq!(other.code, AudioTranscriptionErrorCode::ProviderError);
+
+        let (code, message) =
+            classify_transcription_failure(&eyre::eyre!("hallucination_loop_detected"));
+        assert_eq!(code, AudioTranscriptionErrorCode::TranscriptionFailed);
+        assert!(!message.contains("hallucination"));
+    }
+
+    #[test]
+    fn serializes_audio_transcription_chunk_failure_with_error_code() {
+        let frame = ServerControlFrame::ChunkFailed {
+            file_upload_id: "upload-1".to_string(),
+            chunk_index: 1,
+            error: "The AI provider could not transcribe this passage".to_string(),
+            error_code: AudioTranscriptionErrorCode::ProviderError,
+            audio_transcription: AudioTranscriptionMetadata::default(),
+        };
+
+        let value = serde_json::to_value(frame).expect("transcription frame should serialize");
+        assert_eq!(value["type"], "chunk_failed");
+        assert_eq!(value["file_upload_id"], "upload-1");
+        assert_eq!(value["error_code"], "provider_error");
+        assert!(value.get("audio_transcription").is_some());
+    }
+
+    #[test]
+    fn serializes_audio_dictation_chunk_failure_with_error_code() {
+        let frame = DictationServerControlFrame::ChunkFailed {
+            chunk_index: 3,
+            error: "The AI provider's content filter blocked this passage (reason: SAFETY)"
+                .to_string(),
+            error_code: AudioTranscriptionErrorCode::ProviderContentBlocked,
+        };
+
+        let value = serde_json::to_value(frame).expect("dictation frame should serialize");
+        assert_eq!(value["type"], "chunk_failed");
+        assert_eq!(value["chunk_index"], 3);
+        assert_eq!(value["error_code"], "provider_content_blocked");
+        assert!(value.get("file_upload_id").is_none());
+    }
 
     #[test]
     fn gemini_3_audio_uses_a_supported_thinking_level() {

--- a/frontend/src/hooks/audio/audio-dictation-protocol.ts
+++ b/frontend/src/hooks/audio/audio-dictation-protocol.ts
@@ -23,6 +23,7 @@ function abortRejection(signal: AbortSignal | undefined): unknown {
   // eslint-disable-next-line lingui/no-unlocalized-strings
   return new DOMException("Aborted", "AbortError");
 }
+import type { AudioTranscriptionErrorCode } from "./audioTranscriptionErrors";
 
 export type AudioDictationSocketFrame =
   | {
@@ -40,11 +41,18 @@ export type AudioDictationSocketFrame =
       transcript?: string | null;
     }
   | {
+      type: "chunk_failed";
+      chunk_index: number;
+      error?: string | null;
+      error_code?: AudioTranscriptionErrorCode | null;
+    }
+  | {
       type: "completed";
     }
   | {
       type: "error";
       error?: string | null;
+      error_code?: AudioTranscriptionErrorCode | null;
     };
 
 export function createAudioDictationWebSocketUrl(): string {

--- a/frontend/src/hooks/audio/audioTranscriptionErrors.test.ts
+++ b/frontend/src/hooks/audio/audioTranscriptionErrors.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { describeAudioTranscriptionFailure } from "./audioTranscriptionErrors";
+
+describe("describeAudioTranscriptionFailure", () => {
+  it("explains a provider content block with the passage position and a quotable code", () => {
+    const message = describeAudioTranscriptionFailure(
+      {
+        error:
+          "The AI provider's content filter blocked this passage (reason: SAFETY)",
+        error_code: "provider_content_blocked",
+      },
+      { fallback: "Audio dictation failed.", passageStartMs: 90_000 },
+    );
+
+    expect(message).toContain("starting at 1:30");
+    expect(message).toContain("content filter");
+    expect(message).toContain("Error code: provider_content_blocked");
+    expect(message).not.toContain("SAFETY");
+  });
+
+  it("omits the position when the caller has none", () => {
+    const message = describeAudioTranscriptionFailure(
+      { error_code: "provider_error" },
+      { fallback: "Audio transcription failed." },
+    );
+
+    expect(message).toContain("could not transcribe a passage");
+    expect(message).toContain("Error code: provider_error");
+  });
+
+  it("keeps the server text for unknown codes and falls back when it is empty", () => {
+    expect(
+      describeAudioTranscriptionFailure(
+        {
+          error: "Unexpected chunk index: got 1, expected 0",
+          error_code: null,
+        },
+        { fallback: "Audio dictation failed." },
+      ),
+    ).toBe("Unexpected chunk index: got 1, expected 0");
+
+    expect(
+      describeAudioTranscriptionFailure(
+        { error: "   " },
+        { fallback: "Audio dictation failed." },
+      ),
+    ).toBe("Audio dictation failed.");
+  });
+});

--- a/frontend/src/hooks/audio/audioTranscriptionErrors.ts
+++ b/frontend/src/hooks/audio/audioTranscriptionErrors.ts
@@ -1,0 +1,57 @@
+import { t } from "@lingui/core/macro";
+
+/** Mirrors the backend's `AudioTranscriptionErrorCode` protocol literals. */
+export type AudioTranscriptionErrorCode =
+  | "provider_content_blocked"
+  | "provider_error"
+  | "transcription_failed";
+
+export type AudioTranscriptionFailureFrame = {
+  error?: string | null;
+  error_code?: AudioTranscriptionErrorCode | string | null;
+};
+
+function formatPassageStart(startMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(startMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Turns a failure frame into a message the user can act on and quote to their
+ * team. Unknown codes fall back to the server text or the caller's default.
+ */
+export function describeAudioTranscriptionFailure(
+  frame: AudioTranscriptionFailureFrame,
+  options: { fallback: string; passageStartMs?: number },
+): string {
+  const passage =
+    options.passageStartMs === undefined
+      ? null
+      : formatPassageStart(options.passageStartMs);
+  const code = frame.error_code ?? null;
+  let message: string;
+  switch (code) {
+    case "provider_content_blocked":
+      message = passage
+        ? t`The passage starting at ${passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it.`
+        : t`A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it.`;
+      break;
+    case "provider_error":
+      message = passage
+        ? t`The AI provider could not transcribe the passage starting at ${passage}. Please try again.`
+        : t`The AI provider could not transcribe a passage. Please try again.`;
+      break;
+    case "transcription_failed":
+      message = passage
+        ? t`The passage starting at ${passage} could not be transcribed. Please try again.`
+        : t`A passage could not be transcribed. Please try again.`;
+      break;
+    default: {
+      const serverText = frame.error?.trim() ?? "";
+      return serverText.length > 0 ? serverText : options.fallback;
+    }
+  }
+  return `${message} ${t`Error code: ${code}`}`;
+}

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -36,6 +36,7 @@ import {
   type AudioDictationDiagnostics,
 } from "./audio-pcm-codec";
 import { getAudioEnvironment } from "./audioEnvironment";
+import { describeAudioTranscriptionFailure } from "./audioTranscriptionErrors";
 import { PRE_SPEECH_SILENCE_PRIMER_MS } from "./audioTuning";
 import {
   createSpeechOnsetController,
@@ -586,8 +587,29 @@ export function useAudioDictationRecorder({
               transcript: frame.transcript ?? "",
             });
           }
+          if (frame.type === "chunk_failed") {
+            // Resolve the index with an empty transcript so the ordered append
+            // in the consumer is not held back by the lost passage.
+            onTranscriptChunkRef.current({
+              chunkIndex: frame.chunk_index,
+              transcript: "",
+            });
+            setDictationError(
+              describeAudioTranscriptionFailure(frame, {
+                fallback: t`Audio dictation failed.`,
+                passageStartMs:
+                  frame.chunk_index *
+                  (liveSessionRef.current?.chunkDurationMs ??
+                    DEFAULT_AUDIO_DICTATION_CHUNK_DURATION_MS),
+              }),
+            );
+          }
           if (frame.type === "error") {
-            setDictationError(frame.error ?? t`Audio dictation failed.`);
+            setDictationError(
+              describeAudioTranscriptionFailure(frame, {
+                fallback: t`Audio dictation failed.`,
+              }),
+            );
           }
         } catch {
           setDictationError(t`Could not read audio dictation response.`);

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -26,6 +26,10 @@ import {
   resampleMonoFloat32ToPcm16,
 } from "./audio-pcm-codec";
 import { getAudioEnvironment } from "./audioEnvironment";
+import {
+  type AudioTranscriptionErrorCode,
+  describeAudioTranscriptionFailure,
+} from "./audioTranscriptionErrors";
 import { PRE_SPEECH_SILENCE_PRIMER_MS } from "./audioTuning";
 import {
   createSpeechOnsetController,
@@ -93,6 +97,7 @@ type AudioTranscriptionSocketFrame =
       file_upload_id: string;
       chunk_index: number;
       error?: string | null;
+      error_code?: AudioTranscriptionErrorCode | null;
       audio_transcription?: AudioTranscriptionMetadata;
     }
   | {
@@ -104,6 +109,7 @@ type AudioTranscriptionSocketFrame =
   | {
       type: "error";
       error?: string | null;
+      error_code?: AudioTranscriptionErrorCode | null;
     };
 
 type AudioTranscriptionChunk = {
@@ -283,7 +289,13 @@ function waitForAudioTranscriptionFrame(
         const frame = JSON.parse(event.data) as AudioTranscriptionSocketFrame;
         if (frame.type === "error") {
           cleanup();
-          reject(new Error(frame.error ?? t`Audio transcription failed.`));
+          reject(
+            new Error(
+              describeAudioTranscriptionFailure(frame, {
+                fallback: t`Audio transcription failed.`,
+              }),
+            ),
+          );
           return;
         }
 
@@ -721,8 +733,12 @@ export function useAudioTranscriptionRecorder({
               frame.audio_transcription,
             );
           }
-          if (frame.type === "error") {
-            setRecordingError(frame.error ?? t`Audio transcription failed.`);
+          if (frame.type === "chunk_failed" || frame.type === "error") {
+            setRecordingError(
+              describeAudioTranscriptionFailure(frame, {
+                fallback: t`Audio transcription failed.`,
+              }),
+            );
           }
         } catch {
           setRecordingError(t`Could not read audio transcription response.`);

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4427,11 +4427,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Ein Abschnitt konnte nicht transkribiert werden, weil der Inhaltsfilter des KI-Anbieters ihn blockiert hat. Das passiert auch bei harmlosen Aussagen. Bitte formulieren Sie ihn anders oder tippen Sie ihn ein."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed. Please try again."
-msgstr ""
+msgstr "Ein Abschnitt konnte nicht transkribiert werden. Bitte versuchen Sie es erneut."
 
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
@@ -5022,7 +5022,7 @@ msgstr "Fehler"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "Error code: {code}"
-msgstr ""
+msgstr "Fehlercode: {code}"
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5768,11 +5768,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe a passage. Please try again."
-msgstr ""
+msgstr "Der KI-Anbieter konnte einen Abschnitt nicht transkribieren. Bitte versuchen Sie es erneut."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
-msgstr ""
+msgstr "Der KI-Anbieter konnte den Abschnitt ab {passage} nicht transkribieren. Bitte versuchen Sie es erneut."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
@@ -5809,11 +5809,11 @@ msgstr "Das Mikrofon wurde getrennt. Bitte überprüfen Sie Ihr Mikrofon und sta
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Der Abschnitt ab {passage} konnte nicht transkribiert werden, weil der Inhaltsfilter des KI-Anbieters ihn blockiert hat. Das passiert auch bei harmlosen Aussagen. Bitte formulieren Sie ihn anders oder tippen Sie ihn ein."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed. Please try again."
-msgstr ""
+msgstr "Der Abschnitt ab {passage} konnte nicht transkribiert werden. Bitte versuchen Sie es erneut."
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -4425,6 +4425,14 @@ msgstr ""
 #~ msgid "1 step"
 #~ msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed. Please try again."
+msgstr ""
+
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
 msgstr "Akzeptierte Dateitypen:"
@@ -5011,6 +5019,10 @@ msgstr "Gesprächsende"
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Error"
 msgstr "Fehler"
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "Error code: {code}"
+msgstr ""
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5754,6 +5766,14 @@ msgstr ""
 msgid "Test Locale Changes:"
 msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe a passage. Please try again."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
 msgstr "Die Datei \"{filename}\" kann von der KI nicht verarbeitet werden und wurde nicht hochgeladen."
@@ -5786,6 +5806,14 @@ msgstr "Das Mikrofon wurde getrennt. Bitte überprüfen Sie Ihr Mikrofon und sta
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "The microphone was disconnected. Please check your microphone and start recording again."
 msgstr "Das Mikrofon wurde getrennt. Bitte überprüfen Sie Ihr Mikrofon und starten Sie die Aufnahme erneut."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed. Please try again."
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -4425,6 +4425,14 @@ msgstr "1 shared file"
 #~ msgid "1 step"
 #~ msgstr "1 step"
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed. Please try again."
+msgstr "A passage could not be transcribed. Please try again."
+
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
 msgstr "Accepted types:"
@@ -5011,6 +5019,10 @@ msgstr "End of conversation"
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Error"
 msgstr "Error"
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "Error code: {code}"
+msgstr "Error code: {code}"
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5754,6 +5766,14 @@ msgstr "Teams conversation"
 msgid "Test Locale Changes:"
 msgstr "Test Locale Changes:"
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe a passage. Please try again."
+msgstr "The AI provider could not transcribe a passage. Please try again."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+msgstr "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
 msgstr "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
@@ -5786,6 +5806,14 @@ msgstr "The microphone was disconnected. Please check your microphone and start 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "The microphone was disconnected. Please check your microphone and start recording again."
 msgstr "The microphone was disconnected. Please check your microphone and start recording again."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed. Please try again."
+msgstr "The passage starting at {passage} could not be transcribed. Please try again."
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4427,11 +4427,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "No se pudo transcribir un fragmento porque el filtro de contenido del proveedor de IA lo bloqueó. Esto también ocurre con frases inofensivas. Dilo de otra manera o escríbelo."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed. Please try again."
-msgstr ""
+msgstr "No se pudo transcribir un fragmento. Inténtalo de nuevo."
 
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
@@ -5022,7 +5022,7 @@ msgstr "Error"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "Error code: {code}"
-msgstr ""
+msgstr "Código de error: {code}"
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5768,11 +5768,11 @@ msgstr "Probar cambios de idioma:"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe a passage. Please try again."
-msgstr ""
+msgstr "El proveedor de IA no pudo transcribir un fragmento. Inténtalo de nuevo."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
-msgstr ""
+msgstr "El proveedor de IA no pudo transcribir el fragmento que empieza en {passage}. Inténtalo de nuevo."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
@@ -5809,11 +5809,11 @@ msgstr "El micrófono se desconectó. Comprueba el micrófono y vuelve a iniciar
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "No se pudo transcribir el fragmento que empieza en {passage} porque el filtro de contenido del proveedor de IA lo bloqueó. Esto también ocurre con frases inofensivas. Dilo de otra manera o escríbelo."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed. Please try again."
-msgstr ""
+msgstr "No se pudo transcribir el fragmento que empieza en {passage}. Inténtalo de nuevo."
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -4425,6 +4425,14 @@ msgstr ""
 #~ msgid "1 step"
 #~ msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed. Please try again."
+msgstr ""
+
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
 msgstr "Tipos aceptados:"
@@ -5011,6 +5019,10 @@ msgstr "Fin de la conversación"
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Error"
 msgstr "Error"
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "Error code: {code}"
+msgstr ""
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5754,6 +5766,14 @@ msgstr ""
 msgid "Test Locale Changes:"
 msgstr "Probar cambios de idioma:"
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe a passage. Please try again."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
 msgstr "El archivo \"{filename}\" no puede ser procesado por la IA y no se subió."
@@ -5786,6 +5806,14 @@ msgstr "El micrófono se desconectó. Comprueba el micrófono y vuelve a iniciar
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "The microphone was disconnected. Please check your microphone and start recording again."
 msgstr "El micrófono se desconectó. Comprueba el micrófono y vuelve a iniciar la grabación."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed. Please try again."
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4427,11 +4427,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Un passage n'a pas pu être transcrit, car le filtre de contenu du fournisseur d'IA l'a bloqué. Cela arrive aussi avec des propos anodins. Veuillez le reformuler ou le saisir au clavier."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed. Please try again."
-msgstr ""
+msgstr "Un passage n'a pas pu être transcrit. Veuillez réessayer."
 
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
@@ -5022,7 +5022,7 @@ msgstr "Erreur"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "Error code: {code}"
-msgstr ""
+msgstr "Code d'erreur : {code}"
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5768,11 +5768,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe a passage. Please try again."
-msgstr ""
+msgstr "Le fournisseur d'IA n'a pas pu transcrire un passage. Veuillez réessayer."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
-msgstr ""
+msgstr "Le fournisseur d'IA n'a pas pu transcrire le passage commençant à {passage}. Veuillez réessayer."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
@@ -5809,11 +5809,11 @@ msgstr "Le microphone a été déconnecté. Veuillez vérifier votre microphone 
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Le passage commençant à {passage} n'a pas pu être transcrit, car le filtre de contenu du fournisseur d'IA l'a bloqué. Cela arrive aussi avec des propos anodins. Veuillez le reformuler ou le saisir au clavier."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed. Please try again."
-msgstr ""
+msgstr "Le passage commençant à {passage} n'a pas pu être transcrit. Veuillez réessayer."
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -4425,6 +4425,14 @@ msgstr ""
 #~ msgid "1 step"
 #~ msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed. Please try again."
+msgstr ""
+
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
 msgstr "Types acceptés :"
@@ -5011,6 +5019,10 @@ msgstr "Fin de la conversation"
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Error"
 msgstr "Erreur"
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "Error code: {code}"
+msgstr ""
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5754,6 +5766,14 @@ msgstr ""
 msgid "Test Locale Changes:"
 msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe a passage. Please try again."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
 msgstr "Le fichier \"{filename}\" ne peut pas être traité par l'IA et n'a pas été téléchargé."
@@ -5786,6 +5806,14 @@ msgstr "Le microphone a été déconnecté. Veuillez vérifier votre microphone 
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "The microphone was disconnected. Please check your microphone and start recording again."
 msgstr "Le microphone a été déconnecté. Veuillez vérifier votre microphone et relancer l'enregistrement."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed. Please try again."
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4427,11 +4427,11 @@ msgstr ""
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Nie udało się transkrybować fragmentu, ponieważ filtr treści dostawcy AI go zablokował. Zdarza się to także przy nieszkodliwych wypowiedziach. Powiedz to inaczej lub wpisz tekst ręcznie."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "A passage could not be transcribed. Please try again."
-msgstr ""
+msgstr "Nie udało się transkrybować fragmentu. Spróbuj ponownie."
 
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
@@ -5022,7 +5022,7 @@ msgstr "Błąd"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "Error code: {code}"
-msgstr ""
+msgstr "Kod błędu: {code}"
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5768,11 +5768,11 @@ msgstr "Testuj zmiany języka:"
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe a passage. Please try again."
-msgstr ""
+msgstr "Dostawca AI nie mógł transkrybować fragmentu. Spróbuj ponownie."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
-msgstr ""
+msgstr "Dostawca AI nie mógł transkrybować fragmentu zaczynającego się od {passage}. Spróbuj ponownie."
 
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
@@ -5809,11 +5809,11 @@ msgstr "Mikrofon został odłączony. Sprawdź mikrofon i ponownie rozpocznij na
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
-msgstr ""
+msgstr "Nie udało się transkrybować fragmentu zaczynającego się od {passage}, ponieważ filtr treści dostawcy AI go zablokował. Zdarza się to także przy nieszkodliwych wypowiedziach. Powiedz to inaczej lub wpisz tekst ręcznie."
 
 #: src/hooks/audio/audioTranscriptionErrors.ts
 msgid "The passage starting at {passage} could not be transcribed. Please try again."
-msgstr ""
+msgstr "Nie udało się transkrybować fragmentu zaczynającego się od {passage}. Spróbuj ponownie."
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -4425,6 +4425,14 @@ msgstr ""
 #~ msgid "1 step"
 #~ msgstr ""
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "A passage could not be transcribed. Please try again."
+msgstr ""
+
 #: src/components/ui/FileUpload/FileUpload.tsx
 msgid "Accepted types:"
 msgstr "Akceptowane typy plików:"
@@ -5011,6 +5019,10 @@ msgstr "Koniec rozmowy"
 #: src/components/ui/ToolCall/ToolCallItem.tsx
 msgid "Error"
 msgstr "Błąd"
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "Error code: {code}"
+msgstr ""
 
 #: src/components/ui/ThemeApplier.tsx
 #~ msgid "Error loading theme:"
@@ -5754,6 +5766,14 @@ msgstr ""
 msgid "Test Locale Changes:"
 msgstr "Testuj zmiany języka:"
 
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe a passage. Please try again."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The AI provider could not transcribe the passage starting at {passage}. Please try again."
+msgstr ""
+
 #: src/components/ui/Chat/ChatInput.tsx
 msgid "The file \"{filename}\" cannot be processed by the AI and was not uploaded."
 msgstr "Plik \"{filename}\" nie może być przetworzony przez AI i nie został przesłany."
@@ -5786,6 +5806,14 @@ msgstr "Mikrofon został odłączony. Sprawdź mikrofon i ponownie rozpocznij dy
 #: src/hooks/audio/useAudioTranscriptionRecorder.ts
 msgid "The microphone was disconnected. Please check your microphone and start recording again."
 msgstr "Mikrofon został odłączony. Sprawdź mikrofon i ponownie rozpocznij nagrywanie."
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it."
+msgstr ""
+
+#: src/hooks/audio/audioTranscriptionErrors.ts
+msgid "The passage starting at {passage} could not be transcribed. Please try again."
+msgstr ""
 
 #: src/hooks/audio/useAudioInputLevelPreview.ts
 #: src/hooks/audio/useGuidedAudioCapture.ts


### PR DESCRIPTION
## Problem

A dictation on the internal chat failed with the raw genai error text ("Error while generating a ChatResponse … Error event in stream … Body: {"finishReason":null,"usageMetadata":null}"), including the full request payload with the base64 audio. The user could neither understand nor report it, and every later chunk of the dictation then failed with "Unexpected chunk index".

## Root cause

Vertex AI answers the request with HTTP 200 and no `candidates`, i.e. a prompt-level content-filter block (`promptFeedback.blockReason: "SAFETY"`). The genai fork's Gemini adapter discards that body and reports a synthetic one, so the reason was invisible.

The block itself is a Vertex false positive on `gemini-3.7-flash` and `gemini-3.8-flash` for audio transcription of harmless speech that is phrased as instructions to an assistant. It is deterministic per passage with `thinkingLevel: LOW`, is not affected by `safetySettings: OFF`, and has no console setting. `gemini-3.6-flash` and older do not block; the internal deployments were switched to 3.6 separately.

## Changes

- Backend: every transcription failure is classified into `provider_content_blocked`, `provider_error` or `transcription_failed`. The block reason is read from the captured raw response; the raw body and the cause stay in one WARN log line, the request payload is no longer logged. Frames carry `error_code` and a one-sentence message, which is also what the persisted chunk metadata now stores.
- Backend: dictation gets a per-chunk `chunk_failed` frame and the server advances its expected chunk index on failure, so the session survives a lost passage.
- Frontend: `describeAudioTranscriptionFailure` maps the code to a translated message with the passage position and a quotable error code, e.g. "The passage starting at 0:00 could not be transcribed because the AI provider's content filter blocked it. This also happens with harmless speech. Please say it differently or type it. Error code: provider_content_blocked". The dictation hook resolves the failed index with an empty transcript so the ordered append in the composer is not held back. Catalogs extracted for all locales.