### PR TITLE
Keep the selected microphone across device-list churn (ERMAIN-795)

### DIFF
--- a/frontend/src/components/ui/Settings/AudioInputTabContent.tsx
+++ b/frontend/src/components/ui/Settings/AudioInputTabContent.tsx
@@ -32,13 +32,15 @@ export function AudioInputTabContent({ isActive }: AudioInputTabContentProps) {
   const {
     audioInputDeviceError,
     audioInputDevices,
+    hasResolvedDeviceIds,
     hasResolvedLabels,
     isLoadingAudioInputDevices,
     labelRevealDenied,
     refreshAudioInputDevices,
     revealAudioInputDeviceLabels,
     selectedAudioInputDeviceId,
-    setSelectedAudioInputDeviceId,
+    selectedAudioInputDeviceLabel,
+    setSelectedAudioInputDevice,
   } = useAudioInputDevicePreference();
   const [isAudioInputDropdownOpen, setIsAudioInputDropdownOpen] =
     useState(false);
@@ -56,14 +58,45 @@ export function AudioInputTabContent({ isActive }: AudioInputTabContentProps) {
     id: "preferences.dialog.audio.input.default",
     message: "System default microphone",
   });
+  const listedSelectedDevice = audioInputDevices.find(
+    (device) => device.deviceId === selectedAudioInputDeviceId,
+  );
+  const storedDeviceLabel =
+    selectedAudioInputDeviceLabel ||
+    t({
+      id: "preferences.dialog.audio.input.storedDevice",
+      message: "Selected microphone",
+    });
+  const isSelectedDeviceUnlisted =
+    selectedAudioInputDeviceId !== "" && listedSelectedDevice === undefined;
+  // Only a resolved (post-permission) list can say a device is really gone.
+  const isSelectedDeviceMissing =
+    isSelectedDeviceUnlisted && hasResolvedDeviceIds;
+  const storedDeviceDisplayLabel = isSelectedDeviceMissing
+    ? t({
+        id: "preferences.dialog.audio.input.notConnected",
+        message: `${storedDeviceLabel} (not connected)`,
+      })
+    : storedDeviceLabel;
   const audioInputItems = useMemo<DropdownMenuItem[]>(
     () => [
       {
         id: "audio-input-default",
         label: audioInputDefaultLabel,
         checked: selectedAudioInputDeviceId === "",
-        onClick: () => setSelectedAudioInputDeviceId(""),
+        onClick: () => setSelectedAudioInputDevice(""),
       },
+      ...(isSelectedDeviceUnlisted
+        ? [
+            {
+              id: "audio-input-stored",
+              label: storedDeviceDisplayLabel,
+              checked: true,
+              disabled: true,
+              onClick: () => {},
+            },
+          ]
+        : []),
       // Namespace device items under `device-` so an enumerated device whose
       // deviceId is literally "default" (Chrome/macOS returns one) can't
       // collide with the static "audio-input-default" item's React key.
@@ -71,26 +104,22 @@ export function AudioInputTabContent({ isActive }: AudioInputTabContentProps) {
         id: `audio-input-device-${device.deviceId}`,
         label: device.label,
         checked: device.deviceId === selectedAudioInputDeviceId,
-        onClick: () => setSelectedAudioInputDeviceId(device.deviceId),
+        onClick: () =>
+          setSelectedAudioInputDevice(device.deviceId, device.label),
       })),
     ],
     [
       audioInputDefaultLabel,
       audioInputDevices,
+      isSelectedDeviceUnlisted,
       selectedAudioInputDeviceId,
-      setSelectedAudioInputDeviceId,
+      setSelectedAudioInputDevice,
+      storedDeviceDisplayLabel,
     ],
   );
-  const selectedAudioInputLabel = useMemo(() => {
-    if (!selectedAudioInputDeviceId) {
-      return audioInputDefaultLabel;
-    }
-    return (
-      audioInputDevices.find(
-        (device) => device.deviceId === selectedAudioInputDeviceId,
-      )?.label ?? audioInputDefaultLabel
-    );
-  }, [audioInputDefaultLabel, audioInputDevices, selectedAudioInputDeviceId]);
+  const selectedAudioInputLabel = !selectedAudioInputDeviceId
+    ? audioInputDefaultLabel
+    : (listedSelectedDevice?.label ?? storedDeviceDisplayLabel);
 
   const inputDeviceCount = audioInputDevices.length;
 
