### PR TITLE
Blink a pending dot on the tab favicon for the open chat

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -558,6 +558,14 @@ const eslintConfig = [
     },
   },
 
+  // Favicon composition - SVG markup, selectors and media queries, no UI text
+  {
+    files: ["src/lib/favicon/**/*"],
+    rules: {
+      "lingui/no-unlocalized-strings": "off",
+    },
+  },
+
   // Test files configuration - more lenient rules for testing needs
   {
     files: [

--- a/frontend/src/components/providers/ClientProviders.tsx
+++ b/frontend/src/components/providers/ClientProviders.tsx
@@ -2,6 +2,7 @@
 
 import { ApiProvider } from "./ApiProvider";
 import { GenerationStatusPoller } from "./GenerationStatusPoller";
+import { TabChatIndicator } from "./TabChatIndicator";
 import { ThemeProvider } from "./ThemeProvider";
 import {
   DesktopSidecarConfigurationSync,
@@ -21,6 +22,7 @@ export function ClientProviders({ children }: PropsWithChildren) {
   return (
     <ApiProvider>
       <GenerationStatusPoller />
+      <TabChatIndicator />
       <DesktopSidecarProvider>
         <DesktopSidecarConfigurationSync />
         <ThemeProvider>

--- a/frontend/src/components/providers/TabChatIndicator.test.tsx
+++ b/frontend/src/components/providers/TabChatIndicator.test.tsx
@@ -1,0 +1,134 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
+import { useMessagingStore } from "@/hooks/chat/store/messagingStore";
+import { resetBaseIconCache } from "@/lib/favicon/composeBadgedIcon";
+
+import { TabChatIndicator } from "./TabChatIndicator";
+
+const ticks: Array<() => void> = [];
+
+vi.mock("@/lib/favicon/blinkDriver", () => ({
+  shouldBlink: () => true,
+  startBlink: (onTick: () => void) => {
+    ticks.push(onTick);
+    return { stop: () => {} };
+  },
+}));
+
+const iconHrefs = () =>
+  Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+  ).map((link) => link.getAttribute("href"));
+
+const setHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+const setStreaming = (isStreaming: boolean) => {
+  useMessagingStore.setState({
+    streaming: {
+      isStreaming,
+      isFinalizing: false,
+      currentMessageId: null,
+      content: [],
+      createdAt: null,
+    },
+  });
+};
+
+describe("TabChatIndicator", () => {
+  beforeEach(() => {
+    ticks.length = 0;
+    resetBaseIconCache();
+    document.head.innerHTML =
+      '<link rel="icon" href="/favicon.ico" sizes="any">' +
+      '<link rel="icon" href="/favicon.svg" type="image/svg+xml">';
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          '<svg viewBox="0 0 21 22"><path d="M0 0h21v22H0z"/></svg>',
+          {
+            status: 200,
+            headers: { "content-type": "image/svg+xml" },
+          },
+        ),
+      ),
+    );
+    setHidden(false);
+    setStreaming(false);
+    useGenerationStatusStore.setState({
+      statusByChatId: {},
+      currentChatId: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves the original icons alone while the tab is visible", async () => {
+    setStreaming(true);
+    render(<TabChatIndicator />);
+
+    await waitFor(() => {
+      expect(iconHrefs()).toEqual(["/favicon.ico", "/favicon.svg"]);
+    });
+  });
+
+  it("badges the icon and alternates frames while hidden and generating", async () => {
+    setStreaming(true);
+    setHidden(true);
+    render(<TabChatIndicator />);
+
+    await waitFor(() => {
+      expect(ticks).toHaveLength(1);
+    });
+    const badged = iconHrefs()[0];
+    expect(badged).toContain("circle");
+
+    ticks[0]();
+    const off = iconHrefs()[0];
+    expect(off).not.toContain("circle");
+
+    ticks[0]();
+    expect(iconHrefs()[0]).toBe(badged);
+  });
+
+  it("holds a solid icon for a finished chat rather than blinking", async () => {
+    setStreaming(true);
+    setHidden(true);
+    render(<TabChatIndicator />);
+    await waitFor(() => {
+      expect(ticks).toHaveLength(1);
+    });
+
+    setStreaming(false);
+
+    await waitFor(() => {
+      expect(iconHrefs()[0]).toContain("%231f9d55");
+    });
+    expect(ticks).toHaveLength(1);
+  });
+
+  it("restores the original icons when the tab is looked at", async () => {
+    setStreaming(true);
+    setHidden(true);
+    render(<TabChatIndicator />);
+    await waitFor(() => {
+      expect(iconHrefs()[0]).toContain("circle");
+    });
+
+    setHidden(false);
+
+    await waitFor(() => {
+      expect(iconHrefs()).toEqual(["/favicon.ico", "/favicon.svg"]);
+    });
+  });
+});

--- a/frontend/src/components/providers/TabChatIndicator.tsx
+++ b/frontend/src/components/providers/TabChatIndicator.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useTabChatActivity } from "@/hooks/chat/useTabChatActivity";
+import {
+  shouldBlink,
+  startBlink,
+  type BlinkHandle,
+} from "@/lib/favicon/blinkDriver";
+import { composeBadgedIcon } from "@/lib/favicon/composeBadgedIcon";
+import { applyIconHref, restoreIconLinks } from "@/lib/favicon/iconLinkManager";
+
+/**
+ * Badges the favicon while this tab's chat is generating, awaiting an approval,
+ * or has finished unseen. Renders nothing, and no-ops in browsers that ignore
+ * runtime favicon changes (Safari) since nothing reads the icon back.
+ */
+export function TabChatIndicator() {
+  const activity = useTabChatActivity();
+
+  useEffect(() => {
+    if (activity === "idle") {
+      restoreIconLinks();
+      return;
+    }
+
+    const controller = new AbortController();
+    let handle: BlinkHandle | undefined;
+
+    const blink = activity === "working" && shouldBlink();
+
+    const apply = async () => {
+      const [badged, plain] = await Promise.all([
+        composeBadgedIcon(activity),
+        blink ? composeBadgedIcon(null) : Promise.resolve(null),
+      ]);
+      if (controller.signal.aborted || badged === null) {
+        return;
+      }
+      applyIconHref(badged);
+      if (!blink || plain === null) {
+        return;
+      }
+      let dotVisible = true;
+      handle = startBlink(() => {
+        dotVisible = !dotVisible;
+        applyIconHref(dotVisible ? badged : plain);
+      });
+    };
+
+    void apply();
+
+    return () => {
+      controller.abort();
+      handle?.stop();
+    };
+  }, [activity]);
+
+  useEffect(() => restoreIconLinks, []);
+
+  return null;
+}

--- a/frontend/src/hooks/chat/__tests__/useTabChatActivity.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useTabChatActivity.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
+import { useMessagingStore } from "@/hooks/chat/store/messagingStore";
+import { useTabChatActivity } from "@/hooks/chat/useTabChatActivity";
+
+const startedAt = new Date("2024-01-01T00:00:00.000Z").toISOString();
+
+const setHidden = (hidden: boolean) => {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+};
+
+const setStreaming = (isStreaming: boolean, isFinalizing = false) => {
+  useMessagingStore.setState({
+    streaming: {
+      isStreaming,
+      isFinalizing,
+      currentMessageId: null,
+      content: [],
+      createdAt: null,
+    },
+  });
+};
+
+describe("useTabChatActivity", () => {
+  beforeEach(() => {
+    setHidden(false);
+    setStreaming(false);
+    useGenerationStatusStore.setState({
+      statusByChatId: {},
+      currentChatId: null,
+    });
+  });
+
+  it("stays idle while the tab is visible and generating", () => {
+    setStreaming(true);
+    setHidden(false);
+
+    const { result } = renderHook(() => useTabChatActivity());
+
+    expect(result.current).toBe("idle");
+  });
+
+  it("reports working once the generating tab is hidden", () => {
+    setStreaming(true);
+    const { result } = renderHook(() => useTabChatActivity());
+
+    act(() => {
+      setHidden(true);
+    });
+
+    expect(result.current).toBe("working");
+  });
+
+  it("keeps working through the post-stream finalizing phase", () => {
+    setStreaming(true);
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+
+    act(() => {
+      setStreaming(false, true);
+    });
+
+    expect(result.current).toBe("working");
+  });
+
+  it("latches ready when the chat finishes while hidden", () => {
+    setStreaming(true);
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+
+    act(() => {
+      setStreaming(false);
+    });
+
+    expect(result.current).toBe("ready");
+  });
+
+  it("clears ready once the tab is looked at, and does not latch again", () => {
+    setStreaming(true);
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+    act(() => {
+      setStreaming(false);
+    });
+
+    act(() => {
+      setHidden(false);
+    });
+    expect(result.current).toBe("idle");
+
+    act(() => {
+      setHidden(true);
+    });
+    expect(result.current).toBe("idle");
+  });
+
+  it("does not latch ready for a generation that ended in view", () => {
+    setStreaming(true);
+    const { result } = renderHook(() => useTabChatActivity());
+
+    act(() => {
+      setStreaming(false);
+    });
+    act(() => {
+      setHidden(true);
+    });
+
+    expect(result.current).toBe("idle");
+  });
+
+  it("outranks working with a pending tool approval on the open chat", () => {
+    useGenerationStatusStore.setState({
+      statusByChatId: {
+        "chat-a": { kind: "action_required", startedAt, localSeenAt: 0 },
+      },
+      currentChatId: "chat-a",
+    });
+    setStreaming(true);
+
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+
+    expect(result.current).toBe("attention");
+  });
+
+  it("ignores a pending approval belonging to another chat", () => {
+    useGenerationStatusStore.setState({
+      statusByChatId: {
+        "chat-b": { kind: "action_required", startedAt, localSeenAt: 0 },
+      },
+      currentChatId: "chat-a",
+    });
+
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+
+    expect(result.current).toBe("idle");
+  });
+});

--- a/frontend/src/hooks/chat/__tests__/useTabChatActivity.test.ts
+++ b/frontend/src/hooks/chat/__tests__/useTabChatActivity.test.ts
@@ -137,6 +137,20 @@ describe("useTabChatActivity", () => {
     expect(result.current).toBe("attention");
   });
 
+  it("stays idle inside an iframe, where the favicon is the host page's", () => {
+    const top = window.top;
+    Object.defineProperty(window, "top", { configurable: true, value: {} });
+    setStreaming(true);
+
+    const { result } = renderHook(() => useTabChatActivity());
+    act(() => {
+      setHidden(true);
+    });
+
+    expect(result.current).toBe("idle");
+    Object.defineProperty(window, "top", { configurable: true, value: top });
+  });
+
   it("ignores a pending approval belonging to another chat", () => {
     useGenerationStatusStore.setState({
       statusByChatId: {

--- a/frontend/src/hooks/chat/useTabChatActivity.ts
+++ b/frontend/src/hooks/chat/useTabChatActivity.ts
@@ -5,6 +5,10 @@ import { useMessagingStore } from "@/hooks/chat/store/messagingStore";
 
 export type TabChatActivity = "idle" | "working" | "ready" | "attention";
 
+// Framed (the Teams tab), the favicon belongs to the host page and nothing this
+// hook drives is ever visible.
+const isFramed = (): boolean => window.self !== window.top;
+
 const useDocumentHidden = (): boolean => {
   const [hidden, setHidden] = useState(() => document.hidden);
 
@@ -58,7 +62,7 @@ export const useTabChatActivity = (): TabChatActivity => {
     }
   }, [hidden]);
 
-  if (!hidden) {
+  if (!hidden || isFramed()) {
     return "idle";
   }
   if (awaitingApproval) {

--- a/frontend/src/hooks/chat/useTabChatActivity.ts
+++ b/frontend/src/hooks/chat/useTabChatActivity.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useGenerationStatusStore } from "@/hooks/chat/store/generationStatusStore";
+import { useMessagingStore } from "@/hooks/chat/store/messagingStore";
+
+export type TabChatActivity = "idle" | "working" | "ready" | "attention";
+
+const useDocumentHidden = (): boolean => {
+  const [hidden, setHidden] = useState(() => document.hidden);
+
+  useEffect(() => {
+    const sync = () => {
+      setHidden(document.hidden);
+    };
+    document.addEventListener("visibilitychange", sync);
+    sync();
+    return () => {
+      document.removeEventListener("visibilitychange", sync);
+    };
+  }, []);
+
+  return hidden;
+};
+
+/**
+ * Tab-strip state for the chat this tab has open, and nothing else — a
+ * session-wide signal would blink every tab whenever any chat was running.
+ * Only a hidden tab carries a marker; a visible one is always "idle".
+ */
+export const useTabChatActivity = (): TabChatActivity => {
+  const hidden = useDocumentHidden();
+  const working = useMessagingStore(
+    (state) => state.streaming.isStreaming || state.streaming.isFinalizing,
+  );
+  const awaitingApproval = useGenerationStatusStore((state) => {
+    const chatId = state.currentChatId;
+    return (
+      chatId !== null &&
+      state.statusByChatId[chatId]?.kind === "action_required"
+    );
+  });
+
+  // The store tombstones a viewed chat's completion, so "ready" for the chat the
+  // user sent from exists nowhere else: latch the falling edge while hidden.
+  const [ready, setReady] = useState(false);
+  const wasWorking = useRef(working);
+
+  useEffect(() => {
+    if (wasWorking.current && !working && document.hidden) {
+      setReady(true);
+    }
+    wasWorking.current = working;
+  }, [working]);
+
+  useEffect(() => {
+    if (!hidden) {
+      setReady(false);
+    }
+  }, [hidden]);
+
+  if (!hidden) {
+    return "idle";
+  }
+  if (awaitingApproval) {
+    return "attention";
+  }
+  if (working) {
+    return "working";
+  }
+  return ready ? "ready" : "idle";
+};

--- a/frontend/src/lib/favicon/badgeGeometry.ts
+++ b/frontend/src/lib/favicon/badgeGeometry.ts
@@ -1,0 +1,21 @@
+export const ICON_CANVAS_SIZE = 32;
+
+export interface BadgeGeometry {
+  cx: number;
+  cy: number;
+  dotRadius: number;
+  ringRadius: number;
+}
+
+/** Lower-right dot, sized to stay legible once the tab paints the icon at 16px. */
+export const badgeGeometry = (
+  size: number = ICON_CANVAS_SIZE,
+): BadgeGeometry => {
+  const ringRadius = size * 0.28;
+  return {
+    cx: size - ringRadius,
+    cy: size - ringRadius,
+    dotRadius: ringRadius * 0.72,
+    ringRadius,
+  };
+};

--- a/frontend/src/lib/favicon/blink.worker.ts
+++ b/frontend/src/lib/favicon/blink.worker.ts
@@ -1,0 +1,8 @@
+// Hidden tabs clamp main-thread timers to 1 Hz; a worker timer is exempt.
+const BLINK_INTERVAL_MS = 600;
+
+setInterval(() => {
+  (
+    globalThis as unknown as { postMessage: (message: number) => void }
+  ).postMessage(1);
+}, BLINK_INTERVAL_MS);

--- a/frontend/src/lib/favicon/blinkDriver.ts
+++ b/frontend/src/lib/favicon/blinkDriver.ts
@@ -1,0 +1,36 @@
+const FALLBACK_INTERVAL_MS = 600;
+
+export interface BlinkHandle {
+  stop: () => void;
+}
+
+export const shouldBlink = (): boolean =>
+  typeof window.matchMedia !== "function" ||
+  !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+/**
+ * Ticks from a worker so the blink survives a hidden tab's 1 Hz timer clamp;
+ * a main-thread interval covers browsers or builds without worker support.
+ */
+export const startBlink = (onTick: () => void): BlinkHandle => {
+  try {
+    const worker = new Worker(new URL("./blink.worker.ts", import.meta.url), {
+      type: "module",
+    });
+    worker.onmessage = () => {
+      onTick();
+    };
+    return {
+      stop: () => {
+        worker.terminate();
+      },
+    };
+  } catch {
+    const timer = setInterval(onTick, FALLBACK_INTERVAL_MS);
+    return {
+      stop: () => {
+        clearInterval(timer);
+      },
+    };
+  }
+};

--- a/frontend/src/lib/favicon/composeBadgedIcon.test.ts
+++ b/frontend/src/lib/favicon/composeBadgedIcon.test.ts
@@ -80,4 +80,44 @@ describe("composeBadgedIcon", () => {
 
     await expect(composeBadgedIcon("working")).resolves.toBeNull();
   });
+
+  it("retries the fetch after a failure instead of pinning it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(
+        new Response(THEMED_SVG, {
+          status: 200,
+          headers: { "content-type": "image/svg+xml" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(composeBadgedIcon("working")).resolves.toBeNull();
+    await expect(composeBadgedIcon("working")).resolves.toContain(
+      "data:image/svg+xml,",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a non-image response such as an auth redirect page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      respondWith("<html>sign in</html>", "text/html; charset=utf-8"),
+    );
+
+    await expect(composeBadgedIcon("working")).resolves.toBeNull();
+  });
+
+  it("serves a repeated tone from the frame cache without re-parsing", async () => {
+    vi.stubGlobal("fetch", respondWith(THEMED_SVG, "image/svg+xml"));
+    const parse = vi.spyOn(DOMParser.prototype, "parseFromString");
+
+    const first = await composeBadgedIcon("ready");
+    const second = await composeBadgedIcon("ready");
+
+    expect(second).toBe(first);
+    expect(parse).toHaveBeenCalledTimes(1);
+    parse.mockRestore();
+  });
 });

--- a/frontend/src/lib/favicon/composeBadgedIcon.test.ts
+++ b/frontend/src/lib/favicon/composeBadgedIcon.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { composeBadgedIcon, resetBaseIconCache } from "./composeBadgedIcon";
+
+const THEMED_SVG = `<svg viewBox="0 0 21 22" xmlns="http://www.w3.org/2000/svg">
+  <style>.mark { fill: #050505; } @media (prefers-color-scheme: dark) { .mark { fill: #ffffff; } }</style>
+  <path class="mark" d="M0 0h21v22H0z"/>
+</svg>`;
+
+const respondWith = (body: BodyInit, contentType: string) =>
+  vi.fn().mockResolvedValue(
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": contentType },
+    }),
+  );
+
+const decode = (dataUri: string) =>
+  decodeURIComponent(dataUri.replace("data:image/svg+xml,", ""));
+
+describe("composeBadgedIcon", () => {
+  beforeEach(() => {
+    resetBaseIconCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("nests the themed icon and stamps a toned dot", async () => {
+    vi.stubGlobal("fetch", respondWith(THEMED_SVG, "image/svg+xml"));
+
+    const svg = decode((await composeBadgedIcon("ready")) ?? "");
+
+    expect(svg).toContain('viewBox="0 0 32 32"');
+    expect(svg).toContain('fill="#1f9d55"');
+    expect(svg).toContain('viewBox="0 0 21 22"');
+  });
+
+  it("keeps the base icon's own colour-scheme rules inside the data URI", async () => {
+    vi.stubGlobal("fetch", respondWith(THEMED_SVG, "image/svg+xml"));
+
+    const svg = decode((await composeBadgedIcon("working")) ?? "");
+
+    expect(svg).toContain("prefers-color-scheme: dark");
+  });
+
+  it("omits the dot for a null tone so the blink has an off frame", async () => {
+    vi.stubGlobal("fetch", respondWith(THEMED_SVG, "image/svg+xml"));
+
+    const svg = decode((await composeBadgedIcon(null)) ?? "");
+
+    expect(svg).not.toContain("<circle");
+  });
+
+  it("embeds a raster base when the theme only ships an .ico", async () => {
+    vi.stubGlobal(
+      "fetch",
+      respondWith(new Uint8Array([1, 2, 3]), "image/x-icon"),
+    );
+
+    const svg = decode((await composeBadgedIcon("attention")) ?? "");
+
+    expect(svg).toContain('<image href="data:image/x-icon;base64,');
+    expect(svg).toContain('fill="#b4690e"');
+  });
+
+  it("fetches the base icon once across repeated composes", async () => {
+    const fetchMock = respondWith(THEMED_SVG, "image/svg+xml");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await composeBadgedIcon("working");
+    await composeBadgedIcon(null);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the icon cannot be fetched", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    await expect(composeBadgedIcon("working")).resolves.toBeNull();
+  });
+});

--- a/frontend/src/lib/favicon/composeBadgedIcon.ts
+++ b/frontend/src/lib/favicon/composeBadgedIcon.ts
@@ -16,6 +16,7 @@ type BaseIcon =
   | { kind: "raster"; dataUri: string };
 
 let baseIconPromise: Promise<BaseIcon | null> | null = null;
+const framesByTone = new Map<TabIndicatorTone | null, string>();
 
 const bytesToBase64 = (bytes: Uint8Array): string => {
   let binary = "";
@@ -31,6 +32,11 @@ const fetchBaseIcon = async (): Promise<BaseIcon | null> => {
     return null;
   }
   const contentType = response.headers.get("content-type") ?? "";
+  // An auth redirect lands here as a 200 HTML page; embedding it would paint
+  // garbage as the icon.
+  if (!contentType.startsWith("image/")) {
+    return null;
+  }
   // The backend resolves themed favicons by precedence and answers this .svg
   // path with a theme's .ico bytes when that is all it ships, so the response
   // header decides the branch and the URL extension cannot.
@@ -40,7 +46,7 @@ const fetchBaseIcon = async (): Promise<BaseIcon | null> => {
   const bytes = new Uint8Array(await response.arrayBuffer());
   return {
     kind: "raster",
-    dataUri: `data:${contentType || "image/x-icon"};base64,${bytesToBase64(bytes)}`,
+    dataUri: `data:${contentType};base64,${bytesToBase64(bytes)}`,
   };
 };
 
@@ -77,9 +83,15 @@ const badgeMarkup = (tone: TabIndicatorTone): string => {
 export const composeBadgedIcon = async (
   tone: TabIndicatorTone | null,
 ): Promise<string | null> => {
+  const cached = framesByTone.get(tone);
+  if (cached !== undefined) {
+    return cached;
+  }
   baseIconPromise ??= fetchBaseIcon().catch(() => null);
   const base = await baseIconPromise;
   if (!base) {
+    // Leave a failed fetch uncached so a later transition retries it.
+    baseIconPromise = null;
     return null;
   }
   const inner =
@@ -93,9 +105,12 @@ export const composeBadgedIcon = async (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${ICON_CANVAS_SIZE} ${ICON_CANVAS_SIZE}"` +
     ` width="${ICON_CANVAS_SIZE}" height="${ICON_CANVAS_SIZE}">` +
     `${inner}${tone === null ? "" : badgeMarkup(tone)}</svg>`;
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  const frame = `data:image/svg+xml,${encodeURIComponent(svg)}`;
+  framesByTone.set(tone, frame);
+  return frame;
 };
 
 export const resetBaseIconCache = (): void => {
   baseIconPromise = null;
+  framesByTone.clear();
 };

--- a/frontend/src/lib/favicon/composeBadgedIcon.ts
+++ b/frontend/src/lib/favicon/composeBadgedIcon.ts
@@ -1,0 +1,101 @@
+import { badgeGeometry, ICON_CANVAS_SIZE } from "./badgeGeometry";
+
+const BASE_ICON_URL = "/favicon.svg";
+
+export type TabIndicatorTone = "working" | "ready" | "attention";
+
+/** Literals, not theme tokens: the favicon is an isolated document with no CSS vars. */
+const TONE_FILL: Record<TabIndicatorTone, string> = {
+  working: "#8e9ba1",
+  ready: "#1f9d55",
+  attention: "#b4690e",
+};
+
+type BaseIcon =
+  | { kind: "svg"; markup: string }
+  | { kind: "raster"; dataUri: string };
+
+let baseIconPromise: Promise<BaseIcon | null> | null = null;
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return window.btoa(binary);
+};
+
+const fetchBaseIcon = async (): Promise<BaseIcon | null> => {
+  const response = await fetch(BASE_ICON_URL);
+  if (!response.ok) {
+    return null;
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  // The backend resolves themed favicons by precedence and answers this .svg
+  // path with a theme's .ico bytes when that is all it ships, so the response
+  // header decides the branch and the URL extension cannot.
+  if (contentType.includes("svg")) {
+    return { kind: "svg", markup: await response.text() };
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return {
+    kind: "raster",
+    dataUri: `data:${contentType || "image/x-icon"};base64,${bytesToBase64(bytes)}`,
+  };
+};
+
+/**
+ * Re-sizes the themed icon into a nested `<svg>`, which keeps its own viewBox
+ * and its `prefers-color-scheme` rules live inside the composed data URI.
+ */
+const nestBaseSvg = (markup: string): string | null => {
+  const parsed = new DOMParser().parseFromString(markup, "image/svg+xml");
+  if (
+    parsed.getElementsByTagName("parsererror").length > 0 ||
+    parsed.documentElement.nodeName !== "svg"
+  ) {
+    return null;
+  }
+  const root = parsed.documentElement;
+  root.setAttribute("width", String(ICON_CANVAS_SIZE));
+  root.setAttribute("height", String(ICON_CANVAS_SIZE));
+  root.removeAttribute("x");
+  root.removeAttribute("y");
+  return new XMLSerializer().serializeToString(root);
+};
+
+const badgeMarkup = (tone: TabIndicatorTone): string => {
+  const { cx, cy, dotRadius, ringRadius } = badgeGeometry();
+  // The white ring is what separates the dot from a dark tab strip.
+  return (
+    `<circle cx="${cx}" cy="${cy}" r="${ringRadius}" fill="#ffffff"/>` +
+    `<circle cx="${cx}" cy="${cy}" r="${dotRadius}" fill="${TONE_FILL[tone]}"/>`
+  );
+};
+
+/** `null` tone yields the un-badged frame, which is the blink's "off" state. */
+export const composeBadgedIcon = async (
+  tone: TabIndicatorTone | null,
+): Promise<string | null> => {
+  baseIconPromise ??= fetchBaseIcon().catch(() => null);
+  const base = await baseIconPromise;
+  if (!base) {
+    return null;
+  }
+  const inner =
+    base.kind === "svg"
+      ? nestBaseSvg(base.markup)
+      : `<image href="${base.dataUri}" width="${ICON_CANVAS_SIZE}" height="${ICON_CANVAS_SIZE}"/>`;
+  if (inner === null) {
+    return null;
+  }
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${ICON_CANVAS_SIZE} ${ICON_CANVAS_SIZE}"` +
+    ` width="${ICON_CANVAS_SIZE}" height="${ICON_CANVAS_SIZE}">` +
+    `${inner}${tone === null ? "" : badgeMarkup(tone)}</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};
+
+export const resetBaseIconCache = (): void => {
+  baseIconPromise = null;
+};

--- a/frontend/src/lib/favicon/iconLinkManager.test.ts
+++ b/frontend/src/lib/favicon/iconLinkManager.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { applyIconHref, restoreIconLinks } from "./iconLinkManager";
+
+const seedOriginalLinks = () => {
+  document.head.innerHTML =
+    '<link rel="icon" href="/favicon.ico" sizes="any">' +
+    '<link rel="icon" href="/favicon.svg" type="image/svg+xml">';
+};
+
+const iconLinks = () =>
+  Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'));
+
+describe("iconLinkManager", () => {
+  beforeEach(() => {
+    seedOriginalLinks();
+    restoreIconLinks();
+    seedOriginalLinks();
+  });
+
+  it("leaves a single managed link so the browser cannot pick an original", () => {
+    applyIconHref("data:image/svg+xml,badged");
+
+    const links = iconLinks();
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("data:image/svg+xml,badged");
+  });
+
+  it("reuses the managed link across frames", () => {
+    applyIconHref("data:image/svg+xml,on");
+    const first = iconLinks()[0];
+
+    applyIconHref("data:image/svg+xml,off");
+
+    expect(iconLinks()[0]).toBe(first);
+    expect(first.getAttribute("href")).toBe("data:image/svg+xml,off");
+  });
+
+  it("restores the originals with their selection attributes intact", () => {
+    applyIconHref("data:image/svg+xml,badged");
+    restoreIconLinks();
+
+    const links = iconLinks();
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "/favicon.ico",
+      "/favicon.svg",
+    ]);
+    expect(links[0].getAttribute("sizes")).toBe("any");
+    expect(links[1].getAttribute("type")).toBe("image/svg+xml");
+  });
+
+  it("is a no-op when restoring without an applied badge", () => {
+    restoreIconLinks();
+
+    expect(iconLinks()).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/favicon/iconLinkManager.ts
+++ b/frontend/src/lib/favicon/iconLinkManager.ts
@@ -1,0 +1,41 @@
+const MANAGED_ATTRIBUTE = "data-tab-chat-indicator";
+
+let detachedLinks: HTMLLinkElement[] = [];
+
+const managedLink = (): HTMLLinkElement | null =>
+  document.head.querySelector<HTMLLinkElement>(`link[${MANAGED_ATTRIBUTE}]`);
+
+export const applyIconHref = (href: string): void => {
+  let link = managedLink();
+  if (!link) {
+    // Both originals have to go: their `sizes`/`type` let the browser keep
+    // choosing the one we did not patch.
+    detachedLinks = Array.from(
+      document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'),
+    );
+    for (const original of detachedLinks) {
+      original.remove();
+    }
+    link = document.createElement("link");
+    link.setAttribute(MANAGED_ATTRIBUTE, "");
+    link.setAttribute("rel", "icon");
+    link.setAttribute("type", "image/svg+xml");
+    document.head.appendChild(link);
+  }
+  if (link.getAttribute("href") !== href) {
+    link.setAttribute("href", href);
+  }
+};
+
+/** Re-appends the original nodes, so their attributes and theme URL come back intact. */
+export const restoreIconLinks = (): void => {
+  const link = managedLink();
+  if (!link) {
+    return;
+  }
+  link.remove();
+  for (const original of detachedLinks) {
+    document.head.appendChild(original);
+  }
+  detachedLinks = [];
+};


### PR DESCRIPTION
Badges the browser tab's favicon while the chat **this tab has open** is generating: a grey dot blinking on and off, going solid green when the answer lands, amber when it parks on a tool approval. Only a hidden tab carries a marker — a visible one always shows the original icon.

### Two non-obvious things

**The open chat has no "ready" state to read.** `markTerminalLocal` and `applyPollSnapshot` both write `{ kind: "cleared" }` when the finishing chat is `currentChatId`, because terminal indicators are deliberately suppressed for the chat being viewed. That rule is right for the sidebar and wrong for a tab, since "send, switch tab, dot turns green" *is* the viewed chat completing. So the hook latches the falling edge of `isStreaming || isFinalizing` itself rather than reading a store value that does not exist. It intentionally does not reuse `useGenerationIndicatorCount`.

**Hidden tabs clamp main-thread timers to 1 Hz**, so the blink ticks from a Web Worker, which is exempt (measured: 250 ms held exactly across 1,625 iterations in a hidden tab, against 1000 ms on the main thread). There is a main-thread fallback for builds or browsers without worker support, and `prefers-reduced-motion` gets a static dot.

### Scope

Per-tab, not session-wide: a shared signal would blink *every* open tab whenever any chat anywhere was running, including tabs whose own chat is idle. Each tab has its own store instance, so this falls out naturally.

### Browser support

Chrome, Edge and Firefox blink. **Safari does not** — it never re-reads the icon link (verified: 0 favicon fetches against Chrome's 43 on the same page, matching Apple's long-standing bug). This needs no handling: favicon support cannot be feature-detected, so a browser that ignores the swap simply keeps the static icon. No error path.

The base icon comes from `/favicon.svg`, so customer themes are picked up for free — but the branch is chosen from the response **Content-Type**, since the backend answers that path with a theme's `.ico` bytes when that is all it ships. Composition is SVG-in-SVG rather than canvas, which keeps the icon's own `prefers-color-scheme` rules live and needs no canvas mock in tests