@@ -166,6 +195,18 @@ export function AudioInputTabContent({ isActive }: AudioInputTabContentProps) {
               })}
         </Button>
       </div>
+
+      {isSelectedDeviceMissing ? (
+        <p
+          className="text-xs text-theme-fg-muted"
+          data-testid="audio-input-not-connected"
+        >
+          {t({
+            id: "preferences.dialog.audio.input.notConnectedHint",
+            message: `${storedDeviceLabel} is not connected. Recordings use the system default microphone until it is available again.`,
+          })}
+        </p>
+      ) : null}
 
       <p
         className="text-xs text-theme-fg-muted"

--- a/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
+++ b/frontend/src/components/ui/Settings/UserPreferencesDialog.test.tsx
@@ -178,7 +178,10 @@ function renderDialog({
 
 beforeEach(() => {
   sessionStorage.clear();
-  useAudioInputDeviceStore.setState({ selectedDeviceId: "" });
+  useAudioInputDeviceStore.setState({
+    selectedDeviceId: "",
+    selectedDeviceLabel: "",
+  });
   localStorageValues.clear();
   vi.stubGlobal("localStorage", {
     getItem: vi.fn((key: string) => localStorageValues.get(key) ?? null),
@@ -367,6 +370,93 @@ describe("UserPreferencesDialog", () => {
     });
 
     expect(screen.queryByRole("tab", { name: "Data" })).not.toBeInTheDocument();
+  });
+
+  it("shows a stored microphone that is not listed as not connected and keeps it", async () => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        enumerateDevices: vi.fn(async () => [
+          {
+            deviceId: "mic-built-in",
+            groupId: "group-1",
+            kind: "audioinput",
+            label: "Built-in Microphone",
+            toJSON: () => ({}),
+          },
+        ]),
+      },
+    });
+    useAudioInputDeviceStore.setState({
+      selectedDeviceId: "mic-airpods",
+      selectedDeviceLabel: "AirPods (Bluetooth)",
+    });
+
+    renderDialog({ audioTranscriptionEnabled: true });
+    fireEvent.click(screen.getByRole("tab", { name: "Audio" }));
+
+    const audioPanel = await screen.findByRole("tabpanel", { name: "Audio" });
+    const trigger = await within(audioPanel).findByTestId(
+      "audio-input-dropdown-trigger",
+    );
+    await waitFor(() =>
+      expect(trigger).toHaveTextContent("AirPods (Bluetooth) (not connected)"),
+    );
+    expect(
+      within(audioPanel).getByTestId("audio-input-not-connected"),
+    ).toBeInTheDocument();
+    expect(useAudioInputDeviceStore.getState().selectedDeviceId).toBe(
+      "mic-airpods",
+    );
+
+    fireEvent.click(trigger);
+    expect(
+      await screen.findByRole("menuitem", {
+        name: "AirPods (Bluetooth) (not connected)",
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("menuitem", { name: "Built-in Microphone" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not call a stored microphone missing while device ids are still placeholders", async () => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        enumerateDevices: vi.fn(async () => [
+          {
+            deviceId: "",
+            groupId: "",
+            kind: "audioinput",
+            label: "",
+            toJSON: () => ({}),
+          },
+        ]),
+      },
+    });
+    useAudioInputDeviceStore.setState({
+      selectedDeviceId: "mic-airpods",
+      selectedDeviceLabel: "AirPods (Bluetooth)",
+    });
+
+    renderDialog({ audioTranscriptionEnabled: true });
+    fireEvent.click(screen.getByRole("tab", { name: "Audio" }));
+
+    const audioPanel = await screen.findByRole("tabpanel", { name: "Audio" });
+    await waitFor(() =>
+      expect(
+        within(audioPanel).getByTestId("audio-input-diagnostics"),
+      ).toHaveTextContent("1"),
+    );
+    const trigger = within(audioPanel).getByTestId(
+      "audio-input-dropdown-trigger",
+    );
+    expect(trigger).toHaveTextContent("AirPods (Bluetooth)");
+    expect(trigger).not.toHaveTextContent("not connected");
+    expect(
+      within(audioPanel).queryByTestId("audio-input-not-connected"),
+    ).toBeNull();
   });
 
   it("shows an Audio tab when audio transcription is enabled and persists the selected microphone", async () => {

--- a/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useAudioDictationRecorder.test.ts
@@ -1,12 +1,10 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useAudioInputDeviceStore } from "@/state/audioInputDeviceStore";
+
 import { getAudioLevelBarsFromTimeDomainData } from "../audio-pcm-codec";
 import { useAudioDictationRecorder } from "../useAudioDictationRecorder";
-
-vi.mock("../useAudioInputDevicePreference", () => ({
-  useAudioInputDevicePreference: () => ({ selectedAudioInputDeviceId: "" }),
-}));
 
 vi.mock("../audio-dictation-worklet.ts?worker&url", () => ({
   default: "blob:mock-audio-dictation-worklet",
@@ -305,6 +303,10 @@ describe("useAudioDictationRecorder", () => {
     MockAudioWorkletNode.instances.length = 0;
     vadMock.engines.length = 0;
     vadMock.createRicky0123VadEngine.mockClear();
+    useAudioInputDeviceStore.setState({
+      selectedDeviceId: "",
+      selectedDeviceLabel: "",
+    });
 
     Object.defineProperty(navigator, "mediaDevices", {
       configurable: true,
@@ -341,6 +343,36 @@ describe("useAudioDictationRecorder", () => {
       permission.resolve(new MockMediaStream());
       await permission.promise;
     });
+  });
+
+  it("falls back to the system default for the session when the stored microphone cannot be opened", async () => {
+    useAudioInputDeviceStore.setState({
+      selectedDeviceId: "mic-airpods",
+      selectedDeviceLabel: "AirPods (Bluetooth)",
+    });
+    const getUserMedia = vi
+      .fn<
+        (constraints: MediaStreamConstraints) => Promise<MockMediaStream>
+      >(async () => new MockMediaStream())
+      .mockRejectedValueOnce(new DOMException("gone", "OverconstrainedError"));
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    });
+    const { result } = renderDictationHook();
+
+    await act(async () => {
+      result.current.toggleDictation();
+    });
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(2));
+
+    expect(getUserMedia.mock.calls[0][0]).toMatchObject({
+      audio: { deviceId: { exact: "mic-airpods" } },
+    });
+    expect(getUserMedia.mock.calls[1][0].audio).not.toHaveProperty("deviceId");
+    expect(useAudioInputDeviceStore.getState().selectedDeviceId).toBe(
+      "mic-airpods",
+    );
   });
 
   it("clears starting state when the socket closes before session state", async () => {

--- a/frontend/src/hooks/audio/__tests__/useAudioInputDevicePreference.test.ts
+++ b/frontend/src/hooks/audio/__tests__/useAudioInputDevicePreference.test.ts
@@ -9,6 +9,8 @@ import {
   type Mock,
 } from "vitest";
 
+import { useAudioInputDeviceStore } from "@/state/audioInputDeviceStore";
+
 import { useAudioInputDevicePreference } from "../useAudioInputDevicePreference";
 
 type FakeStream = { getTracks: () => { stop: () => void }[] };
@@ -133,5 +135,130 @@ describe("useAudioInputDevicePreference — revealAudioInputDeviceLabels", () =>
     expect(result.current.audioInputDeviceError).toBeNull();
     expect(result.current.audioInputDevices).toHaveLength(1);
     expect(trackStop).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAudioInputDevicePreference — stored selection survives list churn", () => {
+  const PLACEHOLDER: FakeDevice[] = [
+    { kind: "audioinput", deviceId: "", label: "" },
+  ];
+  const REAL: FakeDevice[] = [
+    {
+      kind: "audioinput",
+      deviceId: "mic-airpods",
+      label: "AirPods (Bluetooth)",
+    },
+    {
+      kind: "audioinput",
+      deviceId: "mic-builtin",
+      label: "Built-in Microphone",
+    },
+  ];
+  let devices: FakeDevice[];
+  let deviceChangeListeners: Array<() => void>;
+
+  const fireDeviceChange = () => {
+    for (const listener of deviceChangeListeners) listener();
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    useAudioInputDeviceStore.setState({
+      selectedDeviceId: "",
+      selectedDeviceLabel: "",
+    });
+    devices = REAL;
+    deviceChangeListeners = [];
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({ getTracks: () => [] })),
+        enumerateDevices: vi.fn(async () => devices),
+        addEventListener: vi.fn((_type: string, listener: () => void) => {
+          deviceChangeListeners.push(listener);
+        }),
+        removeEventListener: vi.fn(),
+      },
+    });
+  });
+
+  it("keeps a selection made after the permission grant while another instance still holds the pre-permission placeholder", async () => {
+    devices = PLACEHOLDER;
+    const stale = renderHook(() => useAudioInputDevicePreference());
+    await waitFor(() =>
+      expect(stale.result.current.audioInputDevices).toHaveLength(1),
+    );
+    expect(stale.result.current.hasResolvedDeviceIds).toBe(false);
+
+    devices = REAL;
+    const prefs = renderHook(() => useAudioInputDevicePreference());
+    await waitFor(() =>
+      expect(prefs.result.current.hasResolvedDeviceIds).toBe(true),
+    );
+
+    act(() => {
+      prefs.result.current.setSelectedAudioInputDevice(
+        "mic-airpods",
+        "AirPods (Bluetooth)",
+      );
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(useAudioInputDeviceStore.getState()).toMatchObject({
+      selectedDeviceId: "mic-airpods",
+      selectedDeviceLabel: "AirPods (Bluetooth)",
+    });
+    expect(stale.result.current.selectedAudioInputDeviceId).toBe("mic-airpods");
+  });
+
+  it("keeps the selection across an enumeration that omits the device", async () => {
+    const { result } = renderHook(() => useAudioInputDevicePreference());
+    await waitFor(() =>
+      expect(result.current.audioInputDevices).toHaveLength(2),
+    );
+    act(() => {
+      result.current.setSelectedAudioInputDevice(
+        "mic-airpods",
+        "AirPods (Bluetooth)",
+      );
+    });
+
+    devices = REAL.filter((device) => device.deviceId !== "mic-airpods");
+    act(fireDeviceChange);
+    await waitFor(() =>
+      expect(result.current.audioInputDevices).toHaveLength(1),
+    );
+    expect(result.current.selectedAudioInputDevice).toBeNull();
+    expect(result.current.selectedAudioInputDeviceId).toBe("mic-airpods");
+
+    devices = REAL;
+    act(fireDeviceChange);
+    await waitFor(() =>
+      expect(result.current.selectedAudioInputDevice?.label).toBe(
+        "AirPods (Bluetooth)",
+      ),
+    );
+    expect(useAudioInputDeviceStore.getState().selectedDeviceId).toBe(
+      "mic-airpods",
+    );
+  });
+
+  it("drops the stored label together with the id", () => {
+    const { result } = renderHook(() => useAudioInputDevicePreference());
+    act(() => {
+      result.current.setSelectedAudioInputDevice(
+        "mic-airpods",
+        "AirPods (Bluetooth)",
+      );
+    });
+    act(() => {
+      result.current.setSelectedAudioInputDevice("");
+    });
+    expect(useAudioInputDeviceStore.getState()).toMatchObject({
+      selectedDeviceId: "",
+      selectedDeviceLabel: "",
+    });
   });
 });

--- a/frontend/src/hooks/audio/useAudioDictationRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioDictationRecorder.ts
@@ -15,6 +15,7 @@ import { useThrottledCallback } from "use-debounce";
 // share the same ESM contract on the file format side, so the worker
 // pipeline output is valid as an AudioWorklet module.
 import { createRicky0123VadEngine } from "@/lib/voice-runtime";
+import { useAudioInputDeviceStore } from "@/state/audioInputDeviceStore";
 import { createLogger } from "@/utils/debugLogger";
 
 import {
@@ -42,7 +43,6 @@ import {
   type SpeechOnsetController,
 } from "./onsetFlipController";
 import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
-import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 import { useMediaStreamTrackWatchdog } from "./useMediaStreamTrackWatchdog";
 
 import type { VoiceVadEngine } from "@/lib/voice-runtime";
@@ -269,10 +269,9 @@ export function useAudioDictationRecorder({
    */
   const isMounted = useMountedState();
   const startInFlightRef = useRef(false);
-  const { selectedAudioInputDeviceId, setSelectedAudioInputDeviceId } =
-    useAudioInputDevicePreference({
-      enabled,
-    });
+  const selectedAudioInputDeviceId = useAudioInputDeviceStore(
+    (state) => state.selectedDeviceId,
+  );
 
   // Capture-track device-loss watchdog (ERMAIN-390). The inline handler
   // references `stopDictation`, which is defined further down — fine, it's a
@@ -774,22 +773,17 @@ export function useAudioDictationRecorder({
             : baseAudioConstraints,
         });
       } catch (firstError) {
-        // Belt-and-braces alongside the auto-clear-on-enumerate logic:
-        // even after we've validated the stored deviceId against the
-        // enumerated list, a Bluetooth disconnect (or any other device
-        // change) can race between enumeration and `getUserMedia`. On
-        // OverconstrainedError, retry once with the system-default mic
-        // and clear the stale stored id so the dropdown reflects
-        // reality and subsequent sessions don't keep hitting it.
+        // The stored device can be gone at capture time (Bluetooth drop or
+        // profile switch): use the system default for this session only.
         if (
           selectedAudioInputDeviceId &&
           firstError instanceof DOMException &&
-          firstError.name === "OverconstrainedError"
+          (firstError.name === "OverconstrainedError" ||
+            firstError.name === "NotFoundError")
         ) {
           stream = await mediaDevices.getUserMedia({
             audio: baseAudioConstraints,
           });
-          setSelectedAudioInputDeviceId("");
         } else {
           throw firstError;
         }
@@ -1109,7 +1103,6 @@ export function useAudioDictationRecorder({
     maxRecordingDurationSeconds,
     selectedAudioInputDeviceId,
     setDictationBarsThrottled,
-    setSelectedAudioInputDeviceId,
     startLiveDictationSession,
     stopDictation,
     stopVadEngine,

--- a/frontend/src/hooks/audio/useAudioInputDevicePreference.ts
+++ b/frontend/src/hooks/audio/useAudioInputDevicePreference.ts
@@ -27,8 +27,11 @@ export function useAudioInputDevicePreference({
   const selectedAudioInputDeviceId = useAudioInputDeviceStore(
     (state) => state.selectedDeviceId,
   );
-  const setSelectedDeviceIdInStore = useAudioInputDeviceStore(
-    (state) => state.setSelectedDeviceId,
+  const selectedAudioInputDeviceLabel = useAudioInputDeviceStore(
+    (state) => state.selectedDeviceLabel,
+  );
+  const setSelectedDeviceInStore = useAudioInputDeviceStore(
+    (state) => state.setSelectedDevice,
   );
 
   const [audioInputDevices, setAudioInputDevices] = useState<
@@ -46,17 +49,20 @@ export function useAudioInputDevicePreference({
   // stream is live. Consumers use it to show a "start the test to see
   // device names" hint and to know labels are still placeholders.
   const [hasResolvedLabels, setHasResolvedLabels] = useState(false);
+  // Pre-permission enumeration is one placeholder with an empty deviceId,
+  // so a stored id cannot be judged against it.
+  const [hasResolvedDeviceIds, setHasResolvedDeviceIds] = useState(false);
   // True when the on-demand label reveal (see `revealAudioInputDeviceLabels`)
   // was blocked because the user denied the microphone permission prompt.
   // Drives a tailored, non-error hint — the device list still works on the
   // system default; only the human-readable names are unavailable.
   const [labelRevealDenied, setLabelRevealDenied] = useState(false);
 
-  const setSelectedAudioInputDeviceId = useCallback(
-    (deviceId: string) => {
-      setSelectedDeviceIdInStore(deviceId);
+  const setSelectedAudioInputDevice = useCallback(
+    (deviceId: string, label = "") => {
+      setSelectedDeviceInStore(deviceId, label);
     },
-    [setSelectedDeviceIdInStore],
+    [setSelectedDeviceInStore],
   );
 
   const refreshAudioInputDevices = useCallback(async () => {
@@ -91,9 +97,14 @@ export function useAudioInputDevicePreference({
         });
       setAudioInputDevices(audioInputs);
       setHasResolvedLabels(sawRealLabel);
+      setHasResolvedDeviceIds(
+        audioInputs.length > 0 &&
+          audioInputs.every((device) => device.deviceId !== ""),
+      );
     } catch {
       setAudioInputDevices([]);
       setHasResolvedLabels(false);
+      setHasResolvedDeviceIds(false);
       setAudioInputDeviceError(t`Could not load audio input devices.`);
     } finally {
       setIsLoadingAudioInputDevices(false);
@@ -177,31 +188,6 @@ export function useAudioInputDevicePreference({
     };
   }, [enabled, refreshAudioInputDevices]);
 
-  // Auto-clear a stale stored deviceId. Whenever a fresh enumeration
-  // produces a non-empty device list (initial load, devicechange,
-  // manual refresh) and our persisted `selectedAudioInputDeviceId`
-  // isn't in it, drop the selection so the next `getUserMedia` call
-  // falls back to the system default instead of throwing
-  // `OverconstrainedError`. Triggers on Bluetooth disconnect, USB
-  // unplug, browser-side deviceId rotation, profile changes, etc.
-  // We guard on `audioInputDevices.length > 0` so a pre-permission
-  // enumeration (which returns an empty list on some browsers)
-  // doesn't wipe a still-valid selection.
-  useEffect(() => {
-    if (!selectedAudioInputDeviceId) return;
-    if (audioInputDevices.length === 0) return;
-    const stillAvailable = audioInputDevices.some(
-      (device) => device.deviceId === selectedAudioInputDeviceId,
-    );
-    if (!stillAvailable) {
-      setSelectedAudioInputDeviceId("");
-    }
-  }, [
-    audioInputDevices,
-    selectedAudioInputDeviceId,
-    setSelectedAudioInputDeviceId,
-  ]);
-
   const selectedAudioInputDevice = useMemo(
     () =>
       audioInputDevices.find(
@@ -213,6 +199,7 @@ export function useAudioInputDevicePreference({
   return {
     audioInputDeviceError,
     audioInputDevices,
+    hasResolvedDeviceIds,
     hasResolvedLabels,
     isLoadingAudioInputDevices,
     labelRevealDenied,
@@ -220,6 +207,7 @@ export function useAudioInputDevicePreference({
     revealAudioInputDeviceLabels,
     selectedAudioInputDevice,
     selectedAudioInputDeviceId,
-    setSelectedAudioInputDeviceId,
+    selectedAudioInputDeviceLabel,
+    setSelectedAudioInputDevice,
   };
 }

--- a/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
+++ b/frontend/src/hooks/audio/useAudioTranscriptionRecorder.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/generated/v1betaApi/v1betaApiComponents";
 import { useV1betaApiContext } from "@/lib/generated/v1betaApi/v1betaApiContext";
 import { createRicky0123VadEngine } from "@/lib/voice-runtime";
+import { useAudioInputDeviceStore } from "@/state/audioInputDeviceStore";
 import { createLogger } from "@/utils/debugLogger";
 
 // `?worker&url` routes the worklet through Vite's worker bundling
@@ -32,7 +33,6 @@ import {
   type SpeechOnsetController,
 } from "./onsetFlipController";
 import { useAudioContextInterruptionRecovery } from "./useAudioContextInterruptionRecovery";
-import { useAudioInputDevicePreference } from "./useAudioInputDevicePreference";
 import { useMediaStreamTrackWatchdog } from "./useMediaStreamTrackWatchdog";
 
 import type {
@@ -451,8 +451,9 @@ export function useAudioTranscriptionRecorder({
   /** Mounted getter for the awaits in startAudioRecording and the
    *  deferred finalization — mirrors useAudioDictationRecorder. */
   const isMounted = useMountedState();
-  const { selectedAudioInputDeviceId, setSelectedAudioInputDeviceId } =
-    useAudioInputDevicePreference();
+  const selectedAudioInputDeviceId = useAudioInputDeviceStore(
+    (state) => state.selectedDeviceId,
+  );
 
   // Capture-track device-loss watchdog (ERMAIN-390). The inline handler
   // references `stopAudioRecording`, which is defined further down — fine,
@@ -1279,19 +1280,17 @@ export function useAudioTranscriptionRecorder({
             : baseAudioConstraints,
         });
       } catch (firstError) {
-        // A stored deviceId can go stale between enumeration and
-        // getUserMedia (e.g. a Bluetooth disconnect). On
-        // OverconstrainedError, retry once with the system-default mic
-        // and clear the stale stored id — mirrors the dictation recorder.
+        // The stored device can be gone at capture time (Bluetooth drop or
+        // profile switch): use the system default for this session only.
         if (
           selectedAudioInputDeviceId &&
           firstError instanceof DOMException &&
-          firstError.name === "OverconstrainedError"
+          (firstError.name === "OverconstrainedError" ||
+            firstError.name === "NotFoundError")
         ) {
           stream = await mediaDevices.getUserMedia({
             audio: baseAudioConstraints,
           });
-          setSelectedAudioInputDeviceId("");
         } else {
           throw firstError;
         }
@@ -1637,7 +1636,6 @@ export function useAudioTranscriptionRecorder({
     startLiveAudioTranscriptionSession,
     flushLiveAudioSamples,
     selectedAudioInputDeviceId,
-    setSelectedAudioInputDeviceId,
     setRecordingBarsThrottled,
     stopVadEngine,
     vadAutoStopEnabled,

--- a/frontend/src/locales/de/messages.po
+++ b/frontend/src/locales/de/messages.po
@@ -3193,6 +3193,16 @@ msgstr "Mikrofon"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnected"
+msgstr "{storedDeviceLabel} (nicht verbunden)"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnectedHint"
+msgstr "{storedDeviceLabel} ist nicht verbunden. Aufnahmen verwenden das Standardmikrofon des Systems, bis es wieder verfügbar ist."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.persisted"
 msgstr "Diese Auswahl wird lokal in diesem Browser gespeichert."
 
@@ -3215,6 +3225,11 @@ msgstr "Der Mikrofonzugriff wurde verweigert, daher können die Gerätenamen nic
 #: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.revealHint"
 msgstr "Aktualisieren Sie die Geräte oder starten Sie unten den Mikrofontest, um Ihre Gerätenamen anzuzeigen."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.storedDevice"
+msgstr "Ausgewähltes Mikrofon"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/GuidedMicCheck.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -3193,6 +3193,16 @@ msgstr "Microphone"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnected"
+msgstr "{storedDeviceLabel} (not connected)"
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnectedHint"
+msgstr "{storedDeviceLabel} is not connected. Recordings use the system default microphone until it is available again."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.persisted"
 msgstr "This selection is saved locally in this browser."
 
@@ -3215,6 +3225,11 @@ msgstr "Microphone access was denied, so device names can't be shown. You can st
 #: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.revealHint"
 msgstr "To show your device names, refresh devices or start the microphone test below."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.storedDevice"
+msgstr "Selected microphone"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/GuidedMicCheck.tsx

--- a/frontend/src/locales/es/messages.po
+++ b/frontend/src/locales/es/messages.po
@@ -3193,6 +3193,16 @@ msgstr "Micrófono"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnectedHint"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.persisted"
 msgstr "Esta selección se guarda localmente en este navegador."
 
@@ -3215,6 +3225,11 @@ msgstr "Se denegó el acceso al micrófono, por lo que no se pueden mostrar los 
 #: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.revealHint"
 msgstr "Para mostrar los nombres de tus dispositivos, actualiza los dispositivos o inicia la prueba del micrófono de abajo."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.storedDevice"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/GuidedMicCheck.tsx

--- a/frontend/src/locales/fr/messages.po
+++ b/frontend/src/locales/fr/messages.po
@@ -3193,6 +3193,16 @@ msgstr "Microphone"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnectedHint"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.persisted"
 msgstr "Cette sélection est enregistrée localement dans ce navigateur."
 
@@ -3215,6 +3225,11 @@ msgstr "L'accès au microphone a été refusé, les noms des appareils ne peuven
 #: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.revealHint"
 msgstr "Pour afficher les noms de vos appareils, actualisez les appareils ou lancez le test du microphone ci-dessous."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.storedDevice"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/GuidedMicCheck.tsx

--- a/frontend/src/locales/pl/messages.po
+++ b/frontend/src/locales/pl/messages.po
@@ -3193,6 +3193,16 @@ msgstr "Mikrofon"
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.notConnectedHint"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.persisted"
 msgstr "Ten wybór jest zapisywany lokalnie w tej przeglądarce."
 
@@ -3215,6 +3225,11 @@ msgstr "Odmówiono dostępu do mikrofonu, więc nie można wyświetlić nazw urz
 #: src/components/ui/Settings/AudioInputTabContent.tsx
 msgid "preferences.dialog.audio.input.revealHint"
 msgstr "Aby wyświetlić nazwy urządzeń, odśwież urządzenia lub uruchom poniżej test mikrofonu."
+
+#. js-lingui-explicit-id
+#: src/components/ui/Settings/AudioInputTabContent.tsx
+msgid "preferences.dialog.audio.input.storedDevice"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/ui/Settings/GuidedMicCheck.tsx

--- a/frontend/src/state/audioInputDeviceStore.ts
+++ b/frontend/src/state/audioInputDeviceStore.ts
@@ -45,7 +45,9 @@ migrateLegacyAudioInputDeviceId();
 
 export interface AudioInputDeviceState {
   selectedDeviceId: string;
-  setSelectedDeviceId: (deviceId: string) => void;
+  /** Captured at selection time so an unplugged device can still be named. */
+  selectedDeviceLabel: string;
+  setSelectedDevice: (deviceId: string, label: string) => void;
 }
 
 export const useAudioInputDeviceStore = create<AudioInputDeviceState>()(
@@ -53,11 +55,15 @@ export const useAudioInputDeviceStore = create<AudioInputDeviceState>()(
     persist(
       (set) => ({
         selectedDeviceId: "",
-        setSelectedDeviceId: (deviceId) =>
+        selectedDeviceLabel: "",
+        setSelectedDevice: (deviceId, label) =>
           set(
-            { selectedDeviceId: deviceId },
+            {
+              selectedDeviceId: deviceId,
+              selectedDeviceLabel: deviceId ? label : "",
+            },
             false,
-            "audioInputDevice/setSelectedDeviceId",
+            "audioInputDevice/setSelectedDevice",
           ),
       }),
       {
@@ -92,7 +98,10 @@ export const useAudioInputDeviceStore = create<AudioInputDeviceState>()(
             }
           },
         })),
-        partialize: (state) => ({ selectedDeviceId: state.selectedDeviceId }),
+        partialize: (state) => ({
+          selectedDeviceId: state.selectedDeviceId,
+          selectedDeviceLabel: state.selectedDeviceLabel,
+        }),
       },
     ),
     {


### PR DESCRIPTION
Fixes ERMAIN-795: picking a microphone in Preferences > Audio (e.g. AirPods) silently reverted to "System default microphone".

## Root cause

`useAudioInputDevicePreference` had an auto-clear effect that validated the shared store value against the instance's own enumerated list and wrote `""` when the id was missing. Every mounted instance ran it: the Preferences tab plus the transcription and dictation recorders in `ChatInput`. Two triggers, both reproduced:

- **First pick after granting permission from inside Preferences.** Before permission, Chrome returns a single placeholder audio input with an empty `deviceId` (a non-empty list, so the `length > 0` guard did not protect). Granting the permission fires no `devicechange`, so the recorder instances kept the placeholder list and wiped the pick made in Preferences within one render. A reload made the same pick stick, which is why it looked intermittent.
- **Any enumeration that omits the selected device** (Bluetooth auto-switch, profile switch when the mic opens, sleep/wake) deleted the persisted preference for good.

Both paths were confirmed in the live app (Chrome 153), in a headed Chromium 143 with real devices, and by two independent agent reviews with their own scripts and tests. The first trigger is Chromium-specific (WebView2 included); WebKit re-fires `devicechange` on first capture, so Safari and Mac Outlook are exposed only through the second.

## Change

- The recorders subscribe to the store directly instead of mounting the enumerating hook, so the Preferences tab is the only instance that enumerates and no instance validates the shared value.
- The auto-clear effect is gone. The store now also persists the device label, and the Preferences dropdown shows an unlisted stored device as "<label> (not connected)" with a hint, gated on a resolved (post-permission) device list so the placeholder state stays quiet.
- The recorders' `getUserMedia` fallback keeps the retry with default constraints (now also on `NotFoundError`) but no longer wipes the preference, so a transient failure at capture time uses the default for that session only